### PR TITLE
[C-API] same mem ptr

### DIFF
--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -690,7 +690,8 @@ ml_tensors_data_set_tensor_data (ml_tensors_data_h data, unsigned int index,
   if (data_size <= 0 || _data->tensors[index].size < data_size)
     return ML_ERROR_INVALID_PARAMETER;
 
-  memcpy (_data->tensors[index].tensor, raw_data, data_size);
+  if (_data->tensors[index].tensor != raw_data)
+    memcpy (_data->tensors[index].tensor, raw_data, data_size);
   return ML_ERROR_NONE;
 }
 


### PR DESCRIPTION
If user gets tensor data and tries to update it, memcpy is unnecessary.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
