### PR TITLE
[CodeClean] remove unnecessary defines @open sesame 6/24 11:42

### DIFF
--- a/ext/nnstreamer/android_source/gstamcsrc.c
+++ b/ext/nnstreamer/android_source/gstamcsrc.c
@@ -93,14 +93,6 @@
 #endif
 
 /**
- * @brief Template for src pad.
- */
-static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
-    GST_PAD_SRC,
-    GST_PAD_ALWAYS,
-    GST_STATIC_CAPS_ANY);
-
-/**
  * @brief Private members in GstAMCSrc
  */
 struct _GstAMCSrcPrivate
@@ -292,7 +284,9 @@ gst_amc_src_class_init (GstAMCSrcClass * klass)
   gstpushsrc_class->create = GST_DEBUG_FUNCPTR (gst_amc_src_create);
 
   /** ElementClass */
-  gst_element_class_add_static_pad_template (gstelement_class, &src_factory);
+  gst_element_class_add_pad_template (gstelement_class,
+      gst_pad_template_new ("src", GST_PAD_SRC, GST_PAD_ALWAYS, GST_CAPS_ANY));
+
   gst_element_class_set_static_metadata (gstelement_class,
       "amcsrc", "Source/AMC",
       "Src element to feed the decoded data from Android MediaCodec (AMC)",

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -65,11 +65,12 @@
      */
 
 /**
- * @brief Default static capability for other/tensors
+ * @brief Caps string for the caps template (other/tensors).
+ * num should be a string format that describes the number of tensors, or the range of incoming tensors.
  */
-#define GST_TENSORS_CAP_DEFAULT \
+#define GST_TENSORS_CAP_WITH_NUM(num) \
     "other/tensors, " \
-    "num_tensors = " GST_TENSOR_NUM_TENSORS_RANGE ", "\
+    "num_tensors = " num ", " \
     "framerate = " GST_TENSOR_RATE_RANGE
     /**
      * type should be one of types in GST_TENSOR_TYPE_ALL
@@ -78,6 +79,12 @@
      * but when we call gst_structure_get_string, it actually is working well.
      * "dimensions = (string) dim1:dim2:dim3:dim4, dim1:dim2:dim3:dim4"
      */
+
+/**
+ * @brief Default static capability for other/tensors
+ */
+#define GST_TENSORS_CAP_DEFAULT \
+    GST_TENSORS_CAP_WITH_NUM(GST_TENSOR_NUM_TENSORS_RANGE)
 
 /**
  * @brief Default static capability for Protocol Buffers

--- a/gst/nnstreamer/tensor_repo/tensor_reposink.c
+++ b/gst/nnstreamer/tensor_repo/tensor_reposink.c
@@ -54,16 +54,6 @@ enum
 #define DEFAULT_QOS TRUE
 #define DEFAULT_INDEX 0
 
-/**
- * @brief tensor_reposink sink template
- */
-#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)        /* >= 1.8 */
-static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",
-    GST_PAD_SINK,
-    GST_PAD_ALWAYS,
-    GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT "; " GST_TENSORS_CAP_DEFAULT));
-#endif
-
 static void gst_tensor_reposink_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec);
 static void gst_tensor_reposink_get_property (GObject * object, guint prop_id,
@@ -97,6 +87,8 @@ gst_tensor_reposink_class_init (GstTensorRepoSinkClass * klass)
   GObjectClass *gobject_class;
   GstElementClass *element_class;
   GstBaseSinkClass *basesink_class;
+  GstPadTemplate *pad_template;
+  GstCaps *pad_caps;
 
   GST_DEBUG_CATEGORY_INIT (gst_tensor_reposink_debug, "tensor_reposink", 0,
       "Sink element to handle tensor repository");
@@ -129,22 +121,13 @@ gst_tensor_reposink_class_init (GstTensorRepoSinkClass * klass)
       "Set element to handle tensor repository",
       "Samsung Electronics Co., Ltd.");
 
