### PR TITLE
[Filter/TFLite] remove ineffective codes

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -225,12 +225,6 @@ TFLiteInterpreter::invoke (const GstTensorMemory * input,
     status = kTfLiteError;
   }
 
-  /** if it is not `nullptr`, tensorflow makes `free()` the memory itself. */
-  int tensorSize = tensors_idx.size ();
-  for (int i = 0; i < tensorSize; ++i) {
-    interpreter->tensor (tensors_idx[i])->data.raw = nullptr;
-  }
-
 #if (DBG)
   gint64 stop_time = g_get_real_time ();
   g_message ("Invoke() is finished: %" G_GINT64_FORMAT,
@@ -284,22 +278,6 @@ TFLiteInterpreter::loadModel (bool use_nnapi)
     }
   }
 #endif
-
-  /** set allocation type to dynamic for in/out tensors */
-  int tensor_idx;
-
-  int tensorSize = interpreter->inputs ().size ();
-  for (int i = 0; i < tensorSize; ++i) {
-    tensor_idx = interpreter->inputs ()[i];
-    interpreter->tensor (tensor_idx)->allocation_type = kTfLiteDynamic;
-  }
-
-  tensorSize = interpreter->outputs ().size ();
-  for (int i = 0; i < tensorSize; ++i) {
-    tensor_idx = interpreter->outputs ()[i];
-    interpreter->tensor (tensor_idx)->allocation_type = kTfLiteDynamic;
-  }
-
   if (interpreter->AllocateTensors () != kTfLiteOk) {
     ml_loge ("Failed to allocate tensors\n");
     return -2;


### PR DESCRIPTION
# Summary
setting the allocation type is not effective anymore.

# Description
previously(at Tensorflow v1.9), the flag `kTfLiteDynamic` for the allocation option of each tensor of Tensorflow-Lite was required. if it was not, there was no way to set input raw data and to get output raw data without `memcpy`.

However, recently, we met a case about a TFLite model not working with the option `kTfLiteDynamic`, and I tried various ways to solve it.

In conclusion, at TF 1.13.1 and 1.15.2 we provide, the option is not effective anymore. In other words, the raw data pointer that we used to still works properly without any problem like memleak or defects.

For this reason, we can solve the problem(the model not working) by removing the setting phrase without any modification of the current policy(not using the `memcpy`).

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped