### PR TITLE
[README] Fix badge is not updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # NNStreamer
 
 [![Gitter][gitter-image]][gitter-url] 
-[![Code Coverage](http://nnsuite.mooo.com/nnstreamer/ci/badge/codecoverage.svg)](http://nnsuite.mooo.com/nnstreamer/ci/gcov_html/index.html) 
+[![Code Coverage](http://nnsuite.mooo.com/nnstreamer/ci/badge/codecoverage.svg?sanitize=true)](http://nnsuite.mooo.com/nnstreamer/ci/gcov_html/index.html) 
 <a href="https://scan.coverity.com/projects/nnsuite-nnstreamer">
 <img alt="Coverity Scan Defect Status" src="https://img.shields.io/endpoint?url=https://nnsuite.mooo.com/nnstreamer/ci/badge/badge_coverity.json" />
 </a> 
-[![DailyBuild](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/daily_build_badge.svg)](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/build_result/)
+[![DailyBuild](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/daily_build_badge.svg?sanitize=true)](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/build_result/)
 ![GitHub repo size](https://img.shields.io/github/repo-size/nnstreamer/nnstreamer)
 ![GitHub issues](https://img.shields.io/github/issues/nnstreamer/nnstreamer)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/nnstreamer/nnstreamer)


### PR DESCRIPTION
Since badge is cached in github, badge is not updated.
For example, current coverage is 83.7%, however, badge on NNStreamer mainpage indicated old value.

Reference : https://stackoverflow.com/questions/13808020/include-an-svg-hosted-on-github-in-markdown/16462143#16462143

Related issure : https://github.com/isaacs/github/issues/316

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>
