### PR TITLE
[Fix/MemLeak] Prevent potential memory leak in tensor info copy @open sesame 6/19 15:30

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -921,6 +921,7 @@ tflite_setInputDim (const GstTensorFilterProperties * prop, void **private_data,
   g_return_val_if_fail (out_info, -EINVAL);
 
   /** get current input tensor info for resetting */
+  gst_tensors_info_init (&cur_in_info);
   status = core->getInputTensorDim (&cur_in_info);
   if (status != 0)
     return status;

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -123,10 +123,8 @@ gst_tensor_info_free (GstTensorInfo * info)
 {
   g_return_if_fail (info != NULL);
 
-  if (info->name) {
-    g_free (info->name);
-    info->name = NULL;
-  }
+  g_free (info->name);
+  info->name = NULL;
 }
 
 /**
@@ -205,6 +203,8 @@ gst_tensor_info_copy_n (GstTensorInfo * dest, const GstTensorInfo * src,
 
   g_return_if_fail (dest != NULL);
   g_return_if_fail (src != NULL);
+
+  g_free (dest->name);
 
   dest->name = g_strdup (src->name);
   dest->type = src->type;

--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -2204,6 +2204,7 @@ gst_tensor_src_iio_fixate (GstBaseSrc * src, GstCaps * caps)
 
   if (self->is_tensor) {
     GstTensorConfig tensor_config;
+    gst_tensor_config_init (&tensor_config);
     gst_tensor_info_copy (&tensor_config.info,
         &(self->tensors_config->info.info[0]));
     tensor_config.rate_n = self->tensors_config->rate_n;

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -1686,6 +1686,7 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
   }
 
   /* compare type and dimension */
+  gst_tensor_config_init (&config);
   if (!gst_tensor_transform_convert_dimension (filter, GST_PAD_SINK,
           &in_config.info, &config.info)) {
     GST_ERROR_OBJECT (filter,


### PR DESCRIPTION
This patch prevents potential memory leaks in tensor info copy

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
