### PR TITLE
[TEST/util] Clean up wait_pipeline_process_buffers

### DIFF
--- a/tests/unittest_util.c
+++ b/tests/unittest_util.c
@@ -77,16 +77,19 @@ getTempFilename (void)
  * @return TRUE on success, FALSE when a time-out occurs
  */
 gboolean
-wait_pipeline_process_buffers (guint *data_received, guint expected_num_buffers, guint timeout_ms)
+wait_pipeline_process_buffers (const guint * data_received,
+    guint expected_num_buffers, guint timeout_ms)
 {
-  guint timer_count = 0;
+  guint timer = 0;
+  guint tick = TEST_DEFAULT_SLEEP_TIME / 1000U;
+  if (tick == 0)
+    tick = 1;
   /* Waiting for expected buffers to arrive */
   while (*data_received < expected_num_buffers) {
-    timer_count++;
     g_usleep (TEST_DEFAULT_SLEEP_TIME);
-    if (timer_count > (timeout_ms / 10)) {
+    timer += tick;
+    if (timer > timeout_ms)
       return FALSE;
-    }
   }
   return TRUE;
 }

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -43,7 +43,7 @@ extern gchar * getTempFilename (void);
  * @brief Wait until the pipeline processing the buffers
  * @return TRUE on success, FALSE when a time-out occurs
  */
-extern gboolean wait_pipeline_process_buffers (guint *data_received, guint expected_num_buffers, guint timeout_ms);
+extern gboolean wait_pipeline_process_buffers (const guint * data_received, guint expected_num_buffers, guint timeout_ms);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
1. apply "const" for data_received. It won't update it
2. make it robust against TEST_DEFAULT_SLEEP_TIME values

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

