### PR TITLE
[Dist/Tizen] Correct LD_LIBRARY_PATH for NCSDK2/Edge-TPU test cases

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -387,9 +387,9 @@ export NNSTREAMER_DECODERS=$(pwd)/build/ext/nnstreamer/tensor_decoder
     bash %{test_script} ./tests
     bash %{test_script} ./tests/tizen_capi/unittest_tizen_capi
     bash %{test_script} ./tests/nnstreamer_filter_extensions_common
-    LD_LIBRARY_PATH=./tests/nnstreamer_filter_mvncsdk2:. bash %{test_script} ./tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2
+    LD_LIBRARY_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/build/tests/nnstreamer_filter_mvncsdk2:. bash %{test_script} ./tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2
 %ifarch aarch64 x86_64
-    LD_LIBRARY_PATH=./tests/nnstreamer_filter_edgetpu:. bash %{test_script} ./tests/nnstreamer_filter_edgetpu/unittest_edgetpu
+    LD_LIBRARY_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/build/tests/nnstreamer_filter_edgetpu:. bash %{test_script} ./tests/nnstreamer_filter_edgetpu/unittest_edgetpu
 %endif #ifarch 64
     pushd tests
     ssat -n --summary summary.txt -cn _n


### PR DESCRIPTION
This patch corrects LD_LIBRARY_PATH where the test helper shared libraries are placed for NCSDK2 and Edge-TPU test cases in the Tizen RPM spec file.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped