### PR TITLE
Filter/Custom/Easy: fix doxygen entry

### DIFF
--- a/gst/nnstreamer/include/tensor_filter_custom_easy.h
+++ b/gst/nnstreamer/include/tensor_filter_custom_easy.h
@@ -55,7 +55,7 @@ G_BEGIN_DECLS
  * @param[in] func The tensor function body
  * @param[in/out] private_data The internal data for the function
  * @param[in] in_info Input tensor metadata.
- * @param[out] out_info Output tensor metadata
+ * @param[in] out_info Output tensor metadata
  * @note NNS_custom_invoke defined in tensor_filter_custom.h
  *       Output buffers for func are preallocated.
  */


### PR DESCRIPTION
Fix easy-custom-filter API's doxygen entry.
It gets output dimenesion info as an input, not output.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

