### PR TITLE
[Bug] Do not call essential ops in assert(). @open sesame 4/18 12:34

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -922,6 +922,7 @@ bb_decode (void **pdata, const GstTensorsConfig * config,
   GstMemory *out_mem;
   GArray *results = NULL;
   const int num_tensors = config->info.num_tensors;
+  gboolean status;
 
   g_assert (outbuf);
   /* Ensure we have outbuf properly allocated */
@@ -933,7 +934,8 @@ bb_decode (void **pdata, const GstTensorsConfig * config,
     }
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
-  g_assert (gst_memory_map (out_mem, &out_info, GST_MAP_WRITE));
+  status = gst_memory_map (out_mem, &out_info, GST_MAP_WRITE);
+  g_assert (status);
 
   /** reset the buffer with alpha 0 / black */
   memset (out_info.data, 0, size);

--- a/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
@@ -150,6 +150,7 @@ dv_decode (void **pdata, const GstTensorsConfig * config,
   /* Direct video uses the first tensor only even if it's multi-tensor */
   const uint32_t *dim = &(config->info.info[0].dimension[0]);
   size_t size = _get_video_xraw_bufsize (dim);
+  gboolean status;
 
   g_assert (outbuf);
   if (gst_buffer_get_size (outbuf) > 0 && gst_buffer_get_size (outbuf) != size) {
@@ -163,7 +164,8 @@ dv_decode (void **pdata, const GstTensorsConfig * config,
   } else {
     out_mem = gst_allocator_alloc (NULL, size, NULL);
   }
-  g_assert (gst_memory_map (out_mem, &out_info, GST_MAP_WRITE));
+  status = gst_memory_map (out_mem, &out_info, GST_MAP_WRITE);
+  g_assert (status);
 
   if (0 == ((dim[0] * dim[1]) % 4)) {
     /* No Padding Required */

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
@@ -233,6 +233,7 @@ il_decode (void **pdata, const GstTensorsConfig * config,
   ImageLabelData *data = *pdata;
   GstMapInfo out_info;
   GstMemory *out_mem;
+  gboolean status;
 
   gsize bpe = gst_tensor_get_element_size (config->info.info[0].type);
   tensor_element max_val;
@@ -279,7 +280,8 @@ il_decode (void **pdata, const GstTensorsConfig * config,
     }
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
-  g_assert (gst_memory_map (out_mem, &out_info, GST_MAP_WRITE));
+  status = gst_memory_map (out_mem, &out_info, GST_MAP_WRITE);
+  g_assert (status);
 
   memcpy (out_info.data, str, size);
 

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
@@ -314,6 +314,7 @@ is_decode (void **pdata, const GstTensorsConfig * config,
   const size_t size = idata->width * idata->height * RGBA_CHANNEL;
   GstMapInfo out_info;
   GstMemory *out_mem;
+  gboolean status;
 
   /* init image segments if seg map is null */
   if (idata->segment_map == NULL) {
@@ -330,7 +331,8 @@ is_decode (void **pdata, const GstTensorsConfig * config,
     }
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
-  g_assert (gst_memory_map (out_mem, &out_info, GST_MAP_WRITE));
+  status = gst_memory_map (out_mem, &out_info, GST_MAP_WRITE);
+  g_assert (status);
 
   memset (out_info.data, 0, size);
 

--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -456,6 +456,7 @@ pose_decode (void **pdata, const GstTensorsConfig * config,
   const GstTensorMemory *detections = NULL;
   float *arr;
   int index, i, j;
+  gboolean status;
 
   g_assert (outbuf);
   /* Ensure we have outbuf properly allocated */
@@ -467,7 +468,8 @@ pose_decode (void **pdata, const GstTensorsConfig * config,
     }
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
-  g_assert (gst_memory_map (out_mem, &out_info, GST_MAP_WRITE));
+  status = gst_memory_map (out_mem, &out_info, GST_MAP_WRITE);
+  g_assert (status);
   /** reset the buffer with alpha 0 / black */
   memset (out_info.data, 0, size);
 

--- a/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
+++ b/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
@@ -567,6 +567,7 @@ gst_tensor_aggregator_concat (GstTensorAggregator * self, GstBuffer * outbuf,
   gsize block_size;
   gsize src_idx, dest_idx;
   gsize frame_size;
+  gboolean status;
 
   frame_size = gst_tensor_info_get_size (info);
   g_assert (frame_size > 0);
@@ -574,8 +575,10 @@ gst_tensor_aggregator_concat (GstTensorAggregator * self, GstBuffer * outbuf,
   srcbuf = gst_buffer_copy (outbuf);
   outbuf = gst_buffer_make_writable (outbuf);
 
-  g_assert (gst_buffer_map (srcbuf, &src_info, GST_MAP_READ));
-  g_assert (gst_buffer_map (outbuf, &dest_info, GST_MAP_WRITE));
+  status = gst_buffer_map (srcbuf, &src_info, GST_MAP_READ);
+  g_assert (status);
+  status = gst_buffer_map (outbuf, &dest_info, GST_MAP_WRITE);
+  g_assert (status);
 
   /**
    * Concatenate output buffer with given axis (frames-dim)

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -728,12 +728,15 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
         int d0, d1;
         unsigned int src_idx = 0, dest_idx = 0;
         size_t size, offset;
+        gboolean status;
 
         inbuf = gst_buffer_new_and_alloc (frame_size);
         gst_buffer_memset (inbuf, 0, 0, frame_size);
 
-        g_assert (gst_buffer_map (buf, &src_info, GST_MAP_READ));
-        g_assert (gst_buffer_map (inbuf, &dest_info, GST_MAP_WRITE));
+        status = gst_buffer_map (buf, &src_info, GST_MAP_READ);
+        g_assert (status);
+        status = gst_buffer_map (inbuf, &dest_info, GST_MAP_WRITE);
+        g_assert (status);
 
         /**
          * Refer: https://gstreamer.freedesktop.org/documentation/design/mediatype-video-raw.html
@@ -774,14 +777,17 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
       frames_in = 1;
 
       if (buf_size != frame_size) {
+        gboolean status;
         GstMapInfo src_info, dest_info;
         gsize block_size = MIN (buf_size, frame_size);
 
         inbuf = gst_buffer_new_and_alloc (frame_size);
         gst_buffer_memset (inbuf, 0, 0, frame_size);
 
-        g_assert (gst_buffer_map (buf, &src_info, GST_MAP_READ));
-        g_assert (gst_buffer_map (inbuf, &dest_info, GST_MAP_WRITE));
+        status = gst_buffer_map (buf, &src_info, GST_MAP_READ);
+        g_assert (status);
+        status = gst_buffer_map (inbuf, &dest_info, GST_MAP_WRITE);
+        g_assert (status);
 
         memcpy (dest_info.data, src_info.data, block_size);
 

--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -460,6 +460,7 @@ gst_tensordec_set_property (GObject * object, guint prop_id,
       const GstTensorDecoderDef *decoder;
       const gchar *mode_string;
       guint i;
+      int status;
 
       mode_string = g_value_get_string (value);
       decoder = nnstreamer_decoder_find (mode_string);
@@ -479,7 +480,9 @@ gst_tensordec_set_property (GObject * object, guint prop_id,
           self->decoder = decoder;
         }
 
-        g_assert (self->decoder->init (&self->plugin_data));
+        status = self->decoder->init (&self->plugin_data);
+        /** @todo Do proper error handling */
+        g_assert (status);
 
         for (i = 0; i < TensorDecMaxOpNum; i++)
           if (!gst_tensordec_process_plugin_options (self, i))
@@ -656,6 +659,7 @@ gst_tensordec_transform (GstBaseTransform * trans,
 {
   GstTensorDec *self;
   GstFlowReturn res;
+  gboolean status;
 
   self = GST_TENSOR_DECODER_CAST (trans);
 
@@ -675,7 +679,8 @@ gst_tensordec_transform (GstBaseTransform * trans,
 
     for (i = 0; i < num_tensors; i++) {
       in_mem[i] = gst_buffer_peek_memory (inbuf, i);
-      g_assert (gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ));
+      status = gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ);
+      g_assert (status);
 
       input[i].data = in_info[i].data;
       input[i].size = in_info[i].size;

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -375,8 +375,11 @@ gst_tensor_filter_transform (GstBaseTransform * trans,
   g_assert (gst_buffer_n_memory (inbuf) == prop->input_meta.num_tensors);
 
   for (i = 0; i < prop->input_meta.num_tensors; i++) {
+    gboolean status;
     in_mem[i] = gst_buffer_peek_memory (inbuf, i);
-    g_assert (gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ));
+    status = gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ);
+    g_assert (status);
+    /** @todo Do proper error handling (clean up and error return) */
 
     in_tensors[i].data = in_info[i].data;
     in_tensors[i].size = in_info[i].size;
@@ -388,6 +391,7 @@ gst_tensor_filter_transform (GstBaseTransform * trans,
   g_assert (gst_buffer_get_size (outbuf) == 0);
 
   for (i = 0; i < prop->output_meta.num_tensors; i++) {
+    gboolean status;
     out_tensors[i].data = NULL;
     out_tensors[i].size = gst_tensor_filter_get_output_size (self, i);
     out_tensors[i].type = prop->output_meta.info[i].type;
@@ -395,7 +399,8 @@ gst_tensor_filter_transform (GstBaseTransform * trans,
     /* allocate memory if allocate_in_invoke is FALSE */
     if (allocate_in_invoke == FALSE) {
       out_mem[i] = gst_allocator_alloc (NULL, out_tensors[i].size, NULL);
-      g_assert (gst_memory_map (out_mem[i], &out_info[i], GST_MAP_WRITE));
+      status = gst_memory_map (out_mem[i], &out_info[i], GST_MAP_WRITE);
+      g_assert (status);
 
       out_tensors[i].data = out_info[i].data;
     }

--- a/gst/nnstreamer/tensor_merge/gsttensormerge.c
+++ b/gst/nnstreamer/tensor_merge/gsttensormerge.c
@@ -479,6 +479,7 @@ gst_tensor_merge_generate_mem (GstTensorMerge * tensor_merge,
   gsize element_size;
   tensor_dim dim;
   tensor_type type;
+  gboolean status;
 
   memcpy (&dim, &tensor_merge->tensors_config.info.info[0].dimension,
       sizeof (tensor_dim));
@@ -487,12 +488,14 @@ gst_tensor_merge_generate_mem (GstTensorMerge * tensor_merge,
 
   for (i = 0; i < num_mem; i++) {
     mem[i] = gst_buffer_peek_memory (tensors_buf, i);
-    g_assert (gst_memory_map (mem[i], &mInfo[i], GST_MAP_READ));
+    status = gst_memory_map (mem[i], &mInfo[i], GST_MAP_READ);
+    g_assert (status); /** @todo Do proper error handling */
     outSize += mInfo[i].size;
   }
 
   outMem = gst_allocator_alloc (NULL, outSize, NULL);
-  g_assert (gst_memory_map (outMem, &outInfo, GST_MAP_WRITE));
+  status = gst_memory_map (outMem, &outInfo, GST_MAP_WRITE);
+  g_assert (status); /** @todo Do proper error handling */
   outptr = outInfo.data;
 
   switch (tensor_merge->mode) {
@@ -654,6 +657,7 @@ gst_tensor_merge_collected (GstCollectPads * pads,
     if (gst_tensor_merge_get_merged_config (tensor_merge,
             &tensor_merge->tensors_config, &config)) {
       g_assert (gst_tensor_config_validate (&config));
+      /** @todo Do proper error handling */
       newcaps = gst_tensor_caps_from_config (&config);
     } else {
       goto nego_error;

--- a/gst/nnstreamer/tensor_mux/gsttensormux.c
+++ b/gst/nnstreamer/tensor_mux/gsttensormux.c
@@ -372,6 +372,7 @@ gst_tensor_mux_collected (GstCollectPads * pads, GstTensorMux * tensor_mux)
   GstClockTime dts_time = GST_CLOCK_TIME_NONE;
   GstClockTime time = 0;
   gboolean isEOS = FALSE;
+  gboolean status;
   GST_DEBUG_OBJECT (tensor_mux, " all pads are collected ");
   if (tensor_mux->need_stream_start) {
     gchar s_id[32];
@@ -408,7 +409,10 @@ gst_tensor_mux_collected (GstCollectPads * pads, GstTensorMux * tensor_mux)
           gst_buffer_n_memory (tensors_buf);
     }
 
-    g_assert (gst_tensors_config_validate (&tensor_mux->tensors_config));
+    status = gst_tensors_config_validate (&tensor_mux->tensors_config);
+    if (FALSE == status)
+      return GST_FLOW_ERROR;
+
     newcaps = gst_tensors_caps_from_config (&tensor_mux->tensors_config);
 
     if (!gst_pad_set_caps (tensor_mux->srcpad, newcaps)) {

--- a/gst/nnstreamer/tensor_repo/tensor_reposrc.c
+++ b/gst/nnstreamer/tensor_repo/tensor_reposrc.c
@@ -310,10 +310,12 @@ gst_tensor_reposrc_gen_dummy_buffer (GstTensorRepoSrc * self)
   num_tensors = self->config.info.num_tensors;
 
   for (i = 0; i < num_tensors; i++) {
+    gboolean status;
     size = gst_tensor_info_get_size (&self->config.info.info[i]);
     mem = gst_allocator_alloc (NULL, size, NULL);
 
-    g_assert (gst_memory_map (mem, &info, GST_MAP_WRITE));
+    status = gst_memory_map (mem, &info, GST_MAP_WRITE);
+    g_assert (status); /** @todo Do proper error handling (err return) */
     memset (info.data, 0, size);
     gst_memory_unmap (mem, &info);
 

--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -1211,6 +1211,7 @@ gst_tensor_src_iio_set_property (GObject * object, guint prop_id,
         gint64 val;
         gchar **strv;
         gchar *endptr = NULL;
+        gboolean status;
 
         /**
          * using direct as we only need to store keys
@@ -1230,8 +1231,9 @@ gst_tensor_src_iio_set_property (GObject * object, guint prop_id,
             self->custom_channel_table = NULL;
             break;
           }
-          g_assert (g_hash_table_insert (self->custom_channel_table,
-                  GINT_TO_POINTER (val), NULL));
+          status = g_hash_table_insert (self->custom_channel_table,
+              GINT_TO_POINTER (val), NULL);
+          g_assert (status);
         }
         self->channels_enabled = CHANNELS_ENABLED_CUSTOM;
         g_strfreev (strv);

--- a/gst/nnstreamer/tensor_split/gsttensorsplit.c
+++ b/gst/nnstreamer/tensor_split/gsttensorsplit.c
@@ -412,6 +412,7 @@ gst_tensor_split_get_splited (GstTensorSplit * split, GstBuffer * buffer,
   int i;
   gsize size, offset;
   GstMapInfo src_info, dest_info;
+  gboolean status;
 
   size = 0;
   offset = 0;
@@ -420,8 +421,10 @@ gst_tensor_split_get_splited (GstTensorSplit * split, GstBuffer * buffer,
   size += gst_tensor_get_element_count (*dim) *
       gst_tensor_get_element_size (split->sink_tensor_conf.info.type);
   mem = gst_allocator_alloc (NULL, size, NULL);
-  g_assert (gst_memory_map (mem, &dest_info, GST_MAP_WRITE));
-  g_assert (gst_buffer_map (buffer, &src_info, GST_MAP_READ));
+  status = gst_memory_map (mem, &dest_info, GST_MAP_WRITE);
+  g_assert (status);
+  status = gst_buffer_map (buffer, &src_info, GST_MAP_READ);
+  g_assert (status);
 
   for (i = 0; i < nth; i++) {
     dim = g_array_index (split->tensorseg, tensor_dim *, i);

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -1388,14 +1388,17 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
 {
   GstFlowReturn res;
   GstTensorTransform *filter = GST_TENSOR_TRANSFORM_CAST (trans);
+  gboolean status;
 
   uint8_t *inptr, *outptr;
   GstMapInfo inInfo, outInfo;
 
   g_return_val_if_fail (filter->loaded, GST_FLOW_ERROR);
 
-  g_assert (gst_buffer_map (inbuf, &inInfo, GST_MAP_READ));
-  g_assert (gst_buffer_map (outbuf, &outInfo, GST_MAP_WRITE));
+  status = gst_buffer_map (inbuf, &inInfo, GST_MAP_READ);
+  g_assert (status);
+  status = gst_buffer_map (outbuf, &outInfo, GST_MAP_WRITE);
+  g_assert (status);
 
   inptr = inInfo.data;
   outptr = outInfo.data;


### PR DESCRIPTION
Some systems may use NDEBUG and skip all assert calls.
Do not call essential ops in there.

Fixes #2282

Reported-by: @ndufresne
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

