### PR TITLE
[Spec] Fix the wrong meson option for armnn @open sesame 5/24 14:42

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -354,9 +354,9 @@ You may enable this package to use Google Edge TPU with NNStreamer and Tizen ML 
 
 # Support ArmNN
 %if 0%{?armnn_support}
-%define enable_armnn -Darmnn_support=enabled
+%define enable_armnn -Darmnn-support=enabled
 %else
-%define enable_armnn -Darmnn_support=disabled
+%define enable_armnn -Darmnn-support=disabled
 %endif
 
 # Support python


### PR DESCRIPTION
Because of the typo for meson option, below warning occurs when
building.
* WARNING: Unknown options: "armnn_support"

This patch fixes this warning.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped