### PR TITLE
[Test/tensordec-pose] Add test case with more buffers

### DIFF
--- a/tests/nnstreamer_decoder_pose/runTest.sh
+++ b/tests/nnstreamer_decoder_pose/runTest.sh
@@ -30,4 +30,7 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc ! videoconvert ! video
 # THIS WON'T FAIL, BUT NOT MUCH MEANINGFUL.
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 1 0 0 $PERFORMANCE
 
+# TEST WITH MORE BUFFERS
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=100 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 option3=notused ! fakesink" 2 0 0 $PERFORMANCE
+
 report


### PR DESCRIPTION
The test with `videotestsrc num_buffers=4` sometimes does not enough to execute some functions. This commit adds a test with more buffers.

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped


