### PR TITLE
[Dist/Debian] Provide a sub-package for the Edge TPU extension 

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev,
  python, python-numpy, python3, python3-dev, python3-numpy,
- tensorflow-lite-dev, pytorch,
+ tensorflow-lite-dev, pytorch, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
  tensorflow-dev [amd64], python2.7-dev, libprotobuf-dev [amd64 arm64 armhf]
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer
@@ -75,6 +75,13 @@ Multi-Arch: same
 Depends: nnstreamer-cpp, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer CPP Filter Subplugin Development Support
  This package allows developers to write custom filters of C++ classes
+
+Package: nnstreamer-edgetpu
+Architecture: any
+Multi-Arch: same
+Depends: nnstreamer, libedgetpu1-std, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer Edge TPU support
+ This package allows nnstreamer to support Edge TPU.
 
 Package: nnstreamer-dev
 Architecture: any

--- a/debian/nnstreamer-edgetpu.install
+++ b/debian/nnstreamer-edgetpu.install
@@ -1,0 +1,1 @@
+/usr/lib/nnstreamer/filters/libnnstreamer_filter_edgetpu.so

--- a/debian/rules
+++ b/debian/rules
@@ -38,7 +38,7 @@ override_dh_auto_configure:
 	mkdir -p build
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
 	-Dinstall-example=true -Dtf-support=$(enable_tf) -Dtflite-support=enabled -Dpytorch-support=enabled -Dcaffe2-support=enabled \
-	-Dpython2-support=enabled -Dpython3-support=enabled -Denable-capi=true -Denable-tizen=false build
+	-Dpython2-support=enabled -Dpython3-support=enabled -Denable-capi=true -Denable-edgetpu=true -Denable-tizen=false build
 
 override_dh_auto_build:
 	ninja -C build

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -1,4 +1,4 @@
-if nnfw_runtime_support_is_available 
+if nnfw_runtime_support_is_available
   filter_sub_nnfw_sources = ['tensor_filter_nnfw.c']
 
   nnstreamer_filter_nnfw_sources = []
@@ -387,7 +387,7 @@ if get_option('enable-mediapipe')
   else
     error('Not Supported System & Architecture. Linux x86_64 is required')
   endif
-  
+
   cmd = run_command('sh', '-c', 'echo $MEDIAPIPE_HOME')
   MEDIAPIPE_HOME = cmd.stdout().strip()
 
@@ -422,7 +422,7 @@ if get_option('enable-mediapipe')
   opencv_highgui_dep = cc.find_library('opencv_highgui', dirs: join_paths(MEDIAPIPE_HOME, opencv_path))
   opencv_videoio_dep = cc.find_library('opencv_videoio', dirs: join_paths(MEDIAPIPE_HOME, opencv_path))
   opencv_features2d_dep = cc.find_library('opencv_features2d', dirs: join_paths(MEDIAPIPE_HOME, opencv_path))
-  
+
   nnstreamer_filter_mediapipe_deps = [
     glib_dep,
     gst_dep,
@@ -445,7 +445,7 @@ if get_option('enable-mediapipe')
   foreach s : filter_sub_mp_sources
     nnstreamer_filter_mediapipe_sources += join_paths(meson.current_source_dir(), s)
   endforeach
-  
+
   shared_library('nnstreamer_filter_mediapipe',
     nnstreamer_filter_mediapipe_sources,
     dependencies: nnstreamer_filter_mediapipe_deps,
@@ -455,7 +455,7 @@ if get_option('enable-mediapipe')
   )
 endif
 
-if snpe_support_is_available  
+if snpe_support_is_available
   snpe_env_exist = run_command('[', '-z', snpe_support_SNPE_ROOT, ']').returncode()
   snpe_dir_not_exist = run_command('[', '-d', snpe_support_SNPE_ROOT, ']').returncode()
 
@@ -474,7 +474,7 @@ if snpe_support_is_available
   snpe_cpp_args += '-Wno-terminate'
 
   filter_sub_snpe_sources = ['tensor_filter_snpe.cc']
- 
+
   nnstreamer_filter_snpe_sources = []
   foreach s : filter_sub_snpe_sources
     nnstreamer_filter_snpe_sources += join_paths(meson.current_source_dir(), s)

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -301,8 +301,16 @@ if get_option('enable-edgetpu')
   if tflite_support_is_available
     edgetpu_dep = dependency('edgetpu', required: false)
     if not edgetpu_dep.found()
-      # Ubuntu edgetpu package does not have pkgconfig file
-      edgetpu_dep = cc.find_library('edgetpu')
+      # Since the developement package for Ubuntu does not have pkgconfig file,
+      # check that the required header and library files exist in the system
+      # include and lib directories.
+      if cxx.has_header('edgetpu.h')
+        edgetpu_dep = declare_dependency (
+          dependencies: cxx.find_library('edgetpu'),
+        )
+      else
+        error('failed to resolve the build dependency of the tensor filter for Edge TPU.')
+      endif
     endif
     filter_sub_edgetpu_sources = ['tensor_filter_edgetpu.cc']
 


### PR DESCRIPTION
This PR addresses providing a debian/ubuntu sub-package that contains the tensor_filter extension for Edge TPU. To this end, 
 - The mechanism that resolves for Edge TPU is modified.
 - The option to enable-edgtpu is set to true by default in the **rules** file.
 - The **control** file is modified and nnstreamer-edgetpu.install is added as well.

libedgetpu1-std and libedgetpu1-max simultaneously provides libedgetpu1 on which libedgetpu-dev depends. This incurs a conflict between these two packages at the build time so that pdebuild fails. To avoid this issue, libedgetpu1-std is added to the **Build-Depends** section of the **control** file.

See also: #1966

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>
