### PR TITLE
[Tests/Filter/EdgeTPU] Enable test() in the meson build script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -435,6 +435,7 @@ if get_option('enable-test')
   testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
   testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
   testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
+  testenv.set('NNSTREAMER_SOURCE_ROOT_PATH', meson.source_root())
 
   subdir('tests')
 endif

--- a/tests/nnstreamer_filter_edgetpu/meson.build
+++ b/tests/nnstreamer_filter_edgetpu/meson.build
@@ -13,6 +13,5 @@ if get_option('enable-edgetpu')
     install_dir: unittest_install_dir
   )
 
-  #TODO: the following test would not work via ninja
-  #test('unittest_edgetpu', unittest_edgetpu, env: testenv)
+  test('unittest_edgetpu', unittest_edgetpu, env: testenv)
 endif

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -80,6 +80,8 @@ foreach ext : extensions
   filter_ext_common_testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
   filter_ext_common_testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
   filter_ext_common_testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
+  filter_ext_common_testenv.set('NNSTREAMER_SOURCE_ROOT_PATH', meson.source_root())
+
   if ext[0] == 'python2'
     py2_module_path = join_paths(meson.build_root(), 'tests/' + ext[0] + '_module')
     run_command('rm', '-rf', py2_module_path, check : true)

--- a/tests/nnstreamer_filter_mvncsdk2/meson.build
+++ b/tests/nnstreamer_filter_mvncsdk2/meson.build
@@ -29,6 +29,7 @@ filter_mvncsdk2_testenv.set('NNSTREAMER_CONF', path_nns_conf)
 filter_mvncsdk2_testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
 filter_mvncsdk2_testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
 filter_mvncsdk2_testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
+filter_mvncsdk2_testenv.set('NNSTREAMER_SOURCE_ROOT_PATH', meson.source_root())
 filter_mvncsdk2_testenv.set('LD_LIBRARY_PATH', meson.current_build_dir())
 
 test('unittest_filter_mvncsdk2', unittest_mvncsdk, env: filter_mvncsdk2_testenv)

--- a/tests/tizen_capi/meson.build
+++ b/tests/tizen_capi/meson.build
@@ -46,5 +46,6 @@ if get_option('enable-tizen-sensor')
   tizen_sensor_testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
   tizen_sensor_testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
   tizen_sensor_testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
+  tizen_sensor_testenv.set('NNSTREAMER_SOURCE_ROOT_PATH', meson.source_root())
   test('unittest_tizen_sensor', unittest_tizen_sensor, env: tizen_sensor_testenv)
 endif


### PR DESCRIPTION
This patch enables test(), which has been commented out, in the meson  build script for the EdgeTPU filter.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**After this PR**
```bash
$ ninja -C build test
[37/38] Running all tests.
 1/17 unittest_common                         OK       0.01 s 
 2/17 unittest_sink                           OK      21.71 s 
 3/17 unittest_plugins                        OK       1.89 s 
 4/17 unittest_src_iio                        OK      11.63 s 
 5/17 unittest_edgetpu                        OK       1.99 s 
 6/17 unittest_filter_mvncsdk2                OK      15.50 s 
 7/17 unittest_cppfilter                      OK       1.04 s 
 8/17 unittest_tizen_custom                   OK       0.02 s 
 9/17 unittest_tizen_custom-set               OK       0.01 s 
10/17 unittest_tizen_tensorflow_lite          OK       0.14 s 
11/17 unittest_tizen_tensorflow_lite-set      OK       0.02 s 
12/17 unittest_tizen_pytorch                  OK       0.19 s 
13/17 unittest_tizen_caffe2                   OK       0.27 s 
14/17 unittest_tizen_python2-get              OK       0.18 s 
15/17 unittest_tizen_python2-set              OK       0.17 s 
16/17 unittest_tizen_python3-get              OK       0.32 s 
17/17 unittest_tizen_python3-set              OK       0.27 s 

Ok:                   17
Expected Fail:         0
Fail:                  0
Unexpected Pass:       0
Skipped:               0
Timeout:               0
```

