### PR TITLE
[Filter/EdgeTPU] Handle the error case when a compiled model is given

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -329,9 +329,13 @@ if get_option('enable-edgetpu')
       rpath_edgetpu_test_helper = join_paths(meson.build_root(), 'tests/nnstreamer_filter_edgetpu')
 
     endif
+
+    tflite_ver_dep = declare_dependency (
+      compile_args : ['-DTFLITE_VER="' + tflite_support_deps[0].version() +'"', ],
+    )
     shared_library('nnstreamer_filter_edgetpu',
       nnstreamer_filter_edgetpu_sources,
-      dependencies: tflite_support_deps + [glib_dep, gst_dep, nnstreamer_dep, edgetpu_dep, libdl_dep],
+      dependencies: tflite_support_deps + [glib_dep, gst_dep, nnstreamer_dep, edgetpu_dep, libdl_dep, tflite_ver_dep],
       install: true,
       install_dir: filter_subplugin_install_dir,
       build_rpath: rpath_edgetpu_test_helper


### PR DESCRIPTION
This PR resolves https://github.com/nnstreamer/nnstreamer/issues/1966#issuecomment-641708718 by handling the error case when a model compiled by edgetpu-compiler is given. In general, a higher version of tensorflow-lite (> 1.13) could support more various types of the tflite models.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

#### Before this PR
```bash
$ ./do.sh 
Null custom op data.
Node number 0 (edgetpu-custom-op) failed to prepare.

Failed to allocate tensors.
Setting pipeline to PAUSED ...
Pipeline is PREROLLING ...
Invoke called on model that is not ready.
Failed to invoke tensorflow-lite + edge-tpu.

** (gst-launch-1.0:1320): CRITICAL **: 19:47:07.893: Tensor-filter invoke failed (error code = -22).

ERROR: from element /GstPipeline:pipeline0/GstImageFreeze:imagefreeze0: Internal data stream error.
Additional debug info:
gstimagefreeze.c(851): gst_image_freeze_src_loop (): /GstPipeline:pipeline0/GstImageFreeze:imagefreeze0:
streaming stopped, reason error (-5)
ERROR: pipeline doesn't want to preroll.
Setting pipeline to NULL ...
Freeing pipeline ...
```
#### After this PR
- updated
```bash
$ ./do.sh 
Null custom op data.
Node number 0 (edgetpu-custom-op) failed to prepare.


** (gst-launch-1.0:7136): CRITICAL **: 20:27:18.061: Failed to allocate tensors.
Setting pipeline to PAUSED ...
Pipeline is PREROLLING ...
Invoke called on model that is not ready.

** (gst-launch-1.0:7136): WARNING **: 20:27:18.066: A compiled model by edgetpu-compiler has been given, but this extension might be statically linked with TensorFlow Lite v1.13.1 which does not support the model.

** (gst-launch-1.0:7136): WARNING **: 20:27:18.066: To use this model, it is highly recommended to build this extension after upgrading tensorflow-lite-dev.
Failed to invoke tensorflow-lite + edge-tpu.

** (gst-launch-1.0:7136): CRITICAL **: 20:27:18.066: Tensor-filter invoke failed (error code = -22).

ERROR: from element /GstPipeline:pipeline0/GstImageFreeze:imagefreeze0: Internal data stream error.
Additional debug info:
gstimagefreeze.c(851): gst_image_freeze_src_loop (): /GstPipeline:pipeline0/GstImageFreeze:imagefreeze0:
streaming stopped, reason error (-5)
ERROR: pipeline doesn't want to preroll.
Setting pipeline to NULL ...
Freeing pipeline ...
```