### PR TITLE
[Decoder] remove build warning

### DIFF
--- a/gst/tensor_decoder/tensordec-boundingbox.c
+++ b/gst/tensor_decoder/tensordec-boundingbox.c
@@ -140,7 +140,7 @@ _init_modes (bounding_boxes * bdata)
 
 /** @brief tensordec-plugin's TensorDecDef callback */
 static gboolean
-_init (GstTensorDec * self)
+bb_init (GstTensorDec * self)
 {
   /** @todo check if we need to ensure plugin_data is not yet allocated */
   bounding_boxes *bdata;
@@ -192,7 +192,7 @@ _exit_modes (bounding_boxes * bdata)
 
 /** @brief tensordec-plugin's TensorDecDef callback */
 static void
-_exit (GstTensorDec * self)
+bb_exit (GstTensorDec * self)
 {
   bounding_boxes *bdata = self->plugin_data;
 
@@ -303,7 +303,7 @@ _setOption_mode (bounding_boxes * bdata, const gchar * param)
 
 /** @brief tensordec-plugin's TensorDecDef callback */
 static gboolean
-_setOption (GstTensorDec * self, int opNum, const gchar * param)
+bb_setOption (GstTensorDec * self, int opNum, const gchar * param)
 {
   bounding_boxes *bdata = self->plugin_data;
 
@@ -403,7 +403,7 @@ _setOption (GstTensorDec * self, int opNum, const gchar * param)
  * If there are third or more tensors, such tensors will be ignored.
  */
 static GstCaps *
-_getOutputDim (GstTensorDec * self, const GstTensorsConfig * config)
+bb_getOutCaps (GstTensorDec * self, const GstTensorsConfig * config)
 {
   /** @todo this is compatible with "SSD" only. expand the capability! */
   bounding_boxes *data = self->plugin_data;
@@ -536,7 +536,7 @@ _ssd_loadBoxPrior (bounding_boxes * bdata)
 
 /** @brief tensordec-plugin's TensorDecDef callback */
 static gsize
-_getTransformSize (GstTensorDec * self, GstCaps * caps,
+bb_getTransformSize (GstTensorDec * self, GstCaps * caps,
     gsize size, GstCaps * othercaps, GstPadDirection direction)
 {
   return 0;
@@ -786,7 +786,8 @@ draw (GstMapInfo * out_info, bounding_boxes * bdata, GArray * results)
 
 /** @brief tensordec-plugin's TensorDecDef callback */
 static GstFlowReturn
-_decode (GstTensorDec * self, const GstTensorMemory * input, GstBuffer * outbuf)
+bb_decode (GstTensorDec * self, const GstTensorMemory * input,
+    GstBuffer * outbuf)
 {
   bounding_boxes *bdata = self->plugin_data;
   const gsize size = bdata->width * bdata->height * 4;  /* RGBA */
@@ -856,12 +857,12 @@ _decode (GstTensorDec * self, const GstTensorMemory * input, GstBuffer * outbuf)
 static TensorDecDef boundingBox = {
   .modename = "bounding_boxes",
   .type = OUTPUT_VIDEO,
-  .init = _init,
-  .exit = _exit,
-  .setOption = _setOption,
-  .getOutputDim = _getOutputDim,
-  .getTransformSize = _getTransformSize,
-  .decode = _decode,
+  .init = bb_init,
+  .exit = bb_exit,
+  .setOption = bb_setOption,
+  .getOutCaps = bb_getOutCaps,
+  .getTransformSize = bb_getTransformSize,
+  .decode = bb_decode,
 };
 
 /** @brief Initialize this object for tensordec-plugin */

--- a/gst/tensor_decoder/tensordec-directvideo.c
+++ b/gst/tensor_decoder/tensordec-directvideo.c
@@ -57,7 +57,7 @@ dv_setOption (GstTensorDec * self, int opNum, const gchar * param)
 
 /** @brief tensordec-plugin's TensorDecDef callback */
 static GstCaps *
-dv_getOutputDim (GstTensorDec * self, const GstTensorsConfig * config)
+dv_getOutCaps (GstTensorDec * self, const GstTensorsConfig * config)
 {
   /* Old gst_tensordec_video_caps_from_config () had this */
   GstVideoFormat format;
@@ -193,7 +193,7 @@ static TensorDecDef directVideo = {
   .init = dv_init,
   .exit = dv_exit,
   .setOption = dv_setOption,
-  .getOutputDim = dv_getOutputDim,
+  .getOutCaps = dv_getOutCaps,
   .getTransformSize = dv_getTransformSize,
   .decode = dv_decode,
 };

--- a/gst/tensor_decoder/tensordec-imagelabel.c
+++ b/gst/tensor_decoder/tensordec-imagelabel.c
@@ -49,7 +49,7 @@ typedef struct
 
 /** @brief tensordec-plugin's TensorDecDef callback */
 static gboolean
-_init (GstTensorDec * self)
+il_init (GstTensorDec * self)
 {
   /** @todo check if we need to ensure plugin_data is not yet allocated */
   self->plugin_data = g_new0 (ImageLabelData, 1);
@@ -58,7 +58,7 @@ _init (GstTensorDec * self)
 
 /** @brief tensordec-plugin's TensorDecDef callback */
 static void
-_exit (GstTensorDec * self)
+il_exit (GstTensorDec * self)
 {
   ImageLabelData *data = self->plugin_data;
   if (data->labels) {
@@ -143,7 +143,7 @@ loadImageLabels (ImageLabelData * data)
 
 /** @brief tensordec-plugin's TensorDecDef callback */
 static gboolean
-_setOption (GstTensorDec * self, int opNum, const gchar * param)
+il_setOption (GstTensorDec * self, int opNum, const gchar * param)
 {
   ImageLabelData *data = self->plugin_data;
 
@@ -168,7 +168,7 @@ _setOption (GstTensorDec * self, int opNum, const gchar * param)
 
 /** @brief tensordec-plugin's TensorDecDef callback */
 static GstCaps *
-_getOutputDim (GstTensorDec * self, const GstTensorsConfig * config)
+il_getOutCaps (GstTensorDec * self, const GstTensorsConfig * config)
 {
   const uint32_t *dim;
   int i;
@@ -190,7 +190,7 @@ _getOutputDim (GstTensorDec * self, const GstTensorsConfig * config)
 
 /** @brief tensordec-plugin's TensorDecDef callback */
 static gsize
-_getTransformSize (GstTensorDec * self, GstCaps * caps,
+il_getTransformSize (GstTensorDec * self, GstCaps * caps,
     gsize size, GstCaps * othercaps, GstPadDirection direction)
 {
   return 0;
@@ -221,7 +221,8 @@ case typename:\
 
 /** @brief tensordec-plugin's TensorDecDef callback */
 static GstFlowReturn
-_decode (GstTensorDec * self, const GstTensorMemory * input, GstBuffer * outbuf)
+il_decode (GstTensorDec * self, const GstTensorMemory * input,
+    GstBuffer * outbuf)
 {
   ImageLabelData *data = self->plugin_data;
   GstMapInfo out_info;
@@ -290,12 +291,12 @@ _decode (GstTensorDec * self, const GstTensorMemory * input, GstBuffer * outbuf)
 static TensorDecDef imageLabeling = {
   .modename = "image_labeling",
   .type = OUTPUT_TEXT,
-  .init = _init,
-  .exit = _exit,
-  .setOption = _setOption,
-  .getOutputDim = _getOutputDim,
-  .getTransformSize = _getTransformSize,
-  .decode = _decode,
+  .init = il_init,
+  .exit = il_exit,
+  .setOption = il_setOption,
+  .getOutCaps = il_getOutCaps,
+  .getTransformSize = il_getTransformSize,
+  .decode = il_decode,
 };
 
 /** @brief Initialize this object for tensordec-plugin */

--- a/gst/tensor_decoder/tensordec.c
+++ b/gst/tensor_decoder/tensordec.c
@@ -168,7 +168,7 @@ gst_tensordec_media_caps_from_tensor (GstTensorDec * self,
 
   if (self->mode == DECODE_MODE_PLUGIN) {
     g_assert (self->decoder);
-    return self->decoder->getOutputDim (self, config);
+    return self->decoder->getOutCaps (self, config);
   }
 
   GST_ERROR_OBJECT (self, "Decoder plugin not yet configured.");

--- a/gst/tensor_decoder/tensordec.h
+++ b/gst/tensor_decoder/tensordec.h
@@ -141,7 +141,7 @@ struct _TensorDecDef
       /**< Object destruction for the decoder */
   gboolean (*setOption) (GstTensorDec *self, int opNum, const gchar *param);
       /**< Process with the given options. It can be called repeatedly */
-  GstCaps *(*getOutputDim) (GstTensorDec *self, const GstTensorsConfig *config);
+  GstCaps *(*getOutCaps) (GstTensorDec *self, const GstTensorsConfig *config);
       /**< The caller should unref the returned GstCaps
         * Current implementation supports single-tensor only.
         * @todo WIP: support multi-tensor for input!!!


### PR DESCRIPTION
rename internal functions and sub-plugin callback

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
