### PR TITLE
[Android/Custom] drop input buffer

### DIFF
--- a/api/android/api/src/main/java/org/nnsuite/nnstreamer/CustomFilter.java
+++ b/api/android/api/src/main/java/org/nnsuite/nnstreamer/CustomFilter.java
@@ -55,6 +55,7 @@ public final class CustomFilter implements AutoCloseable {
          * Called synchronously while processing the pipeline.
          *
          * NNStreamer filter invokes the given custom-filter callback while processing the pipeline.
+         * Note that, if it is unnecessary to execute the input data, return null to drop the buffer.
          *
          * @param in The input data (a single frame, tensor/tensors)
          *

--- a/api/android/api/src/main/jni/nnstreamer-native-customfilter.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-customfilter.c
@@ -121,6 +121,12 @@ nns_customfilter_invoke (const GstTensorFilterProperties * prop,
     goto done;
   }
 
+  if (obj_out_data == NULL) {
+    /* drop current buffer */
+    ret = 1;
+    goto done;
+  }
+
   if (!nns_parse_tensors_data (pipe_info, env, obj_out_data, &out_data, NULL)) {
     nns_loge ("Failed to parse output data.");
     goto done;


### PR DESCRIPTION
In custom-filter interface, returning null in invoke-callback will drop the input buffer.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
