### PR TITLE
[Log] Use ml_log* instead of g_* for logging

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -34,6 +34,7 @@
 #include <armnnTfLiteParser/ITfLiteParser.hpp>
 #include <armnnCaffeParser/ICaffeParser.hpp>
 
+#include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api_filter.h>
 #include <nnstreamer_plugin_api.h>
 #include <nnstreamer_conf.h>
@@ -139,17 +140,17 @@ int
 ArmNNCore::init (const GstTensorFilterProperties * prop)
 {
   if (loadModel (prop)) {
-    g_critical ("Failed to load model\n");
+    ml_loge ("Failed to load model\n");
     return -1;
   }
 
   if (setInputTensorProp ()) {
-    g_critical ("Failed to initialize input tensor\n");
+    ml_loge ("Failed to initialize input tensor\n");
     return -2;
   }
 
   if (setOutputTensorProp ()) {
-    g_critical ("Failed to initialize output tensor\n");
+    ml_loge ("Failed to initialize output tensor\n");
     return -3;
   }
   return 0;
@@ -353,7 +354,7 @@ ArmNNCore::loadModel (const GstTensorFilterProperties * prop)
   armnn::Status status;
 
   if (!g_file_test (model_path, G_FILE_TEST_IS_REGULAR)) {
-    g_critical ("the file of model_path (%s) is not valid (not regular)\n",
+    ml_loge ("the file of model_path (%s) is not valid (not regular)\n",
         model_path);
     return -EINVAL;
   }
@@ -391,15 +392,15 @@ ArmNNCore::loadModel (const GstTensorFilterProperties * prop)
       throw;
     }
     catch (const std::runtime_error & re) {
-      g_critical ("Runtime error while loading the network: %s", re.what ());
+      ml_loge ("Runtime error while loading the network: %s", re.what ());
       return -EINVAL;
     }
     catch (const std::exception & ex) {
-      g_critical ("Exception while loading the network : %s", ex.what ());
+      ml_loge ("Exception while loading the network : %s", ex.what ());
       return -EINVAL;
     }
     catch ( ...) {
-      g_critical ("Unknown exception while loading the network");
+      ml_loge ("Unknown exception while loading the network");
       return -EINVAL;
     }
   }
@@ -427,19 +428,19 @@ ArmNNCore::getGstTensorType (armnn::DataType armType)
       /** Supported with tf, tflite and caffe */
       return _NNS_FLOAT32;
     case armnn::DataType::Float16:
-      g_warning ("Unsupported armnn datatype Float16.");
+      ml_logw ("Unsupported armnn datatype Float16.");
       break;
     case armnn::DataType::QuantisedAsymm8:
       /** Supported with tflite */
       return _NNS_UINT8;
     case armnn::DataType::Boolean:
-      g_warning ("Unsupported armnn datatype Boolean.");
+      ml_logw ("Unsupported armnn datatype Boolean.");
       break;
     case armnn::DataType::QuantisedSymm16:
-      g_warning ("Unsupported armnn datatype QuantisedSym16.");
+      ml_logw ("Unsupported armnn datatype QuantisedSym16.");
       break;
     default:
-      g_warning ("Unsupported armnn datatype unknown.");
+      ml_logw ("Unsupported armnn datatype unknown.");
       /** @todo Support other types */
       break;
   }
@@ -480,19 +481,19 @@ ArmNNCore::setTensorProp (const std::vector < armnn::BindingPointInfo >
     if (gst_info->type == _NNS_END) {
       gst_info->type = getGstTensorType (arm_info.GetDataType ());
     } else if (gst_info->type != getGstTensorType (arm_info.GetDataType ())) {
-      g_warning ("Provided data type info does not match with model.");
+      ml_logw ("Provided data type info does not match with model.");
       return -EINVAL;
     }
 
     if (gst_info->type == _NNS_END) {
-      g_warning ("Data type not supported.");
+      ml_logw ("Data type not supported.");
       return -EINVAL;
     }
 
     /* Set the dimensions */
     int num_dim = arm_info.GetNumDimensions ();
     if (num_dim > NNS_TENSOR_RANK_LIMIT) {
-      g_warning ("Data rank exceeds max supported rank.");
+      ml_logw ("Data rank exceeds max supported rank.");
       return -EINVAL;
     }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <algorithm>
 
+#include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
 #include <nnstreamer_plugin_api_filter.h>
 
@@ -125,7 +126,7 @@ int
 Caffe2Core::init (const GstTensorFilterProperties * prop)
 {
   if (loadModels ()) {
-    g_critical ("Failed to load model\n");
+    ml_loge ("Failed to load model\n");
     return -1;
   }
 
@@ -133,7 +134,7 @@ Caffe2Core::init (const GstTensorFilterProperties * prop)
   gst_tensors_info_copy (&outputTensorMeta, &prop->output_meta);
 
   if (initInputTensor ()) {
-    g_critical ("Failed to initialize input tensor\n");
+    ml_loge ("Failed to initialize input tensor\n");
     return -2;
   }
 
@@ -173,7 +174,7 @@ Caffe2Core::initInputTensor ()
         initializeTensor (int32_t);
         break;
       case _NNS_UINT32:
-        g_critical ("invalid data type is used");
+        ml_loge ("invalid data type is used");
         return -1;
       case _NNS_INT16:
         initializeTensor (int16_t);
@@ -197,10 +198,10 @@ Caffe2Core::initInputTensor ()
         initializeTensor (int64_t);
         break;
       case _NNS_UINT64:
-        g_critical ("invalid data type is used");
+        ml_loge ("invalid data type is used");
         return -1;
       default:
-        g_critical ("invalid data type is used");
+        ml_loge ("invalid data type is used");
         return -1;
     }
 
@@ -243,11 +244,11 @@ Caffe2Core::loadModels ()
   gint64 start_time = g_get_real_time ();
 #endif
   if (!g_file_test (init_model_path, G_FILE_TEST_IS_REGULAR)) {
-    g_critical ("the file of init_model_path is not valid: %s\n", init_model_path);
+    ml_loge ("the file of init_model_path is not valid: %s\n", init_model_path);
     return -1;
   }
   if (!g_file_test (pred_model_path, G_FILE_TEST_IS_REGULAR)) {
-    g_critical ("the file of pred_model_path is not valid: %s\n", pred_model_path);
+    ml_loge ("the file of pred_model_path is not valid: %s\n", pred_model_path);
     return -1;
   }
   CAFFE_ENFORCE (ReadProtoFromFile (init_model_path, &initNet));
@@ -322,7 +323,7 @@ Caffe2Core::run (const GstTensorMemory * input, GstTensorMemory * output)
         inputTensor->ShareExternalPointer ((int32_t*) input[i].data);
         break;
       case _NNS_UINT32:
-        g_critical ("invalid data type is used");
+        ml_loge ("invalid data type is used");
         return -1;
       case _NNS_INT16:
         inputTensor->ShareExternalPointer ((int16_t*) input[i].data);
@@ -346,10 +347,10 @@ Caffe2Core::run (const GstTensorMemory * input, GstTensorMemory * output)
         inputTensor->ShareExternalPointer ((int64_t*) input[i].data);
         break;
       case _NNS_UINT64:
-        g_critical ("invalid data type is used");
+        ml_loge ("invalid data type is used");
         return -1;
       default:
-        g_critical ("invalid data type is used");
+        ml_loge ("invalid data type is used");
         return -1;
     }
   }
