### PR TITLE
[Filter] fix a memory leak

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -542,6 +542,8 @@ gst_tensor_filter_transform (GstBaseTransform * trans,
     /* append the memory block to outbuf */
     if (ret == 0)
       gst_buffer_append_memory (outbuf, out_mem[i]);
+    else if (allocate_in_invoke == FALSE)
+      gst_allocator_free (out_mem[i]->allocator, out_mem[i]);
   }
 
   for (i = 0; i < prop->input_meta.num_tensors; i++) {


### PR DESCRIPTION
the allocated memory(when `allocate_in_invoke` is FALSE) should be free when `invoke()` returns not 0(OK)

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped