### PR TITLE
Tizen/spec: disable mvncsdk/edgeTPU for DA build

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -41,6 +41,12 @@
 %define		vivante_support 0
 %endif
 
+# DA requested to remove unnecessary module builds
+%if 0%{?_with_da_profile}
+%define	mvncsdk2_support 0
+%define	edgetpu_support 0
+%endif
+
 # If it is tizen, we can export Tizen API packages.
 %bcond_with tizen
 


### PR DESCRIPTION
DA requested to remove mvncsdk/edgeTPU from the dependency.
Disable them for their builds.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

