### PR TITLE
[SPEC] Add supproting elements for tizen

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -386,7 +386,7 @@ You may enable this package to use Google Edge TPU with NNStreamer and Tizen ML 
 %define enable_nnfw_runtime -Dnnfw-runtime-support=enabled
 %endif
 # Element restriction in Tizen
-%define restricted_element	'capsfilter input-selector output-selector queue tee valve appsink appsrc audioconvert audiorate audioresample audiomixer videoconvert videocrop videorate videoscale videoflip videomixer compositor fakesrc fakesink filesrc filesink audiotestsrc videotestsrc jpegparse jpegenc jpegdec pngenc pngdec tcpclientsink tcpclientsrc tcpserversink tcpserversrc udpsink udpsrc xvimagesink ximagesink evasimagesink evaspixmapsink glimagesink theoraenc lame vorbisenc wavenc volume oggmux avimux matroskamux v4l2src avsysvideosrc camerasrc tvcamerasrc pulsesrc fimcconvert tizenwlsink'
+%define restricted_element	'capsfilter input-selector output-selector queue tee valve appsink appsrc audioconvert audiorate audioresample audiomixer videoconvert videocrop videorate videoscale videoflip videomixer compositor fakesrc fakesink filesrc filesink audiotestsrc videotestsrc jpegparse jpegenc jpegdec pngenc pngdec tcpclientsink tcpclientsrc tcpserversink tcpserversrc udpsink udpsrc xvimagesink ximagesink evasimagesink evaspixmapsink glimagesink theoraenc lame vorbisenc wavenc volume oggmux avimux matroskamux v4l2src avsysvideosrc camerasrc tvcamerasrc pulsesrc fimcconvert tizenwlsink gdppay gdpdepay'
 %define element_restriction -Denable-element-restriction=true -Drestricted-elements=%{restricted_element}
 %endif #if tizen
 


### PR DESCRIPTION
Adding elements: gdppay, gdpdepay
These elements payload and depayload GStreamer buffers and events using the GStreamer Data Protocol.

Related issue from LFAI technical discuss: https://lists.lfai.foundation/g/nnstreamer-technical-discuss/message/11

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [ *]Skipped