### PR TITLE
TAOS-CI / Enable clang-format for C++ codes @open sesame 6/10 15:57

### DIFF
--- a/.TAOS-CI/config/config-environment.sh
+++ b/.TAOS-CI/config/config-environment.sh
@@ -166,3 +166,6 @@ _cov_email="taos-ci@github.io"
 _cov_token="xxxxxxxxxxxxxxxxxxxxxx"
 _cov_yellow_card=10
 _cov_red_card=50
+
+# Pre-build checker, Clang is applied to C++ files only.
+clang_option="cxx-only"

--- a/.TAOS-CI/config/config-plugins-prebuild.sh
+++ b/.TAOS-CI/config/config-plugins-prebuild.sh
@@ -31,12 +31,12 @@ echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${prebuild_plu
 source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${prebuild_plugins[idx]}.sh
 
 
-#prebuild_plugins[++idx]="pr-prebuild-clang"
-# echo "${prebuild_plugins[idx]} is starting."
-# echo "[MODULE] ${BOT_NAME}/${prebuild_plugins[idx]}: Check the code formatting style with clang-format"
-# echo "[DEBUG] The current path: $(pwd)."
-# echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${prebuild_plugins[idx]}.sh"
-# source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${prebuild_plugins[idx]}.sh
+prebuild_plugins[++idx]="pr-prebuild-clang"
+echo "${prebuild_plugins[idx]} is starting."
+echo "[MODULE] ${BOT_NAME}/${prebuild_plugins[idx]}: Check the code formatting style with clang-format"
+echo "[DEBUG] The current path: $(pwd)."
+echo "[DEBUG] source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${prebuild_plugins[idx]}.sh"
+source ${REFERENCE_REPOSITORY}/ci/taos/plugins-good/${prebuild_plugins[idx]}.sh
 
 #prebuild_plugins[++idx]="pr-prebuild-exclusive-vio"
 # echo "${prebuild_plugins[idx]} is starting."


### PR DESCRIPTION
1. Enable clang TAOS-CI module
2. Add "C++ ONLY" mode for it.

Note that I need to update TAOS-CI to make it accept such options: https://github.com/nnstreamer/TAOS-CI/pull/628

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

Fixes #2044

ps. This needs a new PR in TAOS-CI. Wait for it.