### PR TITLE
[filter] Handle auto/default semantics for tensor_filter

### DIFF
--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -1218,7 +1218,11 @@ ml_check_nnfw_availability (ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw,
 
   if (fw_name) {
     if ((fw = nnstreamer_filter_find (fw_name)) != NULL) {
-      if (fw->checkAvailability
+      /** @todo support GstTensorFilterV1 here */
+      /** Only check for specific HW, ANY/AUTO are always supported */
+      if (hw == ML_NNFW_HW_ANY || hw == ML_NNFW_HW_AUTO) {
+        *available = true;
+      } else if (fw->checkAvailability
           && fw->checkAvailability (ml_nnfw_to_accl_hw (hw)) != 0) {
         ml_logw ("%s is supported but not with the specified hardware.",
             fw_name);

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -45,8 +45,6 @@
 #define OUTPUT_TENSOR_META_CHAR "OutputTensorMeta"
 
 static const gchar *torch_accl_support[] = {
-  ACCL_AUTO_STR,
-  ACCL_DEFAULT_STR,
   ACCL_CPU_STR,
   ACCL_GPU_STR,
   NULL
@@ -131,7 +129,7 @@ TorchCore::setAccelerator (const char *accelerators)
   accelerator = parse_accl_hw (accelerators, torch_accl_support);
   if (accelerator == ACCL_NONE)
     goto use_gpu_ini;
-  if ((accelerator & (ACCL_CPU | ACCL_DEFAULT)) != 0)
+  if ((accelerator & (ACCL_CPU)) != 0)
     use_gpu = FALSE;
 
   return;
@@ -494,7 +492,6 @@ TorchCore::invoke (const GstTensorMemory * input, GstTensorMemory * output)
     ml_loge ("Output is not a tensor.");
     return -3;
   }
-
 
 #if (DBG)
   gint64 stop_time = g_get_real_time ();

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -48,15 +48,20 @@
 #endif
 
 static const gchar *tflite_accl_support[] = {
-  ACCL_AUTO_STR,
-  ACCL_DEFAULT_STR,
-  ACCL_CPU_SIMD_STR,
   ACCL_CPU_NEON_STR,
+  ACCL_CPU_SIMD_STR,
   ACCL_CPU_STR,
   ACCL_GPU_STR,
   ACCL_NPU_STR,
   NULL
 };
+
+#if defined(__x86_64__) || defined(__aarch64__) || defined(__arm__)
+static const gchar *tflite_accl_auto = ACCL_CPU_SIMD_STR;
+#else
+static const gchar *tflite_accl_auto = ACCL_CPU_STR;
+#endif
+static const gchar *tflite_accl_default = ACCL_CPU_STR;
 
 /**
  * @brief Wrapper class for TFLite Interpreter to support model switching
@@ -538,7 +543,8 @@ TFLiteCore::TFLiteCore (const char * _model_path, const char * accelerators)
 void TFLiteCore::setAccelerator (const char * accelerators)
 {
   use_nnapi = TRUE;
-  accelerator = parse_accl_hw (accelerators, tflite_accl_support);
+  accelerator = parse_accl_hw (accelerators, tflite_accl_support,
+      tflite_accl_auto, tflite_accl_default);
   if (accelerators == NULL || accelerator == ACCL_NONE)
     goto use_nnapi_ini;
 
@@ -550,7 +556,7 @@ use_nnapi_ini:
   if (use_nnapi == FALSE) {
     accelerator = ACCL_NONE;
   } else {
-    accelerator = ACCL_AUTO;
+    accelerator = get_accl_hw_type (tflite_accl_auto);
   }
 }
 

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -174,6 +174,8 @@ typedef struct _GstTensorFilterFrameworkInfo
   int verify_model_path; /**< TRUE(nonzero) when the NNS framework, not the sub-plugin, should verify the path of model files. */
   const accl_hw *hw_list; /**< List of supported hardwares by the framework.  Positive response of this check does not guarantee successful running of model with this accelerator. Subplugin is supposed to allocate/deallocate. */
   int num_hw; /**< number of hardware accelerators in the hw_list supported by the framework */
+  accl_hw accl_auto;  /**< accelerator to be used in auto mode (acceleration to be used but accelerator is not specified for the filter) - default -1 implies use first entry from hw_list */
+  accl_hw accl_default;   /**< accelerator to be used by default (valid user input is not provided) - default -1 implies use first entry from hw_list*/
 } GstTensorFilterFrameworkInfo;
 
 /**

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -395,7 +395,7 @@ struct _GstTensorFilterFramework
 
       int (*getFrameworkInfo) (const GstTensorFilterFramework * self,
           const GstTensorFilterProperties * prop, void *private_data,
-	  GstTensorFilterFrameworkInfo *fw_info);
+          GstTensorFilterFrameworkInfo *fw_info);
       /**< Mandatory callback. Get the frameworks statically determined info. Argument 'private_data' can be NULL. If provided 'private_data' is not NULL, then some info, such as 'allocate_in_invoke', can be updated based on the model being used (inferred from the 'private_data' provided). This updated info is useful for custom filter, as some custom filter's ability to support 'allocate_in_invoke' depends on the opened model.
        *
        * @param[in] prop read-only property values
@@ -498,10 +498,33 @@ extern const char *
 get_accl_hw_str (const accl_hw key);
 
 /**
- * @brief parse user given string to extract accelerator based on given regex
+ * @brief Accelerator related arguments for parsing
+ *
+ * @note if optional accelerators are not set, first entry from supported
+ *       accelerator is used.
  */
-extern accl_hw
-parse_accl_hw (const char * accelerators, const char ** supported_accelerators);
+typedef struct {
+  const char * in_accl;       /**< user given input */
+  const char ** sup_accl;     /**< list of supported accelerator */
+  const char * auto_accl;     /**< auto accelerator (optional) */
+  const char * def_accl;      /**< default accelerator (optional) */
+} parse_accl_args;
+
+/**
+ * @brief parse user given string to extract accelerator based on given regex filling in optional arguments
+ *
+ * @note The order of argumemnts for calling this function is:
+ *       - in_accl: user provided input accelerator string
+ *       - sup_accl: list of supported accelerator
+ *       - auto_accl: auto accelerator (optional)
+ *       - def_accl: default accelerator (optional)
+ */
+extern accl_hw parse_accl_hw_fill (parse_accl_args accl_args);
+
+/**
+ * @brief workaround to provide default arguments
+ */
+#define parse_accl_hw(...) parse_accl_hw_fill((parse_accl_args){__VA_ARGS__})
 
 #ifdef __cplusplus
 }

--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
@@ -652,53 +652,6 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, allocateInInvoke_n)
 }
 
 /**
- * @brief Check availability of accelerator support with @EXT_ABBRV@ subplugin
- */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, checkAvailability)
-{
-  int ret;
-  void *data = NULL;
-  gchar **model_files;
-
-  model_files = get_model_files ();
-  ASSERT_TRUE (model_files != nullptr);
-
-  GstTensorFilterProperties prop = {
-    .fwname = "@EXT_NAME@",
-    .fw_opened = 0,
-    .model_files = const_cast<const char **>(model_files),
-    .num_models = (int) g_strv_length (model_files),
-  };
-
-  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("@EXT_NAME@");
-  EXPECT_NE (sp, (void *) NULL);
-
-  if (sp->checkAvailability) {
-    /** auto and default should be supported by all the extensions */
-    ret = sp->checkAvailability (ACCL_AUTO);
-    EXPECT_EQ (ret, 0);
-
-    ret = sp->checkAvailability (ACCL_DEFAULT);
-    EXPECT_EQ (ret, 0);
-
-    /** Once opened, the behavior should not change */
-    ret = sp->open (&prop, &data);
-    EXPECT_EQ (ret, 0);
-
-    /** auto and default should be supported by all the extensions */
-    ret = sp->checkAvailability (ACCL_AUTO);
-    EXPECT_EQ (ret, 0);
-
-    ret = sp->checkAvailability (ACCL_DEFAULT);
-    EXPECT_EQ (ret, 0);
-
-    sp->close (&prop, &data);
-  }
-
-  g_strfreev (model_files);
-}
-
-/**
  * @brief Main gtest
  */
 int

--- a/tests/nnstreamer_filter_pytorch/runTest.sh
+++ b/tests/nnstreamer_filter_pytorch/runTest.sh
@@ -88,7 +88,7 @@ cat info | grep "gpu = 0, accl = cpu"
 testResult $? 2-2 "GPU activation test" 0 1
 
 gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=GRAY8,framerate=0/1 ! tensor_converter ! tensor_filter framework=pytorch model=${PATH_TO_MODEL} output=1:7 outputtype=int8 ! filesink location=tensorfilter.out.log 2>info
-cat info | grep "gpu = 0, accl = default"
+cat info | grep "gpu = 0, accl = cpu"
 testResult $? 2-3 "GPU activation test" 0 1
 
 # Cleanup


### PR DESCRIPTION
Patch to handle auto/default semantics for tensor_filter

Each tensor_filter can now pass its default/auto accelerator
If not passed, the value defaults to first entry from supported list of accelerators
Workaround used to provide this functionality in c - this helps running exisiting code error free with this change, and does not need each filter to essentially declare auto/default accelerators

Passed user input is parsed and if auto/default is used, corresponding accelerators are set and used.

This resolves #2320 for tensor_filter

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>