### PR TITLE
[Filter/v1] Bugfix of TF-V1 subplugin API / C++ support @open sesame 4/21 10:46

### DIFF
--- a/api/capi/src/tensor_filter_single.c
+++ b/api/capi/src/tensor_filter_single.c
@@ -288,11 +288,7 @@ g_tensor_filter_single_invoke (GTensorFilterSingle * self,
     }
   }
 
-  if (GST_TF_FW_V0 (priv->fw))
-    status = priv->fw->invoke_NN
-      (&priv->prop, &priv->privateData, input, output);
-  else
-    status = priv->fw->invoke (&priv->prop, &priv->privateData, input, output);
+  GST_TF_FW_INVOKE_COMPAT (priv, status, input, output);
 
   if (status == 0)
     return TRUE;
@@ -332,7 +328,7 @@ g_tensor_filter_set_input_info (GTensorFilterSingle * self,
       status = priv->fw->setInputDimension (&priv->prop, &priv->privateData,
           in_info, out_info);
   } else {
-    status = priv->fw->getModelInfo (&priv->prop, &priv->privateData,
+    status = priv->fw->getModelInfo (priv->fw, &priv->prop, &priv->privateData,
         SET_INPUT_INFO, (GstTensorsInfo *) in_info, out_info);
   }
 

--- a/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
+++ b/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
@@ -36,8 +36,16 @@
 #define __NNS_TENSOR_FILTER_CPP_SUBPLUGIN_SUPPORT_H__
 #ifdef __cplusplus
 
+#include <stdexcept>
 #include <stdint.h>
+#include <assert.h>
 #include <nnstreamer_plugin_api_filter.h>
+#if __cplusplus < 201103L
+#warn C++11 is required for safe execution
+#else
+#include <type_traits>
+#endif
+
 
 namespace nnstreamer {
 /**
@@ -61,25 +69,73 @@ class tensor_filter_subplugin {
 
     static const GstTensorFilterFramework fwdesc_template; /**< Template for fwdesc. Each subclass or object may have different subplugin_data while the C callbacks are identical. Thus, we copy C callbacks from this template to fwdesc and let each subplugin start customizing based on fwdesc, not on fwdesc_template */
 
+    /** Helper function */
+    static inline tensor_filter_subplugin * get_tfsp_with_checks (void * ptr);
     /** tensor_filter/C wrapper functions */
     static int cpp_open (const GstTensorFilterProperties * prop, void **private_data); /**< C wrapper func, open */
     static void cpp_close (const GstTensorFilterProperties * prop, void **private_data); /**< C wrapper func, close */
-    static int cpp_invoke (const GstTensorFilterProperties *prop, void *private_data, const GstTensorMemory *input, GstTensorMemory *output); /**< C V1 wrapper func, invoke */
-    static int cpp_getFrameworkInfo (const GstTensorFilterProperties * prop, void *private_data, GstTensorFilterFrameworkInfo *fw_info); /**< C V1 wrapper func, getFrameworkInfo */
-    static int cpp_getModelInfo (const GstTensorFilterProperties * prop, void *private_data, model_info_ops ops, GstTensorsInfo *in_info, GstTensorsInfo *out_info); /**< C V1 wrapper func, getModelInfo */
-    static int cpp_eventHandler (const GstTensorFilterProperties * prop, void *private_data, event_ops ops, GstTensorFilterFrameworkEventData *data); /**< C V1 wrapper func, eventHandler */
+    static int cpp_invoke (const GstTensorFilterFramework *tf, const GstTensorFilterProperties *prop, void *private_data, const GstTensorMemory *input, GstTensorMemory *output); /**< C V1 wrapper func, invoke */
+    static int cpp_getFrameworkInfo (const GstTensorFilterFramework *tf, const GstTensorFilterProperties * prop, void *private_data, GstTensorFilterFrameworkInfo *fw_info); /**< C V1 wrapper func, getFrameworkInfo */
+    static int cpp_getModelInfo (const GstTensorFilterFramework *tf, const GstTensorFilterProperties * prop, void *private_data, model_info_ops ops, GstTensorsInfo *in_info, GstTensorsInfo *out_info); /**< C V1 wrapper func, getModelInfo */
+    static int cpp_eventHandler (const GstTensorFilterFramework *tf, const GstTensorFilterProperties * prop, void *private_data, event_ops ops, GstTensorFilterFrameworkEventData *data); /**< C V1 wrapper func, eventHandler */
 
     GstTensorFilterFramework fwdesc; /**< Represents C/V1 wrapper for the derived class and its objects. Derived should not access this anyway; the base class will handle this with the C wrapper functions, base static-functions, and base constructors/destructors. */
 
   protected: /** Derived classes should call these at init/exit */
+/**
+ * @brief Register the subplugin "derived" class.
+ * @detail A derived class MUST register itself with this function in order
+ *         to be available for nnstreamer pipelines, i.e., at its init().
+ *         The derived class type should be the template typename.
+ * @retval Returns an "emptyInstnace" of the derived class. It is recommended
+ *         to keep the object and feed to the unregister function.
+ */
     template<typename T>
-    static T * register_subplugin ();
-        /**< Register this subplugin class (not object) (usually at so-init)
-          * @retval: an empty instance for unregister_subplugin */
+    static T * register_subplugin () {
+#if __cplusplus < 201103L
+#warn C++11 is required for safe execution
+#else
+      /** The given class T should be derived from tensor_filter_subplugin */
+      assert ((std::is_base_of<tensor_filter_subplugin, T>::value));
+#endif
+      T *emptyInstance = new T();
 
+      assert (emptyInstance);
+      memcpy (&emptyInstance->fwdesc, &fwdesc_template,
+          sizeof (fwdesc_template));
+      emptyInstance->fwdesc.subplugin_data = emptyInstance;
+      nnstreamer_filter_probe (&emptyInstance->fwdesc);
+
+      return emptyInstance;
+    }
+
+/**
+ * @brief Unregister the registered "derived" class.
+ * @detail The registered derived class may unregister itself if it can
+ *         guarantee that the class won't be used anymore; i.e., at its exit().
+ *         The derived class type should be the template typename.
+ * @param [in] emptyInstance An emptyInstance that mey be "delete"d by this
+ *             function. It may be created by getEmptyInstance() or the one
+ *             created by register_subplugin(); It is recommended to keep
+ *             the object created by register_subplugin() and feed it to
+ *             unregister_subplugin().
+ */
     template<typename T>
-    static void unregister_subplugin (T * emptyInstance);
-        /**< Unregister this subplugin class (not object) (usually at so-exit) */
+    static void unregister_subplugin (T * emptyInstance) {
+      GstTensorFilterFrameworkInfo info;
+#if __cplusplus < 201103L
+#warn C++11 is required for safe execution
+#else
+      /** The given class T should be derived from tensor_filter_subplugin */
+      assert ((std::is_base_of<tensor_filter_subplugin, T>::value));
+#endif
+      assert (emptyInstance);
+
+      emptyInstance->getFrameworkInfo (info);
+      nnstreamer_filter_exit (info.name);
+
+      delete emptyInstance;
+    }
 
   public:
     /*************************************************************
@@ -95,18 +151,27 @@ class tensor_filter_subplugin {
 
     virtual void configure_instance (const GstTensorFilterProperties *prop) = 0;
         /**< Configure a non-functional "empty" object as a
-             functional "filled" object ready to be invoked */
+             functional "filled" object ready to be invoked.
+
+             Possible exceptions: ... @todo describe them!
+         */
 
     virtual ~tensor_filter_subplugin (); /**< called by Close */
 
-    virtual int invoke (const GstTensorMemory &input, GstTensorMemory &output) = 0;
-        /**< Mandatory virtual method.  Invoke NN */
+    virtual void invoke (const GstTensorMemory *input, GstTensorMemory *output) = 0;
+        /**< Mandatory virtual method.  Invoke NN.
 
-    virtual int getFrameworkInfo (GstTensorFilterFrameworkInfo &info) = 0;
+             Possible exceptions: ... @todo describe them!
+         */
+
+    virtual void getFrameworkInfo (GstTensorFilterFrameworkInfo &info) = 0;
         /**< Mandatory virtual method.
           * An empty instance created by derived() should support this with
           * its default info value.
           * "name" property of info should NEVER be changed.
+          * info.name is deleted and reallocated if info.name is not null.
+          *
+          * Possible exceptions: ... @todo describe them!
           */
 
     virtual int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info) = 0;
@@ -114,10 +179,16 @@ class tensor_filter_subplugin {
           *  For a given opened model (an instance of the derived class),
           * provide input/output dimensions.
           *  At least one of the two possible ops should be available.
-          *  Return -ENOENT if an operation is not available */
+          *  Return -ENOENT if the ops is not available by this object
+          *  Return -EINVAL if it is an invalid request.
+          */
 
     virtual int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data);
-        /**< Optional. If not implemented, no event is handled */
+        /**< Optional. If not implemented, no event is handled
+          *  Return -ENOENT if the ops is not to be handled by this object
+          *                 (e.g., let the framework do "free")
+          *  Return -EINVAL if it is an invalid request.
+          */
 };
 
 } /* namespace nnstreamer */

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -1,17 +1,7 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * NNStreamer API for Tensor_Filter Sub-Plugins
  * Copyright (C) 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation;
