### PR TITLE
[Android] Stop when first error occurs

### DIFF
--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -27,6 +27,7 @@
 # For example, to build library with core plugins for arm64-v8a
 # ./build-android-lib.sh --api_option=lite --target_abi=arm64-v8a
 #
+set -e
 
 # API build option
 # 'all' : default


### PR DESCRIPTION
### Problem
When running `build-android-lib.sh`, it does not stop even though error occur.
For example, `svn` is required for `build-android-lib.sh` 
but the script does not stop even though error occurs as below.
```bash
$ bash ./api/android/build-android-lib.sh 
NNStreamer library name: nnstreamer
...
~/Android/workspace/nnstreamer ~/Android/workspace/nnstreamer
./api/android/build-android-lib.sh: line 227: svn: command not found
./api/android/build-android-lib.sh: line 228: svn: command not found
./api/android/build-android-lib.sh: line 229: svn: command not found
~/Android/workspace/nnstreamer/build_android_lib ~/Android/workspace/nnstreamer ~/Android/workspace/nnstreamer
sed: can't read gradle.properties: No such file or directory
sed: can't read gradle.properties: No such file or directory
sed: can't read local.properties: No such file or directory
sed: can't read local.properties: No such file or directory
tar (child): ./external/tensorflow-lite-1.13.1.tar.xz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
Starting gradle build for Android library.
chmod: cannot access 'gradlew': No such file or directory
sh: 0: Can't open ./gradlew
Failed to build NNStreamer library.
```

### Solution
This patch stops when first error occurs so users can fix it easily as below.

```bash
$ bash ./api/android/build-android-lib.sh
NNStreamer library name: nnstreamer
...
./api/android/build-android-lib.sh: line 229: svn: command not found
$
```

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

