### PR TITLE
[C-Api] fix mem leak @open sesame 6/26 12:54

### DIFF
--- a/api/capi/src/nnstreamer-capi-pipeline.c
+++ b/api/capi/src/nnstreamer-capi-pipeline.c
@@ -1147,7 +1147,7 @@ ml_pipeline_src_input_data (ml_pipeline_src_h h, ml_tensors_data_h data,
     }
 
     mem = gst_memory_new_wrapped (GST_MEMORY_FLAG_READONLY,
-        mem_data, mem_size, 0, mem_size, NULL, NULL);
+        mem_data, mem_size, 0, mem_size, mem_data, g_free);
 
     gst_buffer_append_memory (buffer, mem);
     /** @todo Verify that gst_buffer_append lists tensors/gstmem in the correct order */
@@ -1411,6 +1411,8 @@ ml_pipeline_switch_get_pad_list (ml_pipeline_switch_h h, char ***list)
         break;
     }
   }
+
+  gst_iterator_free (it);
 
   /* There has been no error with that "while" loop. */
   if (ret == ML_ERROR_NONE) {

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
@@ -81,7 +81,7 @@ fbc_get_out_config (const GstCaps * in_cap, GstTensorsConfig * config)
 }
 
 /** @brief tensor converter plugin's NNStreamerExternalConverter callback
- *  @todo : Consider multi frames, return Bufferlist and 
+ *  @todo : Consider multi frames, return Bufferlist and
  *          remove frame size and the number of frames
  */
 static GstBuffer *
@@ -134,7 +134,7 @@ fbc_convert (GstBuffer * in_buf, gsize * frame_size, guint * frames_in,
     mem_data = g_memdup (tensor_data->data (), mem_size);
 
     out_mem = gst_memory_new_wrapped (GST_MEMORY_FLAG_READONLY,
-        mem_data, mem_size, 0, mem_size, NULL, NULL);
+        mem_data, mem_size, 0, mem_size, mem_data, g_free);
 
     gst_buffer_append_memory (out_buf, out_mem);
   }


### PR DESCRIPTION
1. add g_free to release the memory when appending mem block in buffer.
2. free interator in switch api.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
