### PR TITLE
[Conf/MemLeak] Add missing g_free() to nnstreamer_conf.c @open sesame 6/19 15:30

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -533,8 +533,13 @@ nnsconf_get_custom_value_string (const gchar * group, const gchar * key)
       }
     }
 
-    if (value)
+    if (value) {
       g_hash_table_insert (custom_table, hashkey, value);
+    } else {
+      g_free (hashkey);
+    }
+  } else {
+    g_free (hashkey);
   }
 
   return g_strdup (value);


### PR DESCRIPTION
This patch adds missing `g_free()` to `nnstreamer_conf.c`

`nnsconf_get_custom_value_string()` allocates `hashkey` in the first    
line. However, if a value is found in the first hash lookup or a value  
does not exist in anywhere, `hashkey` is not inserted to the hash table,
which results in memory leak.                                           

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
