### PR TITLE
[Android] enable nnfw @open sesame 7/3 17:09

### DIFF
--- a/api/android/README.md
+++ b/api/android/README.md
@@ -152,7 +152,7 @@ Run the build script in NNStreamer.
       - `--build_type=all` to include all features.
       - `--build_type=single` to enable SingleShot API only.
       - `--build_type=lite` to get the minimized library with GStreamer core elements.
-  3. Including sub-plugins: Default TensorFlow-Lite enabled.
+  3. Including sub-plugins: Default TensorFlow-Lite and NNFW enabled.
     To enable each neural network frameworks, you should download and set-up proper environment.
       - `--enable_tflite=yes` to build with TensorFlow-Lite.
       - `--enable_snpe=yes` to build with SNPE (Qualcomm Snapdragon Neural Processing Engine).

--- a/api/android/api/src/main/jni/Android-nnfw-prebuilt.mk
+++ b/api/android/api/src/main/jni/Android-nnfw-prebuilt.mk
@@ -1,0 +1,66 @@
+#------------------------------------------------------
+# NNFW (On-device neural network inference framework, which is developed by Samsung Research.)
+# https://github.com/Samsung/ONE
+#
+# This mk file defines prebuilt libraries for nnfw module.
+# (nnfw core libraries, arm64-v8a only)
+# You can download specific version of nnfw libraries from https://github.com/Samsung/ONE/releases.
+#------------------------------------------------------
+LOCAL_PATH := $(call my-dir)
+
+ifndef NNFW_LIB_PATH
+$(error NNFW_LIB_PATH is not defined!)
+endif
+
+NNFW_PREBUILT_LIBS :=
+
+#------------------------------------------------------
+# nnfw prebuilt shared libraries
+#------------------------------------------------------
+include $(CLEAR_VARS)
+LOCAL_MODULE := nnfw-libbackend_cpu
+LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libbackend_cpu.so
+include $(PREBUILT_SHARED_LIBRARY)
+NNFW_PREBUILT_LIBS += nnfw-libbackend_cpu
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := nnfw-libcircle_loader
+LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libcircle_loader.so
+include $(PREBUILT_SHARED_LIBRARY)
+NNFW_PREBUILT_LIBS += nnfw-libcircle_loader
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := nnfw-libneuralnetworks
+LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libneuralnetworks.so
+include $(PREBUILT_SHARED_LIBRARY)
+NNFW_PREBUILT_LIBS += nnfw-libneuralnetworks
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := nnfw-libnnfw-dev
+LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libnnfw-dev.so
+include $(PREBUILT_SHARED_LIBRARY)
+NNFW_PREBUILT_LIBS += nnfw-libnnfw-dev
+
+#include $(CLEAR_VARS)
+#LOCAL_MODULE := nnfw-libnnfw_lib_benchmark
+#LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libnnfw_lib_benchmark.so
+#include $(PREBUILT_SHARED_LIBRARY)
+#NNFW_PREBUILT_LIBS += nnfw-libnnfw_lib_benchmark
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := nnfw-libonert_core
+LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libonert_core.so
+include $(PREBUILT_SHARED_LIBRARY)
+NNFW_PREBUILT_LIBS += nnfw-libonert_core
+
+#include $(CLEAR_VARS)
+#LOCAL_MODULE := nnfw-libtensorflowlite_jni
+#LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libtensorflowlite_jni.so
+#include $(PREBUILT_SHARED_LIBRARY)
+#NNFW_PREBUILT_LIBS += nnfw-libtensorflowlite_jni
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := nnfw-libtflite_loader
+LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libtflite_loader.so
+include $(PREBUILT_SHARED_LIBRARY)
+NNFW_PREBUILT_LIBS += nnfw-libtflite_loader

--- a/api/android/api/src/main/jni/Android-nnfw.mk
+++ b/api/android/api/src/main/jni/Android-nnfw.mk
@@ -1,0 +1,41 @@
+#------------------------------------------------------
+# NNFW (On-device neural network inference framework, which is developed by Samsung Research.)
+# https://github.com/Samsung/ONE
+#
+# This mk file defines nnfw module with prebuilt shared library.
+# (nnfw core libraries, arm64-v8a only)
+#------------------------------------------------------
+LOCAL_PATH := $(call my-dir)
+
+ifndef NNSTREAMER_ROOT
+$(error NNSTREAMER_ROOT is not defined!)
+endif
+
+include $(NNSTREAMER_ROOT)/jni/nnstreamer.mk
+
+NNFW_DIR := $(LOCAL_PATH)/nnfw
+NNFW_INCLUDES := $(NNFW_DIR)/include $(NNFW_DIR)/include/nnfw
+
+ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
+NNFW_LIB_PATH := $(NNFW_DIR)/lib
+else
+$(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
+endif
+
+#------------------------------------------------------
+# nnfw prebuilt shared libraries
+#------------------------------------------------------
+include $(LOCAL_PATH)/Android-nnfw-prebuilt.mk
+
+#------------------------------------------------------
+# tensor-filter sub-plugin for nnfw
+#------------------------------------------------------
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := nnfw-subplugin
+LOCAL_SRC_FILES := $(NNSTREAMER_FILTER_NNFW_SRCS)
+LOCAL_CFLAGS := -O3 -fPIC
+LOCAL_C_INCLUDES := $(NNFW_INCLUDES) $(NNSTREAMER_INCLUDES) $(GST_HEADERS_COMMON)
+LOCAL_SHARED_LIBRARIES := $(NNFW_PREBUILT_LIBS)
+
+include $(BUILD_STATIC_LIBRARY)

--- a/api/android/api/src/main/jni/Android-nnstreamer-prebuilt.mk
+++ b/api/android/api/src/main/jni/Android-nnstreamer-prebuilt.mk
@@ -1,0 +1,79 @@
+#------------------------------------------------------
+# nnstreamer
+#
+# This mk file defines nnstreamer module with prebuilt shared libraries.
+# ABI: armeabi-v7a, arm64-v8a
+#------------------------------------------------------
+LOCAL_PATH := $(call my-dir)
+
+NNSTREAMER_DIR := $(LOCAL_PATH)/nnstreamer
+
+NNSTREAMER_INCLUDES := $(NNSTREAMER_DIR)/include
+NNSTREAMER_LIB_PATH := $(NNSTREAMER_DIR)/lib/$(TARGET_ARCH_ABI)
+
+ENABLE_TF_LITE := false
+ENABLE_SNAP := false
+ENABLE_NNFW := false
+ENABLE_SNPE := false
+
+#------------------------------------------------------
+# define required libraries for nnstreamer
+#------------------------------------------------------
+NNSTREAMER_LIBS := nnstreamer-native gst-android cpp-shared
+
+#------------------------------------------------------
+# nnstreamer-native
+#------------------------------------------------------
+include $(CLEAR_VARS)
+LOCAL_MODULE := nnstreamer-native
+LOCAL_SRC_FILES := $(NNSTREAMER_LIB_PATH)/libnnstreamer-native.so
+include $(PREBUILT_SHARED_LIBRARY)
+
+#------------------------------------------------------
+# gstreamer android
+#------------------------------------------------------
+include $(CLEAR_VARS)
+LOCAL_MODULE := gst-android
+LOCAL_SRC_FILES := $(NNSTREAMER_LIB_PATH)/libgstreamer_android.so
+include $(PREBUILT_SHARED_LIBRARY)
+
+#------------------------------------------------------
+# c++ shared
+#------------------------------------------------------
+include $(CLEAR_VARS)
+LOCAL_MODULE := cpp-shared
+LOCAL_SRC_FILES := $(NNSTREAMER_LIB_PATH)/libc++_shared.so
+include $(PREBUILT_SHARED_LIBRARY)
+
+#------------------------------------------------------
+# SNAP (arm64-v8a only)
+#------------------------------------------------------
+ifeq ($(ENABLE_SNAP),true)
+SNAP_LIB_PATH := $(NNSTREAMER_LIB_PATH)
+include $(LOCAL_PATH)/Android-snap-prebuilt.mk
+
+NNSTREAMER_LIBS += $(SNAP_PREBUILT_LIBS)
+endif
+
+#------------------------------------------------------
+# NNFW (arm64-v8a only)
+#------------------------------------------------------
+ifeq ($(ENABLE_NNFW),true)
+NNFW_LIB_PATH := $(NNSTREAMER_LIB_PATH)
+include $(LOCAL_PATH)/Android-nnfw-prebuilt.mk
+
+NNSTREAMER_LIBS += $(NNFW_PREBUILT_LIBS)
+endif
+
+#------------------------------------------------------
+# SNPE
+#------------------------------------------------------
+ifeq ($(ENABLE_SNPE),true)
+SNPE_LIB_PATH := $(NNSTREAMER_LIB_PATH)
+include $(LOCAL_PATH)/Android-snpe-prebuilt.mk
+
+NNSTREAMER_LIBS += $(SNPE_PREBUILT_LIBS)
+endif
+
+# Remove any duplicates.
+NNSTREAMER_LIBS := $(sort $(NNSTREAMER_LIBS))

--- a/api/android/api/src/main/jni/Android-tensorflow-lite.mk
+++ b/api/android/api/src/main/jni/Android-tensorflow-lite.mk
@@ -3,11 +3,9 @@
 #
 # This mk file defines tensorflow-lite module with prebuilt static library.
 # To build and run the example with gstreamer binaries, we built a static library (e.g., libtensorflow-lite.a)
-# for Android/Tensorflow-lite from the Tensorflow repository of the Tizen software platform with version 1.9 using the Android-tensorflow-lite.mk.
+# for Android/Tensorflow-lite from the Tensorflow repository of the Tizen software platform.
 # - [Tizen] Tensorflow git repository:
 #    * Repository: https://review.tizen.org/gerrit/p/platform/upstream/tensorflow
-#    * Branch name: sandbox/sangjung/launchpad_bugfix
-#    * Commit: 5c3399d [Debian] add dependency on python 2.7, provides of tensorflow
 #------------------------------------------------------
 LOCAL_PATH := $(call my-dir)
 
@@ -24,10 +22,6 @@ ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
 TF_LITE_LIB_PATH := $(TF_LITE_DIR)/lib/armv7
 else ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
 TF_LITE_LIB_PATH := $(TF_LITE_DIR)/lib/arm64
-else ifeq ($(TARGET_ARCH_ABI),x86)
-TF_LITE_LIB_PATH := $(TF_LITE_DIR)/lib/x86
-else ifeq ($(TARGET_ARCH_ABI),x86_64)
-TF_LITE_LIB_PATH := $(TF_LITE_DIR)/lib/x86_64
 else
 $(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
 endif


### PR DESCRIPTION
Change default option to enable NNFW in android-api build, and clean up build script.
When building android library, download nnfw libs from ONE repo and start to build library.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
