### PR TITLE
[Demux] Bugfix for set_property function

### DIFF
--- a/gst/nnstreamer/tensor_demux/gsttensordemux.c
+++ b/gst/nnstreamer/tensor_demux/gsttensordemux.c
@@ -546,6 +546,12 @@ gst_tensor_demux_set_property (GObject * object, guint prop_id,
       const gchar *param = g_value_get_string (value);
       gchar **strv = g_strsplit_set (param, ",.;/", -1);
       gint num = g_strv_length (strv);
+
+      /* Before setting the new Tensor Pick data, the existing one should be removed. */
+      if (filter->tensorpick) {
+        g_list_free (filter->tensorpick);
+        filter->tensorpick = NULL;
+      }
       for (i = 0; i < num; i++) {
         val = g_ascii_strtoll (strv[i], NULL, 10);
         filter->tensorpick =


### PR DESCRIPTION
If `tensorpick` property of demux element is set twice by calling
`g_object_set()` function, the previous value should be removed and
new one should be written. However, the value is appended and it can
make a problem. This patch fixes this bug.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped


