### PR TITLE
[Filter/Custom/Easy] Add unregister function @open sesame 6/11 15:10 

### DIFF
--- a/gst/nnstreamer/include/tensor_filter_custom_easy.h
+++ b/gst/nnstreamer/include/tensor_filter_custom_easy.h
@@ -63,5 +63,12 @@ extern int NNS_custom_easy_register (const char * modelname,
     NNS_custom_invoke func, void *data,
     const GstTensorsInfo * in_info, const GstTensorsInfo * out_info);
 
+/**
+ * @brief Unregister the custom-easy tensor function.
+ * @param[in] modelname The registered name of custom-easy tensor function.
+ * @return 0 if success, non-zero if error
+ */
+extern int NNS_custom_easy_unregister (const char * modelname);
+
 G_END_DECLS
 #endif /*__NNS_TENSOR_FILTER_CUSTOM_EASY_H__*/

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
@@ -85,6 +85,16 @@ NNS_custom_easy_register (const char *modelname,
 }
 
 /**
+ * @brief Unregister the custom-easy tensor function.
+ * @return 0 if success. -EINVAL if invalid model name.
+ */
+int
+NNS_custom_easy_unregister (const char *modelname)
+{
+  return unregister_subplugin (NNS_EASY_CUSTOM_FILTER, modelname) ? 0 : -EINVAL;
+}
+
+/**
  * @brief Callback required by tensor_filter subplugin
  */
 static int

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -5658,8 +5658,48 @@ TEST (tensor_filter_custom_easy, in_code_func_01)
   EXPECT_FALSE (g_test_data.test_failed);
   _free_test_data ();
 
+  /** cleanup registered custom_easy filter */
+  ret = NNS_custom_easy_unregister("safe_memcpy_10x10");
+  ASSERT_EQ(ret, 0);
+
   /** @todo: Check the data at sink */
 
+}
+
+/**
+ * @brief Test unregister custom_easy filter
+ */
+TEST (tensor_filter_custom_easy, unregister_1_p)
+{
+  int ret;
+  const GstTensorsInfo info_in = {
+    .num_tensors = 1U,
+    .info = {{ .name = NULL, .type = _NNS_UINT8, .dimension = { 1, 10, 1, 1}}},
+  };
+  const GstTensorsInfo info_out = {
+    .num_tensors = 1U,
+    .info = {{ .name = NULL, .type = _NNS_UINT8, .dimension = { 1, 10, 1, 1}}},
+  };
+
+  ret = NNS_custom_easy_register ("safe_memcpy_10x10", cef_func_safe_memcpy,
+      NULL, &info_in, &info_out);
+  ASSERT_EQ(ret, 0);
+
+  /** check unregister custom_easy filter */
+  ret = NNS_custom_easy_unregister("safe_memcpy_10x10");
+  ASSERT_EQ(ret, 0);
+}
+
+/**
+ * @brief Test non-registered custom_easy filter
+ */
+TEST (tensor_filter_custom_easy, unregister_1_n)
+{
+  int ret;
+
+  /** check non-registered custom_easy filter */
+  ret = NNS_custom_easy_unregister("not_registered");
+  ASSERT_NE(ret, 0);
 }
 
 /**


### PR DESCRIPTION
This patch newly add `NNS_custom_easy_unregister()` function to remove registered function so that pipeline itself can be reused without changing custom model name.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