-#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)        /* >= 1.8 */
-  gst_element_class_add_static_pad_template (element_class, &sink_template);
-#elif (GST_VERSION_MAJOR == 1)  /* 1.0 ~ 1.8 */
-  {
-    GstPadTemplate *pad_template;
-    GstCaps *pad_caps;
-    pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT "; "
-        GST_TENSORS_CAP_DEFAULT);
-    pad_template = gst_pad_template_new ("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
-        pad_caps);
-    gst_element_class_add_pad_template (element_class, pad_template);
-    gst_caps_unref (pad_caps);
-  }
-#else
-#error We support GStreamer 1.x only.
-#endif
+  /* pad template */
+  pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT "; "
+      GST_TENSORS_CAP_DEFAULT);
+  pad_template = gst_pad_template_new ("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
+      pad_caps);
+  gst_element_class_add_pad_template (element_class, pad_template);
+  gst_caps_unref (pad_caps);
 
   basesink_class->start = GST_DEBUG_FUNCPTR (gst_tensor_reposink_start);
   basesink_class->stop = GST_DEBUG_FUNCPTR (gst_tensor_reposink_stop);

--- a/gst/nnstreamer/tensor_repo/tensor_reposrc.c
+++ b/gst/nnstreamer/tensor_repo/tensor_reposrc.c
@@ -54,16 +54,6 @@ enum
 #define DEFAULT_SILENT TRUE
 #define DEFAULT_INDEX 0
 
-/**
- * @brief tensor_reposrc src template
- */
-#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)        /* >= 1.8 */
-static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",
-    GST_PAD_SRC,
-    GST_PAD_ALWAYS,
-    GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT "; " GST_TENSORS_CAP_DEFAULT));
-#endif
-
 static void gst_tensor_reposrc_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec);
 static void gst_tensor_reposrc_get_property (GObject * object, guint prop_id,
@@ -86,6 +76,8 @@ gst_tensor_reposrc_class_init (GstTensorRepoSrcClass * klass)
   GstElementClass *element_class = GST_ELEMENT_CLASS (klass);
   GstPushSrcClass *pushsrc_class = GST_PUSH_SRC_CLASS (klass);
   GstBaseSrcClass *basesrc_class = GST_BASE_SRC_CLASS (klass);
+  GstPadTemplate *pad_template;
+  GstCaps *pad_caps;
 
   GST_DEBUG_CATEGORY_INIT (gst_tensor_reposrc_debug, "tensor_reposrc", 0,
       "Source element to handle tensor repository");
@@ -117,22 +109,13 @@ gst_tensor_reposrc_class_init (GstTensorRepoSrcClass * klass)
       "Pop element to handle tensor repository",
       "Samsung Electronics Co., Ltd.");
 
-#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)        /* >= 1.8 */
-  gst_element_class_add_static_pad_template (element_class, &src_template);
-#elif (GST_VERSION_MAJOR == 1)  /* 1.0 ~ 1.8 */
-  {
-    GstPadTemplate *pad_template;
-    GstCaps *pad_caps;
-    pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT "; "
-        GST_TENSORS_CAP_DEFAULT);
-    pad_template = gst_pad_template_new ("src", GST_PAD_SRC, GST_PAD_ALWAYS,
-        pad_caps);
-    gst_element_class_add_pad_template (element_class, pad_template);
-    gst_caps_unref (pad_caps);
-  }
-#else
-#error We support GStreamer 1.x only.
-#endif
+  /* pad template */
+  pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT "; "
+      GST_TENSORS_CAP_DEFAULT);
+  pad_template = gst_pad_template_new ("src", GST_PAD_SRC, GST_PAD_ALWAYS,
+      pad_caps);
+  gst_element_class_add_pad_template (element_class, pad_template);
+  gst_caps_unref (pad_caps);
 }
 
 /**

--- a/gst/nnstreamer/tensor_sink/tensor_sink.c
+++ b/gst/nnstreamer/tensor_sink/tensor_sink.c
@@ -105,16 +105,6 @@ enum
 #define DEFAULT_SYNC FALSE
 
 /**
- * @brief Template for sink pad.
- */
-#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)        /* >= 1.8 */
-static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",
-    GST_PAD_SINK,
-    GST_PAD_ALWAYS,
-    GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT "; " GST_TENSORS_CAP_DEFAULT));
-#endif
-
-/**
  * @brief Variable for signal ids.
  */
 static guint _tensor_sink_signals[LAST_SIGNAL] = { 0 };
@@ -160,6 +150,8 @@ gst_tensor_sink_class_init (GstTensorSinkClass * klass)
   GObjectClass *gobject_class;
   GstElementClass *element_class;
   GstBaseSinkClass *bsink_class;
+  GstPadTemplate *pad_template;
+  GstCaps *pad_caps;
 
   GST_DEBUG_CATEGORY_INIT (gst_tensor_sink_debug, "tensor_sink", 0,
       "Sink element to handle tensor stream");
@@ -245,22 +237,12 @@ gst_tensor_sink_class_init (GstTensorSinkClass * klass)
       "Sink element to handle tensor stream", "Samsung Electronics Co., Ltd.");
 
   /** pad template */
-#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)        /* >= 1.8 */
-  gst_element_class_add_static_pad_template (element_class, &sink_template);
-#elif (GST_VERSION_MAJOR == 1)  /* 1.0 ~ 1.8 */
-  {
-    GstPadTemplate *pad_template;
-    GstCaps *pad_caps;
-    pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT "; "
-        GST_TENSORS_CAP_DEFAULT);
-    pad_template = gst_pad_template_new ("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
-        pad_caps);
-    gst_element_class_add_pad_template (element_class, pad_template);
-    gst_caps_unref (pad_caps);
-  }
-#else
-#error We support GStreamer 1.x only.
-#endif
+  pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT "; "
+      GST_TENSORS_CAP_DEFAULT);
+  pad_template = gst_pad_template_new ("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
+      pad_caps);
+  gst_element_class_add_pad_template (element_class, pad_template);
+  gst_caps_unref (pad_caps);
 
   /** GstBaseSink methods */
   bsink_class->event = GST_DEBUG_FUNCPTR (gst_tensor_sink_event);

--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -259,14 +259,6 @@ enum
 #define AVAIL_FREQUENCY_FILE "sampling_frequency_available"
 #define SAMPLING_FREQUENCY "sampling_frequency"
 
-/**
- * @brief Template for src pad.
- */
-static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
-    GST_PAD_SRC,
-    GST_PAD_ALWAYS,
-    GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT "; " GST_TENSORS_CAP_DEFAULT));
-
 /** Define data processing functions for various types */
 PROCESS_SCANNED_DATA (guint8, gint8);
 PROCESS_SCANNED_DATA (guint16, gint16);
@@ -312,6 +304,8 @@ gst_tensor_src_iio_class_init (GstTensorSrcIIOClass * klass)
   GObjectClass *gobject_class;
   GstElementClass *gstelement_class;
   GstBaseSrcClass *bsrc_class;
+  GstPadTemplate *pad_template;
+  GstCaps *pad_caps;
 
   GST_DEBUG_CATEGORY_INIT (gst_tensor_src_iio_debug, "tensor_src_iio", 0,
       "Source element to handle Linux Industrial I/O sensors as input");
@@ -401,7 +395,13 @@ gst_tensor_src_iio_class_init (GstTensorSrcIIOClass * klass)
       "Parichay Kapoor <pk.kapoor@samsung.com>");
 
   /** pad template */
-  gst_element_class_add_static_pad_template (gstelement_class, &src_factory);
+  pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT "; "
+      GST_TENSORS_CAP_DEFAULT);
+  pad_template = gst_pad_template_new ("src", GST_PAD_SRC, GST_PAD_ALWAYS,
+      pad_caps);
+  gst_element_class_add_pad_template (gstelement_class, pad_template);
+  gst_caps_unref (pad_caps);
+
   gstelement_class->change_state =
       GST_DEBUG_FUNCPTR (gst_tensor_src_iio_change_state);
 


### PR DESCRIPTION
code clean, remove unnecessary predefinition to set pad template.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