- * version 2.1 of the License.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Library General Public License for more details.
- *
  */
 /**
  * @file  nnstreamer_plugin_api_filter.h
@@ -175,12 +165,12 @@ typedef struct _GstTensorFilterProperties
  */
 typedef struct _GstTensorFilterFrameworkInfo
 {
-  const char *name; /**< Name of the neural network framework, searchable by FRAMEWORK property */
+  const char *name; /**< Name of the neural network framework, searchable by FRAMEWORK property. Subplugin is supposed to allocate/deallocate. */
   int allow_in_place; /**< TRUE(nonzero) if InPlace transfer of input-to-output is allowed. Not supported in main, yet */
   int allocate_in_invoke; /**< TRUE(nonzero) if invoke_NN is going to allocate outputptr by itself and return the address via outputptr. Do not change this value after cap negotiation is complete (or the stream has been started). */
   int run_without_model; /**< TRUE(nonzero) when the neural network framework does not need a model file. Tensor-filter will run invoke_NN without model. */
   int verify_model_path; /**< TRUE(nonzero) when the NNS framework, not the sub-plugin, should verify the path of model files. */
-  accl_hw *hw_list; /**< List of supported hardwares by the framework.  Positive response of this check does not guarantee successful running of model with this accelerator. */
+  const accl_hw *hw_list; /**< List of supported hardwares by the framework.  Positive response of this check does not guarantee successful running of model with this accelerator. Subplugin is supposed to allocate/deallocate. */
   int num_hw; /**< number of hardware accelerators in the hw_list supported by the framework */
 } GstTensorFilterFrameworkInfo;
 
@@ -458,7 +448,7 @@ struct _GstTensorFilterFramework
        * @param[in/out] data user sata for the supported handlers (can be NULL)
        * @return 0 if OK. non-zero if error. -ENOENT if operation is not supported. -EINVAL if operation is supported but provided arguments are invalid.
        */
-      void *subplugin_data; /**< A subplugin may store its own private global data here as well. Do not store data of each instance here, it is shared across all instances of a subplugin. */
+      void *subplugin_data; /**< This is used by tensor_filter infrastructure. Subplugin authors should NEVER update this. Only the files in /gst/nnstreamer/tensor_filter/ are allowed to access this. */
     }
 #ifdef __NO_ANONYMOUS_NESTED_STRUCT
         v1

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -246,6 +246,8 @@ typedef struct _GstTensorFilterFrameworkEventData
   };
 } GstTensorFilterFrameworkEventData;
 
+typedef struct _GstTensorFilterFramework GstTensorFilterFramework;
+
 /**
  * @brief Tensor_Filter Subplugin definition
  *
@@ -253,7 +255,7 @@ typedef struct _GstTensorFilterFrameworkEventData
  * prop Filter properties. Read Only.
  * private_data Subplugin's private data. Set this (*private_data = XXX) if you want to change filter->private_data.
  */
-typedef struct _GstTensorFilterFramework
+struct _GstTensorFilterFramework
 {
   uint64_t version;
   /**< Version of the struct
@@ -387,7 +389,8 @@ typedef struct _GstTensorFilterFramework
      */
     struct /** _GstTensorFilterFramework_v1 */
     {
-      int (*invoke) (const GstTensorFilterProperties * prop, void *private_data,
+      int (*invoke) (const GstTensorFilterFramework * self,
+          const GstTensorFilterProperties * prop, void *private_data,
           const GstTensorMemory * input, GstTensorMemory * output);
       /**< Mandatory callback. Invoke the given network model.
        *
@@ -398,8 +401,9 @@ typedef struct _GstTensorFilterFramework
        * @return 0 if OK. non-zero if error.
        */
 
-      int (*getFrameworkInfo) (const GstTensorFilterProperties * prop,
-          void *private_data, GstTensorFilterFrameworkInfo *fw_info);
+      int (*getFrameworkInfo) (const GstTensorFilterFramework * self,
+          const GstTensorFilterProperties * prop, void *private_data,
+	  GstTensorFilterFrameworkInfo *fw_info);
       /**< Mandatory callback. Get the frameworks statically determined info. Argument 'private_data' can be NULL. If provided 'private_data' is not NULL, then some info, such as 'allocate_in_invoke', can be updated based on the model being used (inferred from the 'private_data' provided). This updated info is useful for custom filter, as some custom filter's ability to support 'allocate_in_invoke' depends on the opened model.
        *
        * @param[in] prop read-only property values
@@ -410,7 +414,8 @@ typedef struct _GstTensorFilterFramework
        * @note CAUTION: private_data can be NULL if the framework is not yet opened by the caller.
        */
 
-      int (*getModelInfo) (const GstTensorFilterProperties * prop,
+      int (*getModelInfo) (const GstTensorFilterFramework * self,
+          const GstTensorFilterProperties * prop,
           void *private_data, model_info_ops ops,
           GstTensorsInfo *in_info, GstTensorsInfo *out_info);
       /**< Mandatory callback. Gets the model related tensor info.
@@ -434,7 +439,8 @@ typedef struct _GstTensorFilterFramework
        * @return 0 if OK. non-zero if error. -ENOENT is operation is not supported.
        */
 
-      int (*eventHandler) (const GstTensorFilterProperties * prop,
+      int (*eventHandler) (const GstTensorFilterFramework * self,
+          const GstTensorFilterProperties * prop,
           void *private_data, event_ops ops, GstTensorFilterFrameworkEventData * data);
       /**< Mandatory callback. Runs the event corresponding to the passed operation.
        * If ops == DESTROY_NOTIFY: tensor_filter.c will call it when 'allocate_in_invoke' property of the framework is TRUE. Basically, it is called when the data element is destroyed. If it's set as NULL, g_free() will be used as a default. It will be helpful when the data pointer is included as an object of a nnfw. For instance, if the data pointer is removed when the object is gone, it occurs error. In this case, the objects should be maintained for a while first and destroyed when the data pointer is destroyed. Those kinds of logic could be defined at this method.
@@ -459,7 +465,7 @@ typedef struct _GstTensorFilterFramework
 #endif
     ;
   };
-} GstTensorFilterFramework;
+};
 
 /* extern functions for subplugin management, exist in tensor_filter.c */
 /**

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -320,7 +320,7 @@ gst_tensor_filter_destroy_notify (void *data)
     priv->fw->destroyNotify (&priv->privateData, tensor_data);
   } else if (GST_TF_FW_V1 (priv->fw)) {
     event_data.data = tensor_data;
-    if (priv->fw->eventHandler (&priv->prop, &priv->privateData,
+    if (priv->fw->eventHandler (priv->fw, &priv->prop, priv->privateData,
             DESTROY_NOTIFY, &event_data) == -ENOENT) {
       g_free (tensor_data);
     }
@@ -407,10 +407,8 @@ gst_tensor_filter_transform (GstBaseTransform * trans,
   }
 
   /* 3. Call the filter-subplugin callback, "invoke" */
-  if (GST_TF_FW_V0 (priv->fw))
-    gst_tensor_filter_call (priv, ret, invoke_NN, in_tensors, out_tensors);
-  else
-    gst_tensor_filter_call (priv, ret, invoke, in_tensors, out_tensors);
+  GST_TF_FW_INVOKE_COMPAT (priv, ret, in_tensors, out_tensors);
+
   /** @todo define enum to indicate status code */
   g_assert (ret >= 0);
 
@@ -529,10 +527,10 @@ gst_tensor_filter_configure_tensor (GstTensorFilter * self,
 
       gst_tensors_info_init (&out_info);
       if (GST_TF_FW_V0 (priv->fw)) {
-        gst_tensor_filter_call (priv, res, setInputDimension, &in_config.info,
-            &out_info);
+        gst_tensor_filter_v0_call (priv, res, setInputDimension,
+            &in_config.info, &out_info);
       } else {
-        gst_tensor_filter_call (priv, res, getModelInfo, SET_INPUT_INFO,
+        gst_tensor_filter_v1_call (priv, res, getModelInfo, SET_INPUT_INFO,
             &in_config.info, &out_info);
       }
 
@@ -688,10 +686,10 @@ gst_tensor_filter_transform_caps (GstBaseTransform * trans,
         /* call setInputDimension with given input tensor */
         gst_tensors_info_init (&out_info);
         if (GST_TF_FW_V0 (priv->fw)) {
-          gst_tensor_filter_call (priv, res, setInputDimension, &config.info,
-              &out_info);
+          gst_tensor_filter_v0_call (priv, res, setInputDimension,
+              &config.info, &out_info);
         } else {
-          gst_tensor_filter_call (priv, res, getModelInfo, SET_INPUT_INFO,
+          gst_tensor_filter_v1_call (priv, res, getModelInfo, SET_INPUT_INFO,
               &config.info, &out_info);
         }
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -45,11 +45,29 @@
 /**
  * @brief Invoke callbacks of nn framework. Guarantees calling open for the first call.
  */
-#define gst_tensor_filter_call(priv,ret,funcname,...) do { \
+#define gst_tensor_filter_v0_call(priv,ret,funcname,...) do { \
       gst_tensor_filter_common_open_fw (priv); \
       ret = -1; \
-      if (priv->prop.fw_opened && priv->fw && priv->fw->funcname) { \
-        ret = priv->fw->funcname (&priv->prop, &priv->privateData, __VA_ARGS__); \
+      if ((priv)->prop.fw_opened && (priv)->fw && (priv)->fw->funcname) { \
+        ret = (priv)->fw->funcname (&(priv)->prop, &(priv)->privateData, __VA_ARGS__); \
+      } \
+    } while (0)
+
+#define gst_tensor_filter_v1_call(priv,ret,funcname,...) do { \
+      gst_tensor_filter_common_open_fw (priv); \
+      ret = -1; \
+      if ((priv)->prop.fw_opened && (priv)->fw && (priv)->fw->funcname) { \
+        ret = (priv)->fw->funcname ((priv)->fw, &(priv)->prop, (priv)->privateData, __VA_ARGS__); \
+      } \
+    } while (0)
+
+#define GST_TF_FW_INVOKE_COMPAT(priv,ret,in,out) do { \
+      if (GST_TF_FW_V0 ((priv)->fw)) { \
+        ret = priv->fw->invoke_NN (&(priv)->prop, &(priv)->privateData, (in), (out)); \
+      } else if (GST_TF_FW_V1 ((priv)->fw)) { \
+        ret = priv->fw->invoke ((priv)->fw, &(priv)->prop, (priv)->privateData, (in), (out)); \
+      } else { \
+        g_assert(FALSE); \
       } \
     } while (0)
 


### PR DESCRIPTION
By testing with C++ class tf-subplugin, "edget-tpu",
bugs were found from the recently introduced TF-V1 subplugin API.

- V1 APIs uses void * private_data instead of void ** private_data.
  There are codes that do not reflect this.

In order to make C++ class subplugins work smoothly,
they need to know "this" pointer when they were invoked
by common C++ wrapper infrastructure, which is a set of
static functions of the base class.

Thus, add a new argument for them to find out "this" pointer.

CC: @kparichay

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

ps. This breaks C++ subplugin classes, which are, fortunately, not built by default yet. C++ subplugin classes will be working after PR #2194 (it has fixes)