### PR TITLE
[Debian/control] Add flatbuf-dev build dependent package @open sesame 6/11 12:49 

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev,
  python, python-numpy, python3, python3-dev, python3-numpy,
  tensorflow-lite-dev, pytorch, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
+ libflatbuffers-dev, flatbuffers-compiler,
  tensorflow-dev [amd64], python2.7-dev, libprotobuf-dev [amd64 arm64 armhf]
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -96,6 +96,7 @@ BuildRequires:	python-numpy-devel
 BuildRequires:  pkgconfig(libpng)
 %if 0%{?tensorflow_lite_support}
 # for tensorflow-lite
+BuildRequires: flatbuffers-devel
 BuildRequires: tensorflow-lite-devel
 %endif
 # custom_example_opencv filter requires opencv-devel


### PR DESCRIPTION
As flatbuf headers are separated from tflite-dev pkg, flatbuf-dev pkg is added.

~~*Updated tensorflow-lite-dev package not uploaded yet.~~

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [ *]Skipped
2. Run test: [ *]Passed [ ]Failed []Skipped

