### PR TITLE
[Meson] converter sub-plugin path in test-env

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -424,16 +424,17 @@ if get_option('enable-test')
 
   path_gst_plugin = join_paths(meson.build_root(), 'gst', 'nnstreamer')
   path_nns_conf = join_paths(meson.build_root(), 'nnstreamer-test.ini')
-  path_nns_plugin_filters = join_paths(meson.build_root(), 'ext', 'nnstreamer',
-      'tensor_filter')
-  path_nns_plugin_decoders = join_paths(meson.build_root(), 'ext', 'nnstreamer',
-      'tensor_decoder')
+  path_nns_plugin_prefix = join_paths(meson.build_root(), 'ext', 'nnstreamer')
+  path_nns_plugin_filters = join_paths(path_nns_plugin_prefix, 'tensor_filter')
+  path_nns_plugin_decoders = join_paths(path_nns_plugin_prefix, 'tensor_decoder')
+  path_nns_plugin_converters = join_paths(path_nns_plugin_prefix, 'tensor_converter')
 
   testenv = environment()
   testenv.set('GST_PLUGIN_PATH', path_gst_plugin)
   testenv.set('NNSTREAMER_CONF', path_nns_conf)
   testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
   testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
+  testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
 
   subdir('tests')
 endif

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -79,6 +79,7 @@ foreach ext : extensions
   filter_ext_common_testenv.set('NNSTREAMER_CONF', path_nns_conf)
   filter_ext_common_testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
   filter_ext_common_testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
+  filter_ext_common_testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
   if ext[0] == 'python2'
     py2_module_path = join_paths(meson.build_root(), 'tests/' + ext[0] + '_module')
     run_command('rm', '-rf', py2_module_path, check : true)

--- a/tests/nnstreamer_filter_mvncsdk2/meson.build
+++ b/tests/nnstreamer_filter_mvncsdk2/meson.build
@@ -28,6 +28,7 @@ filter_mvncsdk2_testenv.set('GST_PLUGIN_PATH', path_gst_plugin)
 filter_mvncsdk2_testenv.set('NNSTREAMER_CONF', path_nns_conf)
 filter_mvncsdk2_testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
 filter_mvncsdk2_testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
+filter_mvncsdk2_testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
 filter_mvncsdk2_testenv.set('LD_LIBRARY_PATH', meson.current_build_dir())
 
 test('unittest_filter_mvncsdk2', unittest_mvncsdk, env: filter_mvncsdk2_testenv)

--- a/tests/tizen_capi/meson.build
+++ b/tests/tizen_capi/meson.build
@@ -45,5 +45,6 @@ if get_option('enable-tizen-sensor')
   tizen_sensor_testenv.set('NNSTREAMER_CONF', path_nns_conf)
   tizen_sensor_testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
   tizen_sensor_testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
+  tizen_sensor_testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
   test('unittest_tizen_sensor', unittest_tizen_sensor, env: tizen_sensor_testenv)
 endif


### PR DESCRIPTION
Update sub-plugin path in test-env, set converter plugin path.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
