### PR TITLE
[CONF] Fix nnstreamer conf load function

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -299,7 +299,7 @@ gboolean
 nnsconf_loadconf (gboolean force_reload)
 {
   const gchar root_path_prefix[] = NNSTREAMER_SYS_ROOT_PATH_PREFIX;
-  g_autoptr (GKeyFile) key_file = NULL;
+  GKeyFile *key_file = NULL;
   guint i, t;
 
   if (FALSE == force_reload && TRUE == conf.loaded)


### PR DESCRIPTION
Since key_file is declared using g_autoptr macro, it does not need to clean up variables.
reference link : https://blogs.gnome.org/desrt/2015/01/30/g_autoptr/

It is related to issue #2393. 
The unit tests are failed intermittently.
The nnsconf_loadconf is called while registering the external converter.

## Change
Remove g_autoptr instead of g_key_file_free


#

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped