### PR TITLE
[Conf] parse sub-plugins name

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.h
+++ b/gst/nnstreamer/nnstreamer_conf.h
@@ -86,16 +86,6 @@ extern gboolean
 nnsconf_loadconf (gboolean force_reload);
 
 /**
- * @brief Search for "file2find" file in the configured paths for the type
- * @param[in] file2find The filename including extensions (e.g., .so) to find.
- * @param[in] type The type (FILTERS/DECODERS/CUSTOM_FILTERS)
- * @return The full path to the file. Caller MUST NOT modify this.
- *         Returns NULL if we cannot find the file.
- */
-extern const gchar *
-nnsconf_get_fullpath_from_file (const gchar * file2find, nnsconf_type_path type);
-
-/**
  * @brief Get the configured paths for the type with sub-plugin name.
  * @param[in] The subplugin name except for the prefix and postfix (.so) to find
  * @param[in] type The type (FILTERS/DECODERS/CUSTOM_FILTERS)

--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -562,20 +562,10 @@ gst_tensordec_get_property (GObject * object, guint prop_id,
       total = nnsconf_get_subplugin_info (NNSCONF_PATH_DECODERS, &sinfo);
 
       if (total > 0) {
-        GString *subplugins;
-        const gchar *prefix_str;
-        gsize prefix, extension, len;
-
-        subplugins = g_string_new (NULL);
-
-        prefix_str = nnsconf_get_subplugin_name_prefix (NNSCONF_PATH_DECODERS);
-        prefix = strlen (prefix_str);
-        extension = strlen (NNSTREAMER_SO_FILE_EXTENSION);
+        GString *subplugins = g_string_new (NULL);
 
         for (i = 0; i < total; ++i) {
-          /* remove file extension */
-          len = strlen (sinfo.names[i]) - prefix - extension;
-          g_string_append_len (subplugins, sinfo.names[i] + prefix, len);
+          g_string_append (subplugins, sinfo.names[i]);
 
           if (i < total - 1) {
             g_string_append (subplugins, ",");

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -1584,21 +1584,9 @@ gst_tensor_filter_common_get_property (GstTensorFilterPrivate * priv,
 
       total = nnsconf_get_subplugin_info (NNSCONF_PATH_FILTERS, &sinfo);
 
-      if (total > 0) {
-        const gchar *prefix_str;
-        gsize prefix, extension, len;
-
-        prefix_str = nnsconf_get_subplugin_name_prefix (NNSCONF_PATH_FILTERS);
-        prefix = strlen (prefix_str);
-        extension = strlen (NNSTREAMER_SO_FILE_EXTENSION);
-
-        for (i = 0; i < total; ++i) {
-          g_string_append (subplugins, ",");
-
-          /* remove file extension */
-          len = strlen (sinfo.names[i]) - prefix - extension;
-          g_string_append_len (subplugins, sinfo.names[i] + prefix, len);
-        }
+      for (i = 0; i < total; ++i) {
+        g_string_append (subplugins, ",");
+        g_string_append (subplugins, sinfo.names[i]);
       }
 
       g_value_take_string (value, g_string_free (subplugins, FALSE));


### PR DESCRIPTION
Basename is unnecessary, set sub-plugins name while loading configuration.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
