### PR TITLE
[meson]Correct deprecated arg in features

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -206,7 +206,7 @@ features = {
     'project_args': { 'ENABLE_NNFW_RUNTIME': 1 }
   },
   'tflite-nnapi-delegation': {
-    'additional_deps': [ nnfw_dep ],
+    'extra_deps': [ nnfw_dep ],
     'project_args': { 'ENABLE_TFLITE_NNAPI_DELEGATION': 1 }
   },
   'armnn-support': {


### PR DESCRIPTION
**Changes proposed in this PR:**
- Change `additional_deps` -> `extra_deps` for tflite-nnapi-delegation

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

