### PR TITLE
[C-Api] new ref to get tensor name @open sesame 05/06 15:26

### DIFF
--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -675,6 +675,7 @@ int ml_tensors_info_set_tensor_name (ml_tensors_info_h info, unsigned int index,
 /**
  * @brief Gets the tensor name with given handle of tensors information.
  * @since_tizen 5.5
+ * @remarks If the function succeeds, @a name should be released using g_free().
  * @param[in] info The handle of tensors information.
  * @param[in] index The index of the tensor.
  * @param[out] name The tensor name.

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -324,7 +324,7 @@ ml_tensors_info_get_tensor_name (ml_tensors_info_h info,
   if (tensors_info->num_tensors <= index)
     return ML_ERROR_INVALID_PARAMETER;
 
-  *name = tensors_info->info[index].name;
+  *name = g_strdup (tensors_info->info[index].name);
 
   return ML_ERROR_NONE;
 }

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -1648,6 +1648,7 @@ TEST (nnstreamer_capi_util, tensors_info)
   status = ml_tensors_info_get_tensor_name (info, 1, &out_name);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (out_name && g_str_equal (out_name, "tensor-name-test"));
+  g_free (out_name);
 
   status = ml_tensors_info_get_tensor_type (info, 2, &out_type);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
@@ -2377,6 +2378,7 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
   status = ml_tensors_info_get_tensor_name (in_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_STREQ (name, "wav_data");
+  g_free (name);
 
   status = ml_tensors_info_get_tensor_type (in_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -2399,6 +2401,7 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
   status = ml_tensors_info_get_tensor_name (out_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_STREQ (name, "labels_softmax");
+  g_free (name);
 
   status = ml_tensors_info_get_tensor_type (out_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -3999,6 +4002,7 @@ TEST (nnstreamer_capi_singleshot, invoke_06)
   status = ml_tensors_info_get_tensor_name (in_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_STREQ (name, "data");
+  g_free (name);
 
   status = ml_tensors_info_get_tensor_type (in_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -4021,6 +4025,7 @@ TEST (nnstreamer_capi_singleshot, invoke_06)
   status = ml_tensors_info_get_tensor_name (out_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_STREQ (name, "prob");
+  g_free (name);
 
   status = ml_tensors_info_get_tensor_type (out_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -4147,7 +4152,7 @@ TEST (nnstreamer_capi_singleshot, invoke_07)
 
   status = ml_tensors_info_get_tensor_name (in_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  EXPECT_TRUE (name != NULL);
+  EXPECT_TRUE (name == NULL);
 
   status = ml_tensors_info_get_tensor_type (in_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -4169,7 +4174,7 @@ TEST (nnstreamer_capi_singleshot, invoke_07)
 
   status = ml_tensors_info_get_tensor_name (out_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  EXPECT_TRUE (name != NULL);
+  EXPECT_TRUE (name == NULL);
 
   status = ml_tensors_info_get_tensor_type (out_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);


### PR DESCRIPTION
if tensors-info has name, return new ref when getting the tensor name.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
