### PR TITLE
[Dist/Debian] Add a sub-package that provides the openvino filter @open sesame 7/21 11:30

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,8 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev,
  python, python-numpy, python3, python3-dev, python3-numpy,
  tensorflow-lite-dev, pytorch, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
- libflatbuffers-dev, flatbuffers-compiler, protobuf-compiler17,
- tensorflow-dev [amd64], python2.7-dev, libprotobuf-dev [amd64 arm64 armhf],
+ openvino-dev, openvino-cpu-mkldnn [amd64], libflatbuffers-dev, flatbuffers-compiler,
+ protobuf-compiler17, tensorflow-dev [amd64], python2.7-dev, libprotobuf-dev [amd64 arm64 armhf]
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer
 
@@ -83,6 +83,13 @@ Multi-Arch: same
 Depends: nnstreamer, libedgetpu1-std, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer Edge TPU support
  This package allows nnstreamer to support Edge TPU.
+
+Package: nnstreamer-openvino
+Architecture: any
+Multi-Arch: same
+Depends: nnstreamer, openvino, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer OpenVino support
+ This package allows nnstreamer to support OpenVino.
 
 Package: nnstreamer-dev
 Architecture: any

--- a/debian/nnstreamer-openvino.install
+++ b/debian/nnstreamer-openvino.install
@@ -1,0 +1,1 @@
+/usr/lib/nnstreamer/filters/libnnstreamer_filter_openvino.so

--- a/debian/rules
+++ b/debian/rules
@@ -39,7 +39,8 @@ override_dh_auto_configure:
 	mkdir -p build
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
 	-Dinstall-example=true -Dtf-support=$(enable_tf) -Dtflite-support=enabled -Dpytorch-support=enabled -Dcaffe2-support=enabled \
-	-Dpython2-support=enabled -Dpython3-support=enabled -Denable-capi=true -Denable-edgetpu=true -Denable-tizen=false build
+	-Dpython2-support=enabled -Dpython3-support=enabled -Denable-capi=true -Denable-edgetpu=true -Denable-tizen=false \
+	-Denable-openvino=true build
 
 override_dh_auto_build:
 	ninja -C build

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -371,7 +371,7 @@ if get_option('enable-openvino')
     nnstreamer_filter_openvino_sources,
     cpp_args: openvino_cpp_args,
     dependencies: nnstreamer_filter_openvino_deps,
-    install: false,
+    install: true,
     install_dir: filter_subplugin_install_dir
   )
 
@@ -379,7 +379,7 @@ if get_option('enable-openvino')
     nnstreamer_filter_openvino_sources,
     cpp_args: openvino_cpp_args,
     dependencies: nnstreamer_filter_openvino_deps,
-    install: false,
+    install: true,
     install_dir: nnstreamer_libdir
   )
 


### PR DESCRIPTION
This PR depends on https://review.tizen.org/gerrit/#/c/platform/upstream/dldt/+/238180/ and https://review.tizen.org/gerrit/#/c/platform/adaptation/npu/intel-movidius-firmware/+/227997/.


This patch adds a sub-package that provides the tensor filter for OpenVino to Debian/Ubuntu.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped