### PR TITLE
[TEST] Fix svace defect : nnfw_runtime, tensordec-imagelabel

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
@@ -196,7 +196,7 @@ il_decode (void **pdata, const GstTensorsConfig * config,
   g_assert (max_index < data->labels.total_labels);
 
   /** @todo With option-2, allow to change output format */
-  str = g_strdup_printf ("%s", data->labels.labels[max_index]);
+  str = data->labels.labels[max_index];
   size = strlen (str);
 
   /* Ensure we have outbuf properly allocated */
@@ -208,6 +208,7 @@ il_decode (void **pdata, const GstTensorsConfig * config,
     }
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
+
   if (FALSE == gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
     ml_loge ("Cannot map output memory / tensordec-imagelabel.\n");
     return GST_FLOW_ERROR;
@@ -219,8 +220,6 @@ il_decode (void **pdata, const GstTensorsConfig * config,
 
   if (gst_buffer_get_size (outbuf) == 0)
     gst_buffer_append_memory (outbuf, out_mem);
-
-  g_free (str);
 
   return GST_FLOW_OK;
 }

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -736,7 +736,7 @@ new_data_cb (const ml_tensors_data_h data, const ml_tensors_info_h info,
  */
 TEST (nnstreamer_nnfw_mlapi, invoke_pipeline_00)
 {
-  gchar *pipeline;
+  gchar *pipeline, *test_model;
   ml_pipeline_h handle;
   ml_pipeline_src_h src_handle;
   ml_pipeline_sink_h sink_handle;
@@ -746,9 +746,7 @@ TEST (nnstreamer_nnfw_mlapi, invoke_pipeline_00)
   ml_tensors_data_h input;
   float *data;
   size_t data_size;
-
-  gchar *test_model;
-  guint *sink_called_cnt = (guint *) g_malloc0 (sizeof (guint));
+  guint *sink_called_cnt = NULL;
 
   test_model = get_model_file ();
   ASSERT_TRUE (test_model != nullptr);
@@ -766,6 +764,8 @@ TEST (nnstreamer_nnfw_mlapi, invoke_pipeline_00)
   status = ml_pipeline_src_get_handle (handle, "appsrc", &src_handle);
   EXPECT_EQ (status, ML_ERROR_NONE);
   /* register call back function when new data is arrived on sink pad */
+  sink_called_cnt = (guint *) g_malloc0 (sizeof (guint));
+
   status =
       ml_pipeline_sink_register (handle, "tensor_sink", new_data_cb, sink_called_cnt,
       &sink_handle);
@@ -1009,6 +1009,7 @@ TEST (nnstreamer_nnfw_mlapi, multimodal_01_p)
   float *data0, *data1;
   size_t data_size0, data_size1;
   unsigned int ret;
+  guint *sink_called_cnt = NULL;
 
   const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
   const gchar *orig_model = "add.tflite";
@@ -1016,7 +1017,6 @@ TEST (nnstreamer_nnfw_mlapi, multimodal_01_p)
   gchar *model_file, *manifest_file;
   char *replace_command;
 
-  guint *sink_called_cnt = (guint *) g_malloc0 (sizeof (guint));
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -1057,7 +1057,10 @@ TEST (nnstreamer_nnfw_mlapi, multimodal_01_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_pipeline_src_get_handle (handle, "appsrc_1", &src_handle_1);
   EXPECT_EQ (status, ML_ERROR_NONE);
+
   /* register call back function when new data is arrived on sink pad */
+  sink_called_cnt = (guint *) g_malloc0 (sizeof (guint));
+
   status =
       ml_pipeline_sink_register (handle, "tensor_sink", new_data_cb_2, sink_called_cnt,
       &sink_handle);
@@ -1137,7 +1140,7 @@ TEST (nnstreamer_nnfw_mlapi, multimodal_01_p)
  */
 TEST (nnstreamer_nnfw_mlapi, multimodel_01_p)
 {
-  gchar *pipeline;
+  gchar *pipeline, *test_model;
   ml_pipeline_h handle;
   ml_pipeline_src_h src_handle;
   ml_pipeline_sink_h sink_handle_0, sink_handle_1;
@@ -1147,9 +1150,7 @@ TEST (nnstreamer_nnfw_mlapi, multimodel_01_p)
   ml_tensors_data_h input;
   float *data;
   size_t data_size;
-
-  gchar *test_model;
-  guint *sink_called_cnt = (guint *) g_malloc0 (sizeof (guint));
+  guint *sink_called_cnt = NULL;
 
   test_model = get_model_file ();
   ASSERT_TRUE (test_model != nullptr);
@@ -1169,6 +1170,8 @@ TEST (nnstreamer_nnfw_mlapi, multimodel_01_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* register call back function when new data is arrived on sink pad */
+  sink_called_cnt = (guint *) g_malloc0 (sizeof (guint));
+
   status =
       ml_pipeline_sink_register (handle, "tensor_sink_0", new_data_cb, sink_called_cnt,
       &sink_handle_0);
@@ -1234,7 +1237,7 @@ TEST (nnstreamer_nnfw_mlapi, multimodel_01_p)
  */
 TEST (nnstreamer_nnfw_mlapi, multimodel_02_p)
 {
-  gchar *pipeline;
+  gchar *pipeline, *test_model;
   ml_pipeline_h handle;
   ml_pipeline_src_h src_handle;
   ml_pipeline_sink_h sink_handle_0, sink_handle_1;
@@ -1244,9 +1247,7 @@ TEST (nnstreamer_nnfw_mlapi, multimodel_02_p)
   ml_tensors_data_h input;
   float *data;
   size_t data_size;
-
-  gchar *test_model;
-  guint *sink_called_cnt = (guint *) g_malloc0 (sizeof (guint));
+  guint *sink_called_cnt = NULL;
 
   test_model = get_model_file ();
   ASSERT_TRUE (test_model != nullptr);
@@ -1266,6 +1267,8 @@ TEST (nnstreamer_nnfw_mlapi, multimodel_02_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* register call back function when new data is arrived on sink pad */
+  sink_called_cnt = (guint *) g_malloc0 (sizeof (guint));
+
   status =
       ml_pipeline_sink_register (handle, "tensor_sink_0", new_data_cb, sink_called_cnt,
       &sink_handle_0);


### PR DESCRIPTION
Fix memory leak of nnfw runtime and tensor decoder image labeling unit test.

Related SVACE defects : 440263, 440264, 440265, 440266, 440261

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped