### PR TITLE
[CAPI] Use EPIPE if ESTRPIPE is not available

### DIFF
--- a/api/capi/include/platform/tizen_error.h
+++ b/api/capi/include/platform/tizen_error.h
@@ -24,6 +24,14 @@
 #define __NTZN_TIZEN_ERROR_H__
 
 #include <errno.h>
+
+/**
+ @ref: https://gitlab.freedesktop.org/dude/gst-plugins-base/commit/89095e7f91cfbfe625ec2522da49053f1f98baf8
+ */
+#if !defined(ESTRPIPE)
+#define ESTRPIPE EPIPE
+#endif /* !defined(ESTRPIPE) */
+
 #define TIZEN_ERROR_NONE (0)
 #define TIZEN_ERROR_INVALID_PARAMETER (-EINVAL)
 #define TIZEN_ERROR_STREAMS_PIPE (-ESTRPIPE)


### PR DESCRIPTION
In order to handle the case of the platforms that do not have ESTRPIPE in their errno.h, ESTRPIPE is defined with EPIPE [1] if it is not available.

[1] https://gitlab.freedesktop.org/dude/gst-plugins-base/-/commit/a4b94e6c69525e404354cbd3d0b67ae7e001f385

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped