### PR TITLE
[Vivante Filter,V10] Added a sub-plugin filter for VIM3/Vivante NPU

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -377,6 +377,10 @@ if get_option('enable-openvino')
   )
 endif
 
+if get_option('enable-vivante')
+  subdir('vivante')
+endif
+
 if get_option('enable-mediapipe')
   if host_machine.system() == 'linux' and host_machine.cpu_family() == 'x86_64'
     opencv_path = 'bazel-bin/_solib_k8/_U@linux_Uopencv_S_S_Copencv___Uexternal_Slinux_Uopencv_Slib_Sx86_U64-linux-gnu'

--- a/ext/nnstreamer/tensor_filter/vivante/README.md
+++ b/ext/nnstreamer/tensor_filter/vivante/README.md
@@ -1,0 +1,166 @@
+
+This describes how to enable the NNstreamer tensor filter as a sub-plugin for Vivante NPU.
+
+## Vivante tensor filter
+The entire procedure is as follows:
+ * Read multi-files (e.g., vivante_v3.nb and libvivante_v3.so)
+ * Create a neural network
+ * Execute pre-process for the image data
+ * Verify a graph
+ * Process the graph
+ * Dump all node outputs (optionally, for a debugging)
+ * Do post-process for output data
+ * Release the neural network
+
+## Reference
+ * http://www.vivantecorp.com/
+ * https://www.khadas.com/product-page/vim3 (Amlogic A311D with 5.0 TOPS NPU)
+ 
+## How to buid
+First of all, you must generate a library of a model (e.g., libvivantev3.so, libyolov3.so) to use NNStreamer tensor filter.
+For more details, please refer to the below repository.
+ * https://www.github.com/nnstreamer/reference-models (TODO) - Press 'models' folder.
+
+
+### on VIM3/Ubuntu18.04 (arm64)
+Please append the APT repository as follows for VIM3/Ubuntu 18.04 target board.
+```bash
+vim3$ sudo /usr/sbin/ntpdate jp.pool.ntp.org
+vim3$ sudo apt-get update -o Acquire::https::dl.khadas.com::Verify-Peer=false
+vim3$ cat /etc/apt/sources.list.d/fenix.list
+deb [trusted=yes] https://dl.khadas.com/repos/vim3/ bionic main
+```
+
+Build and run the NNStreamer tensor filter on Ubuntu18.04 (arm64) + the VIM3/Khadas board.
+
+```bash
+vim3$ git clone https://github.com/nnstreamer/nnstreamer.git
+vim3$ cd ./nnstreamer/ext/nnstreamer/tensor_filter/vivante/
+vim3$ ./build_run.sh
+```
+
+### on Tizen/Unified (armv7l)
+Build and run the NNStreamer tensor filter on Tizen (armv7l).
+
+```bash
+$ cp ./gbs-build-conf/.gbs.conf ~/
+$ vi ~/.gbs.conf
+$ gbs build -A armv7l --clean --include-all
+```
+
+## How to run
+You can get the below result when the required packages are prepared on the target board.
+
+
+#### Case study: Run inceptionv3 model on the Ubuntu18.04 + VIM3 NPU board
+The below log message show the execution result of the NNStreamer pipeline on both VIM3/Ubuntu18.04 (aarch64) board.
+Please refer to the "**gst-launch-1.0 ....**" statement in the [./build_run.sh](./build_run.sh) file.
+
+```bash
+ubuntu$ export VSI_NN_LOG_LEVEL={0...5}
+ubuntu$ gst-launch-1.0 filesrc location=/usr/share/dann/sample_pizza_299x299.jpg ! jpegdec ! videoconvert ! video/x-raw,format=RGB,width=299,height=299 ! tensor_converter ! tensor_filter framework=vivante model="/usr/share/dann/inception-v3.nb,/usr/share/vivante/inceptionv3/libinceptionv3.so" ! filesink location=vivante.out.bin
+
+(gst-launch-1.0:4587): GLib-CRITICAL **: 00:43:47.896: g_file_test: assertion 'filename != NULL' failed
+D [setup_node:367]Setup node id[0] uid[0] op[NBG]
+D [print_tensor:129]in : id[   1] shape[ 3, 299, 299, 1   ] fmt[u8 ] qnt[ASM zp=137, scale=0.007292]
+D [print_tensor:129]out: id[   0] shape[ 1001, 1          ] fmt[f16] qnt[NONE]
+D [optimize_node:311]Backward optimize neural network
+D [optimize_node:318]Forward optimize neural network
+I [compute_node:260]Create vx node
+Create Neural Network: 30ms or 30108us
+I [vsi_nn_PrintGraph:1308]Graph:
+I [vsi_nn_PrintGraph:1309]***************** Tensors ******************
+D [print_tensor:137]id[   0] shape[ 1001, 1          ] fmt[f16] qnt[NONE]
+D [print_tensor:137]id[   1] shape[ 3, 299, 299, 1   ] fmt[u8 ] qnt[ASM zp=137, scale=0.007292]
+I [vsi_nn_PrintGraph:1318]***************** Nodes ******************
+I [vsi_nn_PrintNode:156](             NBG)node[0] [in: 1 ], [out: 0 ] [a6981690]
+I [vsi_nn_PrintGraph:1327]******************************************
+Setting pipeline to PAUSED ...
+Pipeline is PREROLLING ...
+Start run graph [1] times...
+Run the 1 time: 33ms or 33170us
+vxProcessGraph execution time:
+Total   33ms or 33244us
+Average 33.24ms or 33244.00us
+I [vsi_nn_ConvertTensorToData:732]Create 2002 data.
+ --- Top5 ---
+208: 0.824707
+209: 0.044342
+223: 0.008614
+268: 0.002846
+185: 0.002605
+I [vsi_nn_ConvertTensorToData:732]Create 2002 data.
+Pipeline is PREROLLED ...
+Setting pipeline to PLAYING ...
+New clock: GstSystemClock
+Got EOS from element "pipeline0".
+Execution ended after 0:00:00.000172250
+Setting pipeline to PAUSED ...
+Setting pipeline to READY ...
+Setting pipeline to NULL ...
+Freeing pipeline ...
+
+
+khadas@Khadas:~/nnstreamer-private-plugins$ ls -al ./vivante.out.bin
+-rw-rw-r-- 1 khadas khadas 2002 Jan 30 00:43 ./vivante.out.bin
+```
+
+#### Case study: Run Yolov3 model on the Ubuntu18.04 + VIM3 NPU board
+Please refer to the "**gst-launch-1.0 ....**" statement in the [./build_run.sh](./build_run.sh) file.
+```bash
+ubuntu$ export VSI_NN_LOG_LEVEL={0...5}
+ubuntu$ gst-launch-1.0 filesrc location=/usr/share/dann/sample_car_bicyle_dog_416x416.jpg ! jpegdec ! videoconvert ! video/x-raw,format=BGR,width=416,height=416 ! tensor_converter ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_transform mode=typecast option=int8 ! tensor_filter framework=vivante model="/usr/share/dann/yolov3.nb,/usr/share/vivante/yolov3/libyolov3.so" ! filesink location=vivante.out.bin
+
+D [setup_node:368]Setup node id[0] uid[0] op[NBG]
+D [print_tensor:136]in(0) : id[   0] vtl[0] const[0] shape[ 416, 416, 3, 1   ] fmt[i8 ] qnt[DFP fl=  7]
+D [print_tensor:136]out(0): id[   1] vtl[0] const[0] shape[ 13, 13, 255, 1   ] fmt[i8 ] qnt[DFP fl=  2]
+D [print_tensor:136]out(1): id[   2] vtl[0] const[0] shape[ 26, 26, 255, 1   ] fmt[i8 ] qnt[DFP fl=  2]
+D [print_tensor:136]out(2): id[   3] vtl[0] const[0] shape[ 52, 52, 255, 1   ] fmt[i8 ] qnt[DFP fl=  2]
+D [optimize_node:312]Backward optimize neural network
+D [optimize_node:319]Forward optimize neural network
+I [compute_node:261]Create vx node
+Create Neural Network: -179140096ms or 41us
+I [vsi_nn_PrintGraph:1421]Graph:
+I [vsi_nn_PrintGraph:1422]***************** Tensors ******************
+D [print_tensor:146]id[   0] vtl[0] const[0] shape[ 416, 416, 3, 1   ] fmt[i8 ] qnt[DFP fl=  7]
+D [print_tensor:146]id[   1] vtl[0] const[0] shape[ 13, 13, 255, 1   ] fmt[i8 ] qnt[DFP fl=  2]
+D [print_tensor:146]id[   2] vtl[0] const[0] shape[ 26, 26, 255, 1   ] fmt[i8 ] qnt[DFP fl=  2]
+D [print_tensor:146]id[   3] vtl[0] const[0] shape[ 52, 52, 255, 1   ] fmt[i8 ] qnt[DFP fl=  2]
+I [vsi_nn_PrintGraph:1431]***************** Nodes ******************
+I [vsi_nn_PrintNode:159](             NBG)node[0] [in: 0 ], [out: 1, 2, 3 ] [ab9fecf0]
+I [vsi_nn_PrintGraph:1440]******************************************
+[DEBUG] input_tensors_num :1
+[DEBUG] output_tensors_num:3
+[DEBUG] input_dim_num[0]:4
+[DEBUG] output_dim_num[0]:4
+[DEBUG] output_dim_num[1]:4
+[DEBUG] output_dim_num[2]:4
+Setting pipeline to PAUSED ...
+Pipeline is PREROLLING ...
+Saving debug file (e.g., ./network_dump)
+D [vsi_nn_DumpGraphNodeOutputsEx:1327]Dump 1 nodes.
+I [vsi_nn_ConvertTensorToData:750]Create 43095 data.
+I [vsi_nn_ConvertTensorToData:750]Create 172380 data.
+I [vsi_nn_ConvertTensorToData:750]Create 689520 data.
+I [vsi_nn_ConvertTensorToData:750]Create 43095 data.
+ --- Top5 ---
+3099: 4.750000
+3098: 4.500000
+1230: 3.750000
+15361: 3.750000
+15273: 3.500000
+I [vsi_nn_ConvertTensorToData:750]Create 43095 data.
+I [vsi_nn_ConvertTensorToData:750]Create 172380 data.
+I [vsi_nn_ConvertTensorToData:750]Create 689520 data.
+I [vsi_nn_ConvertTensorToData:750]Create 43095 data.
+Pipeline is PREROLLED ...
+Setting pipeline to PLAYING ...
+New clock: GstSystemClock
+Got EOS from element "pipeline0".
+Execution ended after 0:00:00.014697750
+Setting pipeline to PAUSED ...
+Setting pipeline to READY ...
+Setting pipeline to NULL ...
+Freeing pipeline ...
+
+```

