### PR TITLE
[Demux/Split] unref incoming buffer

### DIFF
--- a/gst/nnstreamer/tensor_demux/gsttensordemux.c
+++ b/gst/nnstreamer/tensor_demux/gsttensordemux.c
@@ -462,7 +462,7 @@ gst_tensor_demux_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
     srcpad = gst_tensor_demux_get_tensor_pad (tensor_demux, &created, i);
 
     outbuf = gst_buffer_new ();
-    mem = gst_buffer_peek_memory (buf, i);
+    mem = gst_buffer_get_memory (buf, i);
     gst_buffer_append_memory (outbuf, mem);
     ts = GST_BUFFER_TIMESTAMP (buf);
 
@@ -494,6 +494,7 @@ gst_tensor_demux_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
       break;
   }
 
+  gst_buffer_unref (buf);
   return res;
 }
 

--- a/gst/nnstreamer/tensor_split/gsttensorsplit.c
+++ b/gst/nnstreamer/tensor_split/gsttensorsplit.c
@@ -515,6 +515,7 @@ gst_tensor_split_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
       break;
   }
 
+  gst_buffer_unref (buf);
   return res;
 }
 


### PR DESCRIPTION
After demux/split the incoming buffer, unref the buffer to decrease ref count.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
