### PR TITLE
[Tests/CAPI] Add a #ifdef guard for test cases that require tflite

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -4287,6 +4287,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_02)
   ml_tensors_info_destroy (out_res);
 }
 
+#ifdef ENABLE_TENSORFLOW_LITE
 /**
  * @brief Test NNStreamer single shot (tflite)
  * @detail run the `ml_single_invoke_dynamic` api works properly.
@@ -4630,6 +4631,7 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_fail_n)
 
   g_free (test_model);
 }
+#endif /* ENABLE_TENSORFLOW_LITE */
 
 /**
  * @brief Main gtest

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -4517,7 +4517,7 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_success_02_p)
   in_dim[2] = 1;
   in_dim[3] = 1;
 
-  status = ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim); 
+  status = ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_tensors_data_create (in_info, &input);


### PR DESCRIPTION
This patch adds a #ifdef guard for the test cases which require TensorFlow Lite.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped