### PR TITLE
[TEST] Fix nnfw unit test

### DIFF
--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -1231,6 +1231,7 @@ TEST (nnstreamer_nnfw_mlapi, multimodel_01_p)
   g_free (sink_called_cnt);
 }
 
+#ifdef ENABLE_TENSORFLOW_LITE
 /**
  * @brief Test nnfw subplugin multi-model (pipeline, ML-API)
  * @detail Invoke two models which have different framework via Pipeline API, sharing a single input stream
@@ -1327,6 +1328,7 @@ TEST (nnstreamer_nnfw_mlapi, multimodel_02_p)
   g_free (test_model);
   g_free (sink_called_cnt);
 }
+#endif /* ENABLE_TENSORFLOW_LITE */
 
 /**
  * @brief Main gtest


### PR DESCRIPTION
When testing the operation of the multi-framework, if tflite is disabled, the test fails.
If tflite is disabled, skip the test.

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped