### PR TITLE
[Fix/#2303] Add PYTHONPATH env to meson.build

### DIFF
--- a/debian/nnstreamer-python2.install
+++ b/debian/nnstreamer-python2.install
@@ -1,2 +1,2 @@
 /usr/lib/nnstreamer/filters/libnnstreamer_filter_python2.so
-/usr/lib/nnstreamer/filters/nnstreamer_python2.so
+/usr/lib/nnstreamer/filters/nnstreamer_python.so

--- a/debian/nnstreamer-python2.links
+++ b/debian/nnstreamer-python2.links
@@ -1,1 +1,0 @@
-/usr/lib/nnstreamer/filters/nnstreamer_python2.so /usr/lib/python2.7/dist-packages/nnstreamer_python.so

--- a/debian/nnstreamer-python3.install
+++ b/debian/nnstreamer-python3.install
@@ -1,2 +1,2 @@
 /usr/lib/nnstreamer/filters/libnnstreamer_filter_python3.so
-/usr/lib/nnstreamer/filters/nnstreamer_python3.so
+/usr/lib/nnstreamer/filters/nnstreamer_python.abi3.so

--- a/debian/nnstreamer-python3.links
+++ b/debian/nnstreamer-python3.links
@@ -1,1 +1,1 @@
-/usr/lib/nnstreamer/filters/nnstreamer_python3.so /usr/lib/python3/dist-packages/nnstreamer_python.so
+/usr/lib/nnstreamer/filters/nnstreamer_python.abi3.so /usr/lib/python3/dist-packages/nnstreamer_python.so

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -197,6 +197,7 @@ foreach s : filter_sub_python_sources
   nnstreamer_filter_python_sources += join_paths(meson.current_source_dir(), s)
 endforeach
 
+
 if have_python2
   nnstreamer_filter_python2_deps = [python2_deps, libdl_dep, glib_dep, gst_dep, nnstreamer_dep]
 
@@ -214,7 +215,7 @@ if have_python2
     install_dir: nnstreamer_libdir
   )
 
-  shared_library('nnstreamer_python2',
+  shared_library('nnstreamer_python',
     'tensor_filter_python_api.c',
     name_prefix: '',
     dependencies: nnstreamer_filter_python2_deps,
@@ -240,7 +241,8 @@ if have_python3
     install_dir: nnstreamer_libdir
   )
 
-  shared_library('nnstreamer_python3',
+  ### .abi3 See https://www.python.org/dev/peps/pep-3149/, This does not support python < 3.2
+  shared_library('nnstreamer_python.abi3',
     'tensor_filter_python_api.c',
     name_prefix: '',
     dependencies: nnstreamer_filter_python3_deps,

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -452,7 +452,7 @@ popd
 %if 0%{?python_support}
 mkdir -p %{buildroot}%{python_sitelib}
 pushd %{buildroot}%{python_sitelib}
-ln -sf %{_prefix}/lib/nnstreamer/filters/nnstreamer_python2.so nnstreamer_python.so
+ln -sf %{_prefix}/lib/nnstreamer/filters/nnstreamer_python.so nnstreamer_python.so
 popd
 %endif
 
@@ -540,7 +540,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_python2.so
-%{_prefix}/lib/nnstreamer/filters/nnstreamer_python2.so
+%{_prefix}/lib/nnstreamer/filters/nnstreamer_python.so
 %{python_sitelib}/nnstreamer_python.so
 %endif
 

--- a/packaging/run_unittests_binaries.sh
+++ b/packaging/run_unittests_binaries.sh
@@ -19,16 +19,6 @@ export PYTHONPATH=$(pwd)/ext/nnstreamer/tensor_filter/:$PYTHONPATH
 run_entry() {
   entry=$1
 
-  if [[ $entry == *"python3"* ]]; then
-    pushd ext/nnstreamer/tensor_filter
-    ln -sf nnstreamer_python3.so nnstreamer_python.so
-    popd
-  elif [[ $entry == *"python2"* ]]; then
-    pushd ext/nnstreamer/tensor_filter
-    ln -sf nnstreamer_python2.so nnstreamer_python.so
-    popd
-  fi
-
   echo $entry
   ${entry} --gst-plugin-path=. --gtest_output="xml:${entry##*/}.xml"
 

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -8,53 +8,131 @@ tizen_apptest_deps = [
 ]
 
 # Format for adding subplugin into extensions -
-# [name, extension abbreviation, dependencies, model file name/folder path/file path, test name]
-extensions = []
+# {execute_when, name, ext_abbr, test_name, deps, model file/folder, env}
 
-extensions += [['custom', 'custom', nnstreamer_unittest_deps, '../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough.so', 'custom']]
-extensions += [['custom', 'custom', nnstreamer_unittest_deps, '../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough_variable.so', 'custom-set']]
+py_env = environment()
 
-if get_option('enable-tensorflow-lite')
-  extensions += [['tensorflow-lite', 'tflite', nnstreamer_filter_tflite_deps, 'mobilenet_v1_1.0_224_quant.tflite', 'tensorflow_lite']]
-  extensions += [['tensorflow-lite', 'tflite', nnstreamer_filter_tflite_deps, 'add.tflite', 'tensorflow_lite-set']]
-endif
+py_env.append('PYTHONPATH', join_paths(meson.build_root(), 'ext', 'nnstreamer', 'tensor_filter'))
 
-if get_option('enable-tensorflow')
-  extensions += [['tensorflow', 'tf', nnstreamer_filter_tf_deps, 'mnist.pb', 'tensorflow']]
-endif
+nnstreamer_example_dir = join_paths(meson.build_root(), 'nnstreamer_example')
 
-if get_option('enable-nnfw-runtime')
-  extensions += [['nnfw', 'nnfw', nnstreamer_filter_nnfw_deps, 'add.tflite', 'nnfw']]
-endif
-
-if get_option('enable-pytorch')
-  extensions += [['pytorch', 'torch', nnstreamer_filter_torch_deps, 'pytorch_lenet5.pt', 'pytorch']]
-endif
-
-if get_option('enable-caffe2')
-  extensions += [['caffe2', 'caffe2', nnstreamer_filter_caffe2_deps, 'caffe2_init_net.pb,caffe2_predict_net.pb', 'caffe2']]
-endif
-
-if have_python2
-  extensions += [['python2', 'python2', nnstreamer_filter_python2_deps, 'passthrough.py', 'python2-get']]
-  extensions += [['python2', 'python2', nnstreamer_filter_python2_deps, 'scaler.py', 'python2-set']]
-endif
-
-if have_python3
-  extensions += [['python3', 'python3', nnstreamer_filter_python3_deps, 'passthrough.py', 'python3-get']]
-  extensions += [['python3', 'python3', nnstreamer_filter_python3_deps, 'scaler.py', 'python3-set']]
-endif
+extensions = [
+  {
+    'execute_when': true,
+    'name': 'custom',
+    'abbr': 'custom',
+    'test_name': 'custom',
+    'deps': 'nnstreamer_unittest_deps',
+    'model': join_paths(nnstreamer_example_dir, 'custom_example_passthrough' 'libnnstreamer_customfilter_passthrough.so')
+  },
+  {
+    'execute_when': true,
+    'name': 'custom',
+    'abbr': 'custom',
+    'test_name': 'custom-set',
+    'deps': 'nnstreamer_unittest_deps',
+    'model': join_paths(nnstreamer_example_dir, 'custom_example_passthrough' 'libnnstreamer_customfilter_passthrough_variable.so')
+  },
+  {
+    'execute_when': get_option('enable-tensorflow-lite'),
+    'name': 'tensorflow-lite',
+    'abbr': 'tflite',
+    'test_name': 'tensorflow_lite',
+    'deps': 'nnstreamer_filter_tflite_deps',
+    'model': 'mobilenet_v1_1.0_224_quant.tflite'
+  },
+  {
+    'execute_when': get_option('enable-tensorflow-lite'),
+    'name': 'tensorflow-lite',
+    'abbr': 'tflite',
+    'test_name': 'tensorflow_lite-set',
+    'deps': 'nnstreamer_filter_tflite_deps',
+    'model': 'add.tflite'
+  },
+  {
+    'execute_when': get_option('enable-tensorflow'),
+    'name': 'tensorflow',
+    'abbr': 'tf',
+    'test_name': 'tensorflow',
+    'deps': 'nnstreamer_filter_tf_deps',
+    'model': 'mnist.pb'
+  },
+  {
+    'execute_when': get_option('enable-nnfw-runtime'),
+    'name': 'nnfw',
+    'abbr': 'nnfw',
+    'test_name': 'nnfw',
+    'deps': 'nnstreamer_filter_nnfw_deps',
+    'model': 'add.tflite'
+  },
+  {
+    'execute_when': get_option('enable-pytorch'),
+    'name': 'pytorch',
+    'abbr': 'torch',
+    'test_name': 'pytorch',
+    'deps': 'nnstreamer_filter_torch_deps',
+    'model': 'pytorch_lenet5.pt'
+  },
+  {
+    'execute_when': get_option('enable-caffe2'),
+    'name': 'caffe2',
+    'abbr': 'caffe2',
+    'test_name': 'caffe2',
+    'deps': 'nnstreamer_filter_caffe2_deps',
+    'model': 'caffe2_init_net.pb,caffe2_predict_net.pb'
+  },
+  {
+    'execute_when': have_python2,
+    'name': 'python2',
+    'abbr': 'python2',
+    'test_name': 'python2-get',
+    'deps': 'nnstreamer_filter_python2_deps',
+    'model': 'passthrough.py',
+    'env': py_env
+  },
+  {
+    'execute_when': have_python2,
+    'name': 'python2',
+    'abbr': 'python2',
+    'test_name': 'python2-set',
+    'deps': 'nnstreamer_filter_python2_deps',
+    'model': 'scaler.py',
+    'env': py_env
+  },  
+  {
+    'execute_when': have_python3,
+    'name': 'python3',
+    'abbr': 'python3',
+    'test_name': 'python3-get',
+    'deps': 'nnstreamer_filter_python3_deps',
+    'model': 'passthrough.py',
+    'env': py_env
+  },
+  {
+    'execute_when': have_python3,
+    'name': 'python3',
+    'abbr': 'python3',
+    'test_name': 'python3-set',
+    'deps': 'nnstreamer_filter_python3_deps',
+    'model': 'scaler.py',
+    'env': py_env
+  },
+]
 
 sed_command = find_program('sed', required: true)
 ext_test_template_prefix = 'unittest_tizen_'
 ext_test_template = files (ext_test_template_prefix + 'template.cc.in')
 
 foreach ext : extensions
-  ext_test_path_each = ext_test_template_prefix + ext[4] + '.cc'
+  if not ext.get('execute_when', false)
+    continue
+  endif
 
-  sed_ext_name_option = 's|@EXT_NAME@|' + ext[0] + '|'
-  sed_ext_abbrv_option = 's|@EXT_ABBRV@|' + ext[1] + '|'
-  sed_ext_mf_option = 's|@MODEL_FILE@|' + ext[3] + '|'
+  ext_test_path_each = ext_test_template_prefix + ext['test_name'] + '.cc'
+
+  sed_ext_name_option = 's|@EXT_NAME@|' + ext['name'] + '|'
+  sed_ext_abbrv_option = 's|@EXT_ABBRV@|' + ext['abbr'] + '|'
+  sed_ext_mf_option = 's|@MODEL_FILE@|' + ext['model'] + '|'
 
   ext_test_each = custom_target (
     ext_test_path_each,
@@ -66,13 +144,19 @@ foreach ext : extensions
       '&&', 'sed', '-i\'.cc\'', sed_ext_mf_option, '@OUTPUT@']
   )
 
+  _deps = get_variable(ext['deps'], [false])
+
+  if false in _deps
+    error('dependencies not found for @0@'.format(ext['test_name']))
+  endif
+
   exec = executable(
-    ext_test_template_prefix + ext[4],
+    ext_test_template_prefix + ext['test_name'],
     ext_test_each,
-    dependencies: [tizen_apptest_deps, ext[2]],
+    dependencies: [tizen_apptest_deps, _deps],
     install: get_option('install-test'),
     install_dir: unittest_install_dir
   )
 
-  test(ext_test_template_prefix + ext[4], exec, args: ['--gst-plugin-path=../..'])
+  test(ext_test_template_prefix + ext['test_name'], exec, args: ['--gst-plugin-path=../..'], env: ext.get('env', environment()))
 endforeach

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -23,7 +23,7 @@ extensions = [
     'abbr': 'custom',
     'test_name': 'custom',
     'deps': 'nnstreamer_unittest_deps',
-    'model': join_paths(nnstreamer_example_dir, 'custom_example_passthrough' 'libnnstreamer_customfilter_passthrough.so')
+    'model': join_paths(nnstreamer_example_dir, 'custom_example_passthrough', 'libnnstreamer_customfilter_passthrough.so')
   },
   {
     'execute_when': true,
@@ -31,7 +31,7 @@ extensions = [
     'abbr': 'custom',
     'test_name': 'custom-set',
     'deps': 'nnstreamer_unittest_deps',
-    'model': join_paths(nnstreamer_example_dir, 'custom_example_passthrough' 'libnnstreamer_customfilter_passthrough_variable.so')
+    'model': join_paths(nnstreamer_example_dir, 'custom_example_passthrough', 'libnnstreamer_customfilter_passthrough_variable.so')
   },
   {
     'execute_when': get_option('enable-tensorflow-lite'),

--- a/tests/nnstreamer_filter_python/runTest.sh
+++ b/tests/nnstreamer_filter_python/runTest.sh
@@ -42,10 +42,6 @@ else
 fi
 
 FRAMEWORK="python2"
-# This symlink is necessary only for testcases; when installed, symlinks will be made
-pushd ../../build/ext/nnstreamer/tensor_filter
-ln -s nnstreamer_python2.so nnstreamer_python.so
-popd
 
 # Passthrough test
 export PYTHONPATH=../../build/ext/nnstreamer/tensor_filter/:$PYTHONPATH


### PR DESCRIPTION
Add pythonpath env to nnstreamer_filter_extensions_common meson build to alleviate #2303.

 - Add pythonpath env to nnstreamer_filter_extensions_common meson build to
 alleviate #2303 problem(partially fixing).
 - Add .abi3 suffix to python3 .so file. **Note that this is not going
to work on python < 3.2

**Self evaluation:**
1. Build test: [ * ]Passed [ ]Failed [ ]Skipped
2. Run test: [ * ]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

Test result via ninja


[1/2] Running all tests.
 1/11 unittest_common                         OK      0.012771368026733398 s 
 2/11 unittest_sink                           OK      21.868908166885376 s 
 3/11 unittest_plugins                        OK      0.5799074172973633 s 
 4/11 unittest_src_iio                        OK      11.780057191848755 s 
 5/11 unittest_cppfilter                      OK      1.133612871170044 s 
 6/11 unittest_tizen_custom                   OK      0.019491910934448242 s 
 7/11 unittest_tizen_custom-set               OK      0.00789499282836914 s 
 8/11 unittest_tizen_python2-get              OK      0.22201108932495117 s 
 9/11 unittest_tizen_python2-set              OK      0.21953964233398438 s 
10/11 unittest_tizen_python3-get              OK      0.31961941719055176 s 
11/11 unittest_tizen_python3-set              OK      0.2750697135925293 s 

Ok:                 11  
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   
