### PR TITLE
[Test] Add test for imageseg-decoder and tensor_filter profiling

### DIFF
--- a/tests/nnstreamer_decoder_image_segment/runTest.sh
+++ b/tests/nnstreamer_decoder_image_segment/runTest.sh
@@ -78,6 +78,26 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! videoc
 
 callCompareTest test_golden.0 test_output.0 1 "test with videotestsrc" 0
 
+# THIS WON'T FAIL, BUT NOT MUCH MEANINGFUL (TARGET MODEL IS DIFFERENT ONE)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=257,height=257 ! tee name=t \
+    t. ! queue ! mix. \
+    t. ! queue ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,div:255.0 ! \
+        tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} latency=1 throughput=1 ! \
+        tensor_decoder mode=image_segment option1=snpe-deeplab option2=180 ! mix. \
+videomixer name=mix sink_0::alpha=0.7 sink_1::alpha=0.6 ! videoconvert ! fakesink" \
+2 0 0 $PERFORMANCE
+
+# THIS SHOULD EMIT ERROR
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+videotestsrc num_buffers=1 ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=257,height=257 ! tee name=t \
+    t. ! queue ! mix. \
+    t. ! queue ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,div:255.0 ! \
+        tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} ! \
+        tensor_decoder mode=image_segment option1=snpe-depth ! mix. \
+videomixer name=mix sink_0::alpha=0.7 sink_1::alpha=0.6 ! videoconvert ! fakesink" \
+3_n 0 1
+
 rm test_output.*
 
 report


### PR DESCRIPTION
- Add test cases for newly added option `snpe-deeplab` and `snpe-depth`
- It also check profiling option of tensor_filter

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
