### PR TITLE
[Filter/Prop] Add performance properties (lat/fps) for tensor filter

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -157,6 +157,8 @@ typedef struct _GstTensorFilterProperties
     const char *accl_str; /**< accelerator configuration passed in as parameter, use in GstTensorFilterFramework V0 only */
   };
 
+  int latency; /**< The average latency over the recent 10 inferences in microseconds */
+  int throughput; /**< The average throughput in the number of outputs per second */
 } GstTensorFilterProperties;
 
 /**
@@ -236,7 +238,6 @@ typedef struct _GstTensorFilterFrameworkEventData
       accl_hw *hw_list;   /**< accelerators supported by framework intersected with the new user provided accelerator preference */
       int num_hw;         /**< number of hardare accelerators in the hw_list supported by the framework */
     };
-
   };
 } GstTensorFilterFrameworkEventData;
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -71,6 +71,21 @@
       } \
     } while (0)
 
+#define GST_TF_STAT_MAX_RECENT (10)
+
+/**
+ * @brief Structure definition for tensor-filter statistics
+ */
+typedef struct _GstTensorFilterStatistics
+{
+  gint64 total_invoke_num;      /**< number of total invokes */
+  gint64 total_invoke_latency;  /**< accumulated invoke latency (usec) */
+  gint64 old_total_invoke_num;      /**< cached value. number of total invokes */
+  gint64 old_total_invoke_latency;  /**< cached value. accumulated invoke latency (usec) */
+  gint64 latest_invoke_time;    /**< the latest invoke time (usec) */
+  void *recent_latencies;       /**< data structure (e.g., queue) to hold recent latencies */
+} GstTensorFilterStatistics;
+
 /**
  * @brief Structure definition for common tensor-filter properties.
  */
@@ -79,6 +94,7 @@ typedef struct _GstTensorFilterPrivate
   void *privateData; /**< NNFW plugin's private data is stored here */
   GstTensorFilterProperties prop; /**< NNFW plugin's properties */
   GstTensorFilterFrameworkInfo info; /**< NNFW framework info */
+  GstTensorFilterStatistics stat; /**< NNFW plugin's statistics */
   const GstTensorFilterFramework *fw; /**< The implementation core of the NNFW. NULL if not configured */
 
   /* internal properties for tensor-filter */
@@ -87,6 +103,9 @@ typedef struct _GstTensorFilterPrivate
   gboolean is_updatable; /**<  a given model to the filter is updatable if TRUE */
   GstTensorsConfig in_config; /**< input tensor info */
   GstTensorsConfig out_config; /**< output tensor info */
+
+  gint latency_mode;     /**< latency profiling mode (0: off, 1: on, ...) */
+  gint throughput_mode;  /**< throughput profiling mode (0: off, 1: on, ...) */
 } GstTensorFilterPrivate;
 
 /**


### PR DESCRIPTION
This patch adds performance properties (latency/throughput) for tensor filter.

Those properties will be used for the overlay information, to show the performance
of tensor filter (e.g., SNPE).

It resolves #2417 

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
