### PR TITLE
[Fix] Remove unncessary arg checking before calling g_strdup()

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -140,7 +140,7 @@ _strdup_getenv (const gchar * name)
    */
   const gchar *tmp = g_getenv (name);
 
-  return (tmp != NULL) ? g_strdup (tmp) : NULL;
+  return g_strdup (tmp);
 }
 
 /**
@@ -537,7 +537,7 @@ nnsconf_get_custom_value_string (const gchar * group, const gchar * key)
       g_hash_table_insert (custom_table, hashkey, value);
   }
 
-  return (value != NULL) ? g_strdup (value) : NULL;
+  return g_strdup (value);
 }
 
 /** @brief Public function defined in the header */

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -206,7 +206,7 @@ gst_tensor_info_copy_n (GstTensorInfo * dest, const GstTensorInfo * src,
   g_return_if_fail (dest != NULL);
   g_return_if_fail (src != NULL);
 
-  dest->name = (src->name) ? g_strdup (src->name) : NULL;
+  dest->name = g_strdup (src->name);
   dest->type = src->type;
 
   for (i = 0; i < n; i++) {


### PR DESCRIPTION
This patch removes uncessary argument checking before calling g_strdup()

If an argument of g_strdup() is NULL, its return value is also NULL.
So, checking its argument before calling is duplicated and useless.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

