### PR TITLE
[Unittest] apply EXPECT_STREQ for string comparisons

### DIFF
--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -268,7 +268,7 @@ TEST (common_get_tensor_dimension, case1)
   EXPECT_EQ (dim[3], 177U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
-  EXPECT_TRUE (g_str_equal (dim_str, "345:123:433:177"));
+  EXPECT_STREQ (dim_str, "345:123:433:177");
   g_free (dim_str);
 }
 
@@ -289,7 +289,7 @@ TEST (common_get_tensor_dimension, case2)
   EXPECT_EQ (dim[3], 1U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
-  EXPECT_TRUE (g_str_equal (dim_str, "345:123:433:1"));
+  EXPECT_STREQ (dim_str, "345:123:433:1");
   g_free (dim_str);
 }
 
@@ -310,7 +310,7 @@ TEST (common_get_tensor_dimension, case3)
   EXPECT_EQ (dim[3], 1U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
-  EXPECT_TRUE (g_str_equal (dim_str, "345:123:1:1"));
+  EXPECT_STREQ (dim_str, "345:123:1:1");
   g_free (dim_str);
 }
 
@@ -331,7 +331,7 @@ TEST (common_get_tensor_dimension, case4)
   EXPECT_EQ (dim[3], 1U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
-  EXPECT_TRUE (g_str_equal (dim_str, "345:1:1:1"));
+  EXPECT_STREQ (dim_str, "345:1:1:1");
   g_free (dim_str);
 }
 
@@ -350,7 +350,7 @@ TEST (common_tensor_info, copy_tensor)
   gst_tensor_info_copy (&dest, &src);
 
   EXPECT_TRUE (dest.name != src.name);
-  EXPECT_TRUE (g_str_equal (dest.name, test_name));
+  EXPECT_STREQ (dest.name, test_name);
   EXPECT_EQ (dest.type, src.type);
   EXPECT_EQ (dest.dimension[0], src.dimension[0]);
   EXPECT_EQ (dest.dimension[1], src.dimension[1]);
@@ -391,7 +391,7 @@ TEST (common_tensor_info, copy_tensors)
 
   for (i = 0; i < src.num_tensors; i++) {
     EXPECT_TRUE (dest.info[i].name != src.info[i].name);
-    EXPECT_TRUE (g_str_equal (dest.info[i].name, test_name));
+    EXPECT_STREQ (dest.info[i].name, test_name);
     EXPECT_EQ (dest.info[i].type, src.info[i].type);
     EXPECT_EQ (dest.info[i].dimension[0], src.info[i].dimension[0]);
     EXPECT_EQ (dest.info[i].dimension[1], src.info[i].dimension[1]);
@@ -615,7 +615,7 @@ TEST (common_tensors_info_string, dimensions)
   info.num_tensors = num_dims;
 
   str_dims = gst_tensors_info_get_dimensions_string (&info);
-  EXPECT_TRUE (g_str_equal (str_dims, "1:2:3:4"));
+  EXPECT_STREQ (str_dims, "1:2:3:4");
   g_free (str_dims);
 
   /* 4 tensors info */
@@ -625,7 +625,7 @@ TEST (common_tensors_info_string, dimensions)
   info.num_tensors = num_dims;
 
   str_dims = gst_tensors_info_get_dimensions_string (&info);
-  EXPECT_TRUE (g_str_equal (str_dims, "1:1:1:1,2:2:1:1,3:3:3:1,4:4:4:4"));
+  EXPECT_STREQ (str_dims, "1:1:1:1,2:2:1:1,3:3:3:1,4:4:4:4");
   g_free (str_dims);
 
   /* max */
@@ -652,7 +652,7 @@ TEST (common_tensors_info_string, types)
   info.num_tensors = num_types;
 
   str_types = gst_tensors_info_get_types_string (&info);
-  EXPECT_TRUE (g_str_equal (str_types, "uint16"));
+  EXPECT_STREQ (str_types, "uint16");
   g_free (str_types);
 
   /* 4 tensors info */
@@ -663,7 +663,7 @@ TEST (common_tensors_info_string, types)
   info.num_tensors = num_types;
 
   str_types = gst_tensors_info_get_types_string (&info);
-  EXPECT_TRUE (g_str_equal (str_types, "int8,int16,int32,int64"));
+  EXPECT_STREQ (str_types, "int8,int16,int32,int64");
   g_free (str_types);
 
   /* max */
@@ -691,7 +691,7 @@ TEST (common_tensors_info_string, names)
   info.num_tensors = num_names;
 
   str_names = gst_tensors_info_get_names_string (&info);
-  EXPECT_TRUE (g_str_equal (str_names, "t1"));
+  EXPECT_STREQ (str_names, "t1");
   g_free (str_names);
 
   /* 4 tensors info */
@@ -702,7 +702,7 @@ TEST (common_tensors_info_string, names)
   info.num_tensors = num_names;
 
   str_names = gst_tensors_info_get_names_string (&info);
-  EXPECT_TRUE (g_str_equal (str_names, "tensor1,tensor2,tensor3,tensor4"));
+  EXPECT_STREQ (str_names, "tensor1,tensor2,tensor3,tensor4");
   g_free (str_names);
 
   /* empty name string */
@@ -715,7 +715,7 @@ TEST (common_tensors_info_string, names)
   }
 
   str_names = gst_tensors_info_get_names_string (&info);
-  EXPECT_TRUE (g_str_equal (str_names, ",,"));
+  EXPECT_STREQ (str_names, ",,");
   g_free (str_names);
 
   /* max */
@@ -737,19 +737,19 @@ TEST (common_string_util, replace_str_01)
 
   result = replace_string (result, "sourceelement", "src", NULL, &changed);
   EXPECT_EQ (changed, 1U);
-  EXPECT_TRUE (g_str_equal (result, "src ! parser ! converter ! format ! converter ! format ! converter ! sink"));
+  EXPECT_STREQ (result, "src ! parser ! converter ! format ! converter ! format ! converter ! sink");
 
   result = replace_string (result, "format", "fmt", NULL, &changed);
   EXPECT_EQ (changed, 2U);
-  EXPECT_TRUE (g_str_equal (result, "src ! parser ! converter ! fmt ! converter ! fmt ! converter ! sink"));
+  EXPECT_STREQ (result, "src ! parser ! converter ! fmt ! converter ! fmt ! converter ! sink");
 
   result = replace_string (result, "converter", "conv", NULL, &changed);
   EXPECT_EQ (changed, 3U);
-  EXPECT_TRUE (g_str_equal (result, "src ! parser ! conv ! fmt ! conv ! fmt ! conv ! sink"));
+  EXPECT_STREQ (result, "src ! parser ! conv ! fmt ! conv ! fmt ! conv ! sink");
 
   result = replace_string (result, "invalidname", "invalid", NULL, &changed);
   EXPECT_EQ (changed, 0U);
-  EXPECT_TRUE (g_str_equal (result, "src ! parser ! conv ! fmt ! conv ! fmt ! conv ! sink"));
+  EXPECT_STREQ (result, "src ! parser ! conv ! fmt ! conv ! fmt ! conv ! sink");
 
   g_free (result);
 }
@@ -766,19 +766,19 @@ TEST (common_string_util, replace_str_02)
 
   result = replace_string (result, "source", "src", " !", &changed);
   EXPECT_EQ (changed, 4U);
-  EXPECT_TRUE (g_str_equal (result, "src! parser ! sources ! mysource ! src ! format !src! conv src"));
+  EXPECT_STREQ (result, "src! parser ! sources ! mysource ! src ! format !src! conv src");
 
   result = replace_string (result, "src", "mysource", "! ", &changed);
   EXPECT_EQ (changed, 4U);
-  EXPECT_TRUE (g_str_equal (result, "mysource! parser ! sources ! mysource ! mysource ! format !mysource! conv mysource"));
+  EXPECT_STREQ (result, "mysource! parser ! sources ! mysource ! mysource ! format !mysource! conv mysource");
 
   result = replace_string (result, "source", "src", NULL, &changed);
   EXPECT_EQ (changed, 6U);
-  EXPECT_TRUE (g_str_equal (result, "mysrc! parser ! srcs ! mysrc ! mysrc ! format !mysrc! conv mysrc"));
+  EXPECT_STREQ (result, "mysrc! parser ! srcs ! mysrc ! mysrc ! format !mysrc! conv mysrc");
 
   result = replace_string (result, "mysrc", "src", ";", &changed);
   EXPECT_EQ (changed, 0U);
-  EXPECT_TRUE (g_str_equal (result, "mysrc! parser ! srcs ! mysrc ! mysrc ! format !mysrc! conv mysrc"));
+  EXPECT_STREQ (result, "mysrc! parser ! srcs ! mysrc ! mysrc ! format !mysrc! conv mysrc");
 
   g_free (result);
 }

--- a/tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2.cc
+++ b/tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2.cc
@@ -91,7 +91,7 @@ TEST (pipeline_mvncsdk2_filter, launch_normal)
 
     /* Check framework */
     g_object_get (filter, "framework", &fw_name, NULL);
-    EXPECT_TRUE (g_str_equal (fw_name, "movidius-ncsdk2"));
+    EXPECT_STREQ (fw_name, "movidius-ncsdk2");
 
     g_free (fw_name);
     gst_object_unref (filter);

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -135,7 +135,7 @@
   filter = gst_bin_get_by_name (GST_BIN (gstpipe), "tfilter"); \
   EXPECT_NE (filter, nullptr); \
   g_object_get (filter, "framework", &prop_string, NULL); \
-  EXPECT_TRUE (g_str_equal (prop_string, #fw_name)); \
+  EXPECT_STREQ (prop_string, #fw_name); \
   \
   g_free (prop_string); \
   g_free (test_model); \
@@ -162,7 +162,7 @@
       filter = gst_bin_get_by_name (GST_BIN (gstpipe), "tfilter"); \
       EXPECT_NE (filter, nullptr); \
       g_object_get (filter, "framework", &prop_string, NULL); \
-      EXPECT_TRUE (g_str_equal (prop_string, fw_name)); \
+      EXPECT_STREQ (prop_string, fw_name); \
       gst_object_unref (filter); \
     } \
     gst_element_set_state (gstpipe, GST_STATE_PLAYING); \
@@ -2992,11 +2992,11 @@ TEST (test_tensor_filter, reopen_tflite_01_p)
 
   /* get properties */
   gst_harness_get (h, "tensor_filter", "framework", &prop_string, NULL);
-  EXPECT_TRUE (g_str_equal (prop_string, "tensorflow-lite"));
+  EXPECT_STREQ (prop_string, "tensorflow-lite");
   g_free (prop_string);
 
   gst_harness_get (h, "tensor_filter", "model", &prop_string, NULL);
-  EXPECT_TRUE (g_str_equal (prop_string, test_model));
+  EXPECT_STREQ (prop_string, test_model);
   g_free (prop_string);
 
   /* push buffer (dummy input RGB 224x224, output 1001) */
@@ -3116,11 +3116,11 @@ TEST (test_tensor_filter, reload_tflite_set_property)
 
   /* get properties */
   gst_harness_get (h, "tensor_filter", "framework", &prop_string, NULL);
-  EXPECT_TRUE (g_str_equal (prop_string, "tensorflow-lite"));
+  EXPECT_STREQ (prop_string, "tensorflow-lite");
   g_free (prop_string);
 
   gst_harness_get (h, "tensor_filter", "model", &prop_string, NULL);
-  EXPECT_TRUE (g_str_equal (prop_string, test_model));
+  EXPECT_STREQ (prop_string, test_model);
   g_free (prop_string);
 
   gst_harness_get (h, "tensor_filter", "is-updatable", &prop_updatable, NULL);
@@ -3146,7 +3146,7 @@ TEST (test_tensor_filter, reload_tflite_set_property)
   gst_harness_set (h, "tensor_filter", "model", test_model2, NULL);
 
   gst_harness_get (h, "tensor_filter", "model", &prop_string, NULL);
-  EXPECT_TRUE (g_str_equal (prop_string, test_model2));
+  EXPECT_STREQ (prop_string, test_model2);
   g_free (prop_string);
 
   /* push buffer again */

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -1128,7 +1128,7 @@ TEST (tensor_sink_test, signals)
   EXPECT_EQ (g_test_data.end, TRUE);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1225,7 +1225,7 @@ TEST (tensor_sink_test, signal_rate)
   EXPECT_TRUE (g_test_data.received < num_buffers);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1321,7 +1321,7 @@ TEST (tensor_sink_test, caps_tensors)
   EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120 * 2);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensors"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensors");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1387,7 +1387,7 @@ TEST (tensor_stream_test, video_rgb)
   EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1431,7 +1431,7 @@ TEST (tensor_stream_test, video_bgr)
   EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1475,7 +1475,7 @@ TEST (tensor_stream_test, video_rgb_padding)
   EXPECT_EQ (g_test_data.received_size, 3U * 162 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1519,7 +1519,7 @@ TEST (tensor_stream_test, video_bgr_padding)
   EXPECT_EQ (g_test_data.received_size, 3U * 162 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1563,7 +1563,7 @@ TEST (tensor_stream_test, video_rgb_3f)
   EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120 * 3);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1607,7 +1607,7 @@ TEST (tensor_stream_test, video_rgba)
   EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1651,7 +1651,7 @@ TEST (tensor_stream_test, video_bgra)
   EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1695,7 +1695,7 @@ TEST (tensor_stream_test, video_argb)
   EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1739,7 +1739,7 @@ TEST (tensor_stream_test, video_abgr)
   EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1783,7 +1783,7 @@ TEST (tensor_stream_test, video_rgbx)
   EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1827,7 +1827,7 @@ TEST (tensor_stream_test, video_xrgb)
   EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1871,7 +1871,7 @@ TEST (tensor_stream_test, video_xbgr)
   EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1915,7 +1915,7 @@ TEST (tensor_stream_test, video_bgrx)
   EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -1959,7 +1959,7 @@ TEST (tensor_stream_test, video_bgrx_2f)
   EXPECT_EQ (g_test_data.received_size, 4U * 160 * 120 * 2);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2003,7 +2003,7 @@ TEST (tensor_stream_test, video_gray8)
   EXPECT_EQ (g_test_data.received_size, 160U * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2047,7 +2047,7 @@ TEST (tensor_stream_test, video_gray8_padding)
   EXPECT_EQ (g_test_data.received_size, 162U * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2091,7 +2091,7 @@ TEST (tensor_stream_test, video_gray8_3f_padding)
   EXPECT_EQ (g_test_data.received_size, 162U * 120 * 3);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2135,7 +2135,7 @@ TEST (tensor_stream_test, audio_s8)
   EXPECT_EQ (g_test_data.received_size, 500U);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2179,7 +2179,7 @@ TEST (tensor_stream_test, audio_u8_100f)
   EXPECT_EQ (g_test_data.received_size, 100U);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2223,7 +2223,7 @@ TEST (tensor_stream_test, audio_s16)
   EXPECT_EQ (g_test_data.received_size, 500U * 2);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2267,7 +2267,7 @@ TEST (tensor_stream_test, audio_u16_1000f)
   EXPECT_EQ (g_test_data.received_size, 500U * 2 * 2);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2311,7 +2311,7 @@ TEST (tensor_stream_test, audio_s32)
   EXPECT_EQ (g_test_data.received_size, 500U * 4);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2355,7 +2355,7 @@ TEST (tensor_stream_test, audio_u32)
   EXPECT_EQ (g_test_data.received_size, 500U * 4);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2399,7 +2399,7 @@ TEST (tensor_stream_test, audio_f32)
   EXPECT_EQ (g_test_data.received_size, 500U * 4);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2443,7 +2443,7 @@ TEST (tensor_stream_test, audio_f64)
   EXPECT_EQ (g_test_data.received_size, 500U * 8);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2493,7 +2493,7 @@ TEST (tensor_stream_test, text_utf8)
   EXPECT_EQ (g_test_data.received_size, 20U);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2570,7 +2570,7 @@ TEST (tensor_stream_test, text_utf8_3f)
   EXPECT_EQ (g_test_data.received_size, 30U * 3);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2620,7 +2620,7 @@ TEST (tensor_stream_test, octet_current_ts)
   EXPECT_EQ (g_test_data.received_size, 10U);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2670,7 +2670,7 @@ TEST (tensor_stream_test, octet_framerate_ts)
   EXPECT_EQ (g_test_data.received_size, 10U);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2747,7 +2747,7 @@ TEST (tensor_stream_test, octet_valid_ts)
   EXPECT_EQ (g_test_data.received_size, 10U);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2824,7 +2824,7 @@ TEST (tensor_stream_test, octet_invalid_ts)
   EXPECT_EQ (g_test_data.received_size, 10U);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check invalid timestamp */
   EXPECT_TRUE (g_test_data.invalid_timestamp);
@@ -2901,7 +2901,7 @@ TEST (tensor_stream_test, octet_2f)
   EXPECT_EQ (g_test_data.received_size, 5U);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -2945,7 +2945,7 @@ TEST (tensor_stream_test, custom_filter_tensor)
   EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -3006,7 +3006,7 @@ TEST (tensor_stream_test, custom_filter_tensors)
   EXPECT_EQ (g_test_data.received_size, 95616U); /** 160 * 120 * 3 + 120 * 80 * 3 + 64 * 48 * 3 */
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensors"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensors");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -3082,7 +3082,7 @@ TEST (tensor_stream_test, custom_filter_multi)
   EXPECT_EQ (g_test_data.received_size, 1012800U); /** 160 * 120 * 3 + 280 * 40 * 3 + 640 * 480 * 3 */
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensors"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensors");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -3139,7 +3139,7 @@ TEST (tensor_stream_test, filter_properties_1)
 
   /* framework */
   g_object_get (filter, "framework", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "custom"));
+  EXPECT_STREQ (str, "custom");
   g_free (str);
 
   /* model */
@@ -3153,22 +3153,22 @@ TEST (tensor_stream_test, filter_properties_1)
 
   /* input */
   g_object_get (filter, "input", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ""));
+  EXPECT_STREQ (str, "");
   g_free (str);
 
   /* inputtype */
   g_object_get (filter, "inputtype", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ""));
+  EXPECT_STREQ (str, "");
   g_free (str);
 
   /* output */
   g_object_get (filter, "output", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ""));
+  EXPECT_STREQ (str, "");
   g_free (str);
 
   /* outputtype */
   g_object_get (filter, "outputtype", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ""));
+  EXPECT_STREQ (str, "");
   g_free (str);
 
   /* inputlayout */
@@ -3191,32 +3191,32 @@ TEST (tensor_stream_test, filter_properties_1)
 
   /* input */
   g_object_get (filter, "input", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "3:160:120:1"));
+  EXPECT_STREQ (str, "3:160:120:1");
   g_free (str);
 
   /* inputtype */
   g_object_get (filter, "inputtype", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "uint8"));
+  EXPECT_STREQ (str, "uint8");
   g_free (str);
 
   /* inputname */
   g_object_get (filter, "inputname", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ""));
+  EXPECT_STREQ (str, "");
   g_free (str);
 
   /* output */
   g_object_get (filter, "output", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "3:160:120:1"));
+  EXPECT_STREQ (str, "3:160:120:1");
   g_free (str);
 
   /* outputtype */
   g_object_get (filter, "outputtype", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "uint8"));
+  EXPECT_STREQ (str, "uint8");
   g_free (str);
 
   /* outputname */
   g_object_get (filter, "outputname", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ""));
+  EXPECT_STREQ (str, "");
   g_free (str);
 
   /* inputlayout */
@@ -3259,7 +3259,7 @@ TEST (tensor_stream_test, filter_properties_2)
 
   /* framework */
   g_object_get (filter, "framework", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "custom"));
+  EXPECT_STREQ (str, "custom");
   g_free (str);
 
   /* model */
@@ -3273,22 +3273,22 @@ TEST (tensor_stream_test, filter_properties_2)
 
   /* input */
   g_object_get (filter, "input", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ""));
+  EXPECT_STREQ (str, "");
   g_free (str);
 
   /* inputtype */
   g_object_get (filter, "inputtype", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ""));
+  EXPECT_STREQ (str, "");
   g_free (str);
 
   /* output */
   g_object_get (filter, "output", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ""));
+  EXPECT_STREQ (str, "");
   g_free (str);
 
   /* outputtype */
   g_object_get (filter, "outputtype", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ""));
+  EXPECT_STREQ (str, "");
   g_free (str);
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
@@ -3301,32 +3301,32 @@ TEST (tensor_stream_test, filter_properties_2)
 
   /* input */
   g_object_get (filter, "input", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "3:160:120:1,3:120:80:1,3:64:48:1"));
+  EXPECT_STREQ (str, "3:160:120:1,3:120:80:1,3:64:48:1");
   g_free (str);
 
   /* inputtype */
   g_object_get (filter, "inputtype", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "uint8,uint8,uint8"));
+  EXPECT_STREQ (str, "uint8,uint8,uint8");
   g_free (str);
 
   /* inputname */
   g_object_get (filter, "inputname", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ",,"));
+  EXPECT_STREQ (str, ",,");
   g_free (str);
 
   /* output */
   g_object_get (filter, "output", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "3:160:120:1,3:120:80:1,3:64:48:1"));
+  EXPECT_STREQ (str, "3:160:120:1,3:120:80:1,3:64:48:1");
   g_free (str);
 
   /* outputtype */
   g_object_get (filter, "outputtype", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "uint8,uint8,uint8"));
+  EXPECT_STREQ (str, "uint8,uint8,uint8");
   g_free (str);
 
   /* outputname */
   g_object_get (filter, "outputname", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ",,"));
+  EXPECT_STREQ (str, ",,");
   g_free (str);
 
   /* inputlayout */
@@ -3369,7 +3369,7 @@ TEST (tensor_stream_test, filter_properties_3)
 
   /* framework */
   g_object_get (filter, "framework", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "custom"));
+  EXPECT_STREQ (str, "custom");
   g_free (str);
 
   /* model */
@@ -3388,32 +3388,32 @@ TEST (tensor_stream_test, filter_properties_3)
 
   /* input */
   g_object_get (filter, "input", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "3:160:120:1,3:120:80:1,3:64:48:1"));
+  EXPECT_STREQ (str, "3:160:120:1,3:120:80:1,3:64:48:1");
   g_free (str);
 
   /* inputtype */
   g_object_get (filter, "inputtype", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "uint8,uint8,uint8"));
+  EXPECT_STREQ (str, "uint8,uint8,uint8");
   g_free (str);
 
   /* inputname */
   g_object_get (filter, "inputname", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ",,"));
+  EXPECT_STREQ (str, ",,");
   g_free (str);
 
   /* output */
   g_object_get (filter, "output", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "3:160:120:1,3:120:80:1,3:64:48:1"));
+  EXPECT_STREQ (str, "3:160:120:1,3:120:80:1,3:64:48:1");
   g_free (str);
 
   /* outputtype */
   g_object_get (filter, "outputtype", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "uint8,uint8,uint8"));
+  EXPECT_STREQ (str, "uint8,uint8,uint8");
   g_free (str);
 
   /* outputname */
   g_object_get (filter, "outputname", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ",,"));
+  EXPECT_STREQ (str, ",,");
   g_free (str);
 
   /* inputlayout */
@@ -3437,32 +3437,32 @@ TEST (tensor_stream_test, filter_properties_3)
 
   /* input */
   g_object_get (filter, "input", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "3:160:120:1,3:120:80:1,3:64:48:1"));
+  EXPECT_STREQ (str, "3:160:120:1,3:120:80:1,3:64:48:1");
   g_free (str);
 
   /* inputtype */
   g_object_get (filter, "inputtype", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "uint8,uint8,uint8"));
+  EXPECT_STREQ (str, "uint8,uint8,uint8");
   g_free (str);
 
   /* inputname */
   g_object_get (filter, "inputname", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ",,"));
+  EXPECT_STREQ (str, ",,");
   g_free (str);
 
   /* output */
   g_object_get (filter, "output", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "3:160:120:1,3:120:80:1,3:64:48:1"));
+  EXPECT_STREQ (str, "3:160:120:1,3:120:80:1,3:64:48:1");
   g_free (str);
 
   /* outputtype */
   g_object_get (filter, "outputtype", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, "uint8,uint8,uint8"));
+  EXPECT_STREQ (str, "uint8,uint8,uint8");
   g_free (str);
 
   /* outputname */
   g_object_get (filter, "outputname", &str, NULL);
-  EXPECT_TRUE (g_str_equal (str, ",,"));
+  EXPECT_STREQ (str, ",,");
   g_free (str);
 
   /* inputlayout */
@@ -3505,7 +3505,7 @@ TEST (tensor_stream_test, custom_filter_drop_buffer)
   EXPECT_EQ (g_test_data.received_size, 200U * 2);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -3592,7 +3592,7 @@ TEST (tensor_stream_test, custom_filter_passthrough)
   EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120);
 
   /* check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /* check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -3661,7 +3661,7 @@ TEST (tensor_stream_test, tensors_mix)
   EXPECT_EQ (g_test_data.received_size, 500U * 2);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -3727,7 +3727,7 @@ TEST (tensor_stream_test, demux_properties_1)
 
   /* tensorpick */
   g_object_get (demux, "tensorpick", &pick, NULL);
-  EXPECT_TRUE (g_str_equal (pick, "0,2"));
+  EXPECT_STREQ (pick, "0,2");
   g_free (pick);
 
   gst_object_unref (demux);
@@ -3744,7 +3744,7 @@ TEST (tensor_stream_test, demux_properties_1)
   EXPECT_EQ (g_test_data.received_size, 3U * 64 * 48);
 
   /* check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /* check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -3793,7 +3793,7 @@ TEST (tensor_stream_test, demux_properties_2)
 
   /* tensorpick */
   g_object_get (demux, "tensorpick", &pick, NULL);
-  EXPECT_TRUE (g_str_equal (pick, "1,2"));
+  EXPECT_STREQ (pick, "1,2");
   g_free (pick);
 
   gst_object_unref (demux);
@@ -3810,7 +3810,7 @@ TEST (tensor_stream_test, demux_properties_2)
   EXPECT_EQ (g_test_data.received_size, 500U * 2);
 
   /* check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /* check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -3862,7 +3862,7 @@ TEST (tensor_stream_test, typecast_int32)
   EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -3914,7 +3914,7 @@ TEST (tensor_stream_test, typecast_uint32)
   EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -3966,7 +3966,7 @@ TEST (tensor_stream_test, typecast_int16)
   EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4018,7 +4018,7 @@ TEST (tensor_stream_test, typecast_uint16)
   EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4070,7 +4070,7 @@ TEST (tensor_stream_test, typecast_float64)
   EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4122,7 +4122,7 @@ TEST (tensor_stream_test, typecast_float32)
   EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4174,7 +4174,7 @@ TEST (tensor_stream_test, typecast_int64)
   EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4226,7 +4226,7 @@ TEST (tensor_stream_test, typecast_uint64)
   EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4290,7 +4290,7 @@ TEST (tensor_stream_test, video_split)
   EXPECT_EQ (g_test_data.received_size, 160U * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4334,7 +4334,7 @@ TEST (tensor_stream_test, video_aggregate_1)
   EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120 * 10);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4378,7 +4378,7 @@ TEST (tensor_stream_test, video_aggregate_2)
   EXPECT_EQ (g_test_data.received_size, 3U * 1600 * 120);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4422,7 +4422,7 @@ TEST (tensor_stream_test, video_aggregate_3)
   EXPECT_EQ (g_test_data.received_size, 3U * 64 * 48 * 8);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4466,7 +4466,7 @@ TEST (tensor_stream_test, audio_aggregate_s16)
   EXPECT_EQ (g_test_data.received_size, 500U * 2 * 4);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4510,7 +4510,7 @@ TEST (tensor_stream_test, audio_aggregate_u16)
   EXPECT_EQ (g_test_data.received_size, 500U * 2 / 5);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4558,7 +4558,7 @@ TEST (tensor_stream_test, issue739_mux_parallel_1)
   EXPECT_EQ (g_test_data.received_size, 4U);    /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4625,7 +4625,7 @@ TEST (tensor_stream_test, issue739_mux_parallel_2)
   EXPECT_EQ (g_test_data.received_size, 4U);    /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4693,7 +4693,7 @@ TEST (tensor_stream_test, issue739_mux_parallel_3)
   EXPECT_EQ (g_test_data.received_size, 4U);    /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4778,7 +4778,7 @@ TEST (tensor_stream_test, issue739_merge_parallel_1)
   EXPECT_EQ (g_test_data.received_size, 4U);    /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4845,7 +4845,7 @@ TEST (tensor_stream_test, issue739_merge_parallel_2)
   EXPECT_EQ (g_test_data.received_size, 4U);    /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -4913,7 +4913,7 @@ TEST (tensor_stream_test, issue739_merge_parallel_3)
   EXPECT_EQ (g_test_data.received_size, 4U);    /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -5027,7 +5027,7 @@ TEST (tensor_stream_test, tensor_decoder_property)
   EXPECT_EQ (g_test_data.received_size, 64U);   /* uint8_t, 4:4:4:1 */
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);
@@ -5096,7 +5096,7 @@ TEST (tensor_filter_custom_easy, in_code_func_01)
   EXPECT_EQ (g_test_data.received_size, 10U);
 
   /** check caps name */
-  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+  EXPECT_STREQ (g_test_data.caps_name, "other/tensor");
 
   /** check timestamp */
   EXPECT_FALSE (g_test_data.invalid_timestamp);

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -2197,7 +2197,7 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
 
   status = ml_tensors_info_get_tensor_name (in_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  EXPECT_TRUE (g_str_equal (name, "wav_data"));
+  EXPECT_STREQ (name, "wav_data");
 
   status = ml_tensors_info_get_tensor_type (in_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -2219,7 +2219,7 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
 
   status = ml_tensors_info_get_tensor_name (out_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  EXPECT_TRUE (g_str_equal (name, "labels_softmax"));
+  EXPECT_STREQ (name, "labels_softmax");
 
   status = ml_tensors_info_get_tensor_type (out_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -3819,7 +3819,7 @@ TEST (nnstreamer_capi_singleshot, invoke_06)
 
   status = ml_tensors_info_get_tensor_name (in_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  EXPECT_TRUE (g_str_equal (name, "data"));
+  EXPECT_STREQ (name, "data");
 
   status = ml_tensors_info_get_tensor_type (in_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -3841,7 +3841,7 @@ TEST (nnstreamer_capi_singleshot, invoke_06)
 
   status = ml_tensors_info_get_tensor_name (out_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  EXPECT_TRUE (g_str_equal (name, "prob"));
+  EXPECT_STREQ (name, "prob");
 
   status = ml_tensors_info_get_tensor_type (out_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);


### PR DESCRIPTION
using `EXPECT_STREQ` rather than `EXPECT_TRUE( g_str_equal...`

Signed-off-by: HyoungJoo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
