### PR TITLE
[TEST] Fix tizen sensor unit test

### DIFF
--- a/tests/tizen_capi/meson.build
+++ b/tests/tizen_capi/meson.build
@@ -34,7 +34,7 @@ if get_option('enable-tizen-sensor')
   ]
   unittest_tizen_sensor = executable('unittest_tizen_sensor',
     ['unittest_tizen_sensor.cc'],
-    dependencies: [tizen_sensor_apptest_deps],
+    dependencies: [tizen_sensor_apptest_deps, unittest_util_dep],
     install: get_option('install-test'),
     install_dir: unittest_install_dir
   )


### PR DESCRIPTION
Fix tizen sensor unit test.
 - Add macro to wait until start the pipeline.
 - Wait until expected buffers are processed

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped