### PR TITLE
[C-Api] handle invalid info when creating data handle

### DIFF
--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -615,6 +615,11 @@ ml_tensors_data_create (const ml_tensors_info_h info, ml_tensors_data_h * data)
   if (info == NULL || data == NULL)
     return ML_ERROR_INVALID_PARAMETER;
 
+  if (!ml_tensors_info_is_valid (info)) {
+    nns_loge ("Given tensors information is invalid.");
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
   status =
       ml_tensors_data_create_no_alloc (info, (ml_tensors_data_h *) & _data);
 

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -2110,6 +2110,10 @@ TEST (nnstreamer_capi_util, data_create_n)
   status = ml_tensors_data_create (info, nullptr);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
+  /* invalid info */
+  status = ml_tensors_data_create (info, &data);
+  EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
+
   status = ml_tensors_info_destroy (info);
   ASSERT_EQ (status, ML_ERROR_NONE);
 }


### PR DESCRIPTION
When creating the data handle, return error if given tensors-info is invalid.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
