### PR TITLE
[Meson] Provide an environment object to test()  @open sesame 5/18 18:42

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -392,8 +392,6 @@ endif
 
 # Build unittests
 if get_option('enable-test')
-  subdir('tests')
-
   # temporary ini file for test, enable env variables.
   nnstreamer_test_conf = configuration_data()
   nnstreamer_test_conf.merge_from(nnstreamer_conf)
@@ -408,4 +406,19 @@ if get_option('enable-test')
     install_dir: unittest_install_dir,
     configuration: nnstreamer_test_conf
   )
+
+  path_gst_plugin = join_paths(meson.build_root(), 'gst', 'nnstreamer')
+  path_nns_conf = join_paths(meson.build_root(), 'nnstreamer-test.ini')
+  path_nns_plugin_filters = join_paths(meson.build_root(), 'ext', 'nnstreamer',
+      'tensor_filter')
+  path_nns_plugin_decoders = join_paths(meson.build_root(), 'ext', 'nnstreamer',
+      'tensor_decoder')
+
+  testenv = environment()
+  testenv.set('GST_PLUGIN_PATH', path_gst_plugin)
+  testenv.set('NNSTREAMER_CONF', path_nns_conf)
+  testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
+  testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
+
+  subdir('tests')
 endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -74,7 +74,7 @@ if gtest_dep.found()
     install_dir: unittest_install_dir
   )
 
-  test('unittest_common', unittest_common)
+  test('unittest_common', unittest_common, env: testenv)
 
   # Run unittest_sink
   gst18_dep = dependency('gstreamer-' + gst_api_verision, version : '>=1.8', required : false)
@@ -86,7 +86,7 @@ if gtest_dep.found()
       install_dir: unittest_install_dir
     )
 
-    test('unittest_sink', unittest_sink, timeout: 120, args: ['--gst-plugin-path=..'])
+    test('unittest_sink', unittest_sink, timeout: 120, env: testenv)
 
     # Run unittest_plugins
     unittest_plugins = executable('unittest_plugins',
@@ -96,7 +96,7 @@ if gtest_dep.found()
       install_dir: unittest_install_dir
     )
 
-    test('unittest_plugins', unittest_plugins, args: ['--gst-plugin-path=..'])
+    test('unittest_plugins', unittest_plugins, env: testenv)
 
   # Run unittest_src_iio
     if build_platform != 'macos'
@@ -107,7 +107,7 @@ if gtest_dep.found()
         install_dir: unittest_install_dir
       )
 
-      test('unittest_src_iio', unittest_src_iio, timeout: 120, args: ['--gst-plugin-path=..'])
+      test('unittest_src_iio', unittest_src_iio, timeout: 120, env: testenv)
     endif
   endif
 
@@ -120,7 +120,7 @@ if gtest_dep.found()
       install_dir: unittest_install_dir
     )
 
-    test('unittest_filter_armnn', unittest_filter_armnn, args: ['--gst-plugin-path=../..'])
+    test('unittest_filter_armnn', unittest_filter_armnn, env: testenv)
   endif
 
 endif

--- a/tests/nnstreamer_filter_edgetpu/meson.build
+++ b/tests/nnstreamer_filter_edgetpu/meson.build
@@ -24,5 +24,6 @@ if get_option('enable-edgetpu')
     install_dir: unittest_install_dir
   )
 
-  test('unittest_edgetpu', unittest_edgetpu, args: ['--gst-plugin-path=../../'])
+  #TODO: the following test would not work via ninja
+  #test('unittest_edgetpu', unittest_edgetpu, env: testenv)
 endif

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -74,5 +74,28 @@ foreach ext : extensions
     install_dir: unittest_install_dir
   )
 
-  test(ext_test_template_prefix + ext[4], exec, args: ['--gst-plugin-path=../..'])
+  filter_ext_common_testenv = environment()
+  filter_ext_common_testenv.set('GST_PLUGIN_PATH', path_gst_plugin)
+  filter_ext_common_testenv.set('NNSTREAMER_CONF', path_nns_conf)
+  filter_ext_common_testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
+  filter_ext_common_testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
+  if ext[0] == 'python2'
+    py2_module_path = join_paths(meson.build_root(), 'tests/' + ext[0] + '_module')
+    run_command('rm', '-rf', py2_module_path, check : true)
+    run_command('mkdir', '-p', py2_module_path, check : true)
+    run_command('ln', '-sf',
+        join_paths(meson.build_root(), 'ext/nnstreamer/tensor_filter/nnstreamer_python2.so'),
+        py2_module_path + '/nnstreamer_python.so', check : true)
+    filter_ext_common_testenv.set('PYTHONPATH', py2_module_path)
+  elif ext[0] == 'python3'
+    py3_module_path = join_paths(meson.build_root(), 'tests/' + ext[0] + '_module')
+    run_command('rm', '-rf', py3_module_path, check : true)
+    run_command('mkdir', '-p', py3_module_path, check : true)
+    run_command('ln', '-sf',
+        join_paths(meson.build_root(), 'ext/nnstreamer/tensor_filter/nnstreamer_python3.so'),
+        py3_module_path + '/nnstreamer_python.so', check : true)
+    filter_ext_common_testenv.set('PYTHONPATH', py3_module_path)
+  endif
+
+  test(ext_test_template_prefix + ext[4], exec, env: filter_ext_common_testenv)
 endforeach

--- a/tests/nnstreamer_filter_mvncsdk2/meson.build
+++ b/tests/nnstreamer_filter_mvncsdk2/meson.build
@@ -23,4 +23,11 @@ unittest_mvncsdk = executable('unittest_filter_mvncsdk2',
     install_dir: unittest_install_dir
   )
 
-test('LD_PRELOAD=./libmvnc.so unittest_filter_mvncsdk2', unittest_mvncsdk, args: ['--gst-plugin-path=../../'])
+filter_mvncsdk2_testenv = environment()
+filter_mvncsdk2_testenv.set('GST_PLUGIN_PATH', path_gst_plugin)
+filter_mvncsdk2_testenv.set('NNSTREAMER_CONF', path_nns_conf)
+filter_mvncsdk2_testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
+filter_mvncsdk2_testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
+filter_mvncsdk2_testenv.set('LD_LIBRARY_PATH', meson.current_build_dir())
+
+test('unittest_filter_mvncsdk2', unittest_mvncsdk, env: filter_mvncsdk2_testenv)

--- a/tests/tizen_capi/meson.build
+++ b/tests/tizen_capi/meson.build
@@ -10,7 +10,7 @@ unittest_tizen_capi = executable('unittest_tizen_capi',
   install: get_option('install-test'),
   install_dir: unittest_install_dir
 )
-test('unittest_tizen_capi', unittest_tizen_capi, args: ['--gst-plugin-path=../..'])
+test('unittest_tizen_capi', unittest_tizen_capi, env: testenv)
 
 
 if get_option('enable-tizen-sensor')
@@ -38,5 +38,12 @@ if get_option('enable-tizen-sensor')
     install: get_option('install-test'),
     install_dir: unittest_install_dir
   )
-  test('unittest_tizen_sensor', unittest_tizen_sensor, args: ['--gst-plugin-path=../..'])
+  tizen_sensor_testenv = environment()
+  tizen_sensor_testenv.set('GST_PLUGIN_PATH', \
+      join_paths(meson.build_root(), 'ext', 'nnstreamer', 'tensor_source'), \
+      path_gst_plugin)
+  tizen_sensor_testenv.set('NNSTREAMER_CONF', path_nns_conf)
+  tizen_sensor_testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
+  tizen_sensor_testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
+  test('unittest_tizen_sensor', unittest_tizen_sensor, env: tizen_sensor_testenv)
 endif

--- a/tests/tizen_nnfw_runtime/meson.build
+++ b/tests/tizen_nnfw_runtime/meson.build
@@ -5,4 +5,4 @@ unittest_nnfw_runtime_raw = executable('unittest_nnfw_runtime_raw',
   install_dir: join_paths(unittest_install_dir,'tests'),
 )
 
-test('unittest_nnfw_runtime_raw', unittest_nnfw_runtime_raw, args: ['--gst-plugin-path=../..'])
+test('unittest_nnfw_runtime_raw', unittest_nnfw_runtime_raw, env: testenv)


### PR DESCRIPTION
In order to make test() in the meson.build script work, this patch defines an environment object for the unit test cases and provides it to those test() functions as an argument.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

```bash
$ rm -rf build && meson build && ninja -C build
...
$ ninja -C build test
ninja: Entering directory `build'
[1/2] Running all tests.
 1/16 unittest_common                         OK       0.03 s 
 2/16 unittest_sink                           OK      21.58 s 
 3/16 unittest_plugins                        OK       1.98 s 
 4/16 unittest_src_iio                        OK      21.76 s 
 5/16 unittest_filter_mvncsdk2                OK      15.36 s 
 6/16 unittest_cppfilter                      OK       1.48 s 
 7/16 unittest_tizen_custom                   OK       0.02 s 
 8/16 unittest_tizen_custom-set               OK       0.02 s 
 9/16 unittest_tizen_tensorflow_lite          OK       0.22 s 
10/16 unittest_tizen_tensorflow_lite-set      OK       0.02 s 
11/16 unittest_tizen_pytorch                  OK       0.37 s 
12/16 unittest_tizen_caffe2                   OK       0.33 s 
13/16 unittest_tizen_python2-get              OK       0.47 s 
14/16 unittest_tizen_python2-set              OK       0.37 s 
15/16 unittest_tizen_python3-get              OK       0.52 s 
16/16 unittest_tizen_python3-set              OK       0.22 s 

Ok:                   16
Expected Fail:         0
Fail:                  0
Unexpected Pass:       0
Skipped:               0
Timeout:               0

Full log written to /home/wook/Work/NNS/nnstreamer/build/meson-logs/testlog.txt
```

Note that the test( ) line in meson.build for edgetpu has been blocked since it does not work with ```ninja test```.