### PR TITLE
[Tests/Source] Fix broken test cases for the Tizen Sensor extension

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -416,7 +416,7 @@ export NNSTREAMER_DECODERS=$(pwd)/build/ext/nnstreamer/tensor_decoder
 %if %{with tizen}
     bash %{test_script} ./tests/tizen_nnfw_runtime/unittest_nnfw_runtime_raw
     ln -s ext/nnstreamer/tensor_source/*.so .
-    bash %{test_script} ./tests/tizen_capi/unittest_tizen_sensor
+    GST_PLUGIN_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/build/ext/nnstreamer/tensor_source:${GST_PLUGIN_PATH} bash %{test_script} ./tests/tizen_capi/unittest_tizen_sensor
 %endif #if tizen
 %if 0%{?unit_test}
     bash %{test_script} ./tests

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -415,7 +415,6 @@ export NNSTREAMER_DECODERS=$(pwd)/build/ext/nnstreamer/tensor_decoder
 
 %if %{with tizen}
     bash %{test_script} ./tests/tizen_nnfw_runtime/unittest_nnfw_runtime_raw
-    ln -s ext/nnstreamer/tensor_source/*.so .
     GST_PLUGIN_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/build/ext/nnstreamer/tensor_source:${GST_PLUGIN_PATH} bash %{test_script} ./tests/tizen_capi/unittest_tizen_sensor
 %endif #if tizen
 %if 0%{?unit_test}

--- a/packaging/run_unittests_binaries.sh
+++ b/packaging/run_unittests_binaries.sh
@@ -9,7 +9,6 @@
 input=$1
 
 pushd build
-export GST_PLUGIN_PATH=$(pwd)/gst/nnstreamer
 export NNSTREAMER_CONF=$(pwd)/nnstreamer-test.ini
 export NNSTREAMER_FILTERS=$(pwd)/ext/nnstreamer/tensor_filter
 export NNSTREAMER_DECODERS=$(pwd)/ext/nnstreamer/tensor_decoder


### PR DESCRIPTION
This PR fixes the broken test cases for the Tizen sensor tensor source extension.

In detail, 'unittest_tizen_sensor' requires a nnstreamer extension plugin, 'tensor_src_tizensensor', in addition to the other nnstreamer plugins. In order to resolve this dependency at build time, the rpm spec for Tizen is modified to provide extra GST_PLUGIN_PATH to 'unittest_tizen_sensor'.

See also: https://github.com/nnstreamer/nnstreamer/pull/2274

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped