### PR TITLE
[C-API] Add remarks section for ml_tensors_info_get_tensor_name()

### DIFF
--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -842,7 +842,7 @@ int ml_tensors_info_set_tensor_name (ml_tensors_info_h info, unsigned int index,
 /**
  * @brief Gets the tensor name with given handle of tensors information.
  * @since_tizen 5.5
- * @remarks If the function succeeds, @a name should be released using g_free().
+ * @remarks Before 6.0 this function returned the internal pointer so application developers do not need to free. Since 6.0 the name string is internally copied and returned. So if the function succeeds, @a name should be released using g_free().
  * @param[in] info The handle of tensors information.
  * @param[in] index The index of the tensor.
  * @param[out] name The tensor name.


### PR DESCRIPTION
This patch adds the remarks section for
ml_tensors_info_get_tensor_name() since the behavior of this function is
changed since 6.0.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped


### Submit history
#### Submit v2
* Update the `remark section` as @jaeyun-jung  recommanded.
#### Submit v1
* First draft.

