### PR TITLE
[Build/Tests] Fix 'tests/meson.build' to always find 'copy' program @open sesame 6/2 12:41

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -14,6 +14,7 @@ library('nnscustom_drop_buffer',
 )
 
 # Build and copy exe for ssat
+copy = find_program('cp', required: true)
 libpng_dep = dependency('libpng', required: false)
 if libpng_dep.found()
   b2p = executable('bmp2png',
@@ -23,7 +24,6 @@ if libpng_dep.found()
     install_dir: unittest_install_dir
   )
 
-  copy = find_program('cp')
   custom_target('copy-bmp2png',
     input: b2p,
     output: 'b2p',


### PR DESCRIPTION
This patch fixes minor build errors caused when `libpng_dep` does not exist.
`tests/nnstreamer_filter_extensions_common/meson.build` is using this
variable regardless of `libpng_dep`'s existence.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
