### PR TITLE
[Tests/CAPI] Use constexpr instead of define and ifdef for tflite @open sesame 04/13 15:19:47

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -4352,7 +4352,7 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_success_01_p)
   ml_tensors_data_get_tensor_data (output, 0, (void **) &output_buf,
       &data_size);
 
-  EXPECT_EQ (output_buf[0], 3.0f);
+  EXPECT_FLOAT_EQ (output_buf[0], 3.0f);
   EXPECT_EQ (data_size, sizeof (float));
 
   ml_tensors_info_get_count (out_info, &tmp_count);
@@ -4403,11 +4403,11 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_success_01_p)
   ml_tensors_data_get_tensor_data (output, 0, (void **) &output_buf2,
       &data_size);
 
-  EXPECT_EQ (output_buf2[0], 3.0f);
-  EXPECT_EQ (output_buf2[1], 4.0f);
-  EXPECT_EQ (output_buf2[2], 5.0f);
-  EXPECT_EQ (output_buf2[3], 6.0f);
-  EXPECT_EQ (output_buf2[4], 7.0f);
+  EXPECT_FLOAT_EQ (output_buf2[0], 3.0f);
+  EXPECT_FLOAT_EQ (output_buf2[1], 4.0f);
+  EXPECT_FLOAT_EQ (output_buf2[2], 5.0f);
+  EXPECT_FLOAT_EQ (output_buf2[3], 6.0f);
+  EXPECT_FLOAT_EQ (output_buf2[4], 7.0f);
   EXPECT_EQ (data_size, 5 * sizeof (float));
 
   ml_tensors_info_get_count (out_info, &tmp_count);
@@ -4493,7 +4493,7 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_success_02_p)
   ml_tensors_data_get_tensor_data (output, 0, (void **) &output_buf,
       &data_size);
 
-  EXPECT_EQ (output_buf[0], 3.0f);
+  EXPECT_FLOAT_EQ (output_buf[0], 3.0f;
   EXPECT_EQ (data_size, sizeof (float));
 
   ml_tensors_info_get_count (out_info, &tmp_count);
@@ -4549,11 +4549,11 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_success_02_p)
   ml_tensors_data_get_tensor_data (output, 0, (void **) &output_buf2,
       &data_size);
 
-  EXPECT_EQ (output_buf2[0], 3.0f);
-  EXPECT_EQ (output_buf2[1], 4.0f);
-  EXPECT_EQ (output_buf2[2], 5.0f);
-  EXPECT_EQ (output_buf2[3], 6.0f);
-  EXPECT_EQ (output_buf2[4], 7.0f);
+  EXPECT_FLOAT_EQ (output_buf2[0], 3.0f);
+  EXPECT_FLOAT_EQ (output_buf2[1], 4.0f);
+  EXPECT_FLOAT_EQ (output_buf2[2], 5.0f);
+  EXPECT_FLOAT_EQ (output_buf2[3], 6.0f);
+  EXPECT_FLOAT_EQ (output_buf2[4], 7.0f);
   EXPECT_EQ (data_size, 5 * sizeof (float));
 
   ml_tensors_info_get_count (out_info, &tmp_count);


### PR DESCRIPTION
This patch experimentally replaces #define and #ifdef used for checking enable-tensorflow-lite is true with constexpr, which is type-safe replacement for #define.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>