### PR TITLE
[Tests/Regression] GTEST error is ignored

### DIFF
--- a/packaging/run_unittests_binaries.sh
+++ b/packaging/run_unittests_binaries.sh
@@ -34,9 +34,10 @@ run_entry() {
   fi
 
   ${entry} --gtest_output="xml:${entry##*/}.xml"
+  retval=$?
   export PYTHONPATH=${_PYTHONPATH}
 
-  return $?
+  return ${retval}
 }
 
 ret=0


### PR DESCRIPTION
PR #2338 has incurred a regression in the test suite that
make gbs pass even if there is a failed unit test case in gtest.

This fixes the regression of #2338

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

