### PR TITLE
[Bugfix/Auto] Fix the bug accessing the freed memory region in auto fw_name

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -1038,7 +1038,7 @@ _gtfc_setprop_MODEL (GstTensorFilterPrivate * priv,
   gst_tensor_filter_parse_modelpaths_string (prop, model_files);
 
   if (prop->fwname != NULL && g_ascii_strcasecmp (prop->fwname, "auto") == 0)
-    gst_tensor_filter_get_available_framework (priv, prop->fwname);
+    gst_tensor_filter_get_available_framework (priv, "auto");
 
   /**
    * Reload model if FW has been already opened;


### PR DESCRIPTION
This patch fixes the memory bug in auto tensor filter detection.

`gst_tensor_filter_get_available_framework` assumes that `fw_name` and
`prop->fwname` are pointing different memory regions.

However, `_gtfc_setprop_Model` has passed the argument `fw_name` as
`prop->fwname`, which may cause the invalid memory access.

In this case, `fw_name` is being accessed after `prop->fwname` is freed.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped