### PR TITLE
Lower MCD, Increase SAM Score

### DIFF
--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -28,7 +28,7 @@ nnstreamer_internal_deps = []
 
 # Add nnstreamer registerer and common sources
 nnst_common_sources = [
-  'nnstreamer.c',
+  'registerer/nnstreamer.c',
   'nnstreamer_conf.c',
   'nnstreamer_subplugin.c',
   'tensor_common.c'

--- a/gst/nnstreamer/registerer/nnstreamer.c
+++ b/gst/nnstreamer/registerer/nnstreamer.c
@@ -47,21 +47,21 @@
 
 #include <gst/gst.h>
 
-#include "tensor_aggregator/tensor_aggregator.h"
-#include "tensor_converter/tensor_converter.h"
-#include "tensor_decoder/tensordec.h"
-#include "tensor_demux/gsttensordemux.h"
-#include "tensor_filter/tensor_filter.h"
-#include "tensor_merge/gsttensormerge.h"
-#include "tensor_mux/gsttensormux.h"
-#include "tensor_repo/tensor_reposink.h"
-#include "tensor_repo/tensor_reposrc.h"
-#include "tensor_sink/tensor_sink.h"
+#include <tensor_aggregator/tensor_aggregator.h>
+#include <tensor_converter/tensor_converter.h>
+#include <tensor_decoder/tensordec.h>
+#include <tensor_demux/gsttensordemux.h>
+#include <tensor_filter/tensor_filter.h>
+#include <tensor_merge/gsttensormerge.h>
+#include <tensor_mux/gsttensormux.h>
+#include <tensor_repo/tensor_reposink.h>
+#include <tensor_repo/tensor_reposrc.h>
+#include <tensor_sink/tensor_sink.h>
 #if defined(__gnu_linux__) && !defined(__ANDROID__)
-#include "tensor_source/tensor_src_iio.h"
+#include <tensor_source/tensor_src_iio.h>
 #endif /* __gnu_linux__ && !__ANDROID__ */
-#include "tensor_split/gsttensorsplit.h"
-#include "tensor_transform/tensor_transform.h"
+#include <tensor_split/gsttensorsplit.h>
+#include <tensor_transform/tensor_transform.h>
 
 #define NNSTREAMER_INIT(plugin,name,type) \
   do { \

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -27,7 +27,7 @@ NNSTREAMER_COMMON_SRCS := \
 
 # nnstreamer plugins
 NNSTREAMER_PLUGINS_SRCS := \
-    $(NNSTREAMER_GST_HOME)/nnstreamer.c \
+    $(NNSTREAMER_GST_HOME)/registerer/nnstreamer.c \
     $(NNSTREAMER_GST_HOME)/tensor_converter/tensor_converter.c \
     $(NNSTREAMER_GST_HOME)/tensor_aggregator/tensor_aggregator.c \
     $(NNSTREAMER_GST_HOME)/tensor_decoder/tensordec.c \


### PR DESCRIPTION
SAM analysis says that nnstreamer.c is causing cyclic dependency
between modules.

Although I think this is false positive, let's move nnstreamer.c
to a subdirectory so that SAM won't recognize nnstreamer.c is
"parent module" of other nnstreamer elements.

Because this is the only modules that SAM recognizes as MCD issue,
this may enhance SAM score greatly.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

