### PR TITLE
[CAPI] Separate error codes: ml-api-common.h

### DIFF
--- a/api/capi/include/ml-api-common.h
+++ b/api/capi/include/ml-api-common.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * NNStreamer API / Tizen Machine-Learning API Common Header
+ * Copyright (C) 2020 MyungJoo Ham <myungjoo.ham@samsung.com>
+ */
+/**
+ * @file	ml-api-common.h
+ * @date	07 May 2020
+ * @brief	ML-API Common Header
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ * @details
+ *      More entries might be migrated from nnstreamer.h if
+ *    other modules of Tizen-ML APIs use common data structures.
+ */
+#ifndef __ML_API_COMMON_H__
+#define __ML_API_COMMON_H__
+
+#include <tizen_error.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * @brief Enumeration for the error codes of NNStreamer.
+ * @since_tizen 5.5
+ */
+typedef enum {
+  ML_ERROR_NONE                 = TIZEN_ERROR_NONE, /**< Success! */
+  ML_ERROR_INVALID_PARAMETER    = TIZEN_ERROR_INVALID_PARAMETER, /**< Invalid parameter */
+  ML_ERROR_STREAMS_PIPE         = TIZEN_ERROR_STREAMS_PIPE, /**< Cannot create or access the pipeline. */
+  ML_ERROR_TRY_AGAIN            = TIZEN_ERROR_TRY_AGAIN, /**< The pipeline is not ready, yet (not negotiated, yet) */
+  ML_ERROR_UNKNOWN              = TIZEN_ERROR_UNKNOWN,  /**< Unknown error */
+  ML_ERROR_TIMED_OUT            = TIZEN_ERROR_TIMED_OUT,  /**< Time out */
+  ML_ERROR_NOT_SUPPORTED        = TIZEN_ERROR_NOT_SUPPORTED, /**< The feature is not supported */
+  ML_ERROR_PERMISSION_DENIED    = TIZEN_ERROR_PERMISSION_DENIED, /**< Permission denied */
+  ML_ERROR_OUT_OF_MEMORY        = TIZEN_ERROR_OUT_OF_MEMORY, /**< Out of memory (Since 6.0) */
+} ml_error_e;
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __ML_API_COMMON_H__ */

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -26,8 +26,7 @@
 
 #include <stddef.h>
 #include <stdbool.h>
-
-#include <tizen_error.h>
+#include "ml-api-common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -167,22 +166,6 @@ typedef enum _ml_tensor_type_e
   ML_TENSOR_TYPE_UINT64,         /**< Unsigned integer 64bit */
   ML_TENSOR_TYPE_UNKNOWN         /**< Unknown type */
 } ml_tensor_type_e;
-
-/**
- * @brief Enumeration for the error codes of NNStreamer.
- * @since_tizen 5.5
- */
-typedef enum {
-  ML_ERROR_NONE                 = TIZEN_ERROR_NONE, /**< Success! */
-  ML_ERROR_INVALID_PARAMETER    = TIZEN_ERROR_INVALID_PARAMETER, /**< Invalid parameter */
-  ML_ERROR_STREAMS_PIPE         = TIZEN_ERROR_STREAMS_PIPE, /**< Cannot create or access the pipeline. */
-  ML_ERROR_TRY_AGAIN            = TIZEN_ERROR_TRY_AGAIN, /**< The pipeline is not ready, yet (not negotiated, yet) */
-  ML_ERROR_UNKNOWN              = TIZEN_ERROR_UNKNOWN,  /**< Unknown error */
-  ML_ERROR_TIMED_OUT            = TIZEN_ERROR_TIMED_OUT,  /**< Time out */
-  ML_ERROR_NOT_SUPPORTED        = TIZEN_ERROR_NOT_SUPPORTED, /**< The feature is not supported */
-  ML_ERROR_PERMISSION_DENIED    = TIZEN_ERROR_PERMISSION_DENIED, /**< Permission denied */
-  ML_ERROR_OUT_OF_MEMORY        = TIZEN_ERROR_OUT_OF_MEMORY, /**< Out of memory (Since 6.0) */
-} ml_error_e;
 
 /**
  * @brief Enumeration for buffer deallocation policies.

--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -39,6 +39,7 @@ endif
 capi_devel_main = []
 capi_devel_main += join_paths(meson.current_source_dir(), 'include', 'nnstreamer.h')
 capi_devel_main += join_paths(meson.current_source_dir(), 'include', 'nnstreamer-single.h')
+capi_devel_main += join_paths(meson.current_source_dir(), 'include', 'ml-api-common.h')
 if get_option('enable-tizen')
   # header for Tizen internal API
   capi_devel_main += join_paths(meson.current_source_dir(), 'include', 'nnstreamer-tizen-internal.h')

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -253,8 +253,15 @@ NNStreamer's tensor_filter subplugin of Tizen-NNFW Runtime. (5.5 M2 +)
 Summary:	Tizen Native API Devel Kit for NNStreamer
 Group:		Multimedia/Framework
 Requires:	capi-nnstreamer = %{version}-%{release}
+Requires:	capi-ml-common-devel
 %description -n capi-nnstreamer-devel
 Developmental kit for Tizen Native NNStreamer API.
+
+%package -n capi-ml-common-devel
+Summary:	Common headers for Tizen Machine Learning API set.
+Group:		Multimedia/Framework
+%description -n capi-ml-common-devel
+Common headers for Tizen Machine Learning API set.
 
 %package -n nnstreamer-tizen-internal-capi-devel
 Summary:	Tizen internal API to construct the pipeline
@@ -573,6 +580,9 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{_includedir}/nnstreamer/nnstreamer-single.h
 %{_libdir}/pkgconfig/capi-nnstreamer.pc
 %{_libdir}/libcapi-nnstreamer.a
+
+%files -n capi-ml-common-devel
+%{_includedir}/nnstreamer/ml-api-common.h
 
 %files -n nnstreamer-tizen-internal-capi-devel
 %{_includedir}/nnstreamer/nnstreamer-tizen-internal.h


### PR DESCRIPTION
nntrainer wants to share the error codes for its API set.
Separate "common" header and release it via a sub-pacakge.

CC: @jijoongmoon: You can use this for
https://github.com/nnstreamer/nntrainer/issues/75

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