--- a/ext/nnstreamer/tensor_filter/vivante/build_run.sh
+++ b/ext/nnstreamer/tensor_filter/vivante/build_run.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+# @Author: Geunsik Lim <geunsik.lim@samsung.com>
+# @brief: The simple script is to build and run the VIM3/Vivante fiflter 
+# This script has been evaluated on the Ubuntu 18.04 (arm64) + VIM3/Vivante board.
+# @note Please install the below package to enable nnstreamer on a Tizen board
+#   zypper clean; zypper refresh
+#   zypper install meson ninja cmake
+#   zypper install gst-plugins-base-devel
+#   zypper install gst-plugins-good
+#   zypper install gst-plugins-good-devel
+#   zypper install gstreamer-devel
+#   zypper install nnstreamer nnstreamer-devel
+#   zypper install libjpeg libjpeg-devel
+#   zypper install gst-libav
+#
+# @note You must install the below packages to use 'zypper' command.
+#   augeas-libs, bzip2, libsolv, libsolv-tools, libzypp, pacrunner-libproxy, zypper
+# 
+#################### Configuration setting ################################
+# Specify the test items that you want to execute for the .so of Vivante model.
+BUILD=1
+RUN_TEST=1
+RUN_TEST_NUM=1
+CORRECTNESS=0
+
+# Specify higher number (0..5) to display more log messages for debugging.
+export VSI_NN_LOG_LEVEL=5
+
+
+#################### Build ################################################
+if [[ $BUILD == 1 ]]; then
+    echo -e "Compling source .........."
+    rm -rf ./build 
+    meson  -Denable-vivante=true  build 
+    ninja -C build  
+    
+    if [[ $? != 0 ]]; then
+        echo -e "Ooops. The compilation task is failed. Please fix the source code."
+        exit 1;
+    fi
+    
+    filter_dir="/usr/lib/nnstreamer/filters/"
+    echo -e "Copying a Vivante tensor filter to $filter_dir .........."
+    echo -e "Location: $filter_dir " 
+    cp ./build/ext/nnstreamer/tensor_filter/vivante/libnnstreamer_filter_vivante.so  $filter_dir
+    
+    # gst-inspect-1.0 tensor_filter
+else
+    echo -e "Skipping a task for compiling source code .........."
+fi
+
+
+
+#################### Run Test (Aging Test) ##############################
+
+# CMD='gst-launch-1.0 videotestsrc ! videoconvert ! videoscale !   tensor_converter ! fakesink'
+
+# To test the Tensorflow-Lite model
+# CMD='gst-launch-1.0 filesrc location=/mnt/sda2/nnstreamer/tests/test_models/data/orange.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=/mnt/sda2/nnstreamer/tests/test_models/models/mobilenet_v1_1.0_224_quant.tflite  ! filesink location=tensorfilter.out.log '
+
+
+# To test the inceptionv3/Vivante model
+# tensor_transform mode=typecast option=float32 ! tensor_transform mode=arithmetic option=add:-128,div:128 !
+#CMD='gst-launch-1.0 filesrc location=/usr/share/vivante/res/goldfish_299x299.jpg ! jpegdec ! videoconvert ! video/x-raw,format=RGB,width=299,height=299 ! tensor_converter ! tensor_filter framework=vivante model="/usr/share/vivante/inceptionv3/inception_v3.nb,/usr/share/vivante/inceptionv3/libinceptionv3_ori.so" ! filesink location=vivante.out.bin'
+
+
+# To test the yolov3/Vivante model
+# tensor_transform mode=typecast option=float32 ! tensor_transform mode=arithmetic option=add:0,div:256 !
+CMD='gst-launch-1.0 filesrc location=/usr/share/vivante/res/sample_car_bicyle_dog_416x416.jpg ! jpegdec ! videoconvert ! video/x-raw,format=BGR,width=416,height=416 ! tensor_converter ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_transform mode=typecast option=int8 ! tensor_filter framework=vivante model="/usr/share/vivante/yolov3/yolov3.nb,/usr/share/vivante/yolov3/libyolov3_ori.so" ! filesink location=vivante.out.bin'
+
+
+sync
+if [[ $RUN_TEST == 1 ]]; then
+    count=0
+    while [[ true ]]; do
+        ((count++))
+        echo -e "\e[34m ============ Aging Test STEP: $count / $RUN_TEST_NUM ================= \e[0m"
+        start_time=$( date +%s.%N )
+        $CMD
+        if [[ $? != 0 ]]; then
+            echo -e "Oooops. The exectuion is failed. Pleasse fix a bug."
+            exit 1
+        fi
+        elapsed_time=$( date +%s.%N --date="$start_time seconds ago" )
+        echo -e "\e[91m Elapsed Time: $elapsed_time \e[0m"
+        sleep 1
+        if [[ $count -ge $RUN_TEST_NUM ]]; then
+            echo -e "\n\e[91m Congrats!!! The aging test ($RUN_TEST_NUM times) is successfully completed. \e[0m "
+            exit 0
+        fi
+        done
+else
+    echo -e "Skipping a aging test .........."
+fi
+
+
+#################### Checking a correctness of an output tensor ##############################
+# You can find checkLabel.py and gen24BMP.py file at the nnstreamer github repository.
+# python checkLabel.py vivante.out.dat $model_dir/imagenet_slim_labels.txt dog
+
+if [[ $CORRECTNESS == 1 ]]; then
+    ls -al ./*.dat
+    echo -e "Please run the 'diff' command in order to check a difference"
+    echo -e "between the 'output*.dat' file and the 'nnstreamer*.dat' file."
+    echo -e "For example, $ diff -urN ./output*.dat ./nnstreamer*.dat."
+else
+    echo -e "Skipping a correctness check .........."
+fi
+
+

--- a/ext/nnstreamer/tensor_filter/vivante/meson.build
+++ b/ext/nnstreamer/tensor_filter/vivante/meson.build
@@ -1,0 +1,40 @@
+
+cc = meson.get_compiler('c')
+
+libovx_dep = cc.find_library('ovxlib') # ovxlib library
+libdl_dep = cc.find_library('dl') # dl library
+
+
+base_deps = [
+  glib_dep,
+  gobject_dep,
+  nnstreamer_dep
+]
+
+sources = [
+  'tensor_filter_subplugin.c'
+]
+
+# TODO: This header files are specified to support Tizen. 
+# If you use VIM3/Ubuntu18.04(aarch64) board,
+# you need to update the below header folders.
+# - '/usr/include/vivante', '/usr/include/VX'
+# - https://docs.khadas.com/vim3/HowToUseNpu.html
+# - https://dl.khadas.com/repos/vim3/ (Ubuntu 18.04, aarch64, Bionic)
+vivante_todo_incs = []
+vivante_todo_incs += include_directories(
+  '/usr/include/dann',
+  '/usr/include/ovx',
+  '/usr/include/amlogic-vsi-npu-sdk'
+)
+
+vflag = '-ldl'
+
+subplugin_shared = shared_library('nnstreamer_filter_vivante',
+  sources,
+  include_directories: vivante_todo_incs,
+  dependencies: [base_deps, libovx_dep, libdl_dep],
+  link_args : vflag,
+  install: true,
+  install_dir: filter_subplugin_install_dir
+)

--- a/ext/nnstreamer/tensor_filter/vivante/tensor_filter_subplugin.c
+++ b/ext/nnstreamer/tensor_filter/vivante/tensor_filter_subplugin.c
@@ -1,0 +1,605 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ *
+ * GStreamer Tensor_Filter (vivante Code)
+ * Copyright (C) 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
+ * Copyright (C) 2019 Geunsik Lim <geunsik.lim@samsung.com>
+ *
+ */
+
+/**
+ * @file	tensor_filter_subplugin.c
+ * @date	28 Jan 2020
+ * @brief	NNStreamer tensor-filter subplugin template
+ * @see		http://github.com/nnsuite/nnstreamer
+ * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
+ *       	Geunsik Lim <geunsik.lim@samsung.com>
+ * @bug		No known bugs
+ * @note    Example of Pipeline description.
+ * const char description[] = "videotestsrc ! videoconvert ! videoscale ! "
+ * "video/x-raw,format=RGB,width=299,height=299,framerate=(fraction)30/1 ! "
+ * "tensor_converter ! "
+ * "tensor_filter framework=vivante "
+ *   "model=/opt/vivante/model/inception_v3.nb,/opt/vivante/model/libinception_v3.so"
+ *   "input=3:299:299:1 inputtype=UINT8 inputname=data "
+ *   "output=1001:1:1:1 outputtype=UINT16 outputname=prob "
+ * "file_sink location=vivante.out.bin";
+ *
+ * @memo
+ * 1. Common APIs for Vivante NPU
+ * 1.1. Mandatory APIs:
+ * vnn_CreateNeuralNetwork() to create a neural network from .nb file
+ * vsi_nn_VerifyGraph() to verify the generated graph
+ * vsi_nn_RunGraph() to process the graph
+ * vsi_nn_GetTensor() to get meta data from input/output tensor
+ * vsi_nn_CopyDataToTensor to copy the input buffer to the input tensor
+ * vsi_nn_CopyTensorToBuffer() to copy the output tensor to the output buffer
+ * vnn_ReleaseNeuralNetwork() to release the neural network
+ * 1.2. Optional APIs:
+ * vnn_PreProcessNeuralNetwork() to do a pre-process input data (e.g., image)
+ * - Refer to https://github.com/nnsuite/nnstreamer/tree/master/gst/nnstreamer/tensor_transform
+ * vnn_PostProcessNeuralNetwork() to display Top5 and save output tensor data
+ * - The inceptionv3 model does not execute post-process tasks.
+ * vsi_nn_DumpGraphNodeOutputs() to dump the graph for a debugging
+ *
+ * 2. Packaging, Build & run test, and Custom property
+ * 2.1. Distribution: Tizen packaging
+ * ubuntu$ git clone https://github.sec.samsung.net/AIP/vivante-nnstreamer-filter.git
+ * ubuntu$ time gbs build -A armv7l --clean --include-all
+ *
+ * 2.2. Development: Build and run source code on real target
+ * You may run the below script to build and run on the real target boards manually.
+ * target# ./tests/nnstreamer_filter_vivante/build_run.sh
+ *
+ * 2.3 Custom properties for Vivante subplugin
+ * CP = Exp,CP | Exp | NULL
+ * Exp = postprocess | pp      # Both enables post-processing feature of Vivante if possible.
+ *
+ * Usage with Tizen C-API
+ * Pipeline
+ * ... ! tensor_filter framework=vivante model=a.nb,b.so custom=pp ! ...
+ * Single
+ * ... (open "handle")
+ * ml_single_set_property (handle, "custom", "pp");
+ * ... (invoke with "handle") x N
+ * ... (close "handle")
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <glib.h>
+#include <errno.h>
+
+#include <nnstreamer_plugin_api_filter.h>
+
+#include <dlfcn.h>
+
+/** A neural network headers that are provided by the vivante/acuity tool. */
+#include <ovx/vsi_nn_pub.h>
+
+/** A macro for debugging all nodes of a graph */
+#define DEBUG_MODE	0
+
+/** A macro for verifying a corrcteness of the Vivante model (*.nb) */
+#define EVAL_MODE	0
+
+/** Fetch an address of a Vivante API with the dlsym() library call*/
+#define vivante_api_fetch_dlsym(pdata, pname, symstr, errlabel) do { \
+    char *error; \
+    dlerror (); \
+    g_assert (pdata->handle); \
+    pdata->pname = dlsym(pdata->handle, symstr); \
+    if ((error = dlerror()) != NULL) { \
+      g_printerr("Cannot load %s: %s\n", symstr, error); \
+      goto errlabel; \
+    } \
+} while (0)
+
+/** Call a specified API among the Vivante APIs described in 'pdata' */
+#define call(name, err, ...) ( (pdata->name) ? \
+    pdata->name (__VA_ARGS__) : \
+    err)
+
+void init_filter_vivante (void) __attribute__ ((constructor));
+void fini_filter_vivante (void) __attribute__ ((destructor));
+
+/**
+ * @brief If you need to store session or model data,
+ *        this is what you want to fill in.
+ */
+typedef struct
+{
+  gchar *model_path; /**< The model nb file */
+  gchar *so_path; /**< The so file for the .nb file */
+  GstTensorsInfo input_tensor; /**< The description of input tensor */
+  GstTensorsInfo output_tensor; /**< The description of output tensor */
+
+  vsi_nn_graph_t *graph; /**< Graph data structure for handling Vivant neural network */
+  void* handle; /**< Variables for handling the dlopen library call. */
+  vsi_status (*result_vsi_nn_CopyDataToTensor)(vsi_nn_graph_t *, vsi_nn_tensor_t *, uint8_t *);
+  void (*result_vnn_ReleaseNeuralNetwork)(vsi_nn_graph_t *);
+  vsi_nn_graph_t * (*result_vnn_CreateNeuralNetwork)(const char *);
+  vsi_status (*result_vsi_nn_RunGraph)(vsi_nn_graph_t *);
+
+  int postProcess;
+  vsi_status (*postProcessFunc)(vsi_nn_graph_t *graph);
+
+#if EVAL_MODE
+  vsi_status (*result_vnn_PostProcessNeuralNetwork)(vsi_nn_graph_t *);
+#endif
+#if DEBUG_MODE
+  vsi_status (*result_vsi_nn_VerifyGraph)(vsi_nn_graph_t *);
+  void (*result_nn_DumpGraphNodeOutputs)(vsi_nn_graph_t *, const char *, uint32_t *, uint32_t, vsi_bool, vsi_nn_dim_fmt_e);
+#endif
+} vivante_pdata;
+
+/** @brief Parse a custom property and check if post-process is enabled */
+static int
+parseCustomProperty (const char *value, int * postProcess)
+{
+  int i = 0;
+  gchar ** strv;
+
+  /* default value */
+  *postProcess = 0;
+
+  if (!value || !value[0])
+    return 0;
+
+  strv = g_strsplit_set (value, ", :", -1);
+
+  do {
+    if (!g_ascii_strcasecmp (strv[i], "postprocess") ||
+        !g_ascii_strcasecmp (strv[i], "pp")) {
+      *postProcess = 1;
+    }
+    i++;
+  } while (strv[i]);
+
+  g_strfreev (strv);
+  return 0;
+}
+
+/**
+ * @brief Get post-processed output data
+ * @details We assume that post-process does NOT alter output dimensions.
+ */
+static int
+doPostProcess (vivante_pdata *pdata)
+{
+  vsi_status status;
+
+  if (pdata->postProcess && pdata->postProcessFunc) {
+    status = call (postProcessFunc, -EINVAL, pdata->graph);
+    if (status == VSI_SUCCESS)
+      return 0;
+    return VSI_FAILURE;
+  }
+  return -EINVAL;
+}
+
+unsigned int
+convert_tensortype (unsigned tensor_type);
+
+static void
+vivante_close (const GstTensorFilterProperties * prop,
+    void **private_data);
+
+/**
+ *  * @brief Configure private_data
+ *   */
+static int
+allocateData (const GstTensorFilterProperties * prop, void **private_data)
+{
+  vivante_pdata *pdata;
+
+  if (*private_data != NULL) {
+    /* Already opened */
+    pdata = (vivante_pdata *) *private_data;
+
+    if (!prop->model_files[0] || prop->model_files[0][0] == '\0') {
+      printf("Model path (.nb) is not given.");
+      return -1;
+    }
+    if (!prop->model_files[1] || prop->model_files[1][0] == '\0') {
+      printf("Shared library path (.so) is not given.");
+      return -1;
+    }
+    if (pdata->model_path && g_strcmp0 (prop->model_files[0],
+          pdata->model_path) == 0) {
+      return 0; /* Already opened with same model file. Skip ops */
+    }
+    if (pdata->so_path && g_strcmp0 (prop->model_files[1],
+          pdata->so_path) == 0) {
+      return 0; /* Already opened with same so file. Skip ops */
+    }
+    vivante_close (prop, private_data); /* Close before opening one. */
+  }
+
+  *private_data = pdata = g_new0 (vivante_pdata, 1);
+  if (pdata == NULL) {
+      printf("Failed to allocate memory for vivante tensor_filer.");
+    return -1;
+  }
+
+  return 0;
+}
+
+/**
+ * @brief Convert a tesor type from vivant format to nnstreamer format
+ * Note that you must refer to the "linux_sdk/acuity-ovxlib-dev/include/vsi_nn_types.h" file.
+ */
+unsigned int
+convert_tensortype (unsigned tensor_type)
+{
+  switch (tensor_type) {
+  case VSI_NN_TYPE_INT8:
+    return _NNS_INT8;
+  case VSI_NN_TYPE_UINT8:
+    return _NNS_UINT8;
+  case VSI_NN_TYPE_INT16:
+    return _NNS_INT16;
+  case VSI_NN_TYPE_UINT16:
+    return _NNS_UINT16;
+  /** Note that the current nnstreamer (tensor_typedef.h) does not support FLOAT16.
+   *  Let's use UINT16 as a workaround.
+   */
+  case VSI_NN_TYPE_FLOAT16:
+    return _NNS_UINT16;
+  case VSI_NN_TYPE_FLOAT32:
+    return _NNS_FLOAT32;
+  default:
+    /** @todo Support other types */
+    break;
+  }
+  return _NNS_END;
+}
+
+/**
+ * @brief Open the vivante tensor filter
+ * @note
+ * 1. Read multi files (e.g., inception_v3.nb and libinception_v3.so)
+ */
+static int
+vivante_open (const GstTensorFilterProperties * prop, void **private_data)
+{
+  int ret = allocateData (prop, private_data);
+  unsigned int i,j,k;
+  vivante_pdata *pdata = (vivante_pdata *) *private_data;
+
+  if (ret < 0)
+    return ret;
+
+  if (*private_data == NULL)
+    return -ENOMEM;
+
+  pdata->model_path = g_strdup (prop->model_files[0]);
+  pdata->so_path    = g_strdup (prop->model_files[1]);
+
+  ret = parseCustomProperty (prop->custom_properties, &pdata->postProcess);
+  if (ret < 0) {
+    g_free (pdata->model_path);
+    g_free (pdata->so_path);
+    g_free (pdata);
+    return ret;
+  }
+
+  /** Create the neural network with .nb (a network binary of Vivante) */
+  pdata->handle = dlopen(pdata->so_path, RTLD_NOW);
+  if (!pdata->handle) {
+    printf ("vivante_open: dlopen cannot load the shared library (.so).\n");
+    g_free (pdata->model_path);
+    g_free (pdata->so_path);
+    g_free (pdata);
+    return -EINVAL;
+  }
+
+  vivante_api_fetch_dlsym (pdata, result_vsi_nn_CopyDataToTensor,
+      "vsi_nn_CopyDataToTensor", error_dlsym);
+  vivante_api_fetch_dlsym (pdata, result_vnn_ReleaseNeuralNetwork,
+      "vnn_ReleaseNeuralNetwork", error_dlsym);
+  vivante_api_fetch_dlsym (pdata, result_vsi_nn_RunGraph,
+      "vsi_nn_RunGraph", error_dlsym);
+
+  if (pdata->postProcess) {
+    vivante_api_fetch_dlsym (pdata, postProcessFunc,
+        "vnn_PostProcessNeuralNetwork", error_dlsym);
+  }
+
+  vivante_api_fetch_dlsym (pdata, result_vnn_CreateNeuralNetwork,
+      "vnn_CreateNeuralNetwork", error_dlsym);
+  pdata->graph = call (result_vnn_CreateNeuralNetwork, NULL,
+      pdata->model_path);
+
+#if EVAL_MODE
+  vivante_api_fetch_dlsym (pdata, result_vnn_PostProcessNeuralNetwork,
+      "vnn_PostProcessNeuralNetwork", error_dlsym);
+#endif
+#if DEBUG_MODE
+  vivante_api_fetch_dlsym (pdata, result_vsi_nn_VerifyGraph,
+      "vsi_nn_VerifyGraph", error_dlsym);
+  vivante_api_fetch_dlsym (pdata, result_nn_DumpGraphNodeOutputs,
+      "vsi_nn_DumpGraphNodeOutputs", error_dlsym);
+#endif
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+#pragma GCC diagnostic ignored "-Wnested-externs"
+  gst_tensors_info_init (&pdata->input_tensor);
+  gst_tensors_info_init (&pdata->output_tensor);
+
+  /** Note that we must use vsi_nn_GetTensor() to get a meta data
+   * (e.g., input tensor and outout tensor).
+   * ./linux_sdk/acuity-ovxlib-dev/lib/libovxlib.so
+   * ./linux_sdk/acuity-ovxlib-dev/include/vsi_nn_graph.h
+   * ./linux_sdk/acuity-ovxlib-dev/include/vsi_nn_tensor.h
+   */
+
+#if DEBUG_MODE
+  printf ("[DEBUG] input_tensors_num :%d  \n", pdata->graph->input.num);
+  printf ("[DEBUG] output_tensors_num:%d \n", pdata->graph->output.num);
+#endif
+
+  /** Get the meta data from the input tensor. */
+  for (i = 0; i < pdata->graph->input.num; i++) {
+    vsi_nn_tensor_t *i_tensor = vsi_nn_GetTensor(pdata->graph,
+        pdata->graph->input.tensors[i]);
+    if (i_tensor == NULL)
+      return -1;
+
+#if DEBUG_MODE
+    printf ("[DEBUG] input_dim_num[%d]:%d\n", i, i_tensor->attr.dim_num);
+#endif
+    for (j = 0; j < i_tensor->attr.dim_num; ++j) {
+      /** dimension structure: channel, width, height, number */
+      pdata->input_tensor.info[i].dimension[j] = i_tensor->attr.size[j];
+    }
+    for (k = j; k < NNS_TENSOR_RANK_LIMIT; ++k) {
+      pdata->input_tensor.info[i].dimension[k] = 1;
+    }
+
+    /** Get an input data type: VSI_NN_TYPE_UINT8 (u8) in case of inceptionv3 */
+    pdata->input_tensor.info[i].type =
+        convert_tensortype(i_tensor->attr.dtype.vx_type);
+    asprintf (&pdata->input_tensor.info[i].name, "%i",
+        pdata->graph->input.tensors[i]); /** dummy name */
+    pdata->input_tensor.num_tensors = pdata->graph->input.num; /** number of tensors */
+  }
+
+  /** Get the meta data from the output tensor. */
+  for (i = 0; i < pdata->graph->output.num; i++) {
+    vsi_nn_tensor_t *o_tensor = NULL;
+    o_tensor = vsi_nn_GetTensor(pdata->graph, pdata->graph->output.tensors[i]);
+    if (o_tensor == NULL)
+      return -1;
+
+#if DEBUG_MODE
+    printf ("[DEBUG] output_dim_num[%d]:%d\n", i, o_tensor->attr.dim_num);
+#endif
+    for (j = 0; j < o_tensor->attr.dim_num; ++j) {
+      /** dimension structure: channel, width, height, number */
+      pdata->output_tensor.info[i].dimension[j] = o_tensor->attr.size[j];
+    }
+    for (k = j; k < NNS_TENSOR_RANK_LIMIT; ++k) {
+      pdata->output_tensor.info[i].dimension[k] = 1;
+    }
+
+    /** Get an output data type: VSI_NN_TYPE_FLOAT16 (f16) in case of inceptionv3 */
+    pdata->output_tensor.info[i].type =
+        convert_tensortype(o_tensor->attr.dtype.vx_type);
+    asprintf (&pdata->output_tensor.info[i].name, "%i",
+        pdata->graph->output.tensors[i]); /** dummy name */
+    pdata->output_tensor.num_tensors = pdata->graph->output.num; /** number of tensors */
+  }
+
+#pragma GCC diagnostic pop
+  return ret;
+error_dlsym:
+  dlclose (pdata->handle);
+  pdata->handle = NULL;
+  return -EINVAL;
+}
+
+/**
+ * @brief Close the vivante tensor filter
+ * @note Close what you have opened/allocated with vivante_open
+ *  Release a buffer image.
+ */
+static void
+vivante_close (const GstTensorFilterProperties * prop, void **private_data)
+{
+  vivante_pdata *pdata = *private_data;
+
+  call(result_vnn_ReleaseNeuralNetwork, NULL, pdata->graph);
+
+  dlclose(pdata->handle);
+
+  g_free (pdata->model_path);
+  pdata->model_path = NULL;
+  g_free (pdata->so_path);
+  pdata->so_path = NULL;
+
+  g_free (pdata);
+  *private_data = NULL;
+}
+
+/**
+ * @brief The standard tensor_filter callback
+ * @note Call your framework/hardware with the given input
+ *  1. Do a pre-process for the image data (Skipped)
+ *  2. Verify the model data (graph).
+ *  3. Process a network model (graph)
+ *  4. Optionally, dump all node outputs (e.g., ./network_dump) for a debugging.
+ *  5. Do prost-process to output data.
+ */
+static int
+vivante_invoke (const GstTensorFilterProperties * prop,
+    void **private_data, const GstTensorMemory * input,
+    GstTensorMemory * output)
+{
+  int ret = 0;
+  int i;
+  vivante_pdata *pdata = *private_data;
+  vsi_status status = VSI_FAILURE;
+
+  g_assert (*private_data);
+
+#if 1
+  /**
+   * In order to develop a NNStreamer application, Please utilize the 'tensor_transform" element.
+   * Copy input data to a tensor using vsi_nn_CopyDataToTensor instead of
+   * vnn_PreProcessNeuralNetwork() to finalize a pre-process of input data (e.g., image)
+   * Note that the vnn_PreProcessNeuralNetwork API requires jpeg-9a library by default.
+   */
+  for (i = 0; i < pdata->graph->input.num; i++) {
+    vsi_nn_tensor_t *tensor = NULL;
+    tensor = vsi_nn_GetTensor(pdata->graph, pdata->graph->input.tensors[i]);
+
+   /** Copy an input buffer to an input tensor */
+    status = call(result_vsi_nn_CopyDataToTensor, VSI_FAILURE, pdata->graph,
+        tensor, input[i].data);
+  }
+#endif
+
+#if DEBUG_MODE
+  /**
+   * Verify a graph. Note that vnn_VerifyGraph() calls vsi_nn_VerifyGraph()
+   * that is provided by OVXLIB_API.
+   */
+  status = call (result_vsi_nn_VerifyGraph, VSI_FAILURE, pdata->graph);
+#endif
+
+  /**
+   * Process a graph. Note that vnn_ProcessGraph() calls vsi_nn_RunGraph()
+   * that is provided by OVXLIB_API.
+   */
+  status = call (result_vsi_nn_RunGraph, VSI_FAILURE, pdata->graph);
+
+
+#if DEBUG_MODE
+  /** Dump all node outputs */
+  g_print("Saving debug file (e.g., ./network_dump)\n");
+
+  call (result_nn_DumpGraphNodeOutputs, NULL, pdata->graph, "./network_dump", NULL, 0, TRUE, 0);
+#endif
+
+  if (pdata->postProcess)
+    ret = doPostProcess (pdata);
+  if (ret < 0) {
+    g_printerr("PostProcess Failure\n");
+    return ret;
+  }
+
+#if EVAL_MODE
+  /** In case of Inceptionv3, the major goal of of the post-process is as follows.
+   *  a. Show the Top5 result
+   *  b. Save all output tensor data to txt file.
+   */
+  status = call (result_vnn_PostProcessNeuralNetwork, VSI_FAILURE,
+      pdata->graph);
+#endif
+
+  #define _DUMP_FILE_LENGTH 1028
+  #define _DUMP_SHAPE_LENGTH 128
+
+  for (i = 0; i < pdata->graph->output.num; i++) {
+    vsi_nn_tensor_t *out_tensor = vsi_nn_GetTensor(pdata->graph, pdata->graph->output.tensors[i]);
+
+#if DEBUG_MODE
+    char filename[_DUMP_FILE_LENGTH] = {0};
+    char shape[_DUMP_SHAPE_LENGTH] = {0};
+    vsi_nn_ShapeToString(out_tensor->attr.size, out_tensor->attr.dim_num,
+        shape, _DUMP_SHAPE_LENGTH, FALSE );
+    snprintf(filename, _DUMP_FILE_LENGTH, "nnstreamer_output%u_%s.dat", i, shape);
+    vsi_nn_SaveTensorToBinary(pdata->graph, out_tensor, filename);
+#endif
+
+    /** Copy an output tensor to an output buffer */
+    vsi_nn_CopyTensorToBuffer(pdata->graph, out_tensor, output[i].data);
+  }
+  if (status == VSI_FAILURE)
+    return -EINVAL;
+
+  return 0;
+}
+
+
+/**
+ * @brief The standard tensor_filter callback for static input/output dimension.
+ * @note If you want to support flexible/dynamic input/output dimension,
+ *       read nnstreamer_plugin_api_filter.h and supply the
+ *       setInputDimension callback.
+ */
+static int
+vivante_getInputDim (const GstTensorFilterProperties * prop,
+    void **private_data, GstTensorsInfo * info)
+{
+  vivante_pdata *pdata = (vivante_pdata *) *private_data;
+
+  if (!pdata)
+    return -1;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+#pragma GCC diagnostic ignored "-Wnested-externs"
+  gst_tensors_info_copy (info, &pdata->input_tensor);
+#pragma GCC diagnostic pop
+  return 0;
+}
+
+/**
+ * @brief The standard tensor_filter callback for static input/output dimension.
+ * @note If you want to support flexible/dynamic input/output dimension,
+ *       read nnstreamer_plugin_api_filter.h and supply the
+ *       setInputDimension callback.
+ */
+static int
+vivante_getOutputDim (const GstTensorFilterProperties * prop,
+    void **private_data, GstTensorsInfo * info)
+{
+  vivante_pdata *pdata = (vivante_pdata *) *private_data;
+
+  if (!pdata)
+    return -1;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+#pragma GCC diagnostic ignored "-Wnested-externs"
+  gst_tensors_info_copy (info, &pdata->output_tensor);
+#pragma GCC diagnostic pop
+
+  return 0;
+}
+
+static gchar filter_subplugin_vivante[] = "vivante";
+
+static GstTensorFilterFramework NNS_support_vivante = {
+#ifdef GST_TENSOR_FILTER_API_VERSION_DEFINED
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
+#endif
+  .open = vivante_open,
+  .close = vivante_close,
+};
+
+/**@brief Initialize this object for tensor_filter subplugin runtime register */
+void
+init_filter_vivante (void)
+{
+  NNS_support_vivante.name = filter_subplugin_vivante;
+  NNS_support_vivante.allow_in_place = FALSE;
+  NNS_support_vivante.allocate_in_invoke = FALSE;
+  NNS_support_vivante.run_without_model = FALSE;
+  NNS_support_vivante.invoke_NN = vivante_invoke;
+  NNS_support_vivante.getInputDimension = vivante_getInputDim;
+  NNS_support_vivante.getOutputDimension = vivante_getOutputDim;
+  nnstreamer_filter_probe (&NNS_support_vivante);
+}
+
+/** @brief Destruct the subplugin */
+void
+fini_filter_vivante (void)
+{
+  nnstreamer_filter_exit (NNS_support_vivante.name);
+}

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -34,4 +34,5 @@ option('enable-filter-cpp-class', type: 'boolean', value: true) # Allows to acce
 option('enable-tizen-sensor', type: 'boolean', value: false)
 option('enable-edgetpu', type: 'boolean', value: false)
 option('enable-openvino', type: 'boolean', value: false)
