### PR TITLE
[Android/AMC] Set the omitted finalize function

### DIFF
--- a/ext/nnstreamer/android_source/gstamcsrc.c
+++ b/ext/nnstreamer/android_source/gstamcsrc.c
@@ -272,6 +272,7 @@ gst_amc_src_class_init (GstAMCSrcClass * klass)
   /** property-related init */
   gobject_class->set_property = gst_amc_src_set_property;
   gobject_class->get_property = gst_amc_src_get_property;
+  gobject_class->finalize = gst_amc_src_finalize;
 
   g_object_class_install_property (gobject_class, PROP_LOCATION,
       g_param_spec_string ("location", "File Location",


### PR DESCRIPTION
`gst_amc_src_finalize()` exists in the code but the finalize of GObject
class is not set. Because of this reason, gst_amc_src_finalize() function
is not called at all. This patch fixes this bug.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped 
2. Run test: [*]Passed [ ]Failed []Skipped 

