### PR TITLE
[CODEOWNERS] Update reviewer lists

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 # For more details, visit https://help.github.com/articles/about-codeowners/
 # The lists of people and groups are for github.com
 
-# All reviewers of nnstreamer-team are supposed to review each other
-* @nnsuite/nnstreamer @myungjoo @jijoongmoon @again4you @jaeyun-jung @leemgs @wooksong @helloahn @kparichay @dongju-chae @gichan-jang @anyj0527
+# Until we define maintainers/committers per subdirectory, all committers (reviewers) are supposed to review any parts.
+* @nnstreamer/nnstreamer @myungjoo @jijoongmoon @again4you @jaeyun-jung @leemgs @wooksong @helloahn @kparichay @dongju-chae @gichan-jang @anyj0527 @zhoonit
 


### PR DESCRIPTION
1. update organization name
2. add zhoonit, the newly employed member.

This will fix the weird behavior of the reviewer configuration.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>