### PR TITLE
[tests] Fix pipeline state check methods

### DIFF
--- a/tests/cpp_methods/unittest_cpp_methods.cc
+++ b/tests/cpp_methods/unittest_cpp_methods.cc
@@ -92,10 +92,11 @@ TEST (cpp_filter_on_demand, pipeline_01)
   }
 
   if (pipeline) {
-    EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, 500000U), 0);
+    EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
     g_usleep (100000);
-    EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, 500000U), 0);
+
+    EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
     g_usleep (100000);
 
     gst_object_unref (pipeline);
@@ -173,7 +174,7 @@ TEST (cpp_filter_obj, base_01_n)
   }
 
   if (pipeline) {
-    EXPECT_NE (setPipelineStateSync (pipeline, GST_STATE_PLAYING, 500000U), 0);
+    EXPECT_NE (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
     gst_object_unref (pipeline);
 
@@ -215,7 +216,7 @@ TEST (cpp_filter_obj, base_02_n)
   }
 
   if (pipeline) {
-    EXPECT_NE (setPipelineStateSync (pipeline, GST_STATE_PLAYING, 500000U), 0);
+    EXPECT_NE (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
     gst_object_unref (pipeline);
   }
@@ -264,10 +265,11 @@ TEST (cpp_filter_obj, base_03)
   }
 
   if (pipeline) {
-    EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, 500000U), 0);
+    EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
     g_usleep (300000);
-    EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, 500000U), 0);
+    
+    EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
     gst_object_unref (pipeline);
     g_usleep (300000);

--- a/tests/unittest_util.c
+++ b/tests/unittest_util.c
@@ -35,7 +35,7 @@ setPipelineStateSync (GstElement * pipeline, GstState state,
     if (cur_state == state)
       return 0;
     g_usleep (10000);
-  } while ((timeout_ms / 20) < counter++);
+  } while ((timeout_ms / 20) > counter++);
   return -ETIME;
 }
 

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -24,6 +24,8 @@ extern "C" {
 #endif
 #define _print_log(...) if (DBG) g_message (__VA_ARGS__)
 
+#define UNITTEST_STATECHANGE_TIMEOUT (500U)
+
 /**
  * @brief Set pipeline state, wait until it's done.
  * @return 0 success, -EPIPE if failed, -ETIME if timeout happens.


### PR DESCRIPTION
The direction of the operator determining the timeout was wrong and it was modified.
The timeout was too long in the test, so I reduced it.

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped
