### PR TITLE
[Android] initialize native code

### DIFF
--- a/api/android/api/src/main/jni/nnstreamer-native-api.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-api.c
@@ -48,6 +48,11 @@ extern void init_filter_nnfw (void);
 #endif
 
 /**
+ * @brief External function from GStreamer Android.
+ */
+extern void gst_android_init (JNIEnv * env, jobject context);
+
+/**
  * @brief Global lock for native functions.
  */
 G_LOCK_DEFINE_STATIC (nns_native_lock);
@@ -632,6 +637,9 @@ nnstreamer_native_initialize (JNIEnv * env, jobject context)
   nns_logi ("Called native initialize.");
 
   G_LOCK (nns_native_lock);
+
+  if (!gst_is_initialized ())
+    gst_android_init (env, context);
 
   if (!gst_is_initialized ()) {
     nns_loge ("GStreamer is not initialized.");

--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -308,7 +308,6 @@ if [[ -e "$nnstreamer_android_api_lib" ]]; then
     fi
 
     cp -r api/src/main/java/org/freedesktop/* main/java/org/freedesktop
-    cp -r api/src/main/java/org/nnsuite/nnstreamer/NNStreamer.java main/java/org/nnsuite/nnstreamer
     cp -r aar_extracted/jni/* main/jni/nnstreamer/lib
     cp external/Android-nnstreamer-prebuilt.mk main/jni
     # header for C-API


### PR DESCRIPTION
For C-API developers, add gst-init in native code.
Calling initialize() in java is unnecessary.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
