### PR TITLE
Support Tizen 4.0 Backports & GST < 1.8

### DIFF
--- a/Documentation/component-description.md
+++ b/Documentation/component-description.md
@@ -82,6 +82,7 @@ In this page, we focus on the status of each elements. For requirements and desi
 - [tensor\_repo\_sink](../gst/nnstreamer/tensor_repo) (stable)
 - [tensor\_repo\_src](../gst/nnstreamer/tensor_repo) (stable)
 - [tensor\_src\_iio](../gst/nnstreamer/tensor_source) (stable)
+  - Requires GStreamer 1.8 or above.
 - [tensor\_src\_tizensensor](../ext/nnstreamer/tensor_source) (stable)
 - [tensor\_ros\_sink](https://github.com/nnsuite/nnstreamer-ros) (stable for ROS1)
 - [tensor\_ros\_src](https://github.com/nnsuite/nnstreamer-ros) (stable for ROS1)

--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -45,8 +45,17 @@
 
 #define set_feature_state(...) ml_tizen_set_feature_state(__VA_ARGS__)
 #define convert_tizen_element(...) ml_tizen_convert_element(__VA_ARGS__)
+
+#if (TIZENVERSION >= 5) && (TIZENVERSION < 9999)
 #define get_tizen_resource(...) ml_tizen_get_resource(__VA_ARGS__)
 #define release_tizen_resource(...) ml_tizen_release_resource(__VA_ARGS__)
+#elif (TIZENVERSION < 5)
+#define get_tizen_resource(...) (0)
+#define release_tizen_resource(...) do { } while (0)
+#else
+#error Tizen version is not defined.
+#endif
+
 #else
 #define check_feature_state()
 #define set_feature_state(...)

--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -49,9 +49,15 @@
 #if (TIZENVERSION >= 5) && (TIZENVERSION < 9999)
 #define get_tizen_resource(...) ml_tizen_get_resource(__VA_ARGS__)
 #define release_tizen_resource(...) ml_tizen_release_resource(__VA_ARGS__)
+#define TIZEN5PLUS 1
+
 #elif (TIZENVERSION < 5)
 #define get_tizen_resource(...) (0)
 #define release_tizen_resource(...) do { } while (0)
+typedef void * mm_resource_manager_h;
+typedef enum { MM_RESOURCE_MANAGER_RES_TYPE_MAX } mm_resource_manager_res_type_e;
+#define TIZEN5PLUS 0
+
 #else
 #error Tizen version is not defined.
 #endif
@@ -62,6 +68,7 @@
 #define convert_tizen_element(...) ML_ERROR_NONE
 #define get_tizen_resource(...) ML_ERROR_NONE
 #define release_tizen_resource(...)
+#define TIZEN5PLUS 0
 #endif
 
 #ifdef __cplusplus

--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -54,15 +54,26 @@ capi_deps = [
 if (get_option('enable-tizen'))
   message('CAPI is in Tizen mode')
 
-  tizen_deps = [
-    dependency('dpm'),
-    dependency('mm-resource-manager'),
-    dependency('mm-camcorder'),
-    dependency('capi-privacy-privilege-manager'),
-    dependency('capi-base-common'),
-    dependency('capi-system-info'),
-    dependency('dlog')
-  ]
+  if (tizenVmajor == 4)
+    tizen_deps = [
+      dependency('dpm'),
+      dependency('mm-camcorder'),
+      dependency('capi-privacy-privilege-manager'),
+      dependency('capi-base-common'),
+      dependency('capi-system-info'),
+      dependency('dlog')
+    ]
+  else
+    tizen_deps = [
+      dependency('dpm'),
+      dependency('mm-resource-manager'),
+      dependency('mm-camcorder'),
+      dependency('capi-privacy-privilege-manager'),
+      dependency('capi-base-common'),
+      dependency('capi-system-info'),
+      dependency('dlog')
+    ]
+  endif
 
   capi_deps += tizen_deps
 endif

--- a/api/capi/src/nnstreamer-capi-tizen.c
+++ b/api/capi/src/nnstreamer-capi-tizen.c
@@ -30,11 +30,13 @@
 #include <system_info.h>
 #include <restriction.h>        /* device policy manager */
 #include <privacy_privilege_manager.h>
+#include "nnstreamer-capi-private.h"
+#if TIZEN5PLUS
 #include <mm_resource_manager.h>
+#endif
 #include <mm_camcorder.h>
 
 #include "nnstreamer.h"
-#include "nnstreamer-capi-private.h"
 #include "nnstreamer_plugin_api.h"
 
 /* Tizen multimedia framework */
@@ -248,6 +250,8 @@ ml_tizen_get_feature_enabled (void)
   return ML_ERROR_NONE;
 }
 
+/** The following functions are either not used or supported in Tizen 4 */
+#if TIZEN5PLUS
 /**
  * @brief Function to check tizen privilege.
  */
@@ -879,6 +883,35 @@ mm_error:
 
   return status;
 }
+#else
+/**
+ * @brief A dummy function for Tizen 4.0
+ */
+static void
+ml_tizen_mm_res_release (gpointer handle, gboolean destroy)
+{
+}
+
+/**
+ * @brief A dummy function for Tizen 4.0
+ */
+static int
+ml_tizen_mm_res_acquire (ml_pipeline_h pipe,
+    mm_resource_manager_res_type_e res_type)
+{
+  return ML_ERROR_NOT_SUPPORTED;
+}
+
+/**
+ * @brief A dummy function for Tizen 4.0
+ */
+static int
+ml_tizen_mm_convert_element (ml_pipeline_h pipe, gchar ** result,
+    gboolean is_internal)
+{
+  return ML_ERROR_NOT_SUPPORTED;
+}
+#endif
 
 /**
  * @brief Releases the resource handle of Tizen.

--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
@@ -150,12 +150,14 @@ enum
  * @brief Template for src pad.
  * @todo Narrow down allowed tensors/tensor.
  */
+#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8) /* >= 1.8 */
 static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT "; "
         "other/tensors, num_tensors = 1, "
         "framerate = " GST_TENSOR_RATE_RANGE));
+#endif
 
 /** GObject method implementation */
 static void gst_tensor_src_tizensensor_set_property (GObject * object,
@@ -403,7 +405,22 @@ gst_tensor_src_tizensensor_class_init (GstTensorSrcTIZENSENSORClass * klass)
           DEFAULT_PROP_FREQ_N, DEFAULT_PROP_FREQ_D,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
+#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8) /* >= 1.8 */
   gst_element_class_add_static_pad_template (gstelement_class, &src_factory);
+#elif (GST_VERSION_MAJOR == 1) /* 1.0 ~ 1.8 */
+  {
+    GstPadTemplate *pad_template;
+    GstCaps *pad_caps;
+    pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT
+        "; other/tensors, num_tensors = 1, framerate = " GST_TENSOR_RATE_RANGE);
+    pad_template = gst_pad_template_new ("src", GST_PAD_SRC, GST_PAD_ALWAYS,
+        pad_caps);
+    gst_element_class_add_pad_template (gstelement_class, pad_template);
+    gst_caps_unref (pad_caps);
+  }
+#else
+#error We support GStreamer 1.x only.
+#endif
   gst_element_class_set_static_metadata (gstelement_class,
       "TensorSrcTizenSensor", "Source/Tizen-Sensor-FW/Tensor",
       "Creates tensor(s) stream from a given Tizen sensour framework node",

--- a/gst/nnstreamer/nnstreamer.c
+++ b/gst/nnstreamer/nnstreamer.c
@@ -90,7 +90,11 @@ gst_nnstreamer_init (GstPlugin * plugin)
   NNSTREAMER_INIT (plugin, split, SPLIT);
   NNSTREAMER_INIT (plugin, transform, TRANSFORM);
 #if defined(__gnu_linux__) && !defined(__ANDROID__)
+  /* IIO requires Linux / non-Android */
+#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)
+  /* SRC-IIO code uses GST 1.8+ APIs. */
   NNSTREAMER_INIT (plugin, src_iio, SRC_IIO);
+#endif
 #endif /* __gnu_linux__ && !__ANDROID__ */
   return TRUE;
 }

