### PR TITLE
[single] Add implementation to support for hw accelerator

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -341,6 +341,12 @@ int ml_validate_model_file (char **model, unsigned int num_models, ml_nnfw_type_
 int ml_check_plugin_availability (const char *plugin_name, const char *element_name);
 
 /**
+ * @brief Internal function to convert accelerator as tensor_filter property format.
+ * @note returned value must be freed by the caller
+ */
+char* ml_nnfw_to_str_prop (ml_nnfw_hw_e hw);
+
+/**
  * @brief Internal function to get the sub-plugin name.
  */
 const char* ml_get_nnfw_subplugin_name (ml_nnfw_type_e nnfw);

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -522,9 +522,10 @@ ml_single_open_custom (ml_single_h * single, ml_single_preset * info)
   ml_tensors_info_s *in_tensors_info, *out_tensors_info;
   ml_nnfw_type_e nnfw;
   ml_nnfw_hw_e hw;
-  const char *fw_name;
+  const gchar *fw_name;
   gchar **list_models;
   guint num_models;
+  char *hw_name;
 
   check_feature_state ();
 
@@ -572,7 +573,6 @@ ml_single_open_custom (ml_single_h * single, ml_single_preset * info)
 
   /**
    * 3. Construct a pipeline
-   * @todo Set the hw property
    * Set the pipeline desc with nnfw.
    */
   if (nnfw == ML_NNFW_TYPE_TENSORFLOW || nnfw == ML_NNFW_TYPE_SNAP) {
@@ -611,9 +611,11 @@ ml_single_open_custom (ml_single_h * single, ml_single_preset * info)
     }
   }
 
-  /* set framework, model files and custom option */
+  /* set accelerator, framework, model files and custom option */
   fw_name = ml_get_nnfw_subplugin_name (nnfw);
-  g_object_set (filter_obj, "framework", fw_name, "model", info->models, NULL);
+  hw_name = ml_nnfw_to_str_prop (hw);
+  g_object_set (filter_obj, "accelerator", hw_name, "framework", fw_name, "model", info->models, NULL);
+  g_free (hw_name);
 
   if (info->custom_option) {
     g_object_set (filter_obj, "custom", info->custom_option, NULL);

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -1136,6 +1136,24 @@ ml_nnfw_to_accl_hw (const ml_nnfw_hw_e hw)
 }
 
 /**
+ * @brief Internal function to convert accelerator as tensor_filter property format.
+ * @note returned value must be freed by the caller
+ * @note More details on format can be found in gst_tensor_filter_install_properties() in tensor_filter_common.c.
+ */
+char *
+ml_nnfw_to_str_prop (const ml_nnfw_hw_e hw)
+{
+  const gchar *hw_name;
+  const gchar *use_accl = "true:";
+  gchar *str_prop = NULL;
+
+  hw_name = get_accl_hw_str (ml_nnfw_to_accl_hw (hw));
+  str_prop = g_strdup_printf ("%s%s", use_accl, hw_name);
+
+  return str_prop;
+}
+
+/**
  * @brief Internal function to get the sub-plugin name.
  */
 const char *


### PR DESCRIPTION
single API supported hw accelerator for the NNFW
this hw was used to check if it is supported by the framework
however this hw was never passed to the framework to use
this patch sovles this issue

resolves #2374

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>