### PR TITLE
Error return instead of assert for external errors.

### DIFF
--- a/ext/nnstreamer/android_source/gstamcsrc_looper.cc
+++ b/ext/nnstreamer/android_source/gstamcsrc_looper.cc
@@ -26,7 +26,6 @@
 #include "gstamcsrc.h"
 #include "gstamcsrc_looper.h"
 
-#include <assert.h>
 #include <jni.h>
 #include <pthread.h>
 #include <stdio.h>

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
@@ -33,6 +33,7 @@
 #include <gst/gstinfo.h>
 #include <nnstreamer_plugin_api_decoder.h>
 #include <nnstreamer_plugin_api.h>
+#include <nnstreamer_log.h>
 #include "tensordecutil.h"
 
 void init_il (void) __attribute__ ((constructor));
@@ -161,7 +162,6 @@ il_decode (void **pdata, const GstTensorsConfig * config,
   ImageLabelData *data = *pdata;
   GstMapInfo out_info;
   GstMemory *out_mem;
-  gboolean status;
 
   gsize bpe = gst_tensor_get_element_size (config->info.info[0].type);
   tensor_element max_val;
@@ -208,8 +208,10 @@ il_decode (void **pdata, const GstTensorsConfig * config,
     }
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
-  status = gst_memory_map (out_mem, &out_info, GST_MAP_WRITE);
-  g_assert (status);
+  if (FALSE == gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+    ml_loge ("Cannot map output memory / tensordec-imagelabel.\n");
+    return GST_FLOW_ERROR;
+  }
 
   memcpy (out_info.data, str, size);
 

--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -241,7 +241,7 @@ static void
 _g_list_foreach_vstr_helper (gpointer data, gpointer user_data)
 {
   vstr_helper *helper = (vstr_helper *) user_data;
-  g_assert (helper->cursor < helper->size);
+  g_assert (helper->cursor < helper->size); /** library error? internal logic error? */
   helper->vstr[helper->cursor] = data;
   helper->cursor++;
 }
@@ -276,9 +276,9 @@ _fill_in_vstr (gchar *** fullpath_vstr, gchar *** basename_vstr,
   lstB = g_slist_reverse (lstB);
 
   *fullpath_vstr = g_malloc0_n (counter + 1, sizeof (gchar *));
-  g_assert (*fullpath_vstr != NULL);
+  g_assert (*fullpath_vstr != NULL);    /* This won't happen, but doesn't hurt either */
   *basename_vstr = g_malloc0_n (counter + 1, sizeof (gchar *));
-  g_assert (*basename_vstr != NULL);
+  g_assert (*basename_vstr != NULL);    /* This won't happen, but doesn't hurt either */
 
   vstrF.vstr = *fullpath_vstr;
   vstrB.vstr = *basename_vstr;
@@ -360,7 +360,7 @@ nnsconf_loadconf (gboolean force_reload)
 
   if (conf.conffile) {
     key_file = g_key_file_new ();
-    g_assert (key_file != NULL);
+    g_assert (key_file != NULL); /** Internal lib error? out-of-memory? */
 
     /* Read the conf file. It's ok even if we cannot load it. */
     if (g_key_file_load_from_file (key_file, conf.conffile, G_KEY_FILE_NONE,
@@ -536,7 +536,7 @@ nnsconf_get_custom_value_string (const gchar * group, const gchar * key)
     if (NULL == value && conf.conffile) {
       g_autoptr (GKeyFile) key_file = g_key_file_new ();
 
-      g_assert (key_file != NULL);
+      g_assert (key_file != NULL); /** Internal lib error? out-of-memory? */
 
       if (g_key_file_load_from_file (key_file, conf.conffile, G_KEY_FILE_NONE,
               NULL)) {

--- a/gst/nnstreamer/nnstreamer_subplugin.c
+++ b/gst/nnstreamer/nnstreamer_subplugin.c
@@ -253,7 +253,7 @@ static void
 init_subplugin (void)
 {
   G_LOCK (splock);
-  g_assert (NULL == handles);
+  g_assert (NULL == handles); /** Internal error (duplicated init call?) */
   handles = g_ptr_array_new_full (16, _close_handle);
   G_UNLOCK (splock);
 }
@@ -263,7 +263,7 @@ static void
 fini_subplugin (void)
 {
   G_LOCK (splock);
-  g_assert (handles);
+  g_assert (handles); /** Internal error (init not called?) */
 
   /* iterate and call close by calling g_array_clear */
   g_ptr_array_free (handles, TRUE);

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -1082,7 +1082,11 @@ find_key_strv (const gchar ** strv, const gchar * key)
 {
   gint cursor = 0;
 
-  g_assert (strv != NULL);
+  if (strv == NULL) {
+    ml_logf_stacktrace
+        ("find_key_strv is called with a null pointer. Possible internal logic errors.\n");
+    return -1;
+  }
   while (strv[cursor]) {
     if (g_ascii_strcasecmp (strv[cursor], key) == 0)
       return cursor;

--- a/gst/nnstreamer/tensor_common_pipeline.c
+++ b/gst/nnstreamer/tensor_common_pipeline.c
@@ -236,6 +236,10 @@ gst_tensor_time_sync_buffer_from_collectpad (GstCollectPads * collect,
     GstBuffer *buf;
 
     gst_tensors_config_from_structure (&in_configs, s);
+    /** This is an internal logic error.
+        in_configs should be already confirmed valid at
+        the negotiation phase and this function should be
+        called in a running pipeline */
     g_assert (gst_tensors_config_validate (&in_configs));
 
     if (in_configs.rate_d < old_denominator)
@@ -271,6 +275,8 @@ gst_tensor_time_sync_buffer_from_collectpad (GstCollectPads * collect,
     if (GST_IS_BUFFER (buf)) {
       guint n_mem = gst_buffer_n_memory (buf);
 
+      /** These are internal logic error. If given inputs are incorrect,
+          the negotiation should have been failed before this stage. */
       g_assert (n_mem == in_configs.info.num_tensors);
       g_assert ((counting + n_mem) < NNS_TENSOR_SIZE_LIMIT);
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -447,7 +447,10 @@ nnstreamer_filter_probe (GstTensorFilterFramework * tfsp)
     name = tfsp->name;
   } else if (GST_TF_FW_V1 (tfsp)) {
     gst_tensor_filter_properties_init (&prop);
-    g_assert (tfsp->getFrameworkInfo (tfsp, &prop, NULL, &info) == 0);
+    if (0 != tfsp->getFrameworkInfo (tfsp, &prop, NULL, &info)) {
+      ml_loge ("getFrameworkInfo() failed.\n");
+      return FALSE;
+    }
     name = info.name;
   }
 
@@ -1882,7 +1885,12 @@ parse_accl_hw (const gchar * accelerators,
   accl_hw hw;
 
   match_accl = parse_accl_hw_all (accelerators, supported_accelerators);
-  g_assert (g_list_length (match_accl) > 0);
+
+  if (NULL == match_accl) {
+    ml_loge ("There is no match hardware accelerators from {%s}.\n",
+        accelerators);
+    return ACCL_NONE;
+  }
 
   hw = GPOINTER_TO_INT (match_accl->data);
   g_list_free (match_accl);

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
@@ -101,16 +101,33 @@ custom_open (const GstTensorFilterProperties * prop, void **private_data)
     ml_loge
         ("Cannot find the easy-custom model, \"%s\". You should provide a valid model name of easy-custom.",
         prop->model_files[0]);
-    g_free (rd);
-    return -EINVAL;
+    goto errorreturn;
   }
 
-  g_assert (rd->model->func);
-  g_assert (rd->model->in_info);
-  g_assert (rd->model->out_info);
+  if (NULL == rd->model->func) {
+    ml_logf
+        ("A custom-easy filter, \"%s\", should provide invoke function body, 'func'. A null-ptr is supplied instead.\n",
+        prop->model_files[0]);
+    goto errorreturn;
+  }
+  if (NULL == rd->model->in_info) {
+    ml_logf
+        ("A custom-easy filter, \"%s\", should provide input stream metadata, 'in_info'.\n",
+        prop->model_files[0]);
+    goto errorreturn;
+  }
+  if (NULL == rd->model->out_info) {
+    ml_logf
+        ("A custom-easy filter, \"%s\", should provide output stream metadata, 'out_info'.\n",
+        prop->model_files[0]);
+    goto errorreturn;
+  }
 
   *private_data = rd;
   return 0;
+errorreturn:
+  g_free (rd);
+  return -EINVAL;
 }
 
 /**
@@ -122,6 +139,7 @@ custom_invoke (const GstTensorFilterProperties * prop,
     GstTensorMemory * output)
 {
   runtime_data *rd = *private_data;
+  /* Internal Logic Error */
   g_assert (rd && rd->model && rd->model->func);
 
   return rd->model->func (rd->model->data, prop, input, output);
@@ -135,6 +153,7 @@ custom_getInputDim (const GstTensorFilterProperties * prop,
     void **private_data, GstTensorsInfo * info)
 {
   runtime_data *rd = *private_data;
+  /* Internal Logic Error */
   g_assert (rd && rd->model && rd->model->in_info);
   gst_tensors_info_copy (info, rd->model->in_info);
   return 0;
@@ -148,6 +167,7 @@ custom_getOutputDim (const GstTensorFilterProperties * prop,
     void **private_data, GstTensorsInfo * info)
 {
   runtime_data *rd = *private_data;
+  /* Internal Logic Error */
   g_assert (rd && rd->model && rd->model->out_info);
   gst_tensors_info_copy (info, rd->model->out_info);
   return 0;

--- a/gst/nnstreamer/tensor_mux/gsttensormux.c
+++ b/gst/nnstreamer/tensor_mux/gsttensormux.c
@@ -382,7 +382,10 @@ gst_tensor_mux_collected (GstCollectPads * pads, GstTensorMux * tensor_mux)
   }
 
   tensors_buf = gst_buffer_new ();
-  g_assert (tensors_buf);
+  if (NULL == tensors_buf) {
+    ml_logf ("gst_buffer_new() returns NULL. Out of memory?\n");
+    return GST_FLOW_ERROR;
+  }
 
   isEOS =
       gst_tensor_mux_collect_buffer (tensor_mux, tensors_buf, &pts_time,

--- a/gst/nnstreamer/tensor_repo/tensor_repo.c
+++ b/gst/nnstreamer/tensor_repo/tensor_repo.c
@@ -228,13 +228,14 @@ gst_tensor_repo_add_repodata (guint nth, gboolean is_sink)
 
   GST_REPO_LOCK ();
   ret = g_hash_table_insert (_repo.hash, GINT_TO_POINTER (nth), data);
-  g_assert (ret);
 
   if (ret) {
     _repo.num_data++;
 
     if (DBG)
       GST_DEBUG ("Successfully added in hash table with key[%d]", nth);
+  } else {
+    ml_logf ("The key[%d] is duplicated. Cannot proceed.\n", nth);
   }
 
   GST_REPO_UNLOCK ();

--- a/gst/nnstreamer/tensor_repo/tensor_reposrc.c
+++ b/gst/nnstreamer/tensor_repo/tensor_reposrc.c
@@ -310,12 +310,15 @@ gst_tensor_reposrc_gen_dummy_buffer (GstTensorRepoSrc * self)
   num_tensors = self->config.info.num_tensors;
 
   for (i = 0; i < num_tensors; i++) {
-    gboolean status;
     size = gst_tensor_info_get_size (&self->config.info.info[i]);
     mem = gst_allocator_alloc (NULL, size, NULL);
 
-    status = gst_memory_map (mem, &info, GST_MAP_WRITE);
-    g_assert (status); /** @todo Do proper error handling (err return) */
+    if (FALSE == gst_memory_map (mem, &info, GST_MAP_WRITE)) {
+      gst_allocator_free (NULL, mem);
+      ml_logf ("Cannot mep gst memory (tensor-repo-src)\n");
+      gst_buffer_unref (buf);
+      return NULL;
+    }
     memset (info.data, 0, size);
     gst_memory_unmap (mem, &info);
 


### PR DESCRIPTION
If an error might occur by external reasons,
(invalid input/app behaviors and inappropriate environments)
it should not simply assert away, but should provide
appropriate error messages and handling.

This is WIP stage.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