--- a/gst/nnstreamer/tensor_repo/tensor_reposink.c
+++ b/gst/nnstreamer/tensor_repo/tensor_reposink.c
@@ -57,10 +57,12 @@ enum
 /**
  * @brief tensor_reposink sink template
  */
+#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)        /* >= 1.8 */
 static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT "; " GST_TENSORS_CAP_DEFAULT));
+#endif
 
 static void gst_tensor_reposink_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec);
@@ -127,7 +129,22 @@ gst_tensor_reposink_class_init (GstTensorRepoSinkClass * klass)
       "Set element to handle tensor repository",
       "Samsung Electronics Co., Ltd.");
 
+#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)        /* >= 1.8 */
   gst_element_class_add_static_pad_template (element_class, &sink_template);
+#elif (GST_VERSION_MAJOR == 1)  /* 1.0 ~ 1.8 */
+  {
+    GstPadTemplate *pad_template;
+    GstCaps *pad_caps;
+    pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT "; "
+        GST_TENSORS_CAP_DEFAULT);
+    pad_template = gst_pad_template_new ("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
+        pad_caps);
+    gst_element_class_add_pad_template (element_class, pad_template);
+    gst_caps_unref (pad_caps);
+  }
+#else
+#error We support GStreamer 1.x only.
+#endif
 
   basesink_class->start = GST_DEBUG_FUNCPTR (gst_tensor_reposink_start);
   basesink_class->stop = GST_DEBUG_FUNCPTR (gst_tensor_reposink_stop);

--- a/gst/nnstreamer/tensor_repo/tensor_reposrc.c
+++ b/gst/nnstreamer/tensor_repo/tensor_reposrc.c
@@ -57,10 +57,12 @@ enum
 /**
  * @brief tensor_reposrc src template
  */
+#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)        /* >= 1.8 */
 static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT "; " GST_TENSORS_CAP_DEFAULT));
+#endif
 
 static void gst_tensor_reposrc_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec);
@@ -115,7 +117,22 @@ gst_tensor_reposrc_class_init (GstTensorRepoSrcClass * klass)
       "Pop element to handle tensor repository",
       "Samsung Electronics Co., Ltd.");
 
+#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)        /* >= 1.8 */
   gst_element_class_add_static_pad_template (element_class, &src_template);
+#elif (GST_VERSION_MAJOR == 1)  /* 1.0 ~ 1.8 */
+  {
+    GstPadTemplate *pad_template;
+    GstCaps *pad_caps;
+    pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT "; "
+        GST_TENSORS_CAP_DEFAULT);
+    pad_template = gst_pad_template_new ("src", GST_PAD_SRC, GST_PAD_ALWAYS,
+        pad_caps);
+    gst_element_class_add_pad_template (element_class, pad_template);
+    gst_caps_unref (pad_caps);
+  }
+#else
+#error We support GStreamer 1.x only.
+#endif
 }
 
 /**

--- a/gst/nnstreamer/tensor_sink/tensor_sink.c
+++ b/gst/nnstreamer/tensor_sink/tensor_sink.c
@@ -100,10 +100,12 @@ enum
 /**
  * @brief Template for sink pad.
  */
+#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)        /* >= 1.8 */
 static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT "; " GST_TENSORS_CAP_DEFAULT));
