### PR TITLE
[Android] do not convert meta in invoke method

### DIFF
--- a/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
+++ b/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
@@ -222,6 +222,9 @@ public class APITestSingleShot {
                 TensorsInfo info = new TensorsInfo();
                 info.addTensorInfo(NNStreamer.TensorType.FLOAT32, new int[]{1,1,1,i});
 
+                /* change input information */
+                single.setInputInfo(info);
+
                 /* dummy input */
                 TensorsData out = single.invoke(TensorsData.allocate(info));
 

--- a/api/android/api/src/main/java/org/nnsuite/nnstreamer/SingleShot.java
+++ b/api/android/api/src/main/java/org/nnsuite/nnstreamer/SingleShot.java
@@ -137,10 +137,10 @@ public final class SingleShot implements AutoCloseable {
 
     /**
      * Invokes the model with the given input data.
-     * If the model has flexible input data dimensions, input information for this
-     * run of the model can be passed. This changes the currently set input information
-     * for this instance of the model. The corresponding output information can be
-     * extracted.
+     *
+     * Even if the model has flexible input data dimensions,
+     * input data frames of an instance of a model should share the same dimension.
+     * To change the input information, you should call {@link #setInputInfo(TensorsInfo)} before calling invoke method.
      *
      * Note that this has a default timeout of 3 seconds.
      * If an application wants to change the time to wait for an output,
@@ -273,6 +273,8 @@ public final class SingleShot implements AutoCloseable {
     /**
      * Sets the information (tensor dimension, type, name and so on) of input data for the given model.
      * Updates the output information for the model internally.
+     *
+     * Note that a model/framework may not support changing the information.
      *
      * @param in The input tensors information
      *

--- a/api/android/api/src/main/jni/nnstreamer-native-customfilter.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-customfilter.c
@@ -66,7 +66,7 @@ nns_customfilter_priv_set_in_info (pipeline_info_s * pipe_info, JNIEnv * env,
 
   priv = (customfilter_priv_data_s *) pipe_info->priv_data;
 
-  if (priv->in_info && ml_tensors_info_is_equal (in_info, priv->in_info)) {
+  if (ml_tensors_info_is_equal (in_info, priv->in_info)) {
     /* do nothing, tensors info is equal. */
     return TRUE;
   }
@@ -76,15 +76,11 @@ nns_customfilter_priv_set_in_info (pipeline_info_s * pipe_info, JNIEnv * env,
     return FALSE;
   }
 
+  ml_tensors_info_free (priv->in_info);
+  ml_tensors_info_clone (priv->in_info, in_info);
+
   if (priv->in_info_obj)
     (*env)->DeleteGlobalRef (env, priv->in_info_obj);
-
-  if (priv->in_info)
-    ml_tensors_info_free (priv->in_info);
-  else
-    ml_tensors_info_create (&priv->in_info);
-
-  ml_tensors_info_clone (priv->in_info, in_info);
   priv->in_info_obj = (*env)->NewGlobalRef (env, obj_info);
   (*env)->DeleteLocalRef (env, obj_info);
   return TRUE;
@@ -346,6 +342,7 @@ nns_native_custom_initialize (JNIEnv * env, jobject thiz, jstring name)
       "(L" NNS_CLS_TDATA ";)L" NNS_CLS_TDATA ";");
   priv->mid_info = (*env)->GetMethodID (env, pipe_info->cls, "getOutputInfo",
       "(L" NNS_CLS_TINFO ";)L" NNS_CLS_TINFO ";");
+  ml_tensors_info_create (&priv->in_info);
 
   nns_set_priv_data (pipe_info, priv, nns_customfilter_priv_free);
 

--- a/api/android/api/src/main/jni/nnstreamer-native-pipeline.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-pipeline.c
@@ -80,12 +80,13 @@ nns_pipeline_sink_priv_set_out_info (element_data_s * item, JNIEnv * env,
 
   if ((priv = item->priv_data) == NULL) {
     priv = g_new0 (pipeline_sink_priv_data_s, 1);
+    ml_tensors_info_create (&priv->out_info);
 
     item->priv_data = priv;
     item->priv_destroy_func = nns_pipeline_sink_priv_free;
   }
 
-  if (priv->out_info && ml_tensors_info_is_equal (out_info, priv->out_info)) {
+  if (ml_tensors_info_is_equal (out_info, priv->out_info)) {
     /* do nothing, tensors info is equal. */
     return TRUE;
   }
@@ -95,15 +96,11 @@ nns_pipeline_sink_priv_set_out_info (element_data_s * item, JNIEnv * env,
     return FALSE;
   }
 
+  ml_tensors_info_free (priv->out_info);
+  ml_tensors_info_clone (priv->out_info, out_info);
+
   if (priv->out_info_obj)
     (*env)->DeleteGlobalRef (env, priv->out_info_obj);
-
-  if (priv->out_info)
-    ml_tensors_info_free (priv->out_info);
-  else
-    ml_tensors_info_create (&priv->out_info);
-
-  ml_tensors_info_clone (priv->out_info, out_info);
   priv->out_info_obj = (*env)->NewGlobalRef (env, obj_info);
   (*env)->DeleteLocalRef (env, obj_info);
   return TRUE;

--- a/api/android/api/src/main/jni/nnstreamer-native-singleshot.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-singleshot.c
@@ -59,7 +59,7 @@ nns_singleshot_priv_set_out_info (pipeline_info_s * pipe_info, JNIEnv * env,
 
   priv = (singleshot_priv_data_s *) pipe_info->priv_data;
 
-  if (priv->out_info && ml_tensors_info_is_equal (out_info, priv->out_info)) {
+  if (ml_tensors_info_is_equal (out_info, priv->out_info)) {
     /* do nothing, tensors info is equal. */
     return TRUE;
   }
@@ -69,15 +69,11 @@ nns_singleshot_priv_set_out_info (pipeline_info_s * pipe_info, JNIEnv * env,
     return FALSE;
   }
 
+  ml_tensors_info_free (priv->out_info);
+  ml_tensors_info_clone (priv->out_info, out_info);
+
   if (priv->out_info_obj)
     (*env)->DeleteGlobalRef (env, priv->out_info_obj);
-
-  if (priv->out_info)
-    ml_tensors_info_free (priv->out_info);
-  else
-    ml_tensors_info_create (&priv->out_info);
-
-  ml_tensors_info_clone (priv->out_info, out_info);
   priv->out_info_obj = (*env)->NewGlobalRef (env, obj_info);
   (*env)->DeleteLocalRef (env, obj_info);
   return TRUE;
@@ -178,6 +174,7 @@ done:
     ml_tensors_info_h out_info;
 
     priv = g_new0 (singleshot_priv_data_s, 1);
+    ml_tensors_info_create (&priv->out_info);
     nns_set_priv_data (pipe_info, priv, nns_singleshot_priv_free);
 
     /* set output info */


### PR DESCRIPTION
To improve performance, it is necessary to remove metadata conversion in invoke method.
Do not handle dynamic mode in invoke method and update description to change the tensor info.
Also, if output info is changed using set-info method, update cached instance in private data.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
