### PR TITLE
[C-Api] function to get pipeline element

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -351,6 +351,14 @@ char* ml_nnfw_to_str_prop (ml_nnfw_hw_e hw);
  */
 const char* ml_get_nnfw_subplugin_name (ml_nnfw_type_e nnfw);
 
+/**
+ * @brief Gets the element of pipeline itself (GstElement).
+ * @details With the returned reference, you can use GStreamer functions to handle the element in pipeline.
+ *          Note that caller should release the returned reference using gst_object_unref().
+ * @return The reference of pipeline itself. Null if the pipeline is not constructed or closed.
+ */
+GstElement* ml_pipeline_get_element (ml_pipeline_h pipe);
+
 #if defined (__TIZEN__)
 /**
  * @brief Checks whether machine_learning.inference feature is enabled or not.

--- a/api/capi/src/nnstreamer-capi-pipeline.c
+++ b/api/capi/src/nnstreamer-capi-pipeline.c
@@ -1555,3 +1555,25 @@ ml_pipeline_valve_set_open (ml_pipeline_valve_h h, bool open)
 
   handle_exit (h);
 }
+
+/**
+ * @brief Gets the element of pipeline itself (GstElement).
+ */
+GstElement *
+ml_pipeline_get_element (ml_pipeline_h pipe)
+{
+  ml_pipeline *p = (ml_pipeline *) pipe;
+  GstElement *element = NULL;
+
+  if (p) {
+    g_mutex_lock (&p->lock);
+
+    element = p->element;
+    if (element)
+      gst_object_ref (element);
+
+    g_mutex_unlock (&p->lock);
+  }
+
+  return element;
+}


### PR DESCRIPTION
Add new function to get the gst-element from pipeline handle.
For native developers, it is necessary to get pipeline element to use gstreamer functions.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
