### PR TITLE
[Log] add definition log-fatal

### DIFF
--- a/gst/nnstreamer/nnstreamer_log.h
+++ b/gst/nnstreamer/nnstreamer_log.h
@@ -83,5 +83,6 @@
 #define nns_logw ml_logw
 #define nns_loge ml_loge
 #define nns_logd ml_logd
+#define nns_logf ml_logf
 
 #endif /* __NNSTREAMER_LOG_H__ */


### PR DESCRIPTION
define new nns_logf (common fatal-log definition with nns_log prefix)

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