+option('enable-vivante', type: 'boolean', value: false)
 option('framework-priority-tflite', type: 'string', value: 'tensorflow-lite,nnfw,armnn,edgetpu', description: 'A comma separated prioritized list of neural network frameworks to open a .tflite file')

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -5,6 +5,7 @@
 %define		tensorflow_support	0
 %define		tensorflow_lite_support	1
 %define		armnn_support 0
+%define		vivante_support 0
 
 %if 0%{tizen_version_major} >= 5
 %define		python_support 1
@@ -34,6 +35,10 @@
 
 %ifnarch %arm aarch64
 %define armnn_support 0
+%endif
+
+%ifnarch %arm aarch64
+%define		vivante_support 0
 %endif
 
 # If it is tizen, we can export Tizen API packages.
@@ -117,6 +122,16 @@ BuildRequires: lcov
 %if 0%{mvncsdk2_support}
 BuildRequires:	pkgconfig(libmvnc)
 %endif
+
+# for Vivante
+# TODO: dann and opencv will be removed in the near future.
+%if 0%{?vivante_support}
+BuildRequires:  pkgconfig(opencv)
+BuildRequires:  pkgconfig(dann)
+BuildRequires:  pkgconfig(ovxlib)
+BuildRequires:  pkgconfig(amlogic-vsi-npu-sdk)
+%endif
+
 %if %{with tizen}
 BuildRequires:	pkgconfig(dpm)
 %if 0%{tizen_version_major} >= 5
@@ -202,6 +217,22 @@ Summary:	NNStreamer Arm NN support
 Requires:	armnn
 %description armnn
 NNStreamer's tensor_filter subplugin of Arm NN Inference Engine.
+%endif
+
+# Support vivante subplugin
+%if 0%{?vivante_support}
+%package vivante
+Summary:    NNStreamer subplugin for Verisilion's Vivante
+Requires:   nnstreamer = %{version}-%{release}
+Requires:   gst-plugins-good
+Requires:   gst-plugins-good-extra
+Requires:   gst-libav
+%description vivante
+NNStreamer filter subplugin for Verisicon Vivante.
+
+%define enable_vivante -Denable-vivante=true
+%else
+%define enable_vivante -Denable-vivante=false
 %endif
 
 %package devel
@@ -406,7 +437,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir
 	--bindir=%{nnstexampledir} --includedir=%{_includedir} -Dinstall-example=true \
 	%{enable_api} %{enable_tizen} %{element_restriction} -Denable-env-var=false -Denable-symbolic-link=false \
 	%{enable_tf_lite} %{enable_tf} %{enable_pytorch} %{enable_caffe2} %{enable_python} \
-	%{enable_nnfw_runtime} %{enable_mvncsdk2} %{enable_armnn} %{enable_edgetpu} \
+	%{enable_nnfw_runtime} %{enable_mvncsdk2} %{enable_armnn} %{enable_edgetpu}  %{enable_vivante} \
 	%{enable_tizen_sensor} %{enable_test_coverage} \
 	build
 
@@ -607,6 +638,13 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %manifest nnstreamer.manifest
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_movidius-ncsdk2.so
 %endif  # mvncsdk2_support
+
+%if 0%{?vivante_support}
+%files vivante
+%defattr(-,root,root,-)
+%manifest nnstreamer.manifest
+%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_vivante.so
+%endif
 
 %if 0%{tizen_sensor_support}
 %files tizen-sensor


### PR DESCRIPTION
This commit is to append the Vivante sub-plugin based on the tensor filter
of NNStreamer to support the Vivante NPU driver.

**Changelog**

* Version 10:
   * Added license clause
   * Improved statements of the nnsreamer.spec file

* Version 1-9:
   * Fixed memory leak (e.g., g_free)
   * FIxed security (e.g., nnstreamer.nanifest) for Tizen packaging
   * doc: Added how to build and run the Vivante filter on Ubuntu 18.04 (ARM64)
   * Updated the invoke function to support various models
     (e.g., Inception, Yolo, Mobile SSD)
   * Added Tizen package script for Tizen platform
   * Fixed incorrect var type (e.g., unsigned int for num_tensors)
   * Added annotations for code maintenance
   * Added run.sh for Ubuntu18.04 aarch64 + VIM3 board
   * Added convert function for vivante tensor data type
   * Added vsi_nn_GetTensor of OpenVX apis to obtain tensor data (input, output)
   * Added info[i].name with dummy data (e.g., tensor id)
   * Removed deprecated variables and functions
   * Updated the vivante filter with "multi-files" structure for re-usability
     - "model=/opt/vivante/model/inception_v3.nb,
       /opt/vivante/model/libinception_v3.so
   * Updated the existing vivante tensor filter based on dlopen() scheme
   * Added a functions to check the dlopen operation to avoid undefined symbol issue
   * Updated annotaiton (e.g., image size is 299:299)
   * Added Vivante functions (common APIs) in the vivante_open function
   * Added Vivante functions (common APIs) in the vivante_invoke function
   * Added Vivante functions (common APIs) in the vivante_close function
   * Update annotation to avoid misunderstanding
   * Fixed typos (GstTensorsInfo)
   * Add todo list (e.g., glib's time functions)
   * Added vsi_nn_pub.h header file to use libraries of acuity-ovxlib-dev tool
   * Added a skeleton of the Vivate tensor filter
   * Imported the major implementation of the Vivante (inceptionv3 model)
     for Nnstreamer pipeline. libvivante_v3.so will be used by "model=***"
     interface to support a generic approach for re-usability.
   * Added vivante_inception_v3.h header file for .so file of a NN model
   * Added a data structure (e.g., vivante_data) to manage Vivante data

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>