### PR TITLE
[Android] constructor with info

### DIFF
--- a/api/android/api/src/main/java/org/nnsuite/nnstreamer/TensorsData.java
+++ b/api/android/api/src/main/java/org/nnsuite/nnstreamer/TensorsData.java
@@ -59,10 +59,8 @@ public final class TensorsData implements AutoCloseable {
             throw new IllegalArgumentException("Given info is invalid");
         }
 
-        TensorsData data = new TensorsData();
+        TensorsData data = new TensorsData(info);
         int count = info.getTensorsCount();
-
-        data.setTensorsInfo(info);
 
         for (int i = 0; i < count; i++) {
             data.addTensorData(allocateByteBuffer(info.getTensorSize(i)));
@@ -236,5 +234,7 @@ public final class TensorsData implements AutoCloseable {
     /**
      * Private constructor to prevent the instantiation.
      */
-    private TensorsData() {}
+    private TensorsData(TensorsInfo info) {
+        setTensorsInfo(info);
+    }
 }

--- a/api/android/api/src/main/jni/nnstreamer-native.h
+++ b/api/android/api/src/main/jni/nnstreamer-native.h
@@ -94,7 +94,6 @@ typedef struct
   jmethodID mid_init;
   jmethodID mid_add_data;
   jmethodID mid_get_array;
-  jmethodID mid_set_info;
   jmethodID mid_get_info;
 } data_class_info_s;
 


### PR DESCRIPTION
In tensors-data class, update private constructor with tensor-info.
This can remove method call to set metadata in native.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
