### PR TITLE
[Tests] Rename NNSTREAMER_BUILD_ROOT_PATH with NNSTREAMER_SOURCE_ROOT_PATH

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -461,7 +461,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir
 
 ninja -C build %{?_smp_mflags}
 
-export NNSTREAMER_BUILD_ROOT_PATH=$(pwd)
+export NNSTREAMER_SOURCE_ROOT_PATH=$(pwd)
 export GST_PLUGIN_PATH=$(pwd)/build/gst/nnstreamer
 export NNSTREAMER_CONF=$(pwd)/build/nnstreamer-test.ini
 export NNSTREAMER_FILTERS=$(pwd)/build/ext/nnstreamer/tensor_filter
@@ -472,15 +472,15 @@ export NNSTREAMER_CONVERTERS=$(pwd)/build/ext/nnstreamer/tensor_converter
 
 %if %{with tizen}
     bash %{test_script} ./tests/tizen_nnfw_runtime/unittest_nnfw_runtime_raw
-    GST_PLUGIN_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/build/ext/nnstreamer/tensor_source:${GST_PLUGIN_PATH} bash %{test_script} ./tests/tizen_capi/unittest_tizen_sensor
+    GST_PLUGIN_PATH=${NNSTREAMER_SOURCE_ROOT_PATH}/build/ext/nnstreamer/tensor_source:${GST_PLUGIN_PATH} bash %{test_script} ./tests/tizen_capi/unittest_tizen_sensor
 %endif #if tizen
 %if 0%{?unit_test}
     bash %{test_script} ./tests
     bash %{test_script} ./tests/tizen_capi/unittest_tizen_capi
     bash %{test_script} ./tests/nnstreamer_filter_extensions_common
-    LD_LIBRARY_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/build/tests/nnstreamer_filter_mvncsdk2:. bash %{test_script} ./tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2
+    LD_LIBRARY_PATH=${NNSTREAMER_SOURCE_ROOT_PATH}/build/tests/nnstreamer_filter_mvncsdk2:. bash %{test_script} ./tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2
 %ifarch aarch64 x86_64
-    LD_LIBRARY_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/build/tests/nnstreamer_filter_edgetpu:. bash %{test_script} ./tests/nnstreamer_filter_edgetpu/unittest_edgetpu
+    LD_LIBRARY_PATH=${NNSTREAMER_SOURCE_ROOT_PATH}/build/tests/nnstreamer_filter_edgetpu:. bash %{test_script} ./tests/nnstreamer_filter_edgetpu/unittest_edgetpu
 %endif #ifarch 64
     pushd tests
     ssat -n --summary summary.txt -cn _n

--- a/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
+++ b/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
@@ -55,7 +55,7 @@ TEST (nnstreamer_filter_armnn, open_close_01_n)
   int ret;
   void *data = NULL;
   gchar *model_file;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
 
   ASSERT_NE (root_path, nullptr);
 
@@ -94,7 +94,7 @@ TEST (nnstreamer_filter_armnn, get_dimension)
   int ret;
   void *data = NULL;
   gchar *model_file;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   GstTensorsInfo info, res;
 
   ASSERT_NE (root_path, nullptr);
@@ -167,7 +167,7 @@ TEST (nnstreamer_filter_armnn, invoke_00)
   int ret;
   void *data = NULL;
   gchar *model_file;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   GstTensorMemory input, output;
 
   ASSERT_NE (root_path, nullptr);
@@ -250,7 +250,7 @@ TEST (nnstreamer_filter_armnn, invoke_advanced)
   int ret, fd;
   void *data = NULL;
   gchar *model_file;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   GstTensorMemory input, output;
   GstTensorsInfo info, res;
   char *data_file;
@@ -361,7 +361,7 @@ TEST (nnstreamer_filter_armnn, invoke_01)
   int ret;
   void *data = NULL;
   gchar *model_file, *data_file;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *input_uint8_data = NULL;
   gsize input_uint8_size = 0;
   GstTensorMemory output, input;

--- a/tests/nnstreamer_filter_edgetpu/unittest_edgetpu.cc
+++ b/tests/nnstreamer_filter_edgetpu/unittest_edgetpu.cc
@@ -22,7 +22,7 @@ TEST (edgetpu_tflite_direct, run_01)
   GstElement *gstpipe;
   GError *err = NULL;
   int status = 0;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model = g_build_filename (root_path, "tests", "test_models", "models", "mobilenet_v1_1.0_224_quant.tflite", NULL);
 
   /* Create a nnstreamer pipeline */
