### PR TITLE
[Test/android/snpe] Add android tests with snpe @open sesame 7/3 18:02 

### DIFF
--- a/api/android/README.md
+++ b/api/android/README.md
@@ -184,14 +184,27 @@ Before running the unit-test, you should download the test model and copy it int
 
 Make directory and copy test model and label files into the internal storage of your own Android target device.
 
-You can download these files from [nnsuite testcases repository](https://github.com/nnsuite/testcases/tree/master/DeepLearningModels/tensorflow-lite/Mobilenet_v1_1.0_224_quant).
+You can download these files from [nnsuite testcases repository](https://github.com/nnsuite/testcases/tree/master/DeepLearningModels/).
 
 ```
 # You must put the below model and label files in the internal storage of your Android target device.
+
+## For TensorFlow Lite
+# Copy {nnsuite testcases repository}/tensorflow-lite/Mobilenet_v1_1.0_224_quant/* into
 {INTERNAL_STORAGE}/nnstreamer/test/mobilenet_v1_1.0_224_quant.tflite
-{INTERNAL_STORAGE}/nnstreamer/test/add.tflite
 {INTERNAL_STORAGE}/nnstreamer/test/labels.txt
 {INTERNAL_STORAGE}/nnstreamer/test/orange.png
+{INTERNAL_STORAGE}/nnstreamer/test/orange.raw
+
+# Copy {nnsuite testcases repository}/tensorflow-lite/add_tflite/add.tflite into
+{INTERNAL_STORAGE}/nnstreamer/test/add.tflite
+
+## For SNPE
+# Copy {nnsuite testcases repository}/snpe/inception_v3/* into
+{INTERNAL_STORAGE}/nnstreamer/snpe_data/inception_v3_quantized.dlc
+{INTERNAL_STORAGE}/nnstreamer/snpe_data/imagenet_slim_labels.txt
+{INTERNAL_STORAGE}/nnstreamer/snpe_data/plastic_cup.jpg
+{INTERNAL_STORAGE}/nnstreamer/snpe_data/plastic_cup.raw
 ```
 
 To check the testcases, run the build script with an option ```--run_test=yes```.

--- a/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestCommon.java
+++ b/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestCommon.java
@@ -123,6 +123,62 @@ public class APITestCommon {
     }
 
     /**
+     * Reads raw float image file (plastic_cup) and returns TensorsData instance.
+     */
+    public static TensorsData readRawImageDataSNPE() {
+        String root = Environment.getExternalStorageDirectory().getAbsolutePath();
+        File raw = new File(root + "/nnstreamer/snpe_data/plastic_cup.raw");
+
+        if (!raw.exists()) {
+            fail();
+        }
+
+        TensorsInfo info = new TensorsInfo();
+        info.addTensorInfo(NNStreamer.TensorType.FLOAT32, new int[]{3, 299, 299, 1});
+
+        int size = info.getTensorSize(0);
+        TensorsData data = TensorsData.allocate(info);
+
+        try {
+            byte[] content = Files.readAllBytes(raw.toPath());
+            if (content.length != size) {
+                fail();
+            }
+
+            ByteBuffer buffer = TensorsData.allocateByteBuffer(size);
+            buffer.put(content);
+
+            data.setTensorData(0, buffer);
+        } catch (Exception e) {
+            fail();
+        }
+
+        return data;
+    }
+
+    /**
+     * Gets the label index with max score, for SNPE image classification.
+     */
+    public static int getMaxScoreSNPE(ByteBuffer buffer) {
+        int index = -1;
+        float maxScore = -Float.MAX_VALUE;
+
+        if (isValidBuffer(buffer, 4004)) {
+            for (int i = 0; i < 1001; i++) {
+                /* convert to float */
+                float score = buffer.getFloat(i * 4);
+
+                if (score > maxScore) {
+                    maxScore = score;
+                    index = i;
+                }
+            }
+        }
+
+        return index;
+    }
+
+    /**
      * Gets the File object of tensorflow-lite model.
      * Note that, to invoke model in the storage, the permission READ_EXTERNAL_STORAGE is required.
      */

--- a/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
+++ b/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
@@ -814,4 +814,38 @@ public class APITestSingleShot {
             fail();
         }
     }
+
+    @Test
+    public void testSNPEClassificationResult() {
+        if (!NNStreamer.isAvailable(NNStreamer.NNFWType.SNPE)) {
+            /* cannot run the test */
+            return;
+        }
+
+        /* expected label is measuring_cup (648) */
+        final int expected_label = 648;
+
+        try {
+            File model = APITestCommon.getSNPEModel();
+
+            SingleShot single = new SingleShot(model, NNStreamer.NNFWType.SNPE);
+
+            /* let's ignore timeout (set 10 sec) */
+            single.setTimeout(10000);
+
+            /* single-shot invoke */
+            TensorsData in = APITestCommon.readRawImageDataSNPE();
+            TensorsData out = single.invoke(in);
+            int labelIndex = APITestCommon.getMaxScoreSNPE(out.getTensorData(0));
+
+            /* check label index (measuring cup) */
+            if (labelIndex != expected_label) {
+                fail();
+            }
+
+            single.close();
+        } catch (Exception e) {
+            fail();
+        }
+    }
 }


### PR DESCRIPTION
- Add classification result test with inception model
- Add runtime checks

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

