### PR TITLE
[CodeClean] fix invalid index

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -229,7 +229,8 @@ _tflite_ssd_loadBoxPrior (bounding_boxes * bdata)
   if (g_strv_length (priors) < BOX_SIZE) {
     ml_loge ("The given prior file, %s, should have at least %d lines.\n",
         tflite_ssd->box_prior_path, BOX_SIZE);
-    return FALSE;
+    failed = TRUE;
+    goto error;
   }
 
   for (row = 0; row < BOX_SIZE; row++) {
@@ -268,6 +269,7 @@ _tflite_ssd_loadBoxPrior (bounding_boxes * bdata)
     prev_reg = registered;
   }
 
+error:
   g_strfreev (priors);
   g_free (contents);
   return !failed;

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
@@ -251,7 +251,7 @@ set_color_according_to_label (image_segments * idata, GstMapInfo * out_info)
 {
   uint32_t *frame = (uint32_t *) out_info->data;
   uint32_t *pos;
-  int i, j;
+  guint i, j, label_idx;
   const uint32_t label_color[21] = {
     0xFF000040, 0xFF800000, 0xFFFFEFD5, 0xFF40E0D0, 0xFFFFA500,
     0xFF00FF00, 0xFFDC143C, 0xFFF0F8FF, 0xFF008000, 0xFFEE82EE,
@@ -262,12 +262,12 @@ set_color_according_to_label (image_segments * idata, GstMapInfo * out_info)
 
   for (i = 0; i < idata->height; i++) {
     for (j = 0; j < idata->width; j++) {
-      int label_idx = idata->segment_map[i][j];
-      if (label_idx > 20)       /* If out-of-range, don't draw it */
+      label_idx = idata->segment_map[i][j];
+
+      /* If background or out-of-range, don't draw it */
+      if (label_idx == 0 || label_idx > 20)
         continue;
       pos = &frame[i * idata->width + j];
-      if (label_idx == 0)
-        continue;               /*Do not set color for background */
       *pos = label_color[label_idx];
     }
   }

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -794,6 +794,7 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
 
         if (FALSE == gst_buffer_map (buf, &src_info, GST_MAP_READ)) {
           ml_logf ("Cannot map src buffer at tensor_converter/text.\n");
+          gst_buffer_unref (inbuf);     /* the new buffer is wasted. */
           return GST_FLOW_ERROR;
         }
         if (FALSE == gst_buffer_map (inbuf, &dest_info, GST_MAP_WRITE)) {

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -408,7 +408,7 @@ gst_tensor_filter_transform (GstBaseTransform * trans,
         for (j = 0; j < i; j++)
           gst_memory_unmap (out_mem[j], &out_info[j]);
         for (j = 0; j < prop->input_meta.num_tensors; j++)
-          gst_memory_unmap (in_mem[j], &in_info[i]);
+          gst_memory_unmap (in_mem[j], &in_info[j]);
         ml_logf ("Cannot map output memory buffer(%d)\n", i);
         return GST_FLOW_ERROR;
       }


### PR DESCRIPTION
1. fix invalid index when unmapping the mem block
2. unref buffer when failed to get mem

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