@@ -58,7 +58,7 @@ TEST (edgetpu_tflite_direct, error_01_n)
   GstElement *gstpipe;
   GError *err = NULL;
   int status = 0;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model = g_build_filename (root_path, "tests", "test_models", "models", "does_not_exists.0_224_quant.tflite", NULL);
 
   /* Create a nnstreamer pipeline */
@@ -97,7 +97,7 @@ TEST (edgetpu_tflite_direct, error_02_n)
   GstElement *gstpipe;
   GError *err = NULL;
   int status = 0;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model = g_build_filename (root_path, "tests", "test_models", "models", "mobilenet_v1_1.0_224_quant.tflite", NULL);
 
   /* Create a nnstreamer pipeline */

--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
@@ -58,7 +58,7 @@ get_model_files ()
   gchar *model_file, *model_filepath;
   gchar *model_path;
   const gchar *model_filenames = "@MODEL_FILE@";
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar **model_files, **model_files_iterator;
   gchar *dirname;
 

--- a/tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2.cc
+++ b/tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2.cc
@@ -24,7 +24,7 @@
  */
 TEST (pipeline_mvncsdk2_filter, launch_normal)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *pipeline;
   gchar *test_model;
   GstElement *gstpipe;
@@ -111,7 +111,7 @@ TEST (pipeline_mvncsdk2_filter, launch_normal)
 
 #define TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(idx, fail_stage) \
     TEST (pipeline_mvncsdk2_filter, launch_normal_ ##idx##_n) { \
-      const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH"); \
+      const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH"); \
       gchar *pipeline; \
       gchar *test_model; \
       GstElement *gstpipe; \

--- a/tests/nnstreamer_filter_openvino/unittest_openvino.cc
+++ b/tests/nnstreamer_filter_openvino/unittest_openvino.cc
@@ -89,7 +89,7 @@ TensorFilterOpenvinoTest::setOutputsDataMap (
  */
 TEST (tensor_filter_openvino, open_and_close_0)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
   const GstTensorFilterFramework *fw = nnstreamer_filter_find (fw_name);
   GstTensorFilterProperties *prop = NULL;
@@ -219,7 +219,7 @@ TEST (tensor_filter_openvino, open_and_close_0)
  */
 TEST (tensor_filter_openvino, open_and_close_1)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
   const GstTensorFilterFramework *fw = nnstreamer_filter_find (fw_name);
   std::string str_test_model;
@@ -291,7 +291,7 @@ TEST (tensor_filter_openvino, open_and_close_1)
  */
 TEST (tensor_filter_openvino, open_and_close_2)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
   const GstTensorFilterFramework *fw = nnstreamer_filter_find (fw_name);
   std::string str_test_model;
@@ -356,7 +356,7 @@ TEST (tensor_filter_openvino, open_and_close_2)
  */
 TEST (tensor_filter_openvino, open_and_close_0_n)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
   const GstTensorFilterFramework *fw = nnstreamer_filter_find (fw_name);
   GstTensorFilterProperties *prop = NULL;
@@ -458,7 +458,7 @@ TEST (tensor_filter_openvino, open_and_close_0_n)
  */
 TEST (tensor_filter_openvino, open_and_close_1_n)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
   const GstTensorFilterFramework *fw = nnstreamer_filter_find (fw_name);
   GstTensorFilterProperties *prop = NULL;
@@ -527,7 +527,7 @@ TEST (tensor_filter_openvino, open_and_close_1_n)
  */
 TEST (tensor_filter_openvino, open_and_close_2_n)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
   const GstTensorFilterFramework *fw = nnstreamer_filter_find (fw_name);
   GstTensorFilterProperties *prop = NULL;
@@ -583,7 +583,7 @@ TEST (tensor_filter_openvino, open_and_close_2_n)
  */
 TEST (tensor_filter_openvino, getTensorDim_0)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
   const GstTensorFilterFramework *fw = nnstreamer_filter_find (fw_name);
   GstTensorFilterProperties *prop = NULL;
@@ -660,7 +660,7 @@ TEST (tensor_filter_openvino, getTensorDim_0)
  */
 TEST (tensor_filter_openvino, getTensorDim_0_n)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
   const GstTensorFilterFramework *fw = nnstreamer_filter_find (fw_name);
   std::string str_test_model;
@@ -735,7 +735,7 @@ TEST (tensor_filter_openvino, getTensorDim_0_n)
  */
 TEST (tensor_filter_openvino, getTensorDim_1_n)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
   const GstTensorFilterFramework *fw = nnstreamer_filter_find (fw_name);
   std::string str_test_model;
@@ -808,7 +808,7 @@ TEST (tensor_filter_openvino, getTensorDim_1_n)
  */
 TEST (tensor_filter_openvino, getTensorDim_2_n)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
   const GstTensorFilterFramework *fw = nnstreamer_filter_find (fw_name);
   std::string str_test_model;
@@ -880,7 +880,7 @@ TEST (tensor_filter_openvino, getTensorDim_2_n)
  */
 TEST (tensor_filter_openvino, getTensorDim_3_n)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
   const GstTensorFilterFramework *fw = nnstreamer_filter_find (fw_name);
   std::string str_test_model;
@@ -950,7 +950,7 @@ TEST (tensor_filter_openvino, getTensorDim_3_n)
  */
 TEST (tensor_filter_openvino, convertFromIETypeStr_0)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const std::vector<std::string> ie_suport_type_strs = {
     "I8",
     "I16",
@@ -1004,7 +1004,7 @@ TEST (tensor_filter_openvino, convertFromIETypeStr_0)
  */
 TEST (tensor_filter_openvino, convertFromIETypeStr_0_n)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const std::vector<std::string> ie_not_suport_type_strs = {
     "F64",
   };
@@ -1047,7 +1047,7 @@ TEST (tensor_filter_openvino, convertFromIETypeStr_0_n)
  */
 TEST (tensor_filter_openvino, convertFromIETypeStr_1_n)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const std::string ie_suport_type_str ("Q78");
   std::string str_test_model;
   gchar *test_model_xml;
@@ -1109,7 +1109,7 @@ TEST (tensor_filter_openvino, convertFromIETypeStr_1_n)
  */
 TEST (tensor_filter_openvino, convertGstTensorMemoryToBlobPtr_0)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   std::string str_test_model;
   gchar *test_model_xml;
   gchar *test_model_bin;

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -111,7 +111,7 @@
     }
 
 #define GET_MODEL_PATH(model_name) do { \
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH"); \
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH"); \
   \
   if (root_path == NULL) \
     root_path = ".."; \
@@ -3032,7 +3032,7 @@ TEST (test_tensor_filter, reopen_tflite_01_p)
   GstTensorConfig config;
   gchar *str_launch_line, *prop_string;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -3106,7 +3106,7 @@ TEST (test_tensor_filter, reopen_tflite_02_p)
   GstTensorFilterProperties *prop = NULL;
   gpointer private_data = NULL;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* Check if mandatory methods are contained */
@@ -3157,7 +3157,7 @@ TEST (test_tensor_filter, reload_tflite_set_property)
   gboolean prop_updatable;
   gchar *str_launch_line, *prop_string;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model, *test_model2;
 
   /* supposed to run test in build directory */
@@ -3254,7 +3254,7 @@ TEST (test_tensor_filter, reload_tflite_model_not_found_n)
   GstTensorFilterProperties *prop = NULL;
   gpointer private_data = NULL;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* Check if mandatory methods are contained */
@@ -3317,7 +3317,7 @@ TEST (test_tensor_filter, reload_tflite_model_wrong_dims_n)
   GstTensorFilterProperties *prop = NULL;
   gpointer private_data = NULL;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* Check if mandatory methods are contained */
@@ -3372,7 +3372,7 @@ TEST (test_tensor_filter, reload_tflite_same_model_not_found_n)
   GstTensorFilterProperties *prop = NULL;
   gpointer private_data = NULL;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
   gchar *test_model_renamed;
 
@@ -3435,7 +3435,7 @@ TEST (test_tensor_filter, reload_tflite_same_model_wrong_dims_n)
   GstTensorFilterProperties *prop = NULL;
   gpointer private_data = NULL;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
   gchar *test_model_backup;
   gchar *test_model_renamed;
