### PR TITLE
[Test/tensordec-pose] Fix a test case with arithmetic transform

### DIFF
--- a/tests/nnstreamer_decoder_pose/runTest.sh
+++ b/tests/nnstreamer_decoder_pose/runTest.sh
@@ -31,6 +31,6 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc ! videoconvert ! video
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 1 0 0 $PERFORMANCE
 
 # TEST WITH MORE BUFFERS
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=100 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 option3=notused ! fakesink" 2 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=20 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:128,div:255 ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 option3=notused ! fakesink" 2 0 0 $PERFORMANCE
 
 report


### PR DESCRIPTION
- tensordec-pose treats incoming array as float, thus add `tensor_transform mode=arithmetic` to test pipeline
- expecting proper line converage results

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
