### PR TITLE
[Test] use test-env

### DIFF
--- a/tests/cpp_methods/meson.build
+++ b/tests/cpp_methods/meson.build
@@ -13,4 +13,4 @@ unittest_cppfilter = executable('unittest_cppfilter',
   install_dir: unittest_install_dir
 )
 
-test('unittest_cppfilter', unittest_cppfilter, args: ['--gst-plugin-path=../..'])
+test('unittest_cppfilter', unittest_cppfilter, env: testenv)


### PR DESCRIPTION
update unittest arg, use test-env in cpp-method test.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
