### PR TITLE
[NNFW] set backend after loading model

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -203,14 +203,6 @@ nnfw_open (const GstTensorFilterProperties * prop, void **private_data)
     goto unalloc_exit;
   }
 
-  accelerator = nnfw_get_accelerator (pdata, prop->accl_str);
-  status = nnfw_set_available_backends (pdata->session, accelerator);
-  if (status != NNFW_STATUS_NO_ERROR) {
-    err = -EINVAL;
-    g_printerr ("Cannot set nnfw-runtime backend to %s\n", accelerator);
-    goto unalloc_exit;
-  }
-
   /** @note nnfw opens the first model listed in the MANIFEST file */
   model_path = g_path_get_dirname (prop->model_files[0]);
   meta_file = g_build_filename (model_path, "metadata", "MANIFEST", NULL);
@@ -235,6 +227,14 @@ nnfw_open (const GstTensorFilterProperties * prop, void **private_data)
   if (status != NNFW_STATUS_NO_ERROR) {
     err = -EINVAL;
     g_printerr ("Cannot load the model file: %s\n", prop->model_files[0]);
+    goto session_exit;
+  }
+
+  accelerator = nnfw_get_accelerator (pdata, prop->accl_str);
+  status = nnfw_set_available_backends (pdata->session, accelerator);
+  if (status != NNFW_STATUS_NO_ERROR) {
+    err = -EINVAL;
+    g_printerr ("Cannot set nnfw-runtime backend to %s\n", accelerator);
     goto session_exit;
   }
 


### PR DESCRIPTION
recently updated, nnfw set-backend should be called after loading the model.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
