### PR TITLE
[Coverage] Exclude generated files by flatbuf

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -545,7 +545,7 @@ find . -name "CMakeCXXCompilerId*.gcda" -delete
 # Generate report
 lcov -t 'NNStreamer Unit Test Coverage' -o unittest.info -c -d . -b $(pwd) --no-external
 # Exclude generated files (Orc)
-lcov -r unittest.info "*/*-orc.*" "*/tests/*" "*/meson*/*" -o unittest-filtered.info
+lcov -r unittest.info "*/*-orc.*" "*/tests/*" "*/meson*/*" "*/*@sha/*" -o unittest-filtered.info
 # Visualize the report
 genhtml -o result unittest-filtered.info -t "nnstreamer %{version}-%{release} ${VCS}" --ignore-errors source -p ${RPM_BUILD_DIR}
 


### PR DESCRIPTION
Exclude generated files by flatbuf from coverage report

Before : 
![캡처](https://user-images.githubusercontent.com/56856496/85111452-4fd8f300-b24f-11ea-9905-38ae17ea0bca.PNG)

After : 
![수정 후](https://user-images.githubusercontent.com/56856496/85111484-5ebfa580-b24f-11ea-9236-6fd4b104d039.PNG)

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped