### PR TITLE
[hw/accl] Add CPU_SIMD as a backend option

### DIFF
--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -139,7 +139,8 @@ typedef enum {
   ML_NNFW_HW_ANY          = 0,      /**< Hardware resource is not specified. */
   ML_NNFW_HW_AUTO         = 1,      /**< Try to schedule and optimize if possible. */
   ML_NNFW_HW_CPU          = 0x1000, /**< 0x1000: any CPU. 0x1nnn: CPU # nnn-1. */
-  ML_NNFW_HW_CPU_NEON     = 0x1100, /**< 0x1100: NEON in CPU. (Since 6.0) */
+  ML_NNFW_HW_CPU_SIMD     = 0x1100, /**< 0x1100: SIMD in CPU. (Since 6.0) */
+  ML_NNFW_HW_CPU_NEON     = 0x1100, /**< 0x1100: NEON (alias for SIMD) in CPU. (Since 6.0) */
   ML_NNFW_HW_GPU          = 0x2000, /**< 0x2000: any GPU. 0x2nnn: GPU # nnn-1. */
   ML_NNFW_HW_NPU          = 0x3000, /**< 0x3000: any NPU. 0x3nnn: NPU # nnn-1. */
   ML_NNFW_HW_NPU_MOVIDIUS = 0x3001, /**< 0x3001: Intel Movidius Stick. (Since 6.0) */

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -1115,8 +1115,13 @@ ml_nnfw_to_accl_hw (const ml_nnfw_hw_e hw)
       return ACCL_AUTO;
     case ML_NNFW_HW_CPU:
       return ACCL_CPU;
+#if defined(__aarch64__) || defined(__arm__)
     case ML_NNFW_HW_CPU_NEON:
       return ACCL_CPU_NEON;
+#else
+    case ML_NNFW_HW_CPU_SIMD:
+      return ACCL_CPU_SIMD;
+#endif
     case ML_NNFW_HW_GPU:
       return ACCL_GPU;
     case ML_NNFW_HW_NPU:

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -50,6 +50,7 @@
 static const gchar *tflite_accl_support[] = {
   ACCL_AUTO_STR,
   ACCL_DEFAULT_STR,
+  ACCL_CPU_SIMD_STR,
   ACCL_CPU_NEON_STR,
   ACCL_CPU_STR,
   ACCL_GPU_STR,

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -21,6 +21,7 @@
 #define ACCL_DEFAULT_STR  "default"
 #define ACCL_AUTO_STR "auto"
 #define ACCL_CPU_STR  "cpu"
+#define ACCL_CPU_SIMD_STR  "cpu.simd"
 #define ACCL_CPU_NEON_STR  "cpu.neon"
 #define ACCL_GPU_STR  "gpu"
 #define ACCL_NPU_STR  "npu"
@@ -86,7 +87,8 @@ typedef enum
 
   /** Enables acceleration, 0xn000 any version of that device, 0xnxxx: device # xxx-1 */
   ACCL_CPU          = 0x1000,     /**< specify device as CPU, if possible */
-  ACCL_CPU_NEON     = 0x1100,     /**< specify device as NEON in cpu, if possible */
+  ACCL_CPU_SIMD     = 0x1100,     /**< specify device as SIMD in cpu, if possible */
+  ACCL_CPU_NEON     = 0x1100,     /**< specify device as NEON (alias for SIMD) in cpu, if possible */
   ACCL_GPU          = 0x2000,     /**< specify device as GPU, if possible */
   ACCL_NPU          = 0x4000,     /**< specify device as any NPU, if possible */
   ACCL_NPU_MOVIDIUS = 0x4001,     /**< specify device as movidius, if possible */

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -1852,7 +1852,9 @@ parse_accl_hw_all (const gchar * accelerators,
         gchar *word = g_match_info_fetch (match_info, 0);
         accl = get_accl_hw_type (word);
         g_free (word);
-        match_accl = g_list_append (match_accl, GINT_TO_POINTER (accl));
+        if (accl > 0 || (accl == 0 && g_strcmp0 (word, ACCL_NONE_STR) == 0)) {
+          match_accl = g_list_append (match_accl, GINT_TO_POINTER (accl));
+        }
         g_match_info_next (match_info, NULL);
       }
     }
@@ -1910,7 +1912,11 @@ accl_hw_get_type (void)
       {ACCL_DEFAULT, ACCL_DEFAULT_STR, ACCL_DEFAULT_STR},
       {ACCL_AUTO, ACCL_AUTO_STR, ACCL_AUTO_STR},
       {ACCL_CPU, ACCL_CPU_STR, ACCL_CPU_STR},
+#if defined(__aarch64__) || defined(__arm__)
+      /** Retreive NEON_STR when searching for SIMD/NEON on arm architectures */
       {ACCL_CPU_NEON, ACCL_CPU_NEON_STR, ACCL_CPU_NEON_STR},
+#endif
+      {ACCL_CPU_SIMD, ACCL_CPU_SIMD_STR, ACCL_CPU_SIMD_STR},
       {ACCL_GPU, ACCL_GPU_STR, ACCL_GPU_STR},
       {ACCL_NPU, ACCL_NPU_STR, ACCL_NPU_STR},
       {ACCL_NPU_MOVIDIUS, ACCL_NPU_MOVIDIUS_STR, ACCL_NPU_MOVIDIUS_STR},

--- a/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
@@ -177,7 +177,12 @@ testResult $? 2-16 "NNAPI activation test" 0 1
 
 # Property reading test for nnapi
 run_pipeline true:cpu.neon,cpu
-cat info | grep "nnapi = 1, accl = cpu.neon$"
+arch=$(uname -m)
+if [ "$arch" = "aarch64" ] || [ "$arch" = "armv7l" ]; then
+	cat info | grep "nnapi = 1, accl = cpu.neon$"
+else
+	cat info | grep "nnapi = 1, accl = cpu$"
+fi
 testResult $? 2-17 "NNAPI activation test" 0 1
 
 # Cleanup

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -1334,6 +1334,10 @@ TEST (nnstreamer_capi_util, availability_01)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, is_enabled_tensorflow_lite);
 
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_CPU_SIMD, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, is_enabled_tensorflow_lite);
+
   status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_GPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, is_enabled_tensorflow_lite);
@@ -4957,7 +4961,6 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_success_01_p)
     ml_tensors_info_destroy (in_info);
     ml_tensors_info_destroy (out_info);
   }
-
 
   status = ml_single_set_property (single, "input", "5:1:1:1");
   EXPECT_EQ (status, ML_ERROR_NONE);


### PR DESCRIPTION
Added CPU_SIMD as a backend option
CPU_NEON will be alias for CPU_SIMD in enum but different string representation
Only updated tflite supported accelerators list. Others will be updated after #2372.

Refer https://github.com/nnstreamer/nnstreamer/pull/2372#discussion_r424857942 for more details.

cc. @myungjoo 

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>