### PR TITLE
[Filter] bugfix: dangling pointer access.

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -1873,10 +1873,10 @@ parse_accl_hw_all (const gchar * accelerators,
       while (g_match_info_matches (match_info)) {
         gchar *word = g_match_info_fetch (match_info, 0);
         accl = get_accl_hw_type (word);
-        g_free (word);
         if (accl > 0 || (accl == 0 && g_strcmp0 (word, ACCL_NONE_STR) == 0)) {
           match_accl = g_list_append (match_accl, GINT_TO_POINTER (accl));
         }
+        g_free (word);
         g_match_info_next (match_info, NULL);
       }
     } else {


### PR DESCRIPTION
gfree should be called when you completed accesing it.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
