### PR TITLE
[single] single API to process nnfw transparently once opened

### DIFF
--- a/api/capi/include/tensor_filter_single.h
+++ b/api/capi/include/tensor_filter_single.h
@@ -63,7 +63,6 @@ struct _GTensorFilterSingleClass
 {
   GObjectClass parent; /**< inherits GObjectClass */
 
-
   /** Invoke the filter for execution. */
   gboolean (*invoke) (GTensorFilterSingle * self, const GstTensorMemory * input,
       GstTensorMemory * output);
@@ -76,7 +75,7 @@ struct _GTensorFilterSingleClass
   /** Check if the output is already configured */
   gboolean (*output_configured) (GTensorFilterSingle * self);
   /** Set the info about the input tensor */
-  gboolean (*set_input_info) (GTensorFilterSingle * self,
+  gint (*set_input_info) (GTensorFilterSingle * self,
       const GstTensorsInfo * in_info, GstTensorsInfo * out_info);
 };
 

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -293,27 +293,21 @@ ml_single_set_gst_info (ml_single * single_h, const ml_tensors_info_h info)
 {
   GstTensorsInfo gst_in_info, gst_out_info;
   int status = ML_ERROR_NONE;
+  int ret = -EINVAL;
 
-  switch (single_h->nnfw) {
-    case ML_NNFW_TYPE_TENSORFLOW_LITE:
-    case ML_NNFW_TYPE_CUSTOM_FILTER:
-      ml_tensors_info_copy_from_ml (&gst_in_info, info);
+  ml_tensors_info_copy_from_ml (&gst_in_info, info);
 
-      if (!single_h->klass->set_input_info (single_h->filter, &gst_in_info,
-              &gst_out_info)) {
-        status = ML_ERROR_INVALID_PARAMETER;
-        goto exit;
-      }
-
-      ml_tensors_info_copy_from_gst (&single_h->in_info, &gst_in_info);
-      ml_tensors_info_copy_from_gst (&single_h->out_info, &gst_out_info);
-      break;
-    default:
-      status = ML_ERROR_NOT_SUPPORTED;
-      break;
+  ret = single_h->klass->set_input_info (single_h->filter, &gst_in_info,
+          &gst_out_info);
+  if (ret == 0) {
+    ml_tensors_info_copy_from_gst (&single_h->in_info, &gst_in_info);
+    ml_tensors_info_copy_from_gst (&single_h->out_info, &gst_out_info);
+  } else if (ret == -ENOENT) {
+    status = ML_ERROR_NOT_SUPPORTED;
+  } else {
+    status = ML_ERROR_INVALID_PARAMETER;
   }
 
-exit:
   return status;
 }
 


### PR DESCRIPTION
single API should process all the frameworks transparently once the single handle has been opened.
The framework check has been performed when the handle was created and opened.
If the operation is not supported, that should be handled in the nnfw rather than in single API.

Resolves: #2326 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>