### PR TITLE
[Mux] Set sync-mode to slowest as default @open sesame 6/9 23:16

### DIFF
--- a/gst/nnstreamer/tensor_mux/gsttensormux.c
+++ b/gst/nnstreamer/tensor_mux/gsttensormux.c
@@ -210,7 +210,7 @@ gst_tensor_mux_init (GstTensorMux * tensor_mux)
       tensor_mux);
 
   tensor_mux->silent = TRUE;
-  tensor_mux->sync.mode = SYNC_NOSYNC;
+  tensor_mux->sync.mode = SYNC_SLOWEST;
   tensor_mux->sync.option = NULL;
   tensor_mux->need_buffer = FALSE;
   tensor_mux->current_time = 0;
@@ -525,7 +525,7 @@ gst_tensor_mux_set_property (GObject * object, guint prop_id,
       filter->sync.mode =
           gst_tensor_time_sync_get_mode (g_value_get_string (value));
       if (filter->sync.mode == SYNC_END) {
-        filter->sync.mode = SYNC_NOSYNC;
+        filter->sync.mode = SYNC_SLOWEST;
       }
       silent_debug ("Mode = %d(%s)\n", filter->sync.mode,
           gst_tensor_time_sync_get_mode_string (filter->sync.mode));

--- a/tests/nnstreamer_repo_lstm/runTest.sh
+++ b/tests/nnstreamer_repo_lstm/runTest.sh
@@ -51,7 +51,7 @@ fi
 # Generate video_4x4xBGRx.xraw & golden
 python generateTestCase.py
 
-gstTest "--gst-plugin-path=../../build tensor_mux name=mux ! tensor_filter framework=custom model=${LSTM_DIR}/libdummyLSTM.${SO_EXT} ! tensor_demux name=demux ! queue ! tensor_reposink slot-index=0 silent=false demux.src_1 ! queue ! tee name=t ! queue ! tensor_reposink slot-index=1 silent=false tensor_reposrc slot-index=0 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)float32,framerate=(fraction)0/1\" ! mux.sink_0 tensor_reposrc slot-index=1 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)float32,framerate=(fraction)0/1\" ! mux.sink_1 filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=float32 ! mux.sink_2 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=../../build tensor_mux name=mux sync_mode=nosync ! tensor_filter framework=custom model=${LSTM_DIR}/libdummyLSTM.${SO_EXT} ! tensor_demux name=demux ! queue ! tensor_reposink slot-index=0 silent=false demux.src_1 ! queue ! tee name=t ! queue ! tensor_reposink slot-index=1 silent=false tensor_reposrc slot-index=0 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)float32,framerate=(fraction)0/1\" ! mux.sink_0 tensor_reposrc slot-index=1 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)float32,framerate=(fraction)0/1\" ! mux.sink_1 filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=float32 ! mux.sink_2 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
 
 callCompareTest lstm.golden out_9.log 1-1 "Compare 1-1" 1 0
 

--- a/tests/nnstreamer_repo_rnn/runTest.sh
+++ b/tests/nnstreamer_repo_rnn/runTest.sh
@@ -37,7 +37,7 @@ fi
 # Generate video_4x4xBGRx.xraw
 python generateTestCase.py
 
-gstTest "--gst-plugin-path=../../build tensor_mux name=mux ! tensor_filter framework=custom model=${RNN_DIR}/libdummyRNN.${SO_EXT} ! tee name=t ! queue ! tensor_reposink slot-index=0 silent=false filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=uint8 ! mux.sink_0 tensor_reposrc slot-index=0 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)uint8,framerate=(fraction)0/1\" ! mux.sink_1 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=../../build tensor_mux name=mux sync_mode=nosync ! tensor_filter framework=custom model=${RNN_DIR}/libdummyRNN.${SO_EXT} ! tee name=t ! queue ! tensor_reposink slot-index=0 silent=false filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=uint8 ! mux.sink_0 tensor_reposrc slot-index=0 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)uint8,framerate=(fraction)0/1\" ! mux.sink_1 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
 
 callCompareTest rnn.golden out_9.log 1-1 "Compare 1-1" 1 0
 


### PR DESCRIPTION
After passing mux / demux, the framerate is extremely bigger than
before. (Issue #2440) This is mainly because sync_mode of tensor_mux
filter is SYNC_NOSYNC. To fix this bug, this patch set sync_mode to
SYNC_SLOWEST as default.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

* Related Issue: #2440 

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

**Result**
After applying this patch, Default sync-mode is `slowest`.
```bash
$ gst-inspect-1.0 --gst-plugin-path="build" tensor_mux
...
  sync-mode           : Time synchronization mode?
                        flags: readable, writable
                        String. Default: "slowest"
...
```