### PR TITLE
[Example/custom/opencv] Use enumeration in imgproc.hpp

### DIFF
--- a/nnstreamer_example/custom_example_opencv/nnstreamer_customfilter_opencv_scaler.cc
+++ b/nnstreamer_example/custom_example_opencv/nnstreamer_customfilter_opencv_scaler.cc
@@ -140,15 +140,15 @@ pt_allocate_invoke (void *private_data,
   /* Get Mat object from input tensor */
   memcpy (buffer, input[0].data, in_size);
   img_src = cv::Mat (pdata->in_height, pdata->in_width, CV_8UC3, buffer);
-  cv::cvtColor (img_src, img_src, CV_BGR2RGB);
+  cv::cvtColor (img_src, img_src, cv::COLOR_BGR2RGB);
 
   /* Scale from the shape of input tensor to that of output tensor
    * which is given as custom property */
   cv::resize (img_src, img_dst, cv::Size(pdata->out_width, pdata->out_height),
-            0, 0, CV_INTER_NN);
+            0, 0, cv::INTER_NEAREST);
 
   /* Convert Mat object to output tensor */
-  cv::cvtColor (img_dst, img_dst, CV_RGB2BGR);
+  cv::cvtColor (img_dst, img_dst, cv::COLOR_RGB2BGR);
   memcpy (output[0].data, img_dst.data, out_size);
 
   g_free(buffer);

--- a/nnstreamer_example/custom_example_opencv/nnstreamer_customfilter_opencv_scaler.cc
+++ b/nnstreamer_example/custom_example_opencv/nnstreamer_customfilter_opencv_scaler.cc
@@ -140,15 +140,28 @@ pt_allocate_invoke (void *private_data,
   /* Get Mat object from input tensor */
   memcpy (buffer, input[0].data, in_size);
   img_src = cv::Mat (pdata->in_height, pdata->in_width, CV_8UC3, buffer);
+#if CV_MAJOR_VERSION >= 3
   cv::cvtColor (img_src, img_src, cv::COLOR_BGR2RGB);
+#else
+  cv::cvtColor (img_src, img_src, CV_BGR2RGB);
+#endif
 
   /* Scale from the shape of input tensor to that of output tensor
    * which is given as custom property */
+#if CV_MAJOR_VERSION >= 3
   cv::resize (img_src, img_dst, cv::Size(pdata->out_width, pdata->out_height),
             0, 0, cv::INTER_NEAREST);
+#else
+  cv::resize (img_src, img_dst, cv::Size(pdata->out_width, pdata->out_height),
+            0, 0, CV_INTER_NN);
+#endif
 
   /* Convert Mat object to output tensor */
+#if CV_MAJOR_VERSION >= 3
   cv::cvtColor (img_dst, img_dst, cv::COLOR_RGB2BGR);
+#else
+  cv::cvtColor (img_dst, img_dst, CV_RGB2BGR);
+#endif
   memcpy (output[0].data, img_dst.data, out_size);
 
   g_free(buffer);


### PR DESCRIPTION
This imports the gerrit commit from Tae-Young Chung:
https://review.tizen.org/gerrit/#/c/platform/upstream/nnstreamer/+/230088/

And then added a backward compatibility patch.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


commit 90840083d5e5c87a05aeacb6299f4afcaf459b13 (HEAD -> opencvup, github-fork/opencvup)
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Wed Apr 8 10:58:02 2020 +0900

    [Example/custom/opencv] Backward compatibility for old opencv
    
    The previous commit is for OPENCV3. Keep the old code for OPENCV2 or before.
    
    Changed in v2:
    - Per the comment from Tae-Young Chung,
    "opencv3 also supports this change (opencv3 support c++)
    how old opencv version should be supported? for example, opencv2.x?"
    The backward compatibility patch is adjusted to support 2 or before.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit a2ff3f12c9634098c9921f71f8553c14c3e6dc1e
Author: Tae-Young Chung <ty83.chung@samsung.com>
Date:   Wed Apr 8 10:32:23 2020 +0900

    [Example/custom/opencv] Use enumeration in imgproc.hpp
    
    From opencv4, usage of enumeration in c header files causes build failure
    unless they are explicitly included.
    Change the enumeration in types_c.h to InterpolationFlags in imgproc.hpp.
    
    Change-Id: I521a09b9846d15a6beb8dad95f887681e2b59994
    Signed-off-by: Tae-Young Chung <ty83.chung@samsung.com>
