### PR TITLE
[Tizen/Sensor] Do not assert for sensor not available

### DIFF
--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
@@ -580,7 +580,7 @@ _ts_configure_handle (GstTensorSrcTIZENSENSOR * self)
   /* Based on Tizen Native App (Sensor) Guide */
   /* 1. Check if the sensor supported */
   ret = sensor_is_supported (self->type, &supported);
-  if (ret != 0) {
+  if (ret != SENSOR_ERROR_NONE) {
     ml_loge ("Tizen sensor framework is not working (sensor_is_supported).\n");
     return -ENODEV;
   }

--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
@@ -82,6 +82,7 @@
 
 #include <tensor_typedef.h>
 #include <nnstreamer_plugin_api.h>
+#include <nnstreamer_log.h>
 
 #include "tensor_src_tizensensor.h"
 
@@ -570,15 +571,19 @@ _ts_configure_handle (GstTensorSrcTIZENSENSOR * self)
       GINT_TO_POINTER (self->type));
   bool supported = false;
 
-  if (NULL == val)
-    g_printerr ("The given sensor type (%d) is not supported.\n", self->type);
-  g_assert (val);
+  if (NULL == val) {
+    ml_loge ("The given sensor type (%d) is not supported.\n", self->type);
+    return -ENODEV;
+  }
   self->src_spec = val;
 
   /* Based on Tizen Native App (Sensor) Guide */
   /* 1. Check if the sensor supported */
   ret = sensor_is_supported (self->type, &supported);
-  g_assert (ret == 0);
+  if (ret != 0) {
+    ml_loge ("Tizen sensor framework is not working (sensor_is_supported).\n");
+    return -ENODEV;
+  }
 
   if (false == supported) {
     GST_ERROR_OBJECT (self,


### PR DESCRIPTION
If a sensor is not available or unknown,
do not assert, but emit error messages and return errors.

Fixes #2219

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