+#endif
 
 /**
  * @brief Variable for signal ids.
@@ -236,7 +238,22 @@ gst_tensor_sink_class_init (GstTensorSinkClass * klass)
       "Sink element to handle tensor stream", "Samsung Electronics Co., Ltd.");
 
   /** pad template */
+#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)        /* >= 1.8 */
   gst_element_class_add_static_pad_template (element_class, &sink_template);
+#elif (GST_VERSION_MAJOR == 1)  /* 1.0 ~ 1.8 */
+  {
+    GstPadTemplate *pad_template;
+    GstCaps *pad_caps;
+    pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT "; "
+        GST_TENSORS_CAP_DEFAULT);
+    pad_template = gst_pad_template_new ("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
+        pad_caps);
+    gst_element_class_add_pad_template (element_class, pad_template);
+    gst_caps_unref (pad_caps);
+  }
+#else
+#error We support GStreamer 1.x only.
+#endif
 
   /** GstBaseSink methods */
   bsink_class->event = GST_DEBUG_FUNCPTR (gst_tensor_sink_event);

--- a/gst/nnstreamer/tensor_source/meson.build
+++ b/gst/nnstreamer/tensor_source/meson.build
@@ -1,6 +1,12 @@
 tensor_src_sources = [
-  'tensor_src_iio.c'
 ]
+
+gst18_dep = dependency('gstreamer-' + gst_api_verision, version : '>=1.8', required : false)
+if gst18_dep.found()
+  tensor_src_sources += 'tensor_src_iio.c'
+else
+  message('tensor_src_iio requires GStreamer >= 1.8. Skipping it')
+endif
 
 foreach s : tensor_src_sources
   if build_platform != 'macos'

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,10 @@ if get_option('enable-tizen')
   # Pass __TIZEN__ to the compiler
   add_project_arguments('-D__TIZEN__=1', language: ['c', 'cpp'])
   build_platform = 'tizen'
+
+  tizenVmajor = get_option('tizen-version-major')
+  add_project_arguments('-DTIZENVERSION='+tizenVmajor.to_string(), language: ['c', 'cpp'])
+
 elif not meson.is_cross_build()
   if cc.get_id() == 'clang' and cxx.get_id() == 'clang'
     if build_machine.system() == 'darwin'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,6 +15,7 @@ option('enable-symbolic-link', type: 'boolean', value: true)
 option('enable-capi', type: 'boolean', value: false)
 option('enable-python', type: 'boolean', value: false)
 option('enable-tizen', type: 'boolean', value: false)
+option('tizen-version-major', type: 'integer', min : 4, max : 9999, value: 9999) # 9999 means "not Tizen"
 option('enable-element-restriction', type: 'boolean', value: false) # true to restrict gst-elements in api
 option('restricted-elements', type: 'string', value: '')
 option('enable-tflite-nnapi-delegation', type: 'boolean', value: false) # true to enable tensorflow-lite to delegate nnapi interpretation to nnfw backend in tizen

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -5,7 +5,28 @@
 %define		tensorflow_support	0
 %define		tensorflow_lite_support	1
 %define		armnn_support 0
+
+%if 0%{tizen_version_major} >= 5
 %define		python_support 1
+%else
+%define		python_support 0
+%endif
+
+%if 0%{tizen_version_major} >= 6
+%define		mvncsdk2_support 1
+
+%ifarch aarch64 x86_64
+# This supports 64bit systems only
+%define		edgetpu_support 1
+%else
+%define		edgetpu_support 0
+%endif
+
+%else
+%define		mvncsdk2_support 0
+%define		edgetpu_support 0
+%endif
+
 %define		pytorch_support 0
 %define		caffe2_support 0
 
@@ -79,8 +100,7 @@ BuildRequires:  libarmcl
 BuildConflicts: libarmcl-release
 %endif
 
-%ifarch aarch64 x86_64
-# This supports 64bit systems only
+%if 0%{?edgetpu_support}
 BuildRequires:	pkgconfig(edgetpu)
 %endif
 
@@ -90,6 +110,9 @@ BuildRequires: lcov
 # BuildRequires:	taos-ci-unittest-coverage-assessment
 %endif
 
+%if 0%{mvncsdk2_support}
+BuildRequires:	pkgconfig(libmvnc)
+%endif
 %if %{with tizen}
 BuildRequires:	pkgconfig(dpm)
 BuildRequires:	pkgconfig(mm-resource-manager)
@@ -98,7 +121,6 @@ BuildRequires:	pkgconfig(capi-privacy-privilege-manager)
 BuildRequires:	pkgconfig(capi-system-info)
 BuildRequires:	pkgconfig(capi-base-common)
 BuildRequires:	pkgconfig(dlog)
-BuildRequires:	pkgconfig(libmvnc)
 BuildRequires:	gst-plugins-bad-devel
 BuildRequires:	gst-plugins-base-devel
 # For tizen sensor support
@@ -263,7 +285,7 @@ Requires:	capi-system-sensor
 You can include Tizen sensor framework nodes as source elements of GStreamer/NNStreamer pipelines with this package.
 %endif # tizen
 
-%ifarch aarch64 x86_64
+%if 0%{?edgetpu_support}
 %package edgetpu
 Summary:	NNStreamer plugin for Google-Coral Edge TPU
 Requires:	libedgetpu1
@@ -279,10 +301,13 @@ You may enable this package to use Google Edge TPU with NNStreamer and Tizen ML 
 %define enable_nnfw_runtime -Denable-nnfw-runtime=false
 %define element_restriction -Denable-element-restriction=false
 
+%if 0%{mvncsdk2_support}
+%define enable_mvncsdk2 -Denable-movidius-ncsdk2=true
+%endif
+
 %if %{with tizen}
 %define enable_tizen -Denable-tizen=true -Denable-tizen-sensor=true
 %define enable_api -Denable-capi=true
-%define enable_mvncsdk2 -Denable-movidius-ncsdk2=true
 %ifarch %arm aarch64
 %define enable_nnfw_runtime -Denable-nnfw-runtime=true
 %endif
@@ -333,7 +358,7 @@ You may enable this package to use Google Edge TPU with NNStreamer and Tizen ML 
 %endif
 
 # Support edgetpu
-%ifarch aarch64 x86_64
+%if 0%{?edgetpu_support}
 %define enable_edgetpu -Denable-edgetpu=true
 %else
 %define enable_edgetpu -Denable-edgetpu=false
@@ -572,7 +597,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{_includedir}/nnstreamer/tensor_filter_cpp.hh
 %{_libdir}/pkgconfig/nnstreamer-cpp.pc
 
-%ifarch aarch64 x86_64
+%if 0%{?edgetpu_support}
 %files edgetpu
 %manifest nnstreamer.manifest
 %license LICENSE

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -65,7 +65,9 @@ BuildRequires:	meson >= 0.50.0
 
 # To run test cases, we need gst plugins
 BuildRequires:	gst-plugins-good
+%if 0%{tizen_version_major} >= 5
 BuildRequires:	gst-plugins-good-extra
+%endif
 BuildRequires:	gst-plugins-base
 # and gtest
 BuildRequires:	gtest-devel
@@ -115,7 +117,9 @@ BuildRequires:	pkgconfig(libmvnc)
 %endif
 %if %{with tizen}
 BuildRequires:	pkgconfig(dpm)
+%if 0%{tizen_version_major} >= 5
 BuildRequires:	pkgconfig(mm-resource-manager)
+%endif
 BuildRequires:	pkgconfig(mm-camcorder)
 BuildRequires:	pkgconfig(capi-privacy-privilege-manager)
 BuildRequires:	pkgconfig(capi-system-info)
@@ -306,7 +310,7 @@ You may enable this package to use Google Edge TPU with NNStreamer and Tizen ML 
 %endif
 
 %if %{with tizen}
-%define enable_tizen -Denable-tizen=true -Denable-tizen-sensor=true
+%define enable_tizen -Denable-tizen=true -Denable-tizen-sensor=true -Dtizen-version-major=0%{tizen_version_major}
 %define enable_api -Denable-capi=true
 %ifarch %arm aarch64
 %define enable_nnfw_runtime -Denable-nnfw-runtime=true

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -278,13 +278,15 @@ Group:		Multimedia/Framework
 Requires:	capi-nnstreamer-devel = %{version}-%{release}
 %description -n nnstreamer-tizen-internal-capi-devel
 Tizen internal API to construct the pipeline without the permissions.
+%endif # tizen
 
+%if 0%{mvncsdk2_support}
 %package	ncsdk2
 Summary:	NNStreamer Intel Movidius NCSDK2 support
 Group:		Multimedia/Framework
 %description	ncsdk2
 NNStreamer's tensor_fliter subplugin of Intel Movidius Neural Compute stick SDK2.
-%endif # tizen
+%endif # mvncsdk2_support
 
 # Add Tizen's sensor framework API integration
 %if 0%{tizen_sensor_support}
@@ -594,12 +596,14 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %defattr(-,root,root,-)
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_armnn.so
 %endif
+%endif  # tizen
 
+%if 0%{mvncsdk2_support}
 %files -n nnstreamer-ncsdk2
 %defattr(-,root,root,-)
 %manifest nnstreamer.manifest
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_movidius-ncsdk2.so
-%endif  # tizen
+%endif  # mvncsdk2_support
 
 %if 0%{tizen_sensor_support}
 %files tizen-sensor

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -13,6 +13,7 @@
 %endif
 
 %if 0%{tizen_version_major} >= 6
+%define		tizen_sensor_support 1
 %define		mvncsdk2_support 1
 
 %ifarch aarch64 x86_64
@@ -23,6 +24,7 @@
 %endif
 
 %else
+%define		tizen_sensor_support 0
 %define		mvncsdk2_support 0
 %define		edgetpu_support 0
 %endif
@@ -247,6 +249,9 @@ Note that there is no .pc file for this package because nnstreamer.pc file may b
 Summary:	Tizen Native API for NNStreamer
 Group:		Multimedia/Framework
 Requires:	%{name} = %{version}-%{release}
+%if 0%{tizen_sensor_support}
+Requires:	%{name}-tizen-sensor = %{version}-%{release}
+%endif
 %description -n capi-nnstreamer
 Tizen Native API wrapper for NNStreamer.
 You can construct a data stream pipeline with neural networks easily.
@@ -279,15 +284,17 @@ Summary:	NNStreamer Intel Movidius NCSDK2 support
 Group:		Multimedia/Framework
 %description	ncsdk2
 NNStreamer's tensor_fliter subplugin of Intel Movidius Neural Compute stick SDK2.
+%endif # tizen
 
 # Add Tizen's sensor framework API integration
+%if 0%{tizen_sensor_support}
 %package tizen-sensor
 Summary:	NNStreamer integration of tizen sensor framework (tensor_src_tizensensor)
 Requires:	nnstreamer = %{version}-%{release}
 Requires:	capi-system-sensor
 %description tizen-sensor
 You can include Tizen sensor framework nodes as source elements of GStreamer/NNStreamer pipelines with this package.
-%endif # tizen
+%endif # tizen_sensor_support
 
 %if 0%{?edgetpu_support}
 %package edgetpu
@@ -299,7 +306,8 @@ You may enable this package to use Google Edge TPU with NNStreamer and Tizen ML 
 %endif
 
 ## Define build options ##
-%define enable_tizen -Denable-tizen=false -Denable-tizen-sensor=false
+%define enable_tizen -Denable-tizen=false
+%define enable_tizen_sensor -Denable-tizen-sensor=false
 %define enable_api -Denable-capi=false
 %define enable_mvncsdk2 -Denable-movidius-ncsdk2=false
 %define enable_nnfw_runtime -Denable-nnfw-runtime=false
@@ -309,8 +317,12 @@ You may enable this package to use Google Edge TPU with NNStreamer and Tizen ML 
 %define enable_mvncsdk2 -Denable-movidius-ncsdk2=true
 %endif
 
+%if 0%{tizen_sensor_support}
+%define enable_tizen_sensor -Denable-tizen-sensor=true
+%endif
+
 %if %{with tizen}
-%define enable_tizen -Denable-tizen=true -Denable-tizen-sensor=true -Dtizen-version-major=0%{tizen_version_major}
+%define enable_tizen -Denable-tizen=true -Dtizen-version-major=0%{tizen_version_major}
 %define enable_api -Denable-capi=true
 %ifarch %arm aarch64
 %define enable_nnfw_runtime -Denable-nnfw-runtime=true
@@ -395,6 +407,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir
 	%{enable_api} %{enable_tizen} %{element_restriction} -Denable-env-var=false -Denable-symbolic-link=false \
 	%{enable_tf_lite} %{enable_tf} %{enable_pytorch} %{enable_caffe2} %{enable_python} \
 	%{enable_nnfw_runtime} %{enable_mvncsdk2} %{enable_armnn} %{enable_edgetpu} \
+	%{enable_tizen_sensor} \
 	build
 
 ninja -C build %{?_smp_mflags}
@@ -586,11 +599,13 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %defattr(-,root,root,-)
 %manifest nnstreamer.manifest
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_movidius-ncsdk2.so
+%endif  # tizen
 
+%if 0%{tizen_sensor_support}
 %files tizen-sensor
 %manifest nnstreamer.manifest
 %{gstlibdir}/libnnstreamer-tizen-sensor.so
-%endif  # tizen
+%endif  # tizen_sensor_support
 
 %files cpp
 %manifest nnstreamer.manifest

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -77,35 +77,38 @@ if gtest_dep.found()
   test('unittest_common', unittest_common)
 
   # Run unittest_sink
-  unittest_sink = executable('unittest_sink',
-    join_paths('nnstreamer_sink', 'unittest_sink.cc'),
-    dependencies: [nnstreamer_unittest_deps, unittest_util_dep],
-    install: get_option('install-test'),
-    install_dir: unittest_install_dir
-  )
+  gst18_dep = dependency('gstreamer-' + gst_api_verision, version : '>=1.8', required : false)
+  if gst18_dep.found()
+    unittest_sink = executable('unittest_sink',
+      join_paths('nnstreamer_sink', 'unittest_sink.cc'),
+      dependencies: [nnstreamer_unittest_deps, unittest_util_dep],
+      install: get_option('install-test'),
+      install_dir: unittest_install_dir
+    )
 
-  test('unittest_sink', unittest_sink, timeout: 120, args: ['--gst-plugin-path=..'])
+    test('unittest_sink', unittest_sink, timeout: 120, args: ['--gst-plugin-path=..'])
 
-  # Run unittest_plugins
-  unittest_plugins = executable('unittest_plugins',
-    join_paths('nnstreamer_plugins', 'unittest_plugins.cc'),
-    dependencies: [nnstreamer_unittest_deps],
-    install: get_option('install-test'),
-    install_dir: unittest_install_dir
-  )
-
-  test('unittest_plugins', unittest_plugins, args: ['--gst-plugin-path=..'])
-
-  # Run unittest_src_iio
-  if build_platform != 'macos'
-    unittest_src_iio = executable('unittest_src_iio',
-      join_paths('nnstreamer_source', 'unittest_src_iio.cc'),
+    # Run unittest_plugins
+    unittest_plugins = executable('unittest_plugins',
+      join_paths('nnstreamer_plugins', 'unittest_plugins.cc'),
       dependencies: [nnstreamer_unittest_deps],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )
 
-    test('unittest_src_iio', unittest_src_iio, timeout: 120, args: ['--gst-plugin-path=..'])
+    test('unittest_plugins', unittest_plugins, args: ['--gst-plugin-path=..'])
+
+  # Run unittest_src_iio
+    if build_platform != 'macos'
+      unittest_src_iio = executable('unittest_src_iio',
+        join_paths('nnstreamer_source', 'unittest_src_iio.cc'),
+        dependencies: [nnstreamer_unittest_deps],
+        install: get_option('install-test'),
+        install_dir: unittest_install_dir
+      )
+
+      test('unittest_src_iio', unittest_src_iio, timeout: 120, args: ['--gst-plugin-path=..'])
+    endif
   endif
 
   # Armnn unittest


### PR DESCRIPTION
A Tizen 4.0 device has decided to use nnstreamer for its updates
and the PM decided not to upgrade Tizen version of the product :(

WTH, let's support Tizen 4.0 as well.

In the due course, we will be supporting GStreamer 1.6 as well. (NNStreamer requires GStreamer >= 1.8 conventionally.)

Included commits are:

commit ee30eb76d4e84692216ace524c21e30a10e92078 (HEAD -> Tizen4, github-fork/Tizen4)
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Tue Mar 31 12:23:14 2020 +0900

    [Tizen 4.0] Disable mvnc packages in older Tizen
    
    If mvnc build is turned off, do not package them.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit ee66bf6319434b43172aba339e5e2afc085dd134
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Tue Mar 31 11:41:23 2020 +0900

    [Tizen 4.0-5.5] Disable tizen-sensor support if Tizen < 6
    
    Tizen sensor support works since Tizen 5.5 and
    it officially supports sinze Tizen 6.0
    Disable if if it is < 6
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit ae4f069060362aa8ac965dbed2a9d34906bd2c08
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Tue Mar 31 11:13:37 2020 +0900

    [Tizen 4.0] Disable code w/ GST1.8 requirements if GST < 1.8
    
    src_iio uses GST 1.8 APIs.
    A few unit tests uses GST 1.8 APIs
    
    Do not build them if it is < 1.8.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 7c56c3ccd4f659c1e7687f8e55c85416a14c4a18
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Mon Mar 30 19:42:43 2020 +0900

    [Tizen 4.0/CAPI] Disable Tizen 5.5+ advanced features
    
    We cannot support audio/video resource auto detection
    with Tizen 4.0
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


commit ad8432c88923b88653da74372470f15e1f20e555
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Mon Mar 30 19:04:08 2020 +0900

    [Tizen 4.0] Make it compatible with GStreamer 1.6
    
    gst_element_class_add_staic_pad_template is introduced with
    GStreamer 1.8
    
    For Tizen 4.0, which uses GStreamer 1.6, use
    gst_element_class_add_pad_template() instead if
    it is < 1.8.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit ad41d76d5f87e52438dac56af3c01dfafcfd9493
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Fri Mar 27 16:26:23 2020 +0900

    [Tizen 4.0/C-API] Detach mm-resource-manager
    
    mm-resource-manager is not available at Tizen 4.0.
    Do not depend on Tizen API mm-resource-manager if it is Tizen 4.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit e79c68ed5ee406e3ac5653bf2fd1fc434c10dad0
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Fri Mar 27 15:42:10 2020 +0900

    [Tizen 4.0/Dist] Update spec for different Tizen versions.
    
    A Tizen 4.0 device has decided to use nnstreamer for its updates
    and the PM decided not to upgrade Tizen version of the product :(
    
    WTH, let's support Tizen 4.0 as well.
    
    This commit prepares other 4.0 backport tasks by providing
    infra to distinguish Tizen version at build time.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>






Fixes #2221

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

