### PR TITLE
[LF/AI Migration] Update github repo URLs

### DIFF
--- a/.TAOS-CI/config/config-environment.sh
+++ b/.TAOS-CI/config/config-environment.sh
@@ -30,7 +30,7 @@ TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 # Write an account name (or organization name) of the '{master|upstream}' branch
 # e.g., https://github-website/{account_name}/{project_name}/
-GITHUB_ACCOUNT="nnsuite"
+GITHUB_ACCOUNT="nnstreamer"
 
 # Write a project name of a github website of the '{master|upstream}' branch
 # e.g., https://github-website/{account_name}/{project_name}/

--- a/Documentation/coding-convention.md
+++ b/Documentation/coding-convention.md
@@ -55,19 +55,19 @@ However, please try to stick with the same indentation rules (2 spaces) and comm
 - **gst/nnstreamer**: All core nnstreamer codes are located here.
     - **tensor\_\* **: Plugins of nnstreamer.
 - **jni**: Android/Java build scripts.
-- **nnstreamer\_example**: Example custom filters required by test cases. In the old days, we used to have all nnstreamer examples here. Most of such examples are moved to [Example git](https://github.com/nnsuite/nnstreamer-example) except for those who required by test cases.
+- **nnstreamer\_example**: Example custom filters required by test cases. In the old days, we used to have all nnstreamer examples here. Most of such examples are moved to [Example git](https://github.com/nnstreamer/nnstreamer-example) except for those who required by test cases.
 - **packaging**: Tizen RPM build scripts. OpenSUSE/Redhat Linux may reuse this.
 - **tests**: Unit test cases. We have SSAT test cases and GTEST test cases. There are a lot of subdirectories, which are groups of unit test cases.
 - **tools**: Various developmental tools and scripts of NNStreamer.
 
 ## Related git repositories in nnsuite
 
-- [NNStreamer Examplie Applications \& Documents](https://github.com/nnsuite/nnstreamer-example)
+- [NNStreamer Examplie Applications \& Documents](https://github.com/nnstreamer/nnstreamer-example)
 - [TAOS-CI, CI Service for On-Device AI Systems](https://github.com/nnsuite/TAOS-CI)
-- [NNStreamer ROS (Robot OS) Support](https://github.com/nnsuite/nnstreamer-ros)
-- [NNStreamer Android Build Resource](https://github.com/nnsuite/nnstreamer-android-resource): additional files required by Android builds.
+- [NNStreamer ROS (Robot OS) Support](https://github.com/nnstreamer/nnstreamer-ros)
+- [NNStreamer Android Build Resource](https://github.com/nnstreamer/nnstreamer-android-resource): additional files required by Android builds.
 - [ORC, aarch64 support](https://github.com/nnsuite/orc): we are going to support aarch64-ORC to accelerate transform operations of nnstreamer in aarch64 devices.
-- [NNStreamer-Edge](https://github.com/nnsuite/nnstreamer-edge): WIP
+- [NNStreamer-Edge](https://github.com/nnstreamer/nnstreamer-edge): WIP
 - [NNStreamer Yocto/OpenEmbedded Layer](https://github.com/nnsuite/meta-neural-network): refer to [Openembedded layer page](https://layers.openembedded.org/layerindex/branch/master/layer/meta-neural-network/)
 - [NNStreamer/NNSuite Web Page](https://github.com/nnsuite/nnsuite.github.io): WIP
 - **tizenport-\* **: Tizen-ROS support. Refer to [build.tizen.org](https://build.tizen.org/project/show/devel:AIC:Tizen:5.0:nnsuite)

--- a/Documentation/coding-convention.md
+++ b/Documentation/coding-convention.md
@@ -60,16 +60,16 @@ However, please try to stick with the same indentation rules (2 spaces) and comm
 - **tests**: Unit test cases. We have SSAT test cases and GTEST test cases. There are a lot of subdirectories, which are groups of unit test cases.
 - **tools**: Various developmental tools and scripts of NNStreamer.
 
-## Related git repositories in nnsuite
+## Related git repositories
 
 - [NNStreamer Examplie Applications \& Documents](https://github.com/nnstreamer/nnstreamer-example)
-- [TAOS-CI, CI Service for On-Device AI Systems](https://github.com/nnsuite/TAOS-CI)
+- [TAOS-CI, CI Service for On-Device AI Systems](https://github.com/nnstreamer/TAOS-CI)
 - [NNStreamer ROS (Robot OS) Support](https://github.com/nnstreamer/nnstreamer-ros)
 - [NNStreamer Android Build Resource](https://github.com/nnstreamer/nnstreamer-android-resource): additional files required by Android builds.
 - [ORC, aarch64 support](https://github.com/nnsuite/orc): we are going to support aarch64-ORC to accelerate transform operations of nnstreamer in aarch64 devices.
 - [NNStreamer-Edge](https://github.com/nnstreamer/nnstreamer-edge): WIP
-- [NNStreamer Yocto/OpenEmbedded Layer](https://github.com/nnsuite/meta-neural-network): refer to [Openembedded layer page](https://layers.openembedded.org/layerindex/branch/master/layer/meta-neural-network/)
-- [NNStreamer/NNSuite Web Page](https://github.com/nnsuite/nnsuite.github.io): WIP
+- [NNStreamer Yocto/OpenEmbedded Layer](https://github.com/nnstreamer/meta-neural-network): refer to [Openembedded layer page](https://layers.openembedded.org/layerindex/branch/master/layer/meta-neural-network/)
+- [NNStreamer Web Page](https://github.com/nnstreamer/nnstreamer.github.io): WIP
 - **tizenport-\* **: Tizen-ROS support. Refer to [build.tizen.org](https://build.tizen.org/project/show/devel:AIC:Tizen:5.0:nnsuite)
 
 

--- a/Documentation/component-description.md
+++ b/Documentation/component-description.md
@@ -4,7 +4,7 @@
 - other/tensors
 - other/tensorsave (planned --> canceled)
 
-The findtype specifics: refer to the wiki ([other/tensorsave (canceled)](https://github.com/nnsuite/nnstreamer/wiki/Design-External-Save-Format-for-other-tensor-and-other-tensors-Stream-for-TypeFind))
+The findtype specifics: refer to the wiki ([other/tensorsave (canceled)](https://github.com/nnstreamer/nnstreamer/wiki/Design-External-Save-Format-for-other-tensor-and-other-tensors-Stream-for-TypeFind))
 
 Each frame of an other/tensor or other/tensors stream should have only ONE instance of other/tensor or other/tensors.
 
@@ -54,7 +54,7 @@ In this page, we focus on the status of each elements. For requirements and desi
   - ARMNN (stable)
   - WIP: Verisilicon-Vivante, SNAP (Exynos-NPU & Qualcomm-SNPE), ...
   - [Guide on writing a filter subplugin](writing-subplugin-tensor-filter.md)
-  - [Codegen and code template for tensor\_filter subplugin](https://github.com/nnsuite/nnstreamer-example/tree/master/templates)
+  - [Codegen and code template for tensor\_filter subplugin](https://github.com/nnstreamer/nnstreamer-example/tree/master/templates)
 - [tensor\_sink](../gst/nnstreamer/tensor_sink) (stable)
 - [tensor\_transform](../gst/nnstreamer/tensor_transform) (stable)
   - Supported features
@@ -83,8 +83,8 @@ In this page, we focus on the status of each elements. For requirements and desi
 - [tensor\_repo\_src](../gst/nnstreamer/tensor_repo) (stable)
 - [tensor\_src\_iio](../gst/nnstreamer/tensor_source) (stable)
 - [tensor\_src\_tizensensor](../ext/nnstreamer/tensor_source) (stable)
-- [tensor\_ros\_sink](https://github.com/nnsuite/nnstreamer-ros) (stable for ROS1)
-- [tensor\_ros\_src](https://github.com/nnsuite/nnstreamer-ros) (stable for ROS1)
+- [tensor\_ros\_sink](https://github.com/nnstreamer/nnstreamer-ros) (stable for ROS1)
+- [tensor\_ros\_src](https://github.com/nnstreamer/nnstreamer-ros) (stable for ROS1)
 - tensor\_save and tensor\_load canceled.
 
 
@@ -101,9 +101,9 @@ Note that test elements in /tests/ are not elements for applications. They exist
     - Single API: Tizen 5.5 M2
     - Pipeline API: Tizen 6.0 M1
 - JAVA-API (Android)
-  - [Android sample app](https://github.com/nnsuite/nnstreamer-example/tree/master/android/example_app/api-sample) uses JAVA APIs to implement Android-NNStreamer apps.
+  - [Android sample app](https://github.com/nnstreamer/nnstreamer-example/tree/master/android/example_app/api-sample) uses JAVA APIs to implement Android-NNStreamer apps.
   - [Available at JCenter](https://bintray.com/beta/#/nnsuite/nnstreamer?tab=packages)
-  - Note that the Android Sample Applications published via Google Play Store, [Source Code](https://github.com/nnsuite/nnstreamer-example/tree/master/android/example_app), are developed before NNStreamer Java API. They use GStreamer functions.
+  - Note that the Android Sample Applications published via Google Play Store, [Source Code](https://github.com/nnstreamer/nnstreamer-example/tree/master/android/example_app), are developed before NNStreamer Java API. They use GStreamer functions.
 - Web API (HTML5) Planned (Tizen 7.0?)
 
 # Other Components
@@ -118,7 +118,7 @@ Note that test elements in /tests/ are not elements for applications. They exist
   - Used [SSAT](https://github.com/myungjoo/SSAT).
   - Each element and feature is required to register its testcases at [test case directory](../tests/)
 - Examples: Example GStreamer applications using NNStreamer and example sub-plugins for NNStreamer. The binaries from this directory is not supposed to be packaged with the main binary package.
-  - [Example GStreamer applications](https://github.com/nnsuite/nnstreamer-example)
+  - [Example GStreamer applications](https://github.com/nnstreamer/nnstreamer-example)
   - [Example sub-plugins](../nnstreamer_example)
 - Packaing for Distros / SW-Platform Compatibility.
   - [Tizen](../packaging) (stable): RPM packaging for Tizen 5.0+. It is expected to be compatible with other RPM-based distros; however, it is not tested or guaranteed.

--- a/Documentation/doxygen-documentation.md
+++ b/Documentation/doxygen-documentation.md
@@ -27,7 +27,7 @@ Doxygen is the de facto standard tool for generating documentation from annotate
     ```
     # for src app
     $ cd ./gst
-    $ doxygen ../Doxyfile.prj # from https://github.com/nnsuite/TAOS-CI/blob/master/ci/Doxyfile.prj
+    $ doxygen ../Doxyfile.prj # from https://github.com/nnstreamer/TAOS-CI/blob/master/ci/Doxyfile.prj
 
     # launch with the browser to view the results
     $ chromium-browser ./html/index.html

--- a/Documentation/getting-started-macos.md
+++ b/Documentation/getting-started-macos.md
@@ -48,7 +48,7 @@ $ brew install meson ninja pkg-config cmake libffi glib gstreamer gst-plugins-ba
 Clone the master (default) branch of the GitHub repository of NNStreamer.
 
 ```bash
-$ git clone https://github.com/nnsuite/nnstreamer.git
+$ git clone https://github.com/nnstreamer/nnstreamer.git
 Cloning into 'nnstreamer'...
 ...omission...
 Checking out files: 100% (326/326), done.

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -57,7 +57,7 @@ Refer to [PbuilderHowto](https://wiki.ubuntu.com/PbuilderHowto) for more about p
 ```bash
 $ git clone https://github.com/myungjoo/SSAT ssat
 $ git clone https://git.tizen.org/cgit/platform/upstream/tensorflow
-$ git clone https://github.com/nnsuite/nnstreamer
+$ git clone https://github.com/nnstreamer/nnstreamer
 ```
 
 Alternatively, you may simply download binary packages from PPA (ssat and tensorflow):

--- a/Documentation/how-to-run-examples.md
+++ b/Documentation/how-to-run-examples.md
@@ -1,3 +1,3 @@
 # How to run examples
 
-See nnstreamer wiki page [Usage examples and screenshots](https://github.com/nnsuite/nnstreamer/wiki/usage-examples-screenshots)
+See nnstreamer wiki page [Usage examples and screenshots](https://github.com/nnstreamer/nnstreamer/wiki/usage-examples-screenshots)

--- a/Documentation/writing-subplugin-tensor-filter.md
+++ b/Documentation/writing-subplugin-tensor-filter.md
@@ -11,7 +11,7 @@ It is called "**subplugin**" because it is a plugin for a GStreamer plugin, ```t
 You can start writing a ```tensor_filter``` subplugin easily by using code-template/generator from nnstreamer-example.git. It is in ```/templates/tensor_filter_subplugin``` of ```nnstreamer-example.git```. The following is how to start writing a subplugin with the template for Tizen devices (5.5 M2 +). In this example, the target subplugin name is ```example```.
 
 ```
-$ git clone https://github.com/nnsuite/nnstreamer-example.git
+$ git clone https://github.com/nnstreamer/nnstreamer-example.git
 ...
 $ cd nnstreamer-example
 $ cd templates/tensor_filter_subplugin

--- a/Documentation/writing-tizen-native-apps.md
+++ b/Documentation/writing-tizen-native-apps.md
@@ -72,11 +72,11 @@ However, with an internal API, allowed to platform binaries only (.rpm. not .tpk
 
 ## Single
 
-A simple sample Tizen app with Single APIs is at nnstreamer-example.git, [SingleSample](https://github.com/nnsuite/nnstreamer-example/tree/master/Tizen.native/SingleSample).
+A simple sample Tizen app with Single APIs is at nnstreamer-example.git, [SingleSample](https://github.com/nnstreamer/nnstreamer-example/tree/master/Tizen.native/SingleSample).
 
 ## Pipeline
 
-A simple sample Tizen app with Pipeline APIs is at nnstreamer-example.git, [PipelineSample](https://github.com/nnsuite/nnstreamer-example/tree/master/Tizen.native/PipelineSample).
+A simple sample Tizen app with Pipeline APIs is at nnstreamer-example.git, [PipelineSample](https://github.com/nnstreamer/nnstreamer-example/tree/master/Tizen.native/PipelineSample).
 
 
 # Tizen ML API Documentation

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 <a href="https://scan.coverity.com/projects/nnsuite-nnstreamer">
 <img alt="Coverity Scan Defect Status" src="https://img.shields.io/endpoint?url=https://nnsuite.mooo.com/nnstreamer/ci/badge/badge_coverity.json" />
 </a> 
-![GitHub repo size](https://img.shields.io/github/repo-size/nnsuite/nnstreamer) 
-![GitHub issues](https://img.shields.io/github/issues/nnsuite/nnstreamer) 
-![GitHub pull requests](https://img.shields.io/github/issues-pr/nnsuite/nnstreamer) 
+![GitHub repo size](https://img.shields.io/github/repo-size/nnstreamer/nnstreamer)
+![GitHub issues](https://img.shields.io/github/issues/nnstreamer/nnstreamer)
+![GitHub pull requests](https://img.shields.io/github/issues-pr/nnstreamer/nnstreamer)
 
 Neural Network Support as Gstreamer Plugins.
 
@@ -26,7 +26,7 @@ neural network developers to manage neural network pipelines and their filters e
 
 ## Official Releases
 
-|     | [Tizen](http://download.tizen.org/live/devel%3A/AIC%3A/Tizen%3A/5.0%3A/nnsuite/standard/) | [Ubuntu](https://launchpad.net/~nnstreamer/+archive/ubuntu/ppa) | Android/NDK Build | Android/APK | Yocto | macOS |
+|     | [Tizen](http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/) | [Ubuntu](https://launchpad.net/~nnstreamer/+archive/ubuntu/ppa) | Android/NDK Build | Android/APK | Yocto | macOS |
 | :-- | -- | -- | -- | -- | -- | -- |
 |     | 5.5M2 and later | 16.04/18.04 | 7.0/N | 7.0/N | TBD |   |
 | arm | Available  | Available  | Ready | Available| Ready | N/A |
@@ -38,7 +38,7 @@ neural network developers to manage neural network pipelines and their filters e
 
 - Ready: CI system ensures build-ability and unit-testing. Users may easily build and execute. However, we do not have automated release & deployment system for this instance.
 - Available: binary packages are released and deployed automatically and periodically along with CI tests.
-- Daily Release: [(WIP)](https://github.com/nnsuite/TAOS-CI/issues/452)
+- Daily Release: [(WIP)](https://github.com/nnstreamer/TAOS-CI/issues/452)
 - SDK Support: Tizen Studio (5.5 M2+) / Android Studio (JCenter, "nnstreamer")
 
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ NNStreamer is a set of Gstreamer plugins that allow
 Gstreamer developers to adopt neural network models easily and efficiently and
 neural network developers to manage neural network pipelines and their filters easily and efficiently.
 
-[Architectural Description](https://github.com/nnsuite/nnstreamer/wiki/Architectural-Description) (WIP)<br /> <br />
+[Architectural Description](https://github.com/nnstreamer/nnstreamer/wiki/Architectural-Description) (WIP)<br /> <br />
 
 [NNStreamer: Stream Processing Paradigm for Neural Networks ...](https://arxiv.org/abs/1901.04985) [[pdf/tech report](https://arxiv.org/pdf/1901.04985)]<br />
-[GStreamer Conference 2018, NNStreamer](https://gstreamer.freedesktop.org/conference/2018/talks-and-speakers.html#nnstreamer-neural-networks-as-filters) [[media](https://github.com/nnsuite/nnstreamer/wiki/Gstreamer-Conference-2018-Presentation-Video)] [[pdf/slides](https://github.com/nnsuite/nnstreamer/wiki/slides/2018_GSTCON_Ham_181026.pdf)]<br />
+[GStreamer Conference 2018, NNStreamer](https://gstreamer.freedesktop.org/conference/2018/talks-and-speakers.html#nnstreamer-neural-networks-as-filters) [[media](https://github.com/nnstreamer/nnstreamer/wiki/Gstreamer-Conference-2018-Presentation-Video)] [[pdf/slides](https://github.com/nnstreamer/nnstreamer/wiki/slides/2018_GSTCON_Ham_181026.pdf)]<br />
 [Naver Tech Talk (Korean), 2018](https://www.facebook.com/naverengineering/posts/2255360384531425) [[media](https://youtu.be/XvXxcnbRjgU)] [[pdf/slides](https://www.slideshare.net/NaverEngineering/nnstreamer-stream-pipeline-for-arbitrary-neural-networks)]<br />
 [Samsung Developer Conference 2019, NNStreamer](https://www.samsungdeveloperconference.com/schedule/session/1089245) [[media](https://youtu.be/wVbMbpOjbkw)]<br />
 [ResearchGate Page of NNStreamer](https://www.researchgate.net/project/Neural-Network-Streamer-nnstreamer)
@@ -82,8 +82,8 @@ For more details, please access the following manuals.
 * To build an API library for Android, press [here](api/android/README.md).
 
 ## Usage Examples
-- [Example apps](https://github.com/nnsuite/nnstreamer-example) (stable)
-- Wiki page [usage example screenshots](https://github.com/nnsuite/nnstreamer/wiki/usage-examples-screenshots) (stable)
+- [Example apps](https://github.com/nnstreamer/nnstreamer-example) (stable)
+- Wiki page [usage example screenshots](https://github.com/nnstreamer/nnstreamer/wiki/usage-examples-screenshots) (stable)
 
 ## CI Server
 

--- a/api/android/README.md
+++ b/api/android/README.md
@@ -118,7 +118,7 @@ copyjavasource_$(TARGET_ARCH_ABI):
 
 ```bash
 $ cd $ANDROID_DEV_ROOT/workspace
-$ git clone https://github.com/nnsuite/nnstreamer.git
+$ git clone https://github.com/nnstreamer/nnstreamer.git
 ```
 
 #### Build Android API

--- a/api/android/api/src/main/java/org/nnsuite/nnstreamer/NNStreamer.java
+++ b/api/android/api/src/main/java/org/nnsuite/nnstreamer/NNStreamer.java
@@ -29,7 +29,7 @@ import org.freedesktop.gstreamer.GStreamer;
  * Note that, to open a machine learning model in the storage,
  * the permission <code>Manifest.permission.READ_EXTERNAL_STORAGE</code> is required before constructing the pipeline.
  * <br>
- * See <a href="https://github.com/nnsuite/nnstreamer">https://github.com/nnsuite/nnstreamer</a> for the details.
+ * See <a href="https://github.com/nnstreamer/nnstreamer">https://github.com/nnstreamer/nnstreamer</a> for the details.
  */
 public final class NNStreamer {
     /**

--- a/api/android/api/src/main/java/org/nnsuite/nnstreamer/Pipeline.java
+++ b/api/android/api/src/main/java/org/nnsuite/nnstreamer/Pipeline.java
@@ -117,7 +117,7 @@ public final class Pipeline implements AutoCloseable {
      * Creates a new {@link Pipeline} instance with the given pipeline description.
      *
      * @param description The pipeline description. Refer to GStreamer manual or
-     *                    <a href="https://github.com/nnsuite/nnstreamer">NNStreamer</a> documentation for examples and the grammar.
+     *                    <a href="https://github.com/nnstreamer/nnstreamer">NNStreamer</a> documentation for examples and the grammar.
      *
      * @throws IllegalArgumentException if given param is null
      * @throws IllegalStateException if failed to construct the pipeline
@@ -130,7 +130,7 @@ public final class Pipeline implements AutoCloseable {
      * Creates a new {@link Pipeline} instance with the given pipeline description.
      *
      * @param description The pipeline description. Refer to GStreamer manual or
-     *                    <a href="https://github.com/nnsuite/nnstreamer">NNStreamer</a> documentation for examples and the grammar.
+     *                    <a href="https://github.com/nnstreamer/nnstreamer">NNStreamer</a> documentation for examples and the grammar.
      * @param callback    The function to be called when the pipeline state is changed.
      *                    You may set null if it is not required.
      *

--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -176,7 +176,7 @@ mkdir -p build_android_lib
 cp -r ./api/android/* ./build_android_lib
 
 # Get the prebuilt libraries and build-script
-svn --force export https://github.com/nnsuite/nnstreamer-android-resource/trunk/android_api ./build_android_lib
+svn --force export https://github.com/nnstreamer/nnstreamer-android-resource/trunk/android_api ./build_android_lib
 
 pushd ./build_android_lib
 
@@ -217,9 +217,9 @@ publish {\n\
     artifactId = '$nnstreamer_lib_name'\n\
     publishVersion = '$release_version'\n\
     desc = 'NNStreamer API for Android'\n\
-    website = 'https://github.com/nnsuite/nnstreamer'\n\
-    issueTracker = 'https://github.com/nnsuite/nnstreamer/issues'\n\
-    repository = 'https://github.com/nnsuite/nnstreamer.git'\n\
+    website = 'https://github.com/nnstreamer/nnstreamer'\n\
+    issueTracker = 'https://github.com/nnstreamer/nnstreamer/issues'\n\
+    repository = 'https://github.com/nnstreamer/nnstreamer.git'\n\
 }|" api/build.gradle
 fi
 

--- a/api/capi/doc/nnstreamer_doc.h
+++ b/api/capi/doc/nnstreamer_doc.h
@@ -15,7 +15,7 @@
  * @file nnstreamer_doc.h
  * @date 06 March 2019
  * @brief Tizen C-API Declaration for Tizen SDK
- * @see	https://github.com/nnsuite/nnstreamer
+ * @see	https://github.com/nnstreamer/nnstreamer
  * @author MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug No known bugs except for NYI items
  */

--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -16,7 +16,7 @@
  * @date 07 March 2019
  * @brief NNStreamer/Pipeline(main) C-API Private Header.
  *        This file should NOT be exported to SDK or devel package.
- * @see	https://github.com/nnsuite/nnstreamer
+ * @see	https://github.com/nnstreamer/nnstreamer
  * @author MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug No known bugs except for NYI items
  */

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -16,7 +16,7 @@
  * @date 29 March 2019
  * @brief NNStreamer single-shot invocation C-API Header.
  *        This allows to invoke a neural network model directly.
- * @see	https://github.com/nnsuite/nnstreamer
+ * @see	https://github.com/nnstreamer/nnstreamer
  * @author MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug No known bugs except for NYI items
  *

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -16,7 +16,7 @@
  * @date 07 March 2019
  * @brief NNStreamer/Pipeline(main) C-API Header.
  *        This allows to construct and control NNStreamer pipelines.
- * @see	https://github.com/nnsuite/nnstreamer
+ * @see	https://github.com/nnstreamer/nnstreamer
  * @author MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug No known bugs except for NYI items
  */
@@ -251,7 +251,7 @@ typedef void (*ml_pipeline_state_cb) (ml_pipeline_state_e state, void *user_data
  * @remarks http://tizen.org/privilege/externalstorage is needed if @a pipeline_description is relevant to external storage.
  * @remarks http://tizen.org/privilege/camera is needed if @a pipeline_description accesses the camera device.
  * @remarks http://tizen.org/privilege/recorder is needed if @a pipeline_description accesses the recorder device.
- * @param[in] pipeline_description The pipeline description compatible with GStreamer gst_parse_launch(). Refer to GStreamer manual or NNStreamer (https://github.com/nnsuite/nnstreamer) documentation for examples and the grammar.
+ * @param[in] pipeline_description The pipeline description compatible with GStreamer gst_parse_launch(). Refer to GStreamer manual or NNStreamer (https://github.com/nnstreamer/nnstreamer) documentation for examples and the grammar.
  * @param[in] cb The function to be called when the pipeline state is changed. You may set NULL if it's not required.
  * @param[in] user_data Private data for the callback. This value is passed to the callback when it's invoked.
  * @param[out] pipe The NNStreamer pipeline handler from the given description.

--- a/api/capi/include/platform/tizen_error.h
+++ b/api/capi/include/platform/tizen_error.h
@@ -15,7 +15,7 @@
  * @file tizen_error.h
  * @date 24 October 2019
  * @brief C-API internal header emulating tizen_error.h for Non-Tizen platforms
- * @see	https://github.com/nnsuite/nnstreamer
+ * @see	https://github.com/nnstreamer/nnstreamer
  * @author Wook Song <wook16.song@samsung.com>
  * @bug No known bugs except for NYI items
  */

--- a/api/capi/include/tensor_filter_single.h
+++ b/api/capi/include/tensor_filter_single.h
@@ -16,7 +16,7 @@
  * @file	tensor_filter_single.h
  * @date	28 Aug 2019
  * @brief	Element to use general neural network framework individually without gstreamer pipeline
- * @see	  http://github.com/nnsuite/nnstreamer
+ * @see	  http://github.com/nnstreamer/nnstreamer
  * @author	Parichay Kapoor <pk.kapoor@samsung.com>
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug	  No known bugs except for NYI items

--- a/api/capi/src/nnstreamer-capi-pipeline.c
+++ b/api/capi/src/nnstreamer-capi-pipeline.c
@@ -16,7 +16,7 @@
  * @date 11 March 2019
  * @brief NNStreamer/Pipeline(main) C-API Wrapper.
  *        This allows to construct and control NNStreamer pipelines.
- * @see	https://github.com/nnsuite/nnstreamer
+ * @see	https://github.com/nnstreamer/nnstreamer
  * @author MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug No known bugs except for NYI items
  */

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -16,7 +16,7 @@
  * @date 29 Aug 2019
  * @brief NNStreamer/Single C-API Wrapper.
  *        This allows to invoke individual input frame with NNStreamer.
- * @see	https://github.com/nnsuite/nnstreamer
+ * @see	https://github.com/nnstreamer/nnstreamer
  * @author MyungJoo Ham <myungjoo.ham@samsung.com>
  * @author Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug No known bugs except for NYI items

--- a/api/capi/src/nnstreamer-capi-tizen.c
+++ b/api/capi/src/nnstreamer-capi-tizen.c
@@ -16,7 +16,7 @@
  * @file nnstreamer-capi-tizen.c
  * @date 26 August 2019
  * @brief NNStreamer/C-API Tizen dependent functions.
- * @see	https://github.com/nnsuite/nnstreamer
+ * @see	https://github.com/nnstreamer/nnstreamer
  * @author MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug No known bugs except for NYI items
  */

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -15,7 +15,7 @@
  * @file nnstreamer-capi-util.c
  * @date 10 June 2019
  * @brief NNStreamer/Utilities C-API Wrapper.
- * @see	https://github.com/nnsuite/nnstreamer
+ * @see	https://github.com/nnstreamer/nnstreamer
  * @author MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug No known bugs except for NYI items
  */

--- a/api/capi/src/tensor_filter_single.c
+++ b/api/capi/src/tensor_filter_single.c
@@ -16,7 +16,7 @@
  * @file	tensor_filter_single.c
  * @date	28 Aug 2019
  * @brief	Element to use general neural network framework directly without gstreamer pipeline
- * @see	  http://github.com/nnsuite/nnstreamer
+ * @see	  http://github.com/nnstreamer/nnstreamer
  * @author	Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug	  No known bugs except for NYI items
  *

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  tensorflow-lite-dev, pytorch,
  tensorflow-dev [amd64], python2.7-dev, libprotobuf-dev [amd64 arm64 armhf]
 Standards-Version: 3.9.6
-Homepage: https://github.com/nnsuite/nnstreamer
+Homepage: https://github.com/nnstreamer/nnstreamer
 
 Package: nnstreamer
 Architecture: any

--- a/ext/nnstreamer/android_source/gstamcsrc.c
+++ b/ext/nnstreamer/android_source/gstamcsrc.c
@@ -18,7 +18,7 @@
  * @file	  gstamcsrc.c
  * @date	  19 May 2019
  * @brief	  GStreamer source element for Android MediaCodec (AMC)
- * @see		  http://github.com/nnsuite/nnstreamer
+ * @see		  http://github.com/nnstreamer/nnstreamer
  * @author	Dongju Chae <dongju.chae@samsung.com>
  * @bug		  No known bugs except for NYI items
  */
@@ -1006,4 +1006,4 @@ GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
     amcsrc,
     "NNStreamer Android MediaCodec (AMC) Source",
     plugin_init, VERSION, "LGPL", "nnstreamer",
-    "https://github.com/nnsuite/nnstreamer/")
+    "https://github.com/nnstreamer/nnstreamer/")

--- a/ext/nnstreamer/android_source/gstamcsrc.h
+++ b/ext/nnstreamer/android_source/gstamcsrc.h
@@ -18,7 +18,7 @@
  * @file	  gstamcsrc.h
  * @date	  19 May 2019
  * @brief	  GStreamer source element for Android MediaCodec (AMC)
- * @see		  http://github.com/nnsuite/nnstreamer
+ * @see		  http://github.com/nnstreamer/nnstreamer
  * @author	Dongju Chae <dongju.chae@samsung.com>
  * @bug		  No known bugs except for NYI items
  */

--- a/ext/nnstreamer/android_source/gstamcsrc_looper.cc
+++ b/ext/nnstreamer/android_source/gstamcsrc_looper.cc
@@ -18,7 +18,7 @@
  * @file	  gstamcsrc_looper.cc
  * @date	  19 May 2019
  * @brief	  A looper thread to perform event messages between amcsrc and media codec
- * @see		  http://github.com/nnsuite/nnstreamer
+ * @see		  http://github.com/nnstreamer/nnstreamer
  * @author	Dongju Chae <dongju.chae@samsung.com>
  * @bug		  No known bugs except for NYI items
  */

--- a/ext/nnstreamer/android_source/gstamcsrc_looper.h
+++ b/ext/nnstreamer/android_source/gstamcsrc_looper.h
@@ -18,7 +18,7 @@
  * @file	  gstamcsrc_looper.h
  * @date	  19 May 2019
  * @brief   A looper thread to perform event messages between amcsrc and media codec
- * @see     http://github.com/nnsuite/nnstreamer
+ * @see     http://github.com/nnstreamer/nnstreamer
  * @author  Dongju Chae <dongju.chae@samsung.com>
  * @bug     No known bugs except for NYI items
  */

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -22,7 +22,7 @@
  *              transparent background.
  *              This code is NYI/WIP and not compilable.
  *
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
@@ -20,7 +20,7 @@
  * @brief	NNStreamer tensor-decoder subplugin, "direct video",
  *              which converts tensors to video directly.
  *
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_decoder/tensordec-font.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-font.c
@@ -39,7 +39,7 @@
  * @date 20 Nov 2018
  * @brief imported from font.c of https://courses.cs.washington.edu/courses/cse457/98a/tech/OpenGL/font.c
  *        and modified to support tensordec-boundingbox.c
- * @see https://github.com/nnsuite/nnstreamer
+ * @see https://github.com/nnstreamer/nnstreamer
  * @see https://courses.cs.washington.edu/courses/cse457/98a/tech/OpenGL/font.c
  * @bug No known bugs.
  * @author Silicon Graphics Inc. (imported and modified by MyungJoo Ham <myungjoo.ham@samsung.com>)

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
@@ -20,7 +20,7 @@
  * @brief       NNStreamer tensor-decoder subplugin, "image labeling",
  *              which converts image label tensors to text stream.
  *
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
@@ -20,7 +20,7 @@
  * @brief	NNStreamer tensor-decoder subplugin, "image segment",
  *              which detects objects and paints their regions.
  *
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author  Jihoon Lee <ulla4571@gmail.com>
  *          niklasjang <niklasjang@gmail.com>
  * @bug		No known bugs except for NYI items

--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -22,7 +22,7 @@
  *              transparent background.
  *              This code is NYI/WIP and not compilable.
  *
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      Jijoong Moon <jijoong.moon@samsung.com>
  * @bug         No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -16,7 +16,7 @@
  * @file	tensor_filter_armnn.cc
  * @date	20 Nov 2019
  * @brief	ARM NN module for tensor_filter gstreamer plugin
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
@@ -18,7 +18,7 @@
  * @file    tensor_filter_caffe2.cc
  * @date    27 May 2019
  * @brief   Caffe2 module for tensor_filter gstreamer plugin
- * @see     http://github.com/nnsuite/nnstreamer
+ * @see     http://github.com/nnstreamer/nnstreamer
  * @author  HyoungJoo Ahn <hello.ahn@samsung.com>
  * @bug     No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
@@ -17,7 +17,7 @@
  * @file	tensor_filter_cpp.cc
  * @date	26 Sep 2019
  * @brief	Tensor_filter subplugin for C++ custom filters.
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_filter/tensor_filter_cpp.hh
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_cpp.hh
@@ -17,7 +17,7 @@
  * @file	tensor_filter_cpp.hh
  * @date	24 Sep 2019
  * @brief	Custom tensor processing interface for C++ codes.
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
@@ -17,7 +17,7 @@
  * @file	tensor_filter_edgetpu.c
  * @date	10 Dec 2019
  * @brief	Edge-TPU module for tensor_filter gstreamer plugin
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
@@ -19,7 +19,7 @@
  * @file    tensor_filter_movidius_ncsdk2.c
  * @date    13 May 2019
  * @brief   NCSDK2 module for tensor_filter gstreamer plugin
- * @see     http://github.com/nnsuite/nnstreamer
+ * @see     http://github.com/nnstreamer/nnstreamer
  * @author  Wook16.song <wook16.song@samsung.com>
  * @bug     No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -17,7 +17,7 @@
  * @file	tensor_filter_nnfw.c
  * @date	24 Sep 2019
  * @brief	Tizen-NNFW module for tensor_filter gstreamer plugin
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
@@ -17,7 +17,7 @@
  * @file    tensor_filter_openvino.cc
  * @date    23 Dec 2019
  * @brief   Tensor_filter subplugin for OpenVino (DLDT).
- * @see     http://github.com/nnsuite/nnstreamer
+ * @see     http://github.com/nnstreamer/nnstreamer
  * @author  Wook Song <wook16.song@samsung.com>
  * @bug     No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.hh
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.hh
@@ -17,7 +17,7 @@
  * @file    tensor_filter_openvino.hh
  * @date    23 Dec 2019
  * @brief   Tensor_filter subplugin for OpenVino (DLDT).
- * @see     http://github.com/nnsuite/nnstreamer
+ * @see     http://github.com/nnstreamer/nnstreamer
  * @author  Wook Song <wook16.song@samsung.com>
  * @bug     No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -18,7 +18,7 @@
  * @file    tensor_filter_python.cc
  * @date    10 Apr 2019
  * @brief   Python module for tensor_filter gstreamer plugin
- * @see     http://github.com/nnsuite/nnstreamer
+ * @see     http://github.com/nnstreamer/nnstreamer
  * @author  Dongju Chae <dongju.chae@samsung.com>
  * @bug     No known bugs except for NYI items
  */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python_api.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python_api.c
@@ -17,7 +17,7 @@
  * @file	tensor_filter_python_api.c
  * @date	10 Apr 2019
  * @brief	python helper structure for nnstreamer tensor_filter
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	Dongju Chae <dongju.chae@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -18,7 +18,7 @@
  * @file    tensor_filter_pytorch.cc
  * @date    24 April 2019
  * @brief   PyTorch module for tensor_filter gstreamer plugin
- * @see     http://github.com/nnsuite/nnstreamer
+ * @see     http://github.com/nnstreamer/nnstreamer
  * @author  Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug     No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
@@ -19,7 +19,7 @@
  * @file   tensor_filter_tensorflow.cc
  * @date   02 Aug 2018
  * @brief  Tensorflow module for tensor_filter gstreamer plugin
- * @see    http://github.com/nnsuite/nnstreamer
+ * @see    http://github.com/nnstreamer/nnstreamer
  * @author HyoungJoo Ahn <hello.ahn@samsung.com>
  * @author Jijoong Moon <jijoong.moon@samsung.com>
  * @bug    No known bugs except for NYI items

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -17,7 +17,7 @@
  * @file   tensor_filter_tensorflow_lite.cc
  * @date   7 May 2018
  * @brief  Tensorflow-lite module for tensor_filter gstreamer plugin
- * @see    http://github.com/nnsuite/nnstreamer
+ * @see    http://github.com/nnstreamer/nnstreamer
  * @author HyoungJoo Ahn <hello.ahn@samsung.com>
  * @bug    No known bugs except for NYI items
  *

--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
@@ -17,7 +17,7 @@
  * @file	tensor_src_tizensensor.c
  * @date	07 Nov 2019
  * @brief	GStreamer plugin to support Tizen sensor framework (sensord)
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  */
@@ -1307,4 +1307,4 @@ GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
     nnstreamer_tizen_sensor,
     "nnstreamer Tizen sensor framework extension",
     gst_nnstreamer_tizen_sensor_init, VERSION, "LGPL", "nnstreamer",
-    "https://github.com/nnsuite/nnstreamer");
+    "https://github.com/nnstreamer/nnstreamer");

--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.h
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.h
@@ -17,7 +17,7 @@
  * @file	tensor_src_tizensensor.h
  * @date	07 Nov 2019
  * @brief	GStreamer plugin to support Tizen sensor framework (sensord)
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
+++ b/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
@@ -17,7 +17,7 @@
  * @file	tensor_filter_support_cc.h
  * @date	15 Jan 2020
  * @brief	Base class for tensor_filter subplugins of C++ classes.
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -18,7 +18,7 @@
  * @file  nnstreamer_plugin_api.h
  * @date  24 Jan 2019
  * @brief Optional/Addtional NNStreamer APIs for sub-plugin writers. (Need Glib)
- * @see https://github.com/nnsuite/nnstreamer
+ * @see https://github.com/nnstreamer/nnstreamer
  * @author  MyungJoo Ham <myungjoo.ham@samsung.com> and Wook Song <wook16.song@samsung.com>
  * @bug No known bugs except for NYI items
  *

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_converter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_converter.h
@@ -17,7 +17,7 @@
  * @file  nnstreamer_plugin_api_converter.h
  * @date  09 Dec 2019
  * @brief Mandatory APIs for NNStreamer Converter sub-plugins (Need Gst Devel)
- * @see https://github.com/nnsuite/nnstreamer
+ * @see https://github.com/nnstreamer/nnstreamer
  * @author  MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug No known bugs except for NYI items
  */

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_decoder.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_decoder.h
@@ -17,7 +17,7 @@
  * @file  nnstreamer_plugin_api_decoder.h
  * @date  30 Jan 2019
  * @brief Mandatory APIs for NNStreamer Decoder sub-plugins (Need Gst Devel)
- * @see https://github.com/nnsuite/nnstreamer
+ * @see https://github.com/nnstreamer/nnstreamer
  * @author  MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug No known bugs except for NYI items
  */

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -17,7 +17,7 @@
  * @file  nnstreamer_plugin_api_filter.h
  * @date  30 Jan 2019
  * @brief Mandatory APIs for NNStreamer Filter sub-plugins (No External Dependencies)
- * @see https://github.com/nnsuite/nnstreamer
+ * @see https://github.com/nnstreamer/nnstreamer
  * @author  MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug No known bugs except for NYI items
  */

--- a/gst/nnstreamer/include/tensor_filter_custom.h
+++ b/gst/nnstreamer/include/tensor_filter_custom.h
@@ -17,7 +17,7 @@
  * @file	tensor_filter_custom.h
  * @date	01 Jun 2018
  * @brief	Custom tensor post-processing interface for NNStreamer suite for post-processing code developers.
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/include/tensor_filter_custom_easy.h
+++ b/gst/nnstreamer/include/tensor_filter_custom_easy.h
@@ -17,7 +17,7 @@
  * @file	tensor_filter_custom_easy.h
  * @date	24 Oct 2019
  * @brief	Custom tensor processing interface for simple functions
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -17,7 +17,7 @@
  * @file	tensor_typedef.h
  * @date	01 Jun 2018
  * @brief	Common header file for NNStreamer, the GStreamer plugin for neural networks
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/nnstreamer.c
+++ b/gst/nnstreamer/nnstreamer.c
@@ -36,7 +36,7 @@
  * @file	nnstreamer.c
  * @date	11 Oct 2018
  * @brief	Registers all nnstreamer plugins for gstreamer so that we can have a single big binary
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  */
@@ -104,4 +104,4 @@ GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
     nnstreamer,
     "nnstreamer plugin library",
     gst_nnstreamer_init, VERSION, "LGPL", "nnstreamer",
-    "https://github.com/nnsuite/nnstreamer");
+    "https://github.com/nnstreamer/nnstreamer");

--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -16,7 +16,7 @@
  * @file	nnstreamer_conf.c
  * @date	26 Nov 2018
  * @brief	NNStreamer Configuration (conf file, env-var) Management.
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/nnstreamer_conf.h
+++ b/gst/nnstreamer/nnstreamer_conf.h
@@ -17,7 +17,7 @@
  * @file	nnstreamer_conf.h
  * @date	26 Nov 2018
  * @brief	Internal header for conf/env-var management.
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/nnstreamer_log.h
+++ b/gst/nnstreamer/nnstreamer_log.h
@@ -16,7 +16,7 @@
  * @file	nnstreamer_log.h
  * @date	12 Mar 2020
  * @brief	Internal log util for NNStreamer plugins and native APIs.
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	Jaeyun Jung <jy1210.jung@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/nnstreamer_subplugin.c
+++ b/gst/nnstreamer/nnstreamer_subplugin.c
@@ -17,7 +17,7 @@
  * @file	nnstreamer_subplugin.c
  * @date	27 Nov 2018
  * @brief	Subplugin Manager for NNStreamer
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/nnstreamer_subplugin.h
+++ b/gst/nnstreamer/nnstreamer_subplugin.h
@@ -17,7 +17,7 @@
  * @file	nnstreamer_subplugin.h
  * @date	27 Nov 2018
  * @brief	Subplugin Manager for NNStreamer
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
+++ b/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
@@ -21,7 +21,7 @@
  * @file	tensor_aggregator.c
  * @date	29 August 2018
  * @brief	GStreamer plugin to aggregate tensor stream
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jaeyun Jung <jy1210.jung@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/tensor_aggregator/tensor_aggregator.h
+++ b/gst/nnstreamer/tensor_aggregator/tensor_aggregator.h
@@ -19,7 +19,7 @@
  * @file	tensor_aggregator.h
  * @date	29 August 2018
  * @brief	GStreamer plugin to aggregate tensor stream
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jaeyun Jung <jy1210.jung@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -17,7 +17,7 @@
  * @file	tensor_common.c
  * @date	29 May 2018
  * @brief	Common data for NNStreamer, the GStreamer plugin for neural networks
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -17,7 +17,7 @@
  * @file	tensor_common.h
  * @date	23 May 2018
  * @brief	Common header file for NNStreamer, the GStreamer plugin for neural networks
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_converter/converter-media-info.h
+++ b/gst/nnstreamer/tensor_converter/converter-media-info.h
@@ -17,7 +17,7 @@
  * @file  converter-media-info.h
  * @date  26 Mar 2019
  * @brief Define collection of media type and functions to parse media info for the case of no audio/video support
- * @see https://github.com/nnsuite/nnstreamer
+ * @see https://github.com/nnstreamer/nnstreamer
  * @author  Jijoong Moon <jijoong.moon@samsung.com>
  * @bug No known bugs except for NYI items
  */

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -19,7 +19,7 @@
  * @file	tensor_converter.c
  * @date	26 Mar 2018
  * @brief	GStreamer plugin to convert media types to tensors (as a filter for other general neural network filters)
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  * @todo        For flatbuffers, support other/tensors with properties

--- a/gst/nnstreamer/tensor_converter/tensor_converter.h
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.h
@@ -26,7 +26,7 @@
  *               uint8[height][width][RGB]. Note that if rstride=RU4, you need
  *               to add the case in "remove_stride_padding_per_row".
  *
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -19,7 +19,7 @@
  * @file        tensordec.c
  * @date        26 Mar 2018
  * @brief       GStreamer plugin to convert tensors (as a filter for other general neural network filters) to other media types
- * @see    	https://github.com/nnsuite/nnstreamer
+ * @see    	https://github.com/nnstreamer/nnstreamer
  * @author      Jijoong Moon <jijoong.moon@samsung.com>
  * @bug         gst_tensordec_transform_size () may be incorrect if direction is SINK.
  *

--- a/gst/nnstreamer/tensor_decoder/tensordec.h
+++ b/gst/nnstreamer/tensor_decoder/tensordec.h
@@ -20,7 +20,7 @@
  * @date	26 Mar 2018
  * @brief	GStreamer plugin to convert tensors to media types
  *
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_demux/gsttensordemux.c
+++ b/gst/nnstreamer/tensor_demux/gsttensordemux.c
@@ -19,7 +19,7 @@
  * @file	gsttensordemux.c
  * @date	03 July 2018
  * @brief	GStreamer plugin to demux tensors (as a filter for other general neural network filters)
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_demux/gsttensordemux.h
+++ b/gst/nnstreamer/tensor_demux/gsttensordemux.h
@@ -19,7 +19,7 @@
  * @file	gsttensordemux.h
  * @date	03 July 2018
  * @brief	GStreamer plugin to demux tensors (as a filter for other general neural network filters)
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -19,7 +19,7 @@
  * @file	tensor_filter.c
  * @date	24 May 2018
  * @brief	GStreamer plugin to use general neural network frameworks as filters
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  * @todo  set priority among properties

--- a/gst/nnstreamer/tensor_filter/tensor_filter.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.h
@@ -19,7 +19,7 @@
  * @file	tensor_filter.h
  * @date	24 May 2018
  * @brief	GStreamer plugin to use general neural network frameworks as filters
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -16,7 +16,7 @@
  * @file	tensor_filter_common.c
  * @date	28 Aug 2019
  * @brief	Common functions for various tensor_filters
- * @see	  http://github.com/nnsuite/nnstreamer
+ * @see	  http://github.com/nnstreamer/nnstreamer
  * @author	Parichay Kapoor <pk.kapoor@samsung.com>
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug	  No known bugs except for NYI items

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -16,7 +16,7 @@
  * @file	tensor_filter_common.h
  * @date	28 Aug 2019
  * @brief	Common functions for various tensor_filters
- * @see	  http://github.com/nnsuite/nnstreamer
+ * @see	  http://github.com/nnstreamer/nnstreamer
  * @author	Parichay Kapoor <pk.kapoor@samsung.com>
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug	  No known bugs except for NYI items

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
@@ -17,7 +17,7 @@
  * @file	tensor_filter_custom.c
  * @date	01 Jun 2018
  * @brief	Custom tensor post-processing interface for NNStreamer suite between NN developer-plugins and NNstreamer.
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
@@ -17,7 +17,7 @@
  * @file	tensor_filter_custom_easy.c
  * @date	24 Oct 2019
  * @brief	Custom tensor processing interface for simple functions
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
@@ -17,7 +17,7 @@
  * @file	tensor_filter_support_cc.cc
  * @date	22 Jan 2020
  * @brief	Base class for tensor_filter subplugins of C++ classes.
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_merge/gsttensormerge.c
+++ b/gst/nnstreamer/tensor_merge/gsttensormerge.c
@@ -20,7 +20,7 @@
  * @file	gsttensormerge.c
  * @date	03 July 2018
  * @brief	GStreamer plugin to merge tensors (as a filter for other general neural network filters)
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_merge/gsttensormerge.h
+++ b/gst/nnstreamer/tensor_merge/gsttensormerge.h
@@ -19,7 +19,7 @@
  * @file	gsttensormerge.h
  * @date	03 July 2018
  * @brief	GStreamer plugin to merge tensors (as a filter for other general neural network filters)
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_mux/gsttensormux.c
+++ b/gst/nnstreamer/tensor_mux/gsttensormux.c
@@ -20,7 +20,7 @@
  * @file	gsttensormux.c
  * @date	03 July 2018
  * @brief	GStreamer plugin to mux tensors (as a filter for other general neural network filters)
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_mux/gsttensormux.h
+++ b/gst/nnstreamer/tensor_mux/gsttensormux.h
@@ -19,7 +19,7 @@
  * @file	gsttensormux.h
  * @date	03 July 2018
  * @brief	GStreamer plugin to mux tensors (as a filter for other general neural network filters)
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_repo/tensor_repo.c
+++ b/gst/nnstreamer/tensor_repo/tensor_repo.c
@@ -17,7 +17,7 @@
  * @file	tensor_repo.c
  * @date	17 Nov 2018
  * @brief	tensor repo file for NNStreamer, the GStreamer plugin for neural networks
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_repo/tensor_repo.h
+++ b/gst/nnstreamer/tensor_repo/tensor_repo.h
@@ -17,7 +17,7 @@
  * @file	tensor_repo.h
  * @date	17 Nov 2018
  * @brief	tensor repo header file for NNStreamer, the GStreamer plugin for neural networks
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_repo/tensor_reposink.c
+++ b/gst/nnstreamer/tensor_repo/tensor_reposink.c
@@ -23,7 +23,7 @@
  * @file	tensor_reposink.c
  * @date	19 Nov 2018
  * @brief	GStreamer plugin to handle tensor repository
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/tensor_repo/tensor_reposink.h
+++ b/gst/nnstreamer/tensor_repo/tensor_reposink.h
@@ -19,7 +19,7 @@
  * @file	tensor_reposink.h
  * @date	19 Nov 2018
  * @brief	GStreamer plugin to handle tensor repository
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/tensor_repo/tensor_reposrc.c
+++ b/gst/nnstreamer/tensor_repo/tensor_reposrc.c
@@ -23,7 +23,7 @@
  * @file	tensor_reposrc.c
  * @date	19 Nov 2018
  * @brief	GStreamer plugin to handle tensor repository
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/tensor_repo/tensor_reposrc.h
+++ b/gst/nnstreamer/tensor_repo/tensor_reposrc.h
@@ -19,7 +19,7 @@
  * @file	tensor_reposrc.h
  * @date	19 Nov 2018
  * @brief	GStreamer plugin to handle tensor repository
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/tensor_sink/README.md
+++ b/gst/nnstreamer/tensor_sink/README.md
@@ -42,4 +42,4 @@ One "Always" sink pad exists. The capability of sink pad is ```other/tensor``` a
 $ gst-launch-1.0 videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! tensor_converter ! tensor_sink
 ```
 
-For more details, see the [examples](https://github.com/nnsuite/nnstreamer/tree/master/nnstreamer_example/example_sink) to handle the buffer from GstTensorSink.
+For more details, see the [examples](https://github.com/nnstreamer/nnstreamer/tree/master/nnstreamer_example/example_sink) to handle the buffer from GstTensorSink.

--- a/gst/nnstreamer/tensor_sink/tensor_sink.c
+++ b/gst/nnstreamer/tensor_sink/tensor_sink.c
@@ -23,7 +23,7 @@
  * @file	tensor_sink.c
  * @date	15 June 2018
  * @brief	GStreamer plugin to handle tensor stream
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jaeyun Jung <jy1210.jung@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/tensor_sink/tensor_sink.h
+++ b/gst/nnstreamer/tensor_sink/tensor_sink.h
@@ -19,7 +19,7 @@
  * @file	tensor_sink.h
  * @date	15 June 2018
  * @brief	GStreamer plugin to handle tensor stream
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jaeyun Jung <jy1210.jung@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -19,7 +19,7 @@
  * @file	tensor_src_iio.c
  * @date	27 Feb 2019
  * @brief	GStreamer plugin to capture sensor data as tensor(s)
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug		No known bugs except for NYI items
  * @todo  support specific channels as input

--- a/gst/nnstreamer/tensor_source/tensor_src_iio.h
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.h
@@ -19,7 +19,7 @@
  * @file	tensor_src_iio.h
  * @date	26 Feb 2019
  * @brief	GStreamer plugin to support linux IIO as tensor(s)
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/gst/nnstreamer/tensor_split/gsttensorsplit.c
+++ b/gst/nnstreamer/tensor_split/gsttensorsplit.c
@@ -19,7 +19,7 @@
  * @file	gsttensorsplit.c
  * @date	27 Aug 2018
  * @brief	GStreamer plugin to split tensor (as a filter for other general neural network filters)
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_split/gsttensorsplit.h
+++ b/gst/nnstreamer/tensor_split/gsttensorsplit.h
@@ -19,7 +19,7 @@
  * @file	gsttensorsplit.h
  * @date	27 Aug 2018
  * @brief	GStreamer plugin to split tensor (as a filter for other general neural network filters)
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -19,7 +19,7 @@
  * @file	tensor_transform.c
  * @date	10 Jul 2018
  * @brief	GStreamer plugin to transform tensor dimension or type
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		This is NYI.
  *

--- a/gst/nnstreamer/tensor_transform/tensor_transform.h
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.h
@@ -19,7 +19,7 @@
  * @file	tensor_transform.h
  * @date	10 Jul 2018
  * @brief	GStreamer plugin to transform tensor dimension or type
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs.
  *

--- a/tests/bmp2png.c
+++ b/tests/bmp2png.c
@@ -17,7 +17,7 @@
  * @file	bmp2png.c
  * @date	13 Jul 2018
  * @brief	Simple bmp2png converter for testcases
- * @see		http://github.com/nnsuite/nnstreamer
+ * @see		http://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -3,7 +3,7 @@
  * @date 31 May 2018
  * @author MyungJoo Ham <myungjoo.ham@samsung.com>
  * @brief Unit test module for NNStreamer common library
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @bug		No known bugs.
  *
  *  @brief Unit test module for NNStreamer common library

--- a/tests/cpp_methods/cppfilter_test.cc
+++ b/tests/cpp_methods/cppfilter_test.cc
@@ -2,7 +2,7 @@
  * @file        cppfilter_test.cc
  * @date        15 Jan 2019
  * @brief       Unit test cases for tensor_filter::cpp
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  */

--- a/tests/cpp_methods/cppfilter_test.hh
+++ b/tests/cpp_methods/cppfilter_test.hh
@@ -2,7 +2,7 @@
  * @file        cppfilter_test.hh
  * @date        15 Jan 2019
  * @brief       Unit test cases for tensor_filter::cpp
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  */

--- a/tests/cpp_methods/unittest_cpp_methods.cc
+++ b/tests/cpp_methods/unittest_cpp_methods.cc
@@ -2,7 +2,7 @@
  * @file        unittest_cpp_methods.cc
  * @date        15 Jan 2019
  * @brief       Unit test cases for tensor_filter::cpp
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  */

--- a/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
+++ b/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
@@ -2,7 +2,7 @@
  * @file        unittest_filter_armnn.cc
  * @date        13 Dec 2019
  * @brief       Unit test for armnn tensor filter plugin.
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug         No known bugs
  */

--- a/tests/nnstreamer_filter_edgetpu/dummy_edgetpu.cc
+++ b/tests/nnstreamer_filter_edgetpu/dummy_edgetpu.cc
@@ -2,7 +2,7 @@
  * @file        dummy_edgetpu.h
  * @date        17 Dec 2019
  * @brief       Dummy implementation of tflite and edgetpu for unit tests.
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  *

--- a/tests/nnstreamer_filter_edgetpu/edgetpu.hh
+++ b/tests/nnstreamer_filter_edgetpu/edgetpu.hh
@@ -2,7 +2,7 @@
  * @file        edgetpu.hh
  * @date        16 Dec 2019
  * @brief       Dummy implementation of tflite and edgetpu for unit tests.
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  *

--- a/tests/nnstreamer_filter_edgetpu/unittest_edgetpu.cc
+++ b/tests/nnstreamer_filter_edgetpu/unittest_edgetpu.cc
@@ -2,7 +2,7 @@
  * @file        unittest_edgetpu.cpp
  * @date        16 Dec 2019
  * @brief       Unit test for tensor_filter::edgetpu.
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  */

--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
@@ -2,7 +2,7 @@
  * @file        unittest_tizen_@EXT_NAME@.cc
  * @date        19 Dec 2019
  * @brief       Failure Unit tests for tensor filter extension (@EXT_NAME@).
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug         No known bugs
  * @todo        Add support for GstTensorFilterFramework V1

--- a/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.cc
+++ b/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.cc
@@ -3,7 +3,7 @@
  * @date 8 Jan 2020
  * @author  Wook Song <wook16.song@samsung.com>
  * @brief Helper class for testing tensor_filter_mvncsdk2 without an actual device
- * @see https://github.com/nnsuite/nnstreamer
+ * @see https://github.com/nnstreamer/nnstreamer
  * @bug	No known bugs except for NYI items
  *
  *  Copyright 2020 Samsung Electronics

--- a/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.hh
+++ b/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.hh
@@ -3,7 +3,7 @@
  * @date 8 Jan 2020
  * @author  Wook Song <wook16.song@samsung.com>
  * @brief Helper class for testing tensor_filter_mvncsdk2 without an actual device
- * @see https://github.com/nnsuite/nnstreamer
+ * @see https://github.com/nnstreamer/nnstreamer
  * @bug	No known bugs except for NYI items
  *
  *  Copyright 2020 Samsung Electronics

--- a/tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2.cc
+++ b/tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2.cc
@@ -2,7 +2,7 @@
  * @file    unittest_filter_mvncsdk2.cc
  * @date    10 Jan 2020
  * @brief   Unit test for the tensor filter sub-plugin for MVNCSDK2
- * @see     https://github.com/nnsuite/nnstreamer
+ * @see     https://github.com/nnstreamer/nnstreamer
  * @author  Wook Song <wook16.song@samsung.com>
  * @bug     No known bugs.
  */

--- a/tests/nnstreamer_filter_reload/tensor_filter_reload_test.c
+++ b/tests/nnstreamer_filter_reload/tensor_filter_reload_test.c
@@ -4,7 +4,7 @@
  * @file    tensor_filter_reload_test.c
  * @data    19 Dec 2019
  * @brief   test case to test a filter's model reload
- * @see     https://github.com/nnsuite/nnstreamer
+ * @see     https://github.com/nnstreamer/nnstreamer
  * @author  Dongju Chae <dongju.chae@samsung.com>
  * @bug     No known bugs except NYI.
  */

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -2,7 +2,7 @@
  * @file	unittest_plugins.cc
  * @date	7 November 2018
  * @brief	Unit test for nnstreamer plugins. (testcases to check data conversion or buffer transfer)
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jaeyun Jung <jy1210.jung@samsung.com>
  * @bug		No known bugs.
  */

--- a/tests/nnstreamer_repo_dynamicity/tensor_repo_dynamic_test.c
+++ b/tests/nnstreamer_repo_dynamicity/tensor_repo_dynamic_test.c
@@ -4,7 +4,7 @@
  * @file    tensor_repo_dynamic_test.c
  * @date    03 Dec 2018
  * @brief   test case to test tensor repo plugin dynamism
- * @see     https://github.com/nnsuite/nnstreamer
+ * @see     https://github.com/nnstreamer/nnstreamer
  * @author  Jijoong Moon <jijoong.moon@samsung.com>
  * @bug     No known bugs except NYI.
  *

--- a/tests/nnstreamer_repo_lstm/generateTestCase.py
+++ b/tests/nnstreamer_repo_lstm/generateTestCase.py
@@ -8,7 +8,7 @@
 # @brief Generate a sequence of video/x-raw frames & golden
 # @todo Generate corresponding golden results
 # @author Jijoong Moon <jijoong.moon@samsung.com>
-# @url https://github.com/nnsuite/nnstreamer/
+# @url https://github.com/nnstreamer/nnstreamer/
 #
 
 from __future__ import print_function

--- a/tests/nnstreamer_repo_rnn/generateTestCase.py
+++ b/tests/nnstreamer_repo_rnn/generateTestCase.py
@@ -11,7 +11,7 @@
 # @todo Generate corresponding golden results
 # @author MyungJoo Ham <myungjoo.ham@samsung.com>
 # @author Jijoong Moon <jijoong.moon@samsung.com>
-# @url https://github.com/nnsuite/nnstreamer/issues/738
+# @url https://github.com/nnstreamer/nnstreamer/issues/738
 
 
 from __future__ import print_function

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -2,7 +2,7 @@
  * @file	unittest_sink.cc
  * @date	29 June 2018
  * @brief	Unit test for tensor sink plugin
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Jaeyun Jung <jy1210.jung@samsung.com>
  * @bug		No known bugs.
  */

--- a/tests/nnstreamer_source/unittest_src_iio.cc
+++ b/tests/nnstreamer_source/unittest_src_iio.cc
@@ -2,7 +2,7 @@
  * @file	unittest_src_iio.cc
  * @date	22 March 2019
  * @brief	Unit test for tensor_src_iio
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug		No known bugs.
  */

--- a/tests/tizen_capi/dummy_sensor.c
+++ b/tests/tizen_capi/dummy_sensor.c
@@ -4,7 +4,7 @@
  * @file	dummy_sensor.h
  * @date	28 Nov 2019
  * @brief	Dummy Tizen Sensor API support for unit tests.
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  * @details	The sensor framework source plugin should be

--- a/tests/tizen_capi/dummy_sensor.h
+++ b/tests/tizen_capi/dummy_sensor.h
@@ -4,7 +4,7 @@
  * @file	dummy_sensor.h
  * @date	28 Nov 2019
  * @brief	Dummy Tizen Sensor API support for unit tests.
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  * @details	The sensor framework source plugin should be

--- a/tests/tizen_capi/sensor.h
+++ b/tests/tizen_capi/sensor.h
@@ -4,7 +4,7 @@
  * @file	sensor.h
  * @date	28 Nov 2019
  * @brief	Tizen Sensor Framework Simulator
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  */

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -2,7 +2,7 @@
  * @file        unittest_tizen_capi.cc
  * @date        13 Mar 2019
  * @brief       Unit test for Tizen CAPI of NNStreamer. Basis of TCT in the future.
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  */

--- a/tests/tizen_capi/unittest_tizen_sensor.cc
+++ b/tests/tizen_capi/unittest_tizen_sensor.cc
@@ -2,7 +2,7 @@
  * @file	unittest_tizen_sensor.cc
  * @date	25 Nov 2019
  * @brief	Unit test for NNStreamer's tensor-src-tizensensor.
- * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  */

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -2,7 +2,7 @@
  * @file        unittest_tizen_nnfw_runtime_raw.cc
  * @date        07 Oct 2019
  * @brief       Unit test for Tizen nnfw tensor filter plugin.
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  */

--- a/tests/unittest_util.c
+++ b/tests/unittest_util.c
@@ -4,7 +4,7 @@
  * @file        unittest_util.c
  * @date        15 Jan 2019
  * @brief       Unit test utility.
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  */

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -4,7 +4,7 @@
  * @file        unittest_util.h
  * @date        15 Jan 2019
  * @brief       Unit test utility.
- * @see         https://github.com/nnsuite/nnstreamer
+ * @see         https://github.com/nnstreamer/nnstreamer
  * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug         No known bugs
  */

--- a/tools/README.md
+++ b/tools/README.md
@@ -20,7 +20,7 @@ There are three features as following:
 - Profiling(in progress)
 
 If you are interested in the tool technology to optimize your application using NNStremaer, please refer to the below issues.
-* https://github.com/nnsuite/nnstreamer/issues/132
+* https://github.com/nnstreamer/nnstreamer/issues/132
 
 
 ## Development 

--- a/tools/nnstreamer-toolkit.py
+++ b/tools/nnstreamer-toolkit.py
@@ -180,7 +180,7 @@ class PyApp(gtk.Window):
 
       about.set_copyright("(c) Samsung Electronics")
       about.set_comments("About NNStreamer Toolkit")
-      about.set_website("https://github.com/nnsuite/nnstreamer")
+      about.set_website("https://github.com/nnstreamer/nnstreamer")
       about.run()
       about.destroy()
 


### PR DESCRIPTION
1. Update github repo URLs (auto)

This includes automatically replaced parts only.

/NNStreamer/$ grep -H -o -r "github.com\/nnsuite\/nnstreamer" *   | grep -o "^[^:]*" > list
/NNStreamer/$ for X in `cat list`; do sed -i 's|github.com/nnsuite/nnstreamer|github.com/nnstreamer/nnstreamer|' $X; done

2. Update github repo URLs (manual)
    
Update github repo URL related texts manually.


Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

