### PR TITLE
[Mux] add the new sync_mode:REFRESH

### DIFF
--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -56,12 +56,14 @@ G_BEGIN_DECLS
 
 /**
  * @brief time synchronization options
+ * @see https://github.com/nnstreamer/nnstreamer/wiki/Synchronization-Policies-at-Mux-and-Merge
  */
 typedef enum
 {
   SYNC_NOSYNC = 0,
   SYNC_SLOWEST = 1,
   SYNC_BASEPAD = 2,
+  SYNC_REFRESH = 3,
   SYNC_END,
 } tensor_time_sync_mode;
 


### PR DESCRIPTION
This new sync mode allows PUSHING with only one new buffer of sinkpads of `tensor_mux`.

Previously, if `tensor_mux` want to push its buffers to srcpad, all of sink pads had to be filled with new buffers.
However, this new mode, REFRESH, push buffers when `tensor_mux` receive a new buffer.
For the other sink pads, except the one received the new buffer, will use again the previous one.

It decides EOS when any of the sink pads receive it.

related with: https://github.com/nnstreamer/nnstreamer-example/pull/141

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

