### PR TITLE
[Build/Fix] Add a missing header to 'nnstreamer_cppplugin_api_filter.hh'

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
+++ b/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
@@ -39,6 +39,7 @@
 #include <stdexcept>
 #include <stdint.h>
 #include <assert.h>
+#include <string.h>
 #include <nnstreamer_plugin_api_filter.h>
 #if __cplusplus < 201103L
 #warn C++11 is required for safe execution


### PR DESCRIPTION
This patch adds a missing header, `string.h`, to `nnstreamer_cppplugin_api_filter.hh`, which uses `memcpy()`.

The below describes the related build errors.
```
dchae@dchae-ubuntu:~/PR/nnstreamer$ ninja -C build
ninja: Entering directory `build'
[7/10] Compiling C++ object 'ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_snpe@sta/tensor_filter_snpe.cc.o'.
FAILED: ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_snpe@sta/tensor_filter_snpe.cc.o 
ccache c++ -Iext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_snpe@sta -Iext/nnstreamer/tensor_filter -I../ext/nnstreamer/tensor_filter -I/home/dchae/OpenLab/snpe-1.38.0.2034/include/zdl -Igst/nnstreamer -I../gst/nnstreamer -Igst/nnstreamer/./include/ -I../gst/nnstreamer/./include/ -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/gstreamer-1.0 -I/usr/lib/x86_64-linux-gnu/gstreamer-1.0/include -I/usr/include/orc-0.4 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -Werror -std=c++14 -g '-DVERSION="1.5.2"' -Wredundant-decls -Wwrite-strings -Wformat -Wformat-nonliteral -Wformat-security -Winit-self -Waddress -Wno-multichar -Wvla -Wpointer-arith -DENABLE_SNPE=1 -DENABLE_TENSORFLOW_LITE=1 -DENABLE_PYTORCH=1 -DHAVE_ORC=1 -DENABLE_CAFFE2=1 -fPIC -pthread -Wno-terminate -MD -MQ 'ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_snpe@sta/tensor_filter_snpe.cc.o' -MF 'ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_snpe@sta/tensor_filter_snpe.cc.o.d' -o 'ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_snpe@sta/tensor_filter_snpe.cc.o' -c /home/dchae/PR/nnstreamer/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
In file included from /home/dchae/PR/nnstreamer/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc:26:0:
../gst/nnstreamer/./include/nnstreamer_cppplugin_api_filter.hh: In instantiation of ‘static T* nnstreamer::tensor_filter_subplugin::register_subplugin() [with T = nnstreamer::tensor_filter_snpe::snpe_subplugin]’:
/home/dchae/PR/nnstreamer/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc:425:68:   required from here
../gst/nnstreamer/./include/nnstreamer_cppplugin_api_filter.hh:104:14: error: ‘memcpy’ was not declared in this scope
       memcpy (&emptyInstance->fwdesc, &fwdesc_template,
              ^
cc1plus: error: unrecognized command line option ‘-Wno-terminate’ [-Werror]
cc1plus: all warnings being treated as errors
```

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>
