### PR TITLE
[single] Add missing gstTensorFilterFramework v1 support

### DIFF
--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -1218,16 +1218,11 @@ ml_check_nnfw_availability (ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw,
 
   if (fw_name) {
     if ((fw = nnstreamer_filter_find (fw_name)) != NULL) {
-      /** @todo support GstTensorFilterV1 here */
-      /** Only check for specific HW, ANY/AUTO are always supported */
-      if (hw == ML_NNFW_HW_ANY || hw == ML_NNFW_HW_AUTO) {
-        *available = true;
-      } else if (fw->checkAvailability
-          && fw->checkAvailability (ml_nnfw_to_accl_hw (hw)) != 0) {
+      *available = gst_tensor_filter_check_hw_availability
+        (fw, ml_nnfw_to_accl_hw (hw));
+      if (*available == false) {
         ml_logw ("%s is supported but not with the specified hardware.",
             fw_name);
-      } else {
-        *available = true;
       }
     } else {
       ml_logw ("%s is not supported.", fw_name);

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -2038,3 +2038,36 @@ accl_hw_get_type (void)
 
   return g_accl_hw_type_id__volatile;
 }
+
+/**
+ * @brief check if the given hw is supported by the framework
+ */
+gboolean
+gst_tensor_filter_check_hw_availability (const GstTensorFilterFramework * fw,
+    accl_hw hw)
+{
+  gint idx = 0;
+  gboolean available = FALSE;
+  GstTensorFilterFrameworkInfo info;
+  GstTensorFilterProperties prop;
+
+  /** Only check for specific HW, DEFAULT/AUTO are always supported */
+  if (hw == ACCL_AUTO || hw == ACCL_DEFAULT) {
+    available = TRUE;
+  } else if (GST_TF_FW_V0 (fw) &&
+      (!fw->checkAvailability || fw->checkAvailability (hw) == 0)) {
+    available = TRUE;
+  } else if (GST_TF_FW_V1 (fw)) {
+    gst_tensor_filter_properties_init (&prop);
+    if (!fw->getFrameworkInfo (fw, &prop, NULL, &info)) {
+      for (idx = 0; idx < info.num_hw; idx++) {
+        if (info.hw_list[idx] == hw) {
+          available = TRUE;
+          break;
+        }
+      }
+    }
+  }
+
+  return available;
+}

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -184,4 +184,11 @@ extern void gst_tensor_filter_common_open_fw (GstTensorFilterPrivate * priv);
  */
 extern void gst_tensor_filter_common_close_fw (GstTensorFilterPrivate * priv);
 
+/**
+ * @brief check if the given hw is supported by the framework
+ */
+extern gboolean
+gst_tensor_filter_check_hw_availability (const GstTensorFilterFramework *fw,
+    accl_hw hw);
+
 #endif /* __G_TENSOR_FILTER_COMMON_H__ */


### PR DESCRIPTION
Add missing support for gstTensorFilterFramework in checking framework availability
for a given backend accelerator/hardware

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>