@@ -3540,7 +3540,7 @@ TEST (test_tensor_filter, framework_auto_ext_tflite_model_not_found_n)
 {
   gchar *test_model, *str_launch_line;
   const gchar *fw_name = NULL;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
 
   if (root_path == NULL)
     root_path = "..";
@@ -3663,7 +3663,7 @@ TEST (test_tensor_filter, framework_auto_ext_tflite_nnfw_04)
 TEST (test_tensor_filter, framework_auto_ext_pb_01)
 {
   gchar *test_model, *str_launch_line, *data_path;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
 
   if (root_path == NULL)
     root_path = "..";
@@ -3688,7 +3688,7 @@ TEST (test_tensor_filter, framework_auto_ext_pb_tf_disabled_n)
 {
   gchar *test_model, *str_launch_line, *data_path;
   const gchar *fw_name = NULL;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
 
   if (root_path == NULL)
     root_path = "..";
@@ -3715,7 +3715,7 @@ TEST (test_tensor_filter, framework_auto_ext_pb_tf_disabled_n)
 TEST (test_tensor_filter, framework_auto_ext_pb_03)
 {
   gchar *test_model, *str_launch_line, *test_model_2, *data_path;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
 
   if (root_path == NULL)
     root_path = "..";
@@ -3744,7 +3744,7 @@ TEST (test_tensor_filter, framework_auto_ext_pb_caffe2_disabled_n)
 {
   gchar *test_model, *str_launch_line, *test_model_2, *data_path;
   const gchar *fw_name = NULL;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
 
   if (root_path == NULL)
     root_path = "..";
@@ -3774,7 +3774,7 @@ TEST (test_tensor_filter, framework_auto_ext_pb_caffe2_disabled_n)
 TEST (test_tensor_filter, framework_auto_ext_pt_01)
 {
   gchar *test_model, *str_launch_line, *image_path;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
 
   if (root_path == NULL)
     root_path = "..";
@@ -3800,7 +3800,7 @@ TEST (test_tensor_filter, framework_auto_ext_pt_pytorch_disabled_n)
 {
   gchar *test_model, *str_launch_line;
   const gchar *fw_name = NULL;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
 
   if (root_path == NULL)
     root_path = "..";

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -2224,7 +2224,7 @@ TEST (nnstreamer_capi_singleshot, invoke_01)
   char *name = NULL;
   int status;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -2348,7 +2348,7 @@ TEST (nnstreamer_capi_singleshot, invoke_02)
   ml_tensors_data_h input, output;
   int status;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -2410,7 +2410,7 @@ TEST (nnstreamer_capi_singleshot, benchmark_time)
   unsigned long open_duration=0, invoke_duration=0, close_duration=0;
   gint64 start, end;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -2515,7 +2515,7 @@ TEST (nnstreamer_capi_singleshot, invoke_03)
   void *data_ptr;
   size_t data_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -2619,7 +2619,7 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
   void *data_ptr;
   size_t data_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model, *test_file;
   gchar *contents = NULL;
   gsize len = 0;
@@ -2775,7 +2775,7 @@ TEST (nnstreamer_capi_singleshot, unavailable_fw_tf_n)
   ml_tensor_dimension in_dim, out_dim;
   int status;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -2827,7 +2827,7 @@ TEST (nnstreamer_capi_singleshot, open_fail_01_n)
   ml_single_h single;
   int status;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -2890,7 +2890,7 @@ TEST (nnstreamer_capi_singleshot, open_fail_02_n)
   ml_tensor_dimension in_dim, out_dim;
   int status;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -3010,7 +3010,7 @@ TEST (nnstreamer_capi_singleshot, open_dynamic)
   unsigned int count = 0;
   int status;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -3172,7 +3172,7 @@ TEST (nnstreamer_capi_singleshot, invoke_timeout)
   ml_single_h single;
   int status;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -3255,7 +3255,7 @@ skip_test:
  */
 TEST (nnstreamer_capi_singleshot, parallel_runs)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
   const gint num_threads = 3;
   const gint num_cases = 3;
@@ -3314,7 +3314,7 @@ TEST (nnstreamer_capi_singleshot, parallel_runs)
  */
 TEST (nnstreamer_capi_singleshot, close_while_running)
 {
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
   pthread_t thread;
   single_shot_thread_data ss_data;
@@ -3369,7 +3369,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_fail)
   ml_tensors_info_h in_info;
   ml_tensor_dimension in_dim;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -3428,7 +3428,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_fail_01)
   unsigned int count = 0;
   int status;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -3494,7 +3494,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success)
   ml_tensor_dimension in_dim;
   ml_tensors_data_h input, output;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -3571,7 +3571,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_01)
   size_t data_size;
   float *data;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -3730,7 +3730,7 @@ TEST (nnstreamer_capi_singleshot, property_01_p)
   void *data;
   size_t data_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -3808,7 +3808,7 @@ TEST (nnstreamer_capi_singleshot, property_02_n)
   int status;
   char *prop_value = NULL;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -3883,7 +3883,7 @@ TEST (nnstreamer_capi_singleshot, property_03_n)
   void *data;
   size_t data_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -4003,7 +4003,7 @@ TEST (nnstreamer_capi_singleshot, property_04_p)
   size_t data_size;
   float *data;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -4104,7 +4104,7 @@ TEST (nnstreamer_capi_singleshot, invoke_05)
   char *name = NULL;
   int status;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -4232,7 +4232,7 @@ TEST (nnstreamer_capi_singleshot, invoke_06)
   void *data_ptr;
   size_t data_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model, *test_file;
   guint8 *contents_uint8 = NULL;
   gfloat *contents_float = NULL;
@@ -4407,7 +4407,7 @@ TEST (nnstreamer_capi_singleshot, invoke_07)
   void *data_ptr;
   size_t data_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -4532,7 +4532,7 @@ TEST (nnstreamer_capi_singleshot, open_fail_03_n)
   ml_tensors_info_h in_info, out_info;
   ml_tensor_dimension in_dim, out_dim;
   int status;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -4607,7 +4607,7 @@ TEST (nnstreamer_capi_singleshot, invoke_08_n)
   int status;
   size_t data_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
   gfloat *contents_float = NULL;
 
@@ -4690,7 +4690,7 @@ TEST (nnstreamer_capi_singleshot, invoke_09_n)
   int status;
   size_t data_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
   gfloat *contents_float = NULL;
 
@@ -4780,7 +4780,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_02)
   unsigned int count = 0;
   int status, tensor_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -4937,7 +4937,7 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_success_01_p)
   ml_tensor_type_e tmp_type = ML_TENSOR_TYPE_UNKNOWN;
   ml_tensor_dimension tmp_dim;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -5086,7 +5086,7 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_success_02_p)
   ml_tensor_type_e tmp_type = ML_TENSOR_TYPE_UNKNOWN;
   ml_tensor_dimension tmp_dim, in_dim;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -5236,7 +5236,7 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_fail_n)
   ml_tensors_info_h in_info, out_info;
   ml_tensors_data_h input, output;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -5483,7 +5483,7 @@ TEST (nnstreamer_capi_internal, validate_model_file_01_n)
       NNSTREAMER_SO_FILE_EXTENSION;
   int status;
   ml_nnfw_type_e nnfw = ML_NNFW_TYPE_CUSTOM_FILTER;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -5516,7 +5516,7 @@ TEST (nnstreamer_capi_internal, validate_model_file_02_n)
       NNSTREAMER_SO_FILE_EXTENSION;
   int status;
   ml_nnfw_type_e nnfw;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model1, *test_model2;
   gchar *test_models[2];
 

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -29,7 +29,7 @@ get_model_file ()
   gchar *model_file;
   gchar *meta_file;
   gchar *model_path;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
 
   g_return_val_if_fail (root_path != nullptr, FALSE);
 
