### PR TITLE
[Filter/nnfw] Add check nnfw availability

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -649,6 +649,19 @@ nnfw_invoke (const GstTensorFilterProperties * prop,
   return err;
 }
 
+/**
+ * @brief Check support of the backend
+ * @param hw: backend to check support of
+ */
+static int
+nnfw_checkAvailability (accl_hw hw)
+{
+  if (g_strv_contains (nnfw_accl_support, get_accl_hw_str (hw)))
+    return 0;
+
+  return -ENOENT;
+}
+
 static gchar filter_subplugin_nnfw[] = "nnfw";
 
 static GstTensorFilterFramework NNS_support_nnfw = {
@@ -670,6 +683,7 @@ init_filter_nnfw (void)
   NNS_support_nnfw.getInputDimension = nnfw_getInputDim;
   NNS_support_nnfw.getOutputDimension = nnfw_getOutputDim;
   NNS_support_nnfw.setInputDimension = nnfw_setInputDim;
+  NNS_support_nnfw.checkAvailability = nnfw_checkAvailability;
 
   nnstreamer_filter_probe (&NNS_support_nnfw);
 }


### PR DESCRIPTION
Related issue : #2226 [GBS] Failed test cases with --define "unit_test 1"
Add nnfw check availability method.
It fixs 'ml_check_nnfw_availability' with NNFW always returns true for any H/W resources

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed []Skipped
2. Run test: [* ]Passed [ ]Failed []Skipped

