### PR TITLE
[Tensor-If] Make it buildable

### DIFF
--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -52,7 +52,8 @@ nnst_plugins = [
   'tensor_split',
   'tensor_transform',
   'tensor_filter',
-  'tensor_repo'
+  'tensor_repo',
+  'tensor_if',
 ]
 
 foreach p : nnst_plugins

--- a/gst/nnstreamer/registerer/nnstreamer.c
+++ b/gst/nnstreamer/registerer/nnstreamer.c
@@ -62,6 +62,7 @@
 #endif /* __gnu_linux__ && !__ANDROID__ */
 #include <tensor_split/gsttensorsplit.h>
 #include <tensor_transform/tensor_transform.h>
+#include "tensor_if/gsttensorif.h"
 
 #define NNSTREAMER_INIT(plugin,name,type) \
   do { \
@@ -89,6 +90,7 @@ gst_nnstreamer_init (GstPlugin * plugin)
   NNSTREAMER_INIT (plugin, sink, SINK);
   NNSTREAMER_INIT (plugin, split, SPLIT);
   NNSTREAMER_INIT (plugin, transform, TRANSFORM);
+  NNSTREAMER_INIT (plugin, if, IF);
 #if defined(__gnu_linux__) && !defined(__ANDROID__)
   /* IIO requires Linux / non-Android */
 #if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)

--- a/gst/nnstreamer/tensor_if/gsttensorif.c
+++ b/gst/nnstreamer/tensor_if/gsttensorif.c
@@ -87,6 +87,9 @@ enum
   PROP_ELSE_OPTION, /**< Option for FALSE Action */
 };
 
+GST_DEBUG_CATEGORY_STATIC (gst_tensor_if_debug);
+#define GST_CAT_DEFAULT gst_tensor_if_debug
+
 #define CAPS_STRING GST_TENSOR_CAP_DEFAULT "; " GST_TENSORS_CAP_DEFAULT
 /**
  * @brief The capabilities of the inputs
@@ -130,3 +133,243 @@ static gboolean gst_tensor_if_start (GstBaseTransform * trans);
 static gboolean gst_tensor_if_stop (GstBaseTransform * trans);
 static gboolean gst_tensor_if_sink_event (GstBaseTransform * trans,
     GstEvent * event);
+
+static void gst_tensor_if_install_properties (GObjectClass * gobject_class);
+
+/**
+ * @brief initialize the tensor_if's class (GST Standard)
+ */
+static void
+gst_tensor_if_class_init (GstTensorIfClass * klass)
+{
+  GObjectClass *gobject_class;
+  GstElementClass *gstelement_class;
+  GstBaseTransformClass *trans_class;
+
+  GST_DEBUG_CATEGORY_INIT (gst_tensor_if_debug, "tensor_if", 0,
+      "Tensor if to control streams based on tensor(s) values");
+
+  trans_class = (GstBaseTransformClass *) klass;
+  gstelement_class = (GstElementClass *) trans_class;
+  gobject_class = (GObjectClass *) gstelement_class;
+
+  gobject_class->set_property = gst_tensor_if_set_property;
+  gobject_class->get_property = gst_tensor_if_get_property;
+  gobject_class->finalize = gst_tensor_if_finalize;
+
+  gst_tensor_if_install_properties (gobject_class);
+
+  gst_element_class_set_details_simple (gstelement_class,
+      "Tensor_If",
+      "NNStreamer/If",
+      "Controls streams based on the tensor(s) values",
+      "MyungJoo Ham <myungjoo.ham@samsung.com>");
+
+  gst_element_class_add_pad_template (gstelement_class,
+      gst_static_pad_template_get (&src_factory));
+  gst_element_class_add_pad_template (gstelement_class,
+      gst_static_pad_template_get (&sink_factory));
+
+  /* Refer: https://gstreamer.freedesktop.org/documentation/additional/design/element-transform.html */
+  trans_class->passthrough_on_same_caps = FALSE;
+  /**
+   * Tensor-IF always have the same caps on src/sink; however,
+   * it won't pass-through the data
+   */
+
+  /* Processing units */
+  trans_class->transform = GST_DEBUG_FUNCPTR (gst_tensor_if_transform);
+
+  /* Negotiation units */
+  trans_class->transform_caps =
+      GST_DEBUG_FUNCPTR (gst_tensor_if_transform_caps);
+  trans_class->fixate_caps = GST_DEBUG_FUNCPTR (gst_tensor_if_fixate_caps);
+  trans_class->set_caps = GST_DEBUG_FUNCPTR (gst_tensor_if_set_caps);
+
+  /* Allocation units */
+  trans_class->transform_size =
+      GST_DEBUG_FUNCPTR (gst_tensor_if_transform_size);
+
+  /* setup sink event */
+  trans_class->sink_event = GST_DEBUG_FUNCPTR (gst_tensor_if_sink_event);
+
+  /* start/stop to call open/close */
+  trans_class->start = GST_DEBUG_FUNCPTR (gst_tensor_if_start);
+  trans_class->stop = GST_DEBUG_FUNCPTR (gst_tensor_if_stop);
+}
+
+/**
+ * @brief initialize the new element (GST Standard)
+ * instantiate pads and add them to element
+ * set pad calback functions
+ * initialize instance structure
+ */
+static void
+gst_tensor_if_init (GstTensorIf * self)
+{
+  /** @todo NYI: initialize values of self */
+  self->silent = TRUE;
+}
+
+/**
+ * @brief Function to finalize instance. (GST Standard)
+ */
+static void
+gst_tensor_if_finalize (GObject * object)
+{
+  /* GstTensorIf *self = GST_TENSOR_IF (object); */
+
+  /** @todo NYI: finialize (free-up) everything in self */
+
+  G_OBJECT_CLASS (parent_class)->finalize (object);
+}
+
+/**
+ * @brief Setter for tensor_if properties.
+ */
+static void
+gst_tensor_if_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  /* GstTensorIf *self = GST_TENSOR_IF (object); */
+  /** @todo NYI! */
+}
+
+/**
+ * @brief Getter for tensor_if properties.
+ */
+static void
+gst_tensor_if_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  /* GstTensorIf *self = GST_TENSOR_IF (object); */
+  /** @todo NYI! */
+}
+
+/**
+ * @brief non-ip transform. required vmethod of GstBaseTransform.
+ */
+static GstFlowReturn
+gst_tensor_if_transform (GstBaseTransform * trans,
+    GstBuffer * inbuf, GstBuffer * outbuf)
+{
+  /* GstTensorIf *self = GST_TENSOR_IF (object); */
+
+  return GST_FLOW_ERROR; /** @todo NYI! */
+}
+
+/**
+ * @brief configure tensor-srcpad cap from "proposed" cap. (GST Standard)
+ *
+ * @trans ("this" pointer)
+ * @direction (why do we need this?)
+ * @caps sinkpad cap (if direction GST_PAD_SINK)
+ * @if this element's cap (don't know specifically.)
+ *
+ * Be careful not to fix/set caps at this stage. Negotiation not completed yet.
+ */
+static GstCaps *
+gst_tensor_if_transform_caps (GstBaseTransform * trans,
+    GstPadDirection direction, GstCaps * caps, GstCaps * filter)
+{
+  /** @todo : SRC and SINK caps are identical! */
+  return NULL; /** @todo NYI! */
+}
+
+
+/**
+ * @brief fixate caps. required vmethod of GstBaseTransform.
+ */
+static GstCaps *
+gst_tensor_if_fixate_caps (GstBaseTransform * trans,
+    GstPadDirection direction, GstCaps * caps, GstCaps * othercaps)
+{
+  /** @todo : SRC and SINK caps are identical! */
+  return NULL; /** @todo NYI! */
+}
+
+/**
+ * @brief set caps. required vmethod of GstBaseTransform.
+ */
+static gboolean
+gst_tensor_if_set_caps (GstBaseTransform * trans,
+    GstCaps * incaps, GstCaps * outcaps)
+{
+  /** @todo : SRC and SINK caps are identical! */
+  return FALSE; /** @todo NYI! */
+}
+
+/**
+ * @brief Tell the framework the required size of buffer based on the info of the other side pad. optional vmethod of BaseTransform
+ *
+ * This is called when non-ip mode is used.
+ */
+static gboolean
+gst_tensor_if_transform_size (GstBaseTransform * trans,
+    GstPadDirection direction, GstCaps * caps, gsize size,
+    GstCaps * othercaps, gsize * othersize)
+{
+  /* GstTensorIf *self = GST_TENSOR_IF (object); */
+
+  /** @todo : SRC and SINK caps are identical! */
+  return FALSE; /** @todo NYI! */
+}
+
+/**
+ * @brief Event handler for sink pad of tensor if.
+ * @param trans "this" pointer
+ * @param event a passed event object
+ * @return TRUE if there is no error.
+ */
+static gboolean
+gst_tensor_if_sink_event (GstBaseTransform * trans, GstEvent * event)
+{
+  /* GstTensorIf *self = GST_TENSOR_IF (object); */
+
+  switch (GST_EVENT_TYPE (event)) {
+    /** @todo NYI! */
+    default:
+      break;
+  }
+
+  /** other events are handled in the default event handler */
+  return GST_BASE_TRANSFORM_CLASS (parent_class)->sink_event (trans, event);
+}
+
+/**
+ * @brief Called when the element starts processing. optional vmethod of BaseTransform
+ * @param trans "this" pointer
+ * @return TRUE if there is no error.
+ */
+static gboolean
+gst_tensor_if_start (GstBaseTransform * trans)
+{
+  /* GstTensorIf *self = GST_TENSOR_IF (object); */
+
+  return FALSE; /** @todo NYI! Do not allow to start! */
+}
+
+/**
+ * @brief Called when the element stops processing. optional vmethod of BaseTransform
+ * @param trans "this" pointer
+ * @return TRUE if there is no error.
+ */
+static gboolean
+gst_tensor_if_stop (GstBaseTransform * trans)
+{
+  /* GstTensorIf *self = GST_TENSOR_IF (object); */
+
+  return TRUE; /** @todo NYI! but, let's allow to stop! */
+}
+
+/**
+ * @brief Installs all the properties for tensor_if
+ * @param[in] gobject_class Glib object class whose properties will be set
+ */
+static void
+gst_tensor_if_install_properties (GObjectClass * gobject_class)
+{
+  g_object_class_install_property (gobject_class, PROP_SILENT,
+      g_param_spec_boolean ("silent", "Silent", "Produce verbose output",
+          FALSE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+}

--- a/gst/nnstreamer/tensor_if/gsttensorif.h
+++ b/gst/nnstreamer/tensor_if/gsttensorif.h
@@ -20,6 +20,7 @@
 #define __GST_TENSOR_IF_H__
 
 #include <gst/gst.h>
+#include <gst/base/gstbasetransform.h>
 #include <tensor_common.h>
 
 G_BEGIN_DECLS
@@ -85,7 +86,6 @@ typedef enum {
   TIFB_REPEAT_PREVIOUS_FRAME,	/**< Resend the previous output frame. If this is the first, send ZERO values. */
   TIFB_END,
 } tensor_if_behavior;
-
 
 /**
  * @brief Tensor If data structure

--- a/gst/nnstreamer/tensor_if/meson.build
+++ b/gst/nnstreamer/tensor_if/meson.build
@@ -1,0 +1,7 @@
+tensor_if_sources = [
+  'gsttensorif.c'
+]
+
+foreach s : tensor_if_sources
+  nnstreamer_sources += join_paths(meson.current_source_dir(), s)
+endforeach

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -45,7 +45,8 @@ NNSTREAMER_PLUGINS_SRCS := \
     $(NNSTREAMER_GST_HOME)/tensor_repo/tensor_reposrc.c \
     $(NNSTREAMER_GST_HOME)/tensor_sink/tensor_sink.c \
     $(NNSTREAMER_GST_HOME)/tensor_split/gsttensorsplit.c \
-    $(NNSTREAMER_GST_HOME)/tensor_transform/tensor_transform.c
+    $(NNSTREAMER_GST_HOME)/tensor_transform/tensor_transform.c \
+    $(NNSTREAMER_GST_HOME)/tensor_if/gsttensorif.c
 
 # nnstreamer c-api
 NNSTREAMER_CAPI_INCLUDES := \


### PR DESCRIPTION

Add empty functions and build infra for Tensor-If.
    
Tensor-If is a subclass of GstBaseTransform.
    
The src-pad and sink-pad are supposed to have the same
capabilities.
    
It appears that in-place op has no benefit, but
not sure if we need to prohibit it.
    
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
