### PR TITLE
[Common] Allow to fetch nnstreamer version @open sesame 7/1/ 23:04

### DIFF
--- a/debian/nnstreamer-dev.install
+++ b/debian/nnstreamer-dev.install
@@ -1,3 +1,4 @@
+/usr/include/nnstreamer/nnstreamer_version.h
 /usr/include/nnstreamer/nnstreamer_plugin_api.h
 /usr/include/nnstreamer/nnstreamer_plugin_api_converter.h
 /usr/include/nnstreamer/nnstreamer_plugin_api_decoder.h

--- a/gst/nnstreamer/include/meson.build
+++ b/gst/nnstreamer/include/meson.build
@@ -13,6 +13,17 @@ foreach h : nnst_common_headers
   nnstreamer_headers += join_paths(meson.current_source_dir(), h)
 endforeach
 
+version_conf = configuration_data()
+version_conf.set('__NNSTREAMER_VERSION_MAJOR__', version_split[0])
+version_conf.set('__NNSTREAMER_VERSION_MINOR__', version_split[1])
+version_conf.set('__NNSTREAMER_VERSION_MICRO__', version_split[2])
+
+generated_h = configure_file(input: 'nnstreamer_version.h.in',
+  output: 'nnstreamer_version.h',
+  configuration: version_conf
+)
+nnstreamer_headers += generated_h
+
 # Install headers into /{includedir}/nnstreamer
 install_headers(nnstreamer_headers,
   subdir: 'nnstreamer'

--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -29,6 +29,7 @@
 #include <glib.h>
 #include <gst/gst.h>
 #include <tensor_typedef.h>
+#include <nnstreamer_version.h>
 
 G_BEGIN_DECLS
 
@@ -358,6 +359,9 @@ replace_string (gchar * source, const gchar * what, const gchar * to, const gcha
  */
 extern gchar *
 nnstreamer_version_string (void);
+
+extern void nnstreamer_version_fetch (guint * major, guint * minor,
+    guint * micro);
 
 G_END_DECLS
 #endif /* __NNS_PLUGIN_API_H__ */

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -35,10 +35,9 @@
 #define GST_TENSOR_FILTER_FRAMEWORK_V0 (GST_TENSOR_FILTER_FRAMEWORK_BASE)
 #define GST_TENSOR_FILTER_FRAMEWORK_V1 (GST_TENSOR_FILTER_FRAMEWORK_BASE | 0x10000ULL)
 
-/** @todo update this to 1 after supporting version 1 GstTensorFilterFramework in tensor_filter.c */
-#define GST_TENSOR_FILTER_API_VERSION_DEFINED (0)
+#define GST_TENSOR_FILTER_API_VERSION_DEFINED (1)
 #define GST_TENSOR_FILTER_API_VERSION_MIN (0)	/* The minimum API version supported (could be obsolete) */
-#define GST_TENSOR_FILTER_API_VERSION_MAX (0)	/* The maximum API version supported (recommended) */
+#define GST_TENSOR_FILTER_API_VERSION_MAX (1)	/* The maximum API version supported (recommended) */
 
 /**
  * @brief Check the value of the version field of GstTensorFilterFramework

--- a/gst/nnstreamer/include/nnstreamer_version.h.in
+++ b/gst/nnstreamer/include/nnstreamer_version.h.in
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * NNStreamer Version Identifier, Updated by meson/mk scripts
+ * Copyright (C) 2020 MyungJoo Ham <myungjoo.ham@samsung.com>
+ */
+
+/**
+ * @file	nnstreamer_version.h
+ * @date	12 Jun 2020
+ * @brief	NNStreamer Version Identifier
+ * @see		http://github.com/nnstreamer/nnstreamer
+ * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ * @detail 	meson or nnstreamer.mk file will update this.
+ */
+#ifndef __NNSTREAMER_VERSION_H__
+#define __NNSTREAMER_VERSION_H__
+#define NNSTREAMER_VERSION_MAJOR	(@__NNSTREAMER_VERSION_MAJOR__@)
+#define NNSTREAMER_VERSION_MINOR	(@__NNSTREAMER_VERSION_MINOR__@)
+#define NNSTREAMER_VERSION_MICRO	(@__NNSTREAMER_VERSION_MICRO__@)
+#if NNSTREAMER_VERSION_MAJOR < 1
+#error Version is not configured properly. Check if you are using proper build scripts (meson or build-android.lib.sh).
+#endif
+#endif

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -1176,7 +1176,7 @@ replace_string (gchar * source, const gchar * what, const gchar * to,
 }
 
 /**
- * @brief Get the version of NNStreamer.
+ * @brief Get the version of NNStreamer (string).
  * @return Newly allocated string. The returned string should be freed with g_free().
  */
 gchar *
@@ -1186,4 +1186,21 @@ nnstreamer_version_string (void)
 
   version = g_strdup_printf ("NNStreamer %s", VERSION);
   return version;
+}
+
+/**
+ * @brief Get the version of NNStreamer (int, divided).
+ * @param[out] major MAJOR.minor.micro, won't set if it's null.
+ * @param[out] minor major.MINOR.micro, won't set if it's null.
+ * @param[out] micro major.minor.MICRO, won't set if it's null.
+ */
+void
+nnstreamer_version_fetch (guint * major, guint * minor, guint * micro)
+{
+  if (major)
+    *major = (NNSTREAMER_VERSION_MAJOR);
+  if (minor)
+    *minor = (NNSTREAMER_VERSION_MINOR);
+  if (micro)
+    *micro = (NNSTREAMER_VERSION_MICRO);
 }

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -9,10 +9,21 @@ $(error GSTREAMER_ROOT_ANDROID is not defined!)
 endif
 
 NNSTREAMER_VERSION  := 1.5.3
+NNSTREAMER_VERSION_MAJOR := $(word 1,$(subst ., ,${NNSTREAMER_VERSION}))
+NNSTREAMER_VERSION_MINOR := $(word 2,$(subst ., ,${NNSTREAMER_VERSION}))
+NNSTREAMER_VERSION_MICRO := $(word 3,$(subst ., ,${NNSTREAMER_VERSION}))
 
 NNSTREAMER_GST_HOME := $(NNSTREAMER_ROOT)/gst/nnstreamer
 NNSTREAMER_EXT_HOME := $(NNSTREAMER_ROOT)/ext/nnstreamer
 NNSTREAMER_CAPI_HOME := $(NNSTREAMER_ROOT)/api/capi
+
+CMDRESULT1 := $(shell sed "s/@__NNSTREAMER_VERSION_MAJOR__@/${NNSTREAMER_VERSION_MAJOR}/" ${NNSTREAMER_GST_HOME}/include/nnstreamer_version.h.in > ${NNSTREAMER_GST_HOME}/include/nnstreamer_version.h && echo "Processed sed 1")
+CMDRESULT2 := $(shell sed -i "s/@__NNSTREAMER_VERSION_MINOR__@/${NNSTREAMER_VERSION_MINOR}/" ${NNSTREAMER_GST_HOME}/include/nnstreamer_version.h && echo "Processed sed 2")
+CMDRESULT3 := $(shell sed -i "s/@__NNSTREAMER_VERSION_MICRO__@/${NNSTREAMER_VERSION_MICRO}/" ${NNSTREAMER_GST_HOME}/include/nnstreamer_version.h && echo "Processed sed 3")
+
+$(info ${CMDRESULT1})
+$(info ${CMDRESULT2})
+$(info ${CMDRESULT3})
 
 # nnstreamer common headers
 NNSTREAMER_INCLUDES := \

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,10 @@ project('nnstreamer', 'c', 'cpp',
 )
 
 add_project_arguments('-DVERSION="' + meson.project_version() + '"', language: ['c', 'cpp'])
+version_split = meson.project_version().split('.')
+add_project_arguments('-DVERSION_MAJOR="' + version_split[0] + '"', language: ['c', 'cpp'])
+add_project_arguments('-DVERSION_MINOR="' + version_split[1] + '"', language: ['c', 'cpp'])
+add_project_arguments('-DVERSION_MICRO="' + version_split[2] + '"', language: ['c', 'cpp'])
 
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -600,6 +600,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{_includedir}/nnstreamer/nnstreamer_plugin_api_decoder.h
 %{_includedir}/nnstreamer/nnstreamer_plugin_api_converter.h
 %{_includedir}/nnstreamer/nnstreamer_plugin_api.h
+%{_includedir}/nnstreamer/nnstreamer_version.h
 %{_includedir}/nnstreamer/tensor_filter_cpp.hh
 %{_includedir}/nnstreamer/nnstreamer_cppplugin_api_filter.hh
 %{_libdir}/*.a

--- a/tests/codegen/runTest.sh
+++ b/tests/codegen/runTest.sh
@@ -37,7 +37,7 @@ Description: temporary nnstreamer pkgconfig for unittesting during build
 Version: 0.1.2
 Requires:
 Libs: -L${pwd}/../../build/gst/nnstreamer -lnnstreamer
-Cflags: -I${pwd}/../../gst/nnstreamer -I${pwd}/../../gst/nnstreamer/include
+Cflags: -I${pwd}/../../gst/nnstreamer -I${pwd}/../../gst/nnstreamer/include -I${pwd}/${PATH_TO_PLUGIN}/gst/nnstreamer/include
 EOF
 
 function do_test() {

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -19,6 +19,7 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <nnstreamer_conf.h>
+#include <nnstreamer_plugin_api.h>
 
 /**
  * @brief Test for int32 type string.
@@ -947,6 +948,59 @@ TEST (conf_custom, env_str_01)
   g_free (f4);
   g_free (f5);
   g_free (f6);
+}
+
+/**
+ * @brief Test version control (positive)
+ */
+TEST (version_control , get_ver_01)
+{
+  gchar * verstr = nnstreamer_version_string();
+  guint major, minor, micro;
+  gchar * verstr2, * verstr3;
+  nnstreamer_version_fetch (&major, &minor, &micro);
+
+  verstr2 = g_strdup_printf ("NNStreamer %u.%u.%u", major, minor, micro);
+  verstr3 = g_strdup_printf ("%u.%u.%u", major, minor, micro);
+
+  EXPECT_STRCASEEQ (verstr, verstr2);
+
+  EXPECT_STRCASEEQ (VERSION, verstr3);
+
+  EXPECT_EQ ((int) major, NNSTREAMER_VERSION_MAJOR);
+  EXPECT_EQ ((int) minor, NNSTREAMER_VERSION_MINOR);
+  EXPECT_EQ ((int) micro, NNSTREAMER_VERSION_MICRO);
+
+  g_free (verstr);
+  g_free (verstr2);
+  g_free (verstr3);
+}
+
+/**
+ * @brief Test version control (negative)
+ */
+TEST (version_control , get_ver_02_n)
+{
+  guint major, minor, micro;
+  guint m1, m2;
+  nnstreamer_version_fetch (&major, &minor, &micro);
+  nnstreamer_version_fetch (&m1, &m2, nullptr);
+  EXPECT_EQ (m1, major);
+  EXPECT_EQ (m2, minor);
+  nnstreamer_version_fetch (&m1, nullptr, &m2);
+  EXPECT_EQ (m1, major);
+  EXPECT_EQ (m2, micro);
+  nnstreamer_version_fetch (nullptr, &m1, &m2);
+  EXPECT_EQ (m1, minor);
+  EXPECT_EQ (m2, micro);
+}
+
+/**
+ * @brief Test version control (negative)
+ */
+TEST (version_control , get_ver_03_n)
+{
+  nnstreamer_version_fetch (nullptr, nullptr, nullptr);
 }
 
 /**


### PR DESCRIPTION
Let external nnstreamer plugins to probe nnstreamer version
at both run-time and build-time.

Fixes #2294

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