@@ -296,7 +296,7 @@ TEST (nnstreamer_nnfw_runtime_raw_functions, DISABLED_invoke_advanced)
   int ret;
   void *data = NULL;
   gchar *model_file, *manifest_file, *data_file;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar *orig_model = "add.tflite";
   const gchar *new_model = "mobilenet_v1_1.0_224_quant.tflite";
   GstTensorMemory input, output;
@@ -556,7 +556,7 @@ TEST (nnstreamer_nnfw_mlapi, invoke_single_01_n)
   ml_tensor_dimension in_dim, out_dim;
   int status;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -832,7 +832,7 @@ TEST (nnstreamer_nnfw_mlapi, invoke_pipeline_01_n)
 {
   gchar *pipeline;
   ml_pipeline_h handle;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
   int status;
 
@@ -878,7 +878,7 @@ TEST (nnstreamer_nnfw_mlapi, invoke_pipeline_02_n)
   ml_pipeline_state_e state;
   ml_tensors_data_h input;
   int status;
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -1011,7 +1011,7 @@ TEST (nnstreamer_nnfw_mlapi, multimodal_01_p)
   unsigned int ret;
   guint *sink_called_cnt = NULL;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar *orig_model = "add.tflite";
   const gchar *new_model = "mobilenet_v1_1.0_224_quant.tflite";
   gchar *model_file, *manifest_file;


### PR DESCRIPTION
In most cases, the environment variable, NNSTREAMER_BUILD_ROOT_PATH, is used for indicating the root directory of the path to which the 'test_models' directory belongs, which means the source root path. To avoid confusion, this patch renames it with NNSTREAMER_SOURCE_ROOT_PATH.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped