### PR TITLE
[C-API] Add remarks section in ml_tensors_data_create()

### DIFF
--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -922,6 +922,7 @@ int ml_tensors_info_get_tensor_size (ml_tensors_info_h info, int index, size_t *
 /**
  * @brief Creates a tensor data frame with the given tensors information.
  * @since_tizen 5.5
+ * @remarks Before 6.0, this function returned #ML_ERROR_STREAMS_PIPE in case of an internal error. Since 6.0, #ML_ERROR_OUT_OF_MEMORY is returned in such cases, so #ML_ERROR_STREAMS_PIPE is not returned by this function anymore.
  * @param[in] info The handle of tensors information for the allocation.
  * @param[out] data The handle of tensors data. The caller is responsible for freeing the allocated data with ml_tensors_data_destroy().
  * @return @c 0 on success. Otherwise a negative error value.


### PR DESCRIPTION
Since 6.0, ML_ERROR_STREAMS_PIPE error code is removed in
ml_tensors_data_create() function and ML_ERROR_OUT_OF_MEMORY is returned
for this internal error. This patch adds a remarks section in
ml_tensors_data_create() for Tizen application developers.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


**Related ACR**
* https://code.sec.samsung.net/jira/browse/ACR-1572