@@ -363,13 +364,13 @@ Caffe2Core::run (const GstTensorMemory * input, GstTensorMemory * output)
       workSpace.RunNet (predictNet.name ());
       first_run = false;
     } catch(const std::runtime_error& re) {
-      g_critical ("Runtime error while running the model: %s", re.what());
+      ml_loge ("Runtime error while running the model: %s", re.what());
       return -4;
     } catch(const std::exception& ex)	{
-      g_critical ("Exception while running the model : %s", ex.what());
+      ml_loge ("Exception while running the model : %s", ex.what());
       return -4;
     } catch (...) {
-      g_critical ("Unknown exception while running the model");
+      ml_loge ("Unknown exception while running the model");
       return -4;
     }
   } else {
@@ -385,7 +386,7 @@ Caffe2Core::run (const GstTensorMemory * input, GstTensorMemory * output)
         output[i].data = out.data<int32_t>();
         break;
       case _NNS_UINT32:
-        g_critical ("invalid data type (uint32) is used");
+        ml_loge ("invalid data type (uint32) is used");
         return -1;
       case _NNS_INT16:
         output[i].data = out.data<int16_t>();
@@ -409,10 +410,10 @@ Caffe2Core::run (const GstTensorMemory * input, GstTensorMemory * output)
         output[i].data = out.data<int64_t>();
         break;
       case _NNS_UINT64:
-        g_critical ("invalid data type (uint64) is used");
+        ml_loge ("invalid data type (uint64) is used");
         return -1;
       default:
-        g_critical ("invalid data type is used");
+        ml_loge ("invalid data type is used");
         return -1;
     }
   }
@@ -458,7 +459,7 @@ caffe2_loadModelFile (const GstTensorFilterProperties * prop,
   const gchar *pred_model;
 
   if (prop->num_models != 2) {
-    g_critical ("Caffe2 requires two model files\n");
+    ml_loge ("Caffe2 requires two model files\n");
     return -1;
   }
 
@@ -478,7 +479,7 @@ caffe2_loadModelFile (const GstTensorFilterProperties * prop,
 
   core = new Caffe2Core (init_model, pred_model);
   if (core == NULL) {
-    g_critical ("Failed to allocate memory for filter subplugin: Caffe2\n");
+    ml_loge ("Failed to allocate memory for filter subplugin: Caffe2\n");
     return -1;
   }
 
@@ -486,7 +487,7 @@ caffe2_loadModelFile (const GstTensorFilterProperties * prop,
     *private_data = NULL;
     delete core;
 
-    g_critical ("failed to initialize the object: Caffe2");
+    ml_loge ("failed to initialize the object: Caffe2");
     return -2;
   }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
@@ -34,6 +34,7 @@
 #include <glib.h>
 #include <gmodule.h>
 
+#include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api_filter.h>
 
 #include "tensor_filter_cpp.hh"
@@ -133,7 +134,7 @@ int tensor_filter_cpp::__unregister (const char *name)
     return -EINVAL; /** Not found */
   if (filters[name]->ref_count > 0) {
     unsigned int cnt = filters[name]->ref_count;
-    g_critical ("The reference counter of c++ filter, %s, is %u. Anyway, we are closing this because this is being closed by destructor of .so file.", name, cnt);
+    ml_loge ("The reference counter of c++ filter, %s, is %u. Anyway, we are closing this because this is being closed by destructor of .so file.", name, cnt);
   }
   size_t num = filters.erase (name);
   if (num != 1)

--- a/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
@@ -31,6 +31,7 @@
 
 #include <stdint.h>
 
+#include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api_filter.h>
 #include <tensor_common.h>
 #include <glib.h>
@@ -337,7 +338,7 @@ edgetpu_invoke (const GstTensorFilterProperties *prop,
   }
 
   if (status != kTfLiteOk) {
-    g_critical ("Failed to invoke");
+    ml_loge ("Failed to invoke");
     return -1;
   }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
@@ -31,6 +31,7 @@
 #include <glib/gstdio.h>
 #include <gst/gst.h>
 #include <mvnc2/mvnc.h>
+#include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api_filter.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -305,7 +306,7 @@ _mvncsdk2_invoke (const GstTensorFilterProperties * prop, void **private_data,
 
   g_return_val_if_fail (prop->input_configured, -1);
   if (prop->input_meta.num_tensors != NNS_MVNCSDK2_MAX_NUM_TENOSORS_SUPPORTED) {
-    g_critical ("The number of input tensor should be one: "
+    ml_loge ("The number of input tensor should be one: "
         "The MVNCSDK API supports single tensor input and output only");
     goto err_destroy;
   }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -57,6 +57,7 @@
 #include <string.h>
 #include <dlfcn.h>
 
+#include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
 #include <nnstreamer_plugin_api_filter.h>
 #include <nnstreamer_conf.h>
@@ -77,7 +78,7 @@
 #define PYCORE_LIB_NAME_FORMAT "libpython%d.%dm.so.1.0"
 #endif
 
-#define Py_ERRMSG(...) do {PyErr_Print(); g_critical (__VA_ARGS__);} while (0);
+#define Py_ERRMSG(...) do {PyErr_Print(); ml_loge (__VA_ARGS__);} while (0);
 
 static const gchar *python_accl_support[] = {
   ACCL_AUTO_STR,
@@ -592,7 +593,7 @@ PYCore::freeOutputTensors (void *data)
     Py_XDECREF(it->second);
     outputArrayMap.erase (it);
   } else {
-    g_critical("Cannot find output data: 0x%lx", (unsigned long) data);
+    ml_loge("Cannot find output data: 0x%lx", (unsigned long) data);
   }
 }
 
@@ -641,7 +642,7 @@ PYCore::run (const GstTensorMemory * input, GstTensorMemory * output)
         Py_XINCREF(output_array);
         outputArrayMap.insert (std::make_pair (output[i].data, output_array));
       } else {
-        g_critical ("Output tensor type/size is not matched\n");
+        ml_loge ("Output tensor type/size is not matched\n");
         res = -2;
         break;
       }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python_api.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python_api.c
@@ -49,6 +49,7 @@
 
 #include <glib.h>
 #include <tensor_typedef.h>
+#include <nnstreamer_log.h>
 
 /** @brief object structure for custom Python type: TensorShape */
 typedef struct
@@ -172,7 +173,7 @@ TensorShape_init (TensorShapeObject * self, PyObject * args, PyObject * kw)
       self->type = dtype;
       Py_XINCREF (dtype);
     } else
-      g_critical ("Wrong data type");
+      ml_loge ("Wrong data type");
   }
 
   return 0;

--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <glib.h>
 
+#include "nnstreamer_log.h"
 #include "nnstreamer_conf.h"
 
 /**
@@ -208,7 +209,7 @@ _get_subplugin_with_type (nnsconf_type_path type, gchar *** basename,
 {
   if (type >= NNSCONF_PATH_END) {
     /* unknown type */
-    g_critical ("Failed to get sub-plugins, unknown sub-plugin type.");
+    ml_loge ("Failed to get sub-plugins, unknown sub-plugin type.");
     return FALSE;
   }
 
@@ -391,7 +392,7 @@ nnsconf_loadconf (gboolean force_reload)
      * Failed to get the configuration.
      * Note that Android API does not use the configuration.
      */
-    g_warning ("Failed to load the configuration, no config file found.");
+    ml_logw ("Failed to load the configuration, no config file found.");
   }
 
   for (t = 0; t < NNSCONF_PATH_END; t++) {

--- a/gst/nnstreamer/nnstreamer_log.h
+++ b/gst/nnstreamer/nnstreamer_log.h
@@ -24,8 +24,6 @@
 #ifndef __NNSTREAMER_LOG_H__
 #define __NNSTREAMER_LOG_H__
 
-G_BEGIN_DECLS
-
 #define TAG_NAME "nnstreamer"
 
 #if defined(__TIZEN__)
@@ -72,5 +70,4 @@ G_BEGIN_DECLS
 #define nns_loge ml_loge
 #define nns_logd ml_logd
 
-G_END_DECLS
 #endif /* __NNSTREAMER_LOG_H__ */

--- a/gst/nnstreamer/nnstreamer_subplugin.c
+++ b/gst/nnstreamer/nnstreamer_subplugin.c
@@ -26,6 +26,7 @@
 #include <glib.h>
 #include <gmodule.h>
 
+#include "nnstreamer_log.h"
 #include "nnstreamer_subplugin.h"
 #include "nnstreamer_conf.h"
 
@@ -106,7 +107,7 @@ _search_subplugin (subpluginType type, const gchar * name, const gchar * path)
   module = g_module_open (path, 0);
   /* If this is a correct subplugin, it will register itself */
   if (module == NULL) {
-    g_critical ("Cannot open %s(%s) with error %s.", name, path,
+    ml_loge ("Cannot open %s(%s) with error %s.", name, path,
         g_module_error ());
     return NULL;
   }
@@ -115,7 +116,7 @@ _search_subplugin (subpluginType type, const gchar * name, const gchar * path)
   if (spdata) {
     g_ptr_array_add (handles, (gpointer) module);
   } else {
-    g_critical
+    ml_loge
         ("nnstreamer_subplugin of %s(%s) is broken. It does not call register_subplugin with its init function.",
         name, path);
     g_module_close (module);
@@ -183,20 +184,20 @@ register_subplugin (subpluginType type, const char *name, const void *data)
 
   /* check the sub-pugin name */
   if (g_ascii_strcasecmp (name, "auto") == 0) {
-    g_critical ("Failed, the name %s is not allowed.", name);
+    ml_loge ("Failed, the name %s is not allowed.", name);
     return FALSE;
   }
 
   spdata = _get_subplugin_data (type, name);
   if (spdata) {
     /* already exists */
-    g_warning ("Subplugin %s is already registered.", name);
+    ml_logw ("Subplugin %s is already registered.", name);
     return FALSE;
   }
 
   spdata = g_new0 (subpluginData, 1);
   if (spdata == NULL) {
-    g_critical ("Failed to allocate memory for subplugin registration.");
+    ml_loge ("Failed to allocate memory for subplugin registration.");
     return FALSE;
   }
 

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -47,6 +47,7 @@
 #include <string.h>
 #include "tensor_converter.h"
 #include "converter-media-info.h"
+#include <nnstreamer_log.h>
 #include <nnstreamer_subplugin.h>
 #include <nnstreamer_plugin_api_converter.h>
 
@@ -1449,7 +1450,7 @@ gst_tensor_converter_parse_caps (GstTensorConverter * self,
         frames_dim = 3;
         self->frame_size = GST_VIDEO_INFO_SIZE (&info);
       } else {
-        g_critical
+        ml_loge
             ("\n This binary does not support video type. Please build NNStreamer with disable-video-support : false\n");
         return FALSE;
       }
@@ -1473,7 +1474,7 @@ gst_tensor_converter_parse_caps (GstTensorConverter * self,
         frames_dim = 1;
         self->frame_size = GST_AUDIO_INFO_BPF (&info);
       } else {
-        g_critical
+        ml_loge
             ("\n This binary does not support audio type. Please build NNStreamer with disable-audio-support : false\n");
         return FALSE;
       }
@@ -1490,7 +1491,7 @@ gst_tensor_converter_parse_caps (GstTensorConverter * self,
         GST_ERROR_OBJECT (self,
             "Failed to get tensor info, need to update string size.");
 
-        g_critical ("Please set the property input-dim to convert stream.\n"
+        ml_loge ("Please set the property input-dim to convert stream.\n"
             "For example, input-dim=30 to handle up to 30 bytes of string per frame.");
         return FALSE;
       }
@@ -1512,7 +1513,7 @@ gst_tensor_converter_parse_caps (GstTensorConverter * self,
         GST_ERROR_OBJECT (self,
             "Failed to get tensor info, need to update dimension and type.");
 
-        g_critical
+        ml_loge
             ("Please set the properties input-dim and input-type to convert stream.\n"
             "For example, input-dim=30 input-type=unit8 to handle 30 bytes of bin data.");
         return FALSE;
@@ -1536,7 +1537,7 @@ gst_tensor_converter_parse_caps (GstTensorConverter * self,
             GST_ERROR_OBJECT (self,
                 "Failed to get tensor info from %s. Check the given options.",
                 name);
-            g_critical ("Please set the options property correctly.\n");
+            ml_loge ("Please set the options property correctly.\n");
             self->externalConverter = NULL;
             return FALSE;
           }

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -25,6 +25,7 @@
 
 #include <string.h>
 
+#include <nnstreamer_log.h>
 #include <tensor_common.h>
 
 #include "tensor_filter_common.h"
@@ -333,7 +334,7 @@ verify_model_path (const GstTensorFilterPrivate * priv)
   if ((prop->model_files != NULL) && (verify_model_path == TRUE)) {
     for (i = 0; i < prop->num_models; i++) {
       if (!g_file_test (prop->model_files[i], G_FILE_TEST_IS_REGULAR)) {
-        g_critical ("Cannot find the model file [%d]: %s\n",
+        ml_loge ("Cannot find the model file [%d]: %s\n",
             i, prop->model_files[i]);
         ret = FALSE;
       }
@@ -716,7 +717,7 @@ gst_tensor_filter_parse_accelerator (GstTensorFilterPrivate * priv,
   if (info->name == NULL) {
     status = priv->fw->getFrameworkInfo (prop, priv->privateData, info);
     if (status != 0 || info->hw_list == NULL) {
-      g_warning ("Unable to fetch accelerators supported by the framework.");
+      ml_logw ("Unable to fetch accelerators supported by the framework.");
       return;
     }
   }
@@ -932,7 +933,7 @@ gst_tensor_filter_common_set_property (GstTensorFilterPrivate * priv,
           gst_tensor_filter_common_close_fw (priv);
           priv->fw = NULL;
         } else {
-          g_debug ("Framework = %s\n", fw_name);
+          ml_logd ("Framework = %s\n", fw_name);
           break;
         }
       }
@@ -990,7 +991,7 @@ gst_tensor_filter_common_set_property (GstTensorFilterPrivate * priv,
         if (status == 0) {
           g_strfreev_const (_prop.model_files);
         } else {
-          g_critical ("Fail to reload model\n");
+          ml_loge ("Fail to reload model\n");
           g_strfreev_const (prop->model_files);
           prop->model_files = _prop.model_files;
           prop->num_models = _prop.num_models;

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
@@ -33,6 +33,7 @@
 #include "tensor_filter_custom.h"
 #include "nnstreamer_plugin_api_filter.h"
 #include "nnstreamer_conf.h"
+#include <nnstreamer_log.h>
 
 void init_filter_custom (void) __attribute__ ((constructor));
 void fini_filter_custom (void) __attribute__ ((destructor));
@@ -84,7 +85,7 @@ custom_loadlib (const GstTensorFilterProperties * prop, void **private_data)
 
   ptr = *private_data = g_new0 (internal_data, 1);
   if (ptr == NULL) {
-    g_critical ("Failed to allocate memory for custom filter.");
+    ml_loge ("Failed to allocate memory for custom filter.");
     return -1;
   }
 
@@ -97,7 +98,7 @@ custom_loadlib (const GstTensorFilterProperties * prop, void **private_data)
   }
 
   if (!g_module_symbol (ptr->module, "NNStreamer_custom", &custom_cls)) {
-    g_critical ("tensor_filter_custom:loadlib error: %s\n", g_module_error ());
+    ml_loge ("tensor_filter_custom:loadlib error: %s\n", g_module_error ());
     g_module_close (ptr->module);
     g_free (ptr);
     *private_data = NULL;

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
@@ -25,6 +25,7 @@
 #include <errno.h>
 #include <glib.h>
 #include <tensor_filter_custom_easy.h>
+#include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
 #include <nnstreamer_subplugin.h>
 
@@ -97,7 +98,7 @@ custom_open (const GstTensorFilterProperties * prop, void **private_data)
   rd->model = get_subplugin (NNS_EASY_CUSTOM_FILTER, prop->model_files[0]);
 
   if (NULL == rd->model) {
-    g_critical
+    ml_loge
         ("Cannot find the easy-custom model, \"%s\". You should provide a valid model name of easy-custom.",
         prop->model_files[0]);
     g_free (rd);

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -49,6 +49,7 @@
 
 #include <string.h>
 #include <math.h>
+#include <nnstreamer_log.h>
 #include "tensor_transform.h"
 
 #ifdef HAVE_ORC
@@ -739,7 +740,7 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       gchar **strv = NULL;
 
       if (!g_regex_match_simple (REGEX_DIMCHG_OPTION, filter->option, 0, 0)) {
-        g_critical
+        ml_loge
             ("%s: dimchg: \'%s\' is not valid option string: it should be in the form of IDX_DIM_FROM:IDX_DIM_TO: with a regex, "
             REGEX_DIMCHG_OPTION "\n", filter_name, filter->option);
         break;
@@ -759,7 +760,7 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
         filter->data_typecast.to = gst_tensor_get_type (filter->option);
         filter->loaded = TRUE;
       } else {
-        g_critical
+        ml_loge
             ("%s: typecast: \'%s\' is not valid data type for tensor: data type of tensor should be one of %s\n",
             filter_name, filter->option, GST_TENSOR_TYPE_ALL);
       }
@@ -798,7 +799,7 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
               1, 0, NULL, NULL)) {
         str_option = g_regex_replace (regex_option_tc, filter->option, -1, 1,
             "", 0, 0);
-        g_critical
+        ml_loge
             ("%s: arithmetic: [typecast:TYPE,] should be located at the first to prevent memory re-allocation: typecast(s) in the middle of \'%s\' will be ignored\n",
             filter_name, filter->option);
       } else {
@@ -807,7 +808,7 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       g_regex_unref (regex_option_tc);
 
       if (!g_regex_match_simple (REGEX_ARITH_OPTION, str_option, 0, 0)) {
-        g_critical
+        ml_loge
             ("%s: arithmetic: \'%s\' is not valid option string: it should be in the form of [typecast:TYPE,]add|mul|div:NUMBER..., ...\n",
             filter_name, str_option);
         g_free (str_option);
@@ -891,7 +892,7 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       gchar **strv = NULL;
 
       if (!g_regex_match_simple (REGEX_TRANSPOSE_OPTION, filter->option, 0, 0)) {
-        g_critical
+        ml_loge
             ("%s: transpose: \'%s\' is not valid option string: it should be in the form of NEW_IDX_DIM0:NEW_IDX_DIM1:NEW_IDX_DIM2:3 (note that the index of the last dim is alwayes fixed to 3)\n",
             filter_name, filter->option);
         break;
@@ -912,7 +913,7 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       filter->data_stand.mode =
           gst_tensor_transform_get_stand_mode (filter->option);
       if (filter->data_stand.mode == STAND_END) {
-        g_critical
+        ml_loge
             ("%s: stand: \'%s\' is not valid option string: it should be \'default\', currently the only supported mode.\n",
             filter_name, filter->option);
         break;


### PR DESCRIPTION
With ml_log* nnstreamer internal APIs,
we can enable dlog in Tizen and Android logging in Android
while keep using GLIB's logging in other systems.

Fixes #1905

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

