### PR TITLE
[Android/Build] flag to handle exception

### DIFF
--- a/api/android/api/src/main/jni/Android-nnstreamer.mk
+++ b/api/android/api/src/main/jni/Android-nnstreamer.mk
@@ -44,7 +44,7 @@ LOCAL_C_INCLUDES := \
 # common headers (gstreamer, glib)
 LOCAL_C_INCLUDES += $(GST_HEADERS_COMMON)
 
-LOCAL_CFLAGS += -O2 $(NNS_API_FLAGS)
-LOCAL_CXXFLAGS += -std=c++11 -O2 $(NNS_API_FLAGS)
+LOCAL_CFLAGS += -O2 -fPIC $(NNS_API_FLAGS)
+LOCAL_CXXFLAGS += -std=c++11 -O2 -fPIC -frtti -fexceptions $(NNS_API_FLAGS)
 
 include $(BUILD_STATIC_LIBRARY)

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
@@ -39,13 +39,6 @@
 
 #include <nnstreamer_cppplugin_api_filter.hh>
 
-/** Android NDK does not support exception handling by default */
-#ifdef __ANDROID__
-#define throw
-#define try	if(true)
-#define catch(...)	if(false)
-#endif
-
 namespace nnstreamer {
 
 /******************************************************

--- a/jni/Android-nnstreamer.mk
+++ b/jni/Android-nnstreamer.mk
@@ -97,8 +97,8 @@ include $(CLEAR_VARS)
 
 # Please keep the pthread and openmp library for checking a compatibility
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -O0 -DVERSION=\"$(NNSTREAMER_VERSION)\"
-LOCAL_CXXFLAGS      += -std=c++11 -DVERSION=\"$(NNSTREAMER_VERSION)\"
+LOCAL_CFLAGS        += -O0 -fPIC -DVERSION=\"$(NNSTREAMER_VERSION)\"
+LOCAL_CXXFLAGS      += -std=c++11 -fPIC -frtti -fexceptions -DVERSION=\"$(NNSTREAMER_VERSION)\"
 LOCAL_CFLAGS        += -pthread -fopenmp
 
 ifeq ($(NO_AUDIO), true)

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -71,8 +71,8 @@ include $(CLEAR_VARS)
 
 # Please keep the pthread and openmp library for checking a compatibility
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -O0 -DVERSION=\"$(NNSTREAMER_VERSION)\"
-LOCAL_CXXFLAGS      += -std=c++11 -DVERSION=\"$(NNSTREAMER_VERSION)\"
+LOCAL_CFLAGS        += -O0 -fPIC -DVERSION=\"$(NNSTREAMER_VERSION)\"
+LOCAL_CXXFLAGS      += -std=c++11 -fPIC -frtti -fexceptions -DVERSION=\"$(NNSTREAMER_VERSION)\"
 LOCAL_CFLAGS        += -pthread -fopenmp
 
 ifeq ($(NO_AUDIO), true)


### PR DESCRIPTION
add cxx-flag in android build, enable exception handling.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
