### PR TITLE
[C-Api] error code when failed to allocate tensor data

### DIFF
--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -746,7 +746,6 @@ int ml_tensors_info_get_tensor_size (ml_tensors_info_h info, int index, size_t *
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
- * @retval #ML_ERROR_STREAMS_PIPE Failed to allocate new memory.
  * @retval #ML_ERROR_OUT_OF_MEMORY Failed to allocate required memory.
  */
 int ml_tensors_data_create (const ml_tensors_info_h info, ml_tensors_data_h *data);

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -621,9 +621,6 @@ ml_tensors_data_create (const ml_tensors_info_h info, ml_tensors_data_h * data)
   if (status != ML_ERROR_NONE) {
     return status;
   }
-  if (!_data) {
-    return ML_ERROR_STREAMS_PIPE;
-  }
 
   for (i = 0; i < _data->num_tensors; i++) {
     _data->tensors[i].tensor = g_malloc0 (_data->tensors[i].size);

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -1280,6 +1280,36 @@ TEST (nnstreamer_capi_switch, failure_01_n)
 }
 
 /**
+ * @brief Test NNStreamer Utility for checking plugin availability (invalid param)
+ */
+TEST (nnstreamer_capi_util, plugin_availability_fail_invalid_n)
+{
+  int status;
+
+  status = ml_check_plugin_availability ("nnstreamer", NULL);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_check_plugin_availability (NULL, "tensor_filter");
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test NNStreamer Utility for checking nnfw availability (invalid param)
+ */
+TEST (nnstreamer_capi_util, nnfw_availability_fail_invalid_n)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_ANY, NULL);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  /* any is unknown nnfw type */
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ANY, ML_NNFW_HW_ANY, &result);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
  * @brief Test NNStreamer Utility for checking availability of NNFW
  */
 TEST (nnstreamer_capi_util, availability_00)
@@ -2082,6 +2112,17 @@ TEST (nnstreamer_capi_util, data_create_n)
 
   status = ml_tensors_info_destroy (info);
   ASSERT_EQ (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test utility functions (internal)
+ */
+TEST (nnstreamer_capi_util, data_create_internal_n)
+{
+  int status;
+
+  status = ml_tensors_data_create_no_alloc (NULL, NULL);
+  EXPECT_NE (status, ML_ERROR_NONE);
 }
 
 /*


### PR DESCRIPTION
Remove unnecessary error code (stream-pipe).
If failed to allocate mem for tensors-data handle, API returns out-of-mem error.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
