### PR TITLE
[tflite] bug fix for tflite unittest

### DIFF
--- a/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
@@ -97,87 +97,87 @@ function run_pipeline() {
 
 # Property reading test for nnapi
 run_pipeline true:cpu,npu,gpu
-cat info | grep "nnapi = 1, accl = cpu"
+cat info | grep "nnapi = 1, accl = cpu$"
 testResult $? 2-1 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:!cpu
-cat info | grep "nnapi = 1, accl = auto"
+cat info | grep "nnapi = 1, accl = auto$"
 testResult $? 2-2 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:!npu,gpu
-cat info | grep "nnapi = 1, accl = gpu"
+cat info | grep "nnapi = 1, accl = gpu$"
 testResult $? 2-3 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:!npu,gpu,abcd
-cat info | grep "nnapi = 1, accl = gpu"
+cat info | grep "nnapi = 1, accl = gpu$"
 testResult $? 2-4 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:!npu,!abcd,gpu
-cat info | grep "nnapi = 1, accl = gpu"
+cat info | grep "nnapi = 1, accl = gpu$"
 testResult $? 2-5 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:auto
-cat info | grep "nnapi = 1, accl = auto"
+cat info | grep "nnapi = 1, accl = auto$"
 testResult $? 2-6 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:default,cpu
-cat info | grep "nnapi = 1, accl = default"
+cat info | grep "nnapi = 1, accl = default$"
 testResult $? 2-7 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:!cpu,default
-cat info | grep "nnapi = 1, accl = default"
+cat info | grep "nnapi = 1, accl = default$"
 testResult $? 2-8 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:!default
-cat info | grep "nnapi = 1, accl = auto"
+cat info | grep "nnapi = 1, accl = auto$"
 testResult $? 2-9 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:npu.srcn
-cat info | grep "nnapi = 1, accl = npu"
+cat info | grep "nnapi = 1, accl = npu$"
 testResult $? 2-10 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline false:abcd
-cat info | grep "nnapi = 0, accl = none"
+cat info | grep "nnapi = 0, accl = none$"
 testResult $? 2-11 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline false
-cat info | grep "nnapi = 0, accl = none"
+cat info | grep "nnapi = 0, accl = none$"
 testResult $? 2-12 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:
-cat info | grep "nnapi = 1, accl = auto"
+cat info | grep "nnapi = 1, accl = auto$"
 testResult $? 2-13 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true
-cat info | grep "nnapi = 1, accl = auto"
+cat info | grep "nnapi = 1, accl = auto$"
 testResult $? 2-14 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline auto
-cat info | grep "nnapi = 0, accl = none"
+cat info | grep "nnapi = 0, accl = none$"
 testResult $? 2-15 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:!npu,abcd,gpu
-cat info | grep "nnapi = 1, accl = gpu"
+cat info | grep "nnapi = 1, accl = gpu$"
 testResult $? 2-16 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:cpu.neon,cpu
-cat info | grep "nnapi = 1, accl = cpu.neon"
+cat info | grep "nnapi = 1, accl = cpu.neon$"
 testResult $? 2-17 "NNAPI activation test" 0 1
 
 # Cleanup


### PR DESCRIPTION
unittest of tflite compared output with grep "exp"
however some expressions could be prefix of different exp
this could lead to false positives
added line end marker

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>