### PR TITLE
[RepoSink] ignore sync and preroll

### DIFF
--- a/gst/nnstreamer/tensor_repo/tensor_reposink.c
+++ b/gst/nnstreamer/tensor_repo/tensor_reposink.c
@@ -178,6 +178,10 @@ gst_tensor_reposink_init (GstTensorRepoSink * self)
   self->in_caps = NULL;
 
   gst_base_sink_set_qos_enabled (basesink, DEFAULT_QOS);
+
+  /* ignore sync and preroll in repo */
+  gst_base_sink_set_sync (basesink, FALSE);
+  gst_base_sink_set_async_enabled (basesink, FALSE);
 }
 
 /**


### PR DESCRIPTION
repo-sink may not receive a buffer when pipeline constructed.
set sync and async option to ignore this case.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
