### PR TITLE
[Ext/Filter/Meson/EdgeTPU] Add build_rpath when test is enabled

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -317,11 +317,22 @@ if get_option('enable-edgetpu')
       nnstreamer_filter_edgetpu_sources += join_paths(meson.current_source_dir(), s)
     endforeach
 
+    rpath_edgetpu_test_helper = ''
+    if get_option('enable-test')
+      '''
+      In order to use the test helper library, add build_rpath.
+      This temporarily overrides the runtime dependency on edge tpu and
+      it is removed after installation.
+      '''
+      rpath_edgetpu_test_helper = join_paths(meson.build_root(), 'tests/nnstreamer_filter_edgetpu')
+
+    endif
     shared_library('nnstreamer_filter_edgetpu',
       nnstreamer_filter_edgetpu_sources,
       dependencies: [glib_dep, gst_dep, nnstreamer_dep, edgetpu_dep, tflite_dep, libdl_dep],
       install: true,
-      install_dir: filter_subplugin_install_dir
+      install_dir: filter_subplugin_install_dir,
+      build_rpath: rpath_edgetpu_test_helper
     )
   else
     error ('enable-tensorflow-lite should be set as \'true\' to build the tensor filter for Edge TPU.')


### PR DESCRIPTION
#2225 requires this PR.

In order to provide the proper location of the test helper library which mocks edgetpu.so, this patch adds build_rpath to the shared_object statement in the meson build script for the edgeTPU filter extensions when 'enable-test' is true.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped