### PR TITLE
[Fix/Info] Replace info->num_tensors to NNS_TENSOR_SIZE_LIMIT @open sesame 7/28 14:01

### DIFF
--- a/api/android/api/src/main/java/org/nnsuite/nnstreamer/TensorsInfo.java
+++ b/api/android/api/src/main/java/org/nnsuite/nnstreamer/TensorsInfo.java
@@ -342,34 +342,34 @@ public final class TensorsInfo implements AutoCloseable, Cloneable {
             NNStreamer.TensorType type = NNStreamer.TensorType.UNKNOWN;
 
             switch (value) {
-                case 0:
+                case 1:
                     type = NNStreamer.TensorType.INT32;
                     break;
-                case 1:
+                case 2:
                     type = NNStreamer.TensorType.UINT32;
                     break;
-                case 2:
+                case 3:
                     type = NNStreamer.TensorType.INT16;
                     break;
-                case 3:
+                case 4:
                     type = NNStreamer.TensorType.UINT16;
                     break;
-                case 4:
+                case 5:
                     type = NNStreamer.TensorType.INT8;
                     break;
-                case 5:
+                case 6:
                     type = NNStreamer.TensorType.UINT8;
                     break;
-                case 6:
+                case 7:
                     type = NNStreamer.TensorType.FLOAT64;
                     break;
-                case 7:
+                case 8:
                     type = NNStreamer.TensorType.FLOAT32;
                     break;
-                case 8:
+                case 9:
                     type = NNStreamer.TensorType.INT64;
                     break;
-                case 9:
+                case 10:
                     type = NNStreamer.TensorType.UINT64;
                     break;
                 default:

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -168,7 +168,8 @@ typedef enum {
  */
 typedef enum _ml_tensor_type_e
 {
-  ML_TENSOR_TYPE_INT32 = 0,      /**< Integer 32bit */
+  ML_TENSOR_TYPE_UNKNOWN = 0,    /**< Unknown type */
+  ML_TENSOR_TYPE_INT32,          /**< Integer 32bit */
   ML_TENSOR_TYPE_UINT32,         /**< Unsigned integer 32bit */
   ML_TENSOR_TYPE_INT16,          /**< Integer 16bit */
   ML_TENSOR_TYPE_UINT16,         /**< Unsigned integer 16bit */
@@ -178,7 +179,6 @@ typedef enum _ml_tensor_type_e
   ML_TENSOR_TYPE_FLOAT32,        /**< Float 32bit */
   ML_TENSOR_TYPE_INT64,          /**< Integer 64bit */
   ML_TENSOR_TYPE_UINT64,         /**< Unsigned integer 64bit */
-  ML_TENSOR_TYPE_UNKNOWN         /**< Unknown type */
 } ml_tensor_type_e;
 
 /**

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -333,7 +333,8 @@ ml_single_get_gst_info (ml_single * single_h, gboolean is_input,
 static int
 ml_single_set_gst_info (ml_single * single_h, const ml_tensors_info_h info)
 {
-  GstTensorsInfo gst_in_info, gst_out_info;
+  GstTensorsInfo gst_in_info;
+  GstTensorsInfoDeclare0 (gst_out_info);
   int status = ML_ERROR_NONE;
   int ret = -EINVAL;
 

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -135,7 +135,7 @@ ml_tensor_info_validate (const ml_tensor_info_s * info)
   if (!info)
     return FALSE;
 
-  if (info->type < 0 || info->type >= ML_TENSOR_TYPE_UNKNOWN)
+  if (info->type <= ML_TENSOR_TYPE_UNKNOWN || info->type > ML_TENSOR_TYPE_UINT64)
     return FALSE;
 
   for (i = 0; i < ML_TENSOR_RANK_LIMIT; i++) {
@@ -862,7 +862,7 @@ ml_tensors_info_copy_from_ml (GstTensorsInfo * gst_info,
         gst_info->info[i].type = _NNS_UINT64;
         break;
       default:
-        gst_info->info[i].type = _NNS_END;
+        gst_info->info[i].type = _NNS_NONE;
         break;
     }
 

--- a/ext/nnstreamer/include/nnstreamer.fbs
+++ b/ext/nnstreamer/include/nnstreamer.fbs
@@ -9,8 +9,10 @@
 
 namespace nnstreamer.flatbuf;
 
-enum Tensor_type : int { 
-  NNS_INT32 = 0,
+enum Tensor_type : int {
+  NNS_NONE = 0,
+
+  NNS_INT32,
   NNS_UINT32,
   NNS_INT16,
   NNS_UINT16,
@@ -20,8 +22,6 @@ enum Tensor_type : int {
   NNS_FLOAT32,
   NNS_INT64,
   NNS_UINT64,
-
-  NNS_END
   }
 
 struct frame_rate {
@@ -31,9 +31,9 @@ struct frame_rate {
 
 table Tensor {
   name  : string;
-  type : Tensor_type = NNS_END;
+  type : Tensor_type = NNS_NONE;
   dimension : [uint32]; // support up to 4th ranks.
-  data : [ubyte]; 
+  data : [ubyte];
 }
 
 table Tensors {

--- a/ext/nnstreamer/include/nnstreamer.proto
+++ b/ext/nnstreamer/include/nnstreamer.proto
@@ -5,16 +5,17 @@ package nnstreamer.protobuf;
 message Tensor {
   string name = 1;
   enum Tensor_type {
-    NNS_INT32 = 0;
-    NNS_UINT32 = 1;
-    NNS_INT16 = 2;
-    NNS_UINT16 = 3;
-    NNS_INT8 = 4;
-    NNS_UINT8 = 5;
-    NNS_FLOAT64 = 6;
-    NNS_FLOAT32 = 7;
-    NNS_INT64 = 8;
-    NNS_UINT64 = 9;
+    NNS_NONE = 0;
+    NNS_INT32 = 1;
+    NNS_UINT32 = 2;
+    NNS_INT16 = 3;
+    NNS_UINT16 = 4;
+    NNS_INT8 = 5;
+    NNS_UINT8 = 6;
+    NNS_FLOAT64 = 7;
+    NNS_FLOAT32 = 8;
+    NNS_INT64 = 9;
+    NNS_UINT64 = 10;
   }
   Tensor_type type = 2;
   repeated uint32 dimension = 3;

--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -439,7 +439,7 @@ ArmNNCore::getGstTensorType (armnn::DataType armType)
       break;
   }
 
-  return _NNS_END;
+  return _NNS_NONE;
 }
 
 /**
@@ -472,14 +472,14 @@ ArmNNCore::setTensorProp (const std::vector < armnn::BindingPointInfo >
     }
 
     /* Set the type */
-    if (gst_info->type == _NNS_END) {
+    if (gst_info->type == _NNS_NONE) {
       gst_info->type = getGstTensorType (arm_info.GetDataType ());
     } else if (gst_info->type != getGstTensorType (arm_info.GetDataType ())) {
       ml_logw ("Provided data type info does not match with model.");
       return -EINVAL;
     }
 
-    if (gst_info->type == _NNS_END) {
+    if (gst_info->type == _NNS_NONE) {
       ml_logw ("Data type not supported.");
       return -EINVAL;
     }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
@@ -492,7 +492,7 @@ tensor_type edgetpu_subplugin::getTensorType (TfLiteType tfType)
       break;
   }
 
-  return _NNS_END;
+  return _NNS_NONE;
 }
 
 /**

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -327,7 +327,7 @@ nnfw_tensor_type_to_gst (const NNFW_TYPE nnfw_type, tensor_type * type)
       *type = _NNS_UINT8;
       break;
     default:
-      *type = _NNS_END;
+      *type = _NNS_NONE;
       err = -EINVAL;
   }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
@@ -59,7 +59,7 @@ const std::string TensorFilterOpenvino::extXml = ".xml";
 /**
  * @brief Convert the string representing the tensor data type to _nns_tensor_type
  * @param type a std::string representing the tensor data type in InferenceEngine
- * @return _nns_tensor_type corresponding to the tensor data type in InferenceEngine if OK, otherwise _NNS_END
+ * @return _nns_tensor_type corresponding to the tensor data type in InferenceEngine if OK, otherwise _NNS_NONE
  */
 tensor_type
 TensorFilterOpenvino::convertFromIETypeStr (std::string type)
@@ -80,9 +80,9 @@ TensorFilterOpenvino::convertFromIETypeStr (std::string type)
     if (type[2] == '3')
       return _NNS_FLOAT32;
     else
-      return _NNS_END;
+      return _NNS_NONE;
   } else {
-    return _NNS_END;
+    return _NNS_NONE;
   }
 }
 
@@ -316,7 +316,7 @@ TensorFilterOpenvino::getInputTensorDim (GstTensorsInfo * info)
 
     ieTensorTypeStr = eachInputInfo->getPrecision ().name ();
     nnsTensorType = TensorFilterOpenvino::convertFromIETypeStr (ieTensorTypeStr);
-    if (nnsTensorType == _NNS_END) {
+    if (nnsTensorType == _NNS_NONE) {
       ml_loge ("The type of tensor elements, %s, "
           "in the model is not supported", ieTensorTypeStr.c_str ());
       ret = RetEInval;
@@ -388,7 +388,7 @@ TensorFilterOpenvino::getOutputTensorDim (GstTensorsInfo * info)
 
     ieTensorTypeStr = eachOutputInfo->getPrecision ().name ();
     nnsTensorType = TensorFilterOpenvino::convertFromIETypeStr (ieTensorTypeStr);
-    if (nnsTensorType == _NNS_END) {
+    if (nnsTensorType == _NNS_NONE) {
       ml_loge ("The type of tensor elements, %s, "
           "in the model is not supported", ieTensorTypeStr.c_str ());
       ret = RetEInval;

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -720,7 +720,7 @@ PYCore::getTensorType (NPY_TYPES npyType)
       break;
   }
 
-  return _NNS_END;
+  return _NNS_NONE;
 }
 
 /**

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -250,7 +250,7 @@ TorchCore::getTensorTypeFromTorch (torch::Dtype torchType)
       break;
   }
 
-  return _NNS_END;
+  return _NNS_NONE;
 }
 
 /**

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
@@ -307,7 +307,7 @@ TFCore::getTensorTypeFromTF (TF_DataType tfType)
       break;
   }
 
-  return _NNS_END;
+  return _NNS_NONE;
 }
 
 /**

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -913,7 +913,7 @@ tflite_setInputDim (const GstTensorFilterProperties * prop, void **private_data,
     const GstTensorsInfo * in_info, GstTensorsInfo * out_info)
 {
   TFLiteCore *core = static_cast<TFLiteCore *>(*private_data);
-  GstTensorsInfo cur_in_info;
+  GstTensorsInfoDeclare0 (cur_in_info);
   int status, failedAt, recoveryStatus;
 
   g_return_val_if_fail (core, -EINVAL);

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -328,7 +328,7 @@ TFLiteInterpreter::getTensorType (TfLiteType tfType)
       break;
   }
 
-  return _NNS_END;
+  return _NNS_NONE;
 }
 
 /**

--- a/ext/nnstreamer/tensor_filter/vivante/tensor_filter_subplugin.c
+++ b/ext/nnstreamer/tensor_filter/vivante/tensor_filter_subplugin.c
@@ -254,7 +254,7 @@ convert_tensortype (unsigned tensor_type)
     /** @todo Support other types */
     break;
   }
-  return _NNS_END;
+  return _NNS_NONE;
 }
 
 /**

--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -328,7 +328,7 @@ gst_tensor_get_element_size (tensor_type type);
 
 /**
  * @brief Get tensor type from string input.
- * @return Corresponding tensor_type. _NNS_END if unrecognized value is there.
+ * @return Corresponding tensor_type. _NNS_NONE if unrecognized value is there.
  * @param typestr The string type name, supposed to be one of tensor_element_typename[]
  */
 extern tensor_type

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -100,7 +100,9 @@
  */
 typedef enum _nns_tensor_type
 {
-  _NNS_INT32 = 0,
+  _NNS_NONE = 0,
+
+  _NNS_INT32,
   _NNS_UINT32,
   _NNS_INT16,
   _NNS_UINT16,
@@ -111,7 +113,7 @@ typedef enum _nns_tensor_type
   _NNS_INT64,
   _NNS_UINT64,
 
-  _NNS_END,
+  _NNS_MAX,
 } tensor_type;
 
 /**
@@ -172,6 +174,7 @@ typedef struct
   tensor_type type; /**< Type of each element in the tensor. User must designate this. */
   tensor_dim dimension; /**< Dimension. We support up to 4th ranks.  */
 } GstTensorInfo;
+#define GstTensorInfoDeclare0(info) GstTensorInfo info = {0}
 
 /**
  * @brief Internal meta data exchange format for a other/tensors instance
@@ -181,6 +184,7 @@ typedef struct
   unsigned int num_tensors; /**< The number of tensors */
   GstTensorInfo info[NNS_TENSOR_SIZE_LIMIT]; /**< The list of tensor info */
 } GstTensorsInfo;
+#define GstTensorsInfoDeclare0(info) GstTensorsInfo info = {0}
 
 /**
  * @brief Internal data structure for configured tensor info (for other/tensor).
@@ -191,6 +195,7 @@ typedef struct
   int rate_n; /**< framerate is in fraction, which is numerator/denominator */
   int rate_d; /**< framerate is in fraction, which is numerator/denominator */
 } GstTensorConfig;
+#define GstTensorConfigDeclare0(config) GstTensorConfig config = {0}
 
 /**
  * @brief Internal data structure for configured tensors info (for other/tensors).
@@ -201,5 +206,6 @@ typedef struct
   int rate_n; /**< framerate is in fraction, which is numerator/denominator */
   int rate_d; /**< framerate is in fraction, which is numerator/denominator */
 } GstTensorsConfig;
+#define GstTensorsConfigDeclare0(config) GstTensorsConfig config = {0}
 
 #endif /*__GST_TENSOR_TYPEDEF_H__*/

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -30,6 +30,7 @@
  * @brief String representations for each tensor element type.
  */
 static const gchar *tensor_element_typename[] = {
+  [_NNS_NONE] = NULL,
   [_NNS_INT32] = "int32",
   [_NNS_UINT32] = "uint32",
   [_NNS_INT16] = "int16",
@@ -40,13 +41,13 @@ static const gchar *tensor_element_typename[] = {
   [_NNS_FLOAT32] = "float32",
   [_NNS_INT64] = "int64",
   [_NNS_UINT64] = "uint64",
-  [_NNS_END] = NULL,
 };
 
 /**
  * @brief Byte-per-element of each tensor element type.
  */
 static const guint tensor_element_size[] = {
+  [_NNS_NONE] = 0,
   [_NNS_INT32] = 4,
   [_NNS_UINT32] = 4,
   [_NNS_INT16] = 2,
@@ -57,8 +58,6 @@ static const guint tensor_element_size[] = {
   [_NNS_FLOAT32] = 4,
   [_NNS_INT64] = 8,
   [_NNS_UINT64] = 8,
-
-  [_NNS_END] = 0,
 };
 
 /**
@@ -107,7 +106,7 @@ gst_tensor_info_init (GstTensorInfo * info)
   g_return_if_fail (info != NULL);
 
   info->name = NULL;
-  info->type = _NNS_END;
+  info->type = _NNS_NONE;
 
   for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
     info->dimension[i] = 0;
@@ -155,7 +154,7 @@ gst_tensor_info_validate (const GstTensorInfo * info)
 {
   g_return_val_if_fail (info != NULL, FALSE);
 
-  if (info->type == _NNS_END) {
+  if (info->type == _NNS_NONE) {
     return FALSE;
   }
 
@@ -712,7 +711,7 @@ gst_tensor_caps_from_config (const GstTensorConfig * config)
     g_free (dim_str);
   }
 
-  if (config->info.type != _NNS_END) {
+  if (config->info.type != _NNS_NONE) {
     gst_caps_set_simple (caps, "type", G_TYPE_STRING,
         gst_tensor_get_type_string (config->info.type), NULL);
   }
@@ -1010,7 +1009,7 @@ gst_tensor_get_element_size (tensor_type type)
 
 /**
  * @brief Get tensor type from string input.
- * @return Corresponding tensor_type. _NNS_END if unrecognized value is there.
+ * @return Corresponding tensor_type. _NNS_NONE if unrecognized value is there.
  * @param typestr The string type name, supposed to be one of tensor_element_typename[]
  */
 tensor_type
@@ -1018,10 +1017,10 @@ gst_tensor_get_type (const gchar * typestr)
 {
   gsize size, len;
   gchar *type_string;
-  tensor_type type = _NNS_END;
+  tensor_type type = _NNS_NONE;
 
   if (typestr == NULL)
-    return _NNS_END;
+    return _NNS_NONE;
 
   /* remove spaces */
   type_string = g_strdup (typestr);
@@ -1031,7 +1030,7 @@ gst_tensor_get_type (const gchar * typestr)
 
   if (len == 0) {
     g_free (type_string);
-    return _NNS_END;
+    return _NNS_NONE;
   }
 
   if (g_regex_match_simple ("^uint(8|16|32|64)$",

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -123,10 +123,8 @@ gst_tensor_info_free (GstTensorInfo * info)
 {
   g_return_if_fail (info != NULL);
 
-  if (info->name) {
-    g_free (info->name);
-    info->name = NULL;
-  }
+  g_free (info->name);
+  info->name = NULL;
 }
 
 /**
@@ -274,7 +272,7 @@ gst_tensors_info_free (GstTensorsInfo * info)
 
   g_return_if_fail (info != NULL);
 
-  for (i = 0; i < info->num_tensors; i++) {
+  for (i = 0; i < NNS_TENSOR_SIZE_LIMIT; i++) {
     gst_tensor_info_free (&info->info[i]);
   }
 }

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -974,7 +974,7 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
       break;
     case _NNS_MEDIA_PLUGINS:
     {
-      GstTensorsConfig new_config;
+      GstTensorsConfigDeclare0 (new_config);
 
       if (self->externalConverter == NULL ||
           self->externalConverter->convert == NULL)
@@ -1772,7 +1772,7 @@ gst_tensor_converter_update_caps (GstTensorConverter * self,
       st = gst_caps_get_structure (peer_caps, 0);
 
       if (g_strcmp0 (gst_structure_get_name (st), "other/tensor") == 0) {
-        GstTensorConfig tensor_config;
+        GstTensorConfigDeclare0 (tensor_config);
 
         tensor_config.info = config->info.info[0];
         tensor_config.rate_n = config->rate_n;

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -416,7 +416,7 @@ gst_tensor_converter_set_property (GObject * object, guint prop_id,
 
       /* prevent invalid value, init types. */
       for (i = num; i < NNS_TENSOR_SIZE_LIMIT; ++i) {
-        info->info[i].type = _NNS_END;
+        info->info[i].type = _NNS_NONE;
       }
 
       info->num_tensors = num;
@@ -1223,7 +1223,7 @@ gst_tensor_converter_parse_video (GstTensorConverter * self,
   }
 
   self->frame_size = GST_VIDEO_INFO_SIZE (&vinfo);
-  return (config->info.info[0].type != _NNS_END);
+  return (config->info.info[0].type != _NNS_NONE);
 }
 
 /**
@@ -1307,7 +1307,7 @@ gst_tensor_converter_parse_audio (GstTensorConverter * self,
   config->rate_d = 1;
 
   self->frame_size = GST_AUDIO_INFO_BPF (&ainfo);
-  return (config->info.info[0].type != _NNS_END);
+  return (config->info.info[0].type != _NNS_NONE);
 }
 
 /**
@@ -1377,7 +1377,7 @@ gst_tensor_converter_parse_text (GstTensorConverter * self,
   }
 
   self->frame_size = gst_tensor_info_get_size (&config->info.info[0]);
-  return (config->info.info[0].type != _NNS_END);
+  return (config->info.info[0].type != _NNS_NONE);
 }
 
 /**
@@ -1431,7 +1431,7 @@ gst_tensor_converter_parse_octet (GstTensorConverter * self,
   }
 
   self->frame_size = gst_tensors_info_get_size (&config->info, -1);
-  return (config->info.info[0].type != _NNS_END);
+  return (config->info.info[0].type != _NNS_NONE);
 }
 
 /**
@@ -1520,7 +1520,7 @@ gst_tensor_converter_get_possible_media_caps (GstTensorConverter * self)
           case _NNS_AUDIO:
             /* audio caps from tensor info */
             if (is_audio_supported (self)
-                && config.info.info[0].type != _NNS_END) {
+                && config.info.info[0].type != _NNS_NONE) {
               gint ch, rate;
               GstAudioFormat aformat;
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -723,7 +723,7 @@ gst_tensor_filter_caps_from_config (GstTensorFilter * self,
   g_return_val_if_fail (config != NULL, NULL);
 
   if (config->info.num_tensors < 2) {
-    GstTensorConfig c;
+    GstTensorConfigDeclare0 (c);
 
     /**
      * supposed other/tensor if the number of tensor is less than 2.

--- a/gst/nnstreamer/tensor_merge/gsttensormerge.c
+++ b/gst/nnstreamer/tensor_merge/gsttensormerge.c
@@ -595,8 +595,8 @@ static gboolean
 gst_tensor_merge_set_src_caps (GstTensorMerge * tensor_merge)
 {
   if (!tensor_merge->negotiated) {
+    GstTensorConfigDeclare0 (config);
     GstCaps *newcaps;
-    GstTensorConfig config;
 
     if (!gst_tensor_merge_get_merged_config (tensor_merge,
             &tensor_merge->tensors_config, &config)) {

--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -2203,7 +2203,7 @@ gst_tensor_src_iio_fixate (GstBaseSrc * src, GstCaps * caps)
   self = GST_TENSOR_SRC_IIO_CAST (src);
 
   if (self->is_tensor) {
-    GstTensorConfig tensor_config;
+    GstTensorConfigDeclare0 (tensor_config);
     gst_tensor_info_copy (&tensor_config.info,
         &(self->tensors_config->info.info[0]));
     tensor_config.rate_n = self->tensors_config->rate_n;

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -432,7 +432,7 @@ gst_tensor_transform_set_value (GstTensorTransform * filter,
 
   /* init tensor value */
   memset (value, 0, sizeof (tensor_transform_operand_s));
-  value->type = _NNS_END;
+  value->type = _NNS_NONE;
 
   switch (type) {
     case _NNS_INT32:
@@ -653,7 +653,7 @@ gst_tensor_transform_typecast_value (GstTensorTransform * filter,
   gboolean is_float;
 
   g_return_val_if_fail (value != NULL, FALSE);
-  g_return_val_if_fail (type != _NNS_END, FALSE);
+  g_return_val_if_fail (type != _NNS_NONE, FALSE);
 
   /* do nothing when transform to same type */
   if (value->type != type) {
@@ -778,7 +778,7 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       guint i, num_operators, num_op;
       GRegex *regex_option_tc;
 
-      filter->data_arithmetic.out_type = _NNS_END;
+      filter->data_arithmetic.out_type = _NNS_NONE;
 
       if (filter->operators) {
         GST_WARNING_OBJECT (filter,
@@ -1537,18 +1537,18 @@ gst_tensor_transform_convert_dimension (GstTensorTransform * filter,
         out_info->type = filter->data_typecast.to;
       } else {
         /* cannot get the incoming data type on sink pad */
-        out_info->type = _NNS_END;
+        out_info->type = _NNS_NONE;
       }
       break;
 
     case GTT_ARITHMETIC:
       /* check arith mode option has typecast operator */
-      if (filter->data_arithmetic.out_type != _NNS_END) {
+      if (filter->data_arithmetic.out_type != _NNS_NONE) {
         if (direction == GST_PAD_SINK) {
           out_info->type = filter->data_arithmetic.out_type;
         } else {
           /* cannot get the incoming data type on sink pad */
-          out_info->type = _NNS_END;
+          out_info->type = _NNS_NONE;
         }
       }
       break;

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -1671,7 +1671,7 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
 {
   GstTensorTransform *filter;
   GstTensorConfig in_config, out_config;
-  GstTensorConfig config;
+  GstTensorConfigDeclare0 (config);
   gboolean allowed = FALSE;
 
   filter = GST_TENSOR_TRANSFORM_CAST (trans);

--- a/gst/nnstreamer/tensor_transform/tensor_transform.h
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.h
@@ -92,7 +92,7 @@ typedef struct _tensor_transform_dimchg {
  * @brief Internal data structure for typecast mode.
  */
 typedef struct _tensor_transform_typecast {
-  tensor_type to; /**< tensor_type after cast. _NNS_END if unknown */
+  tensor_type to; /**< tensor_type after cast. _NNS_NONE if unknown */
 } tensor_transform_typecast;
 
 /**

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -26,8 +26,8 @@
  */
 TEST (common_get_tensor_type, failure_n)
 {
-  EXPECT_EQ (gst_tensor_get_type (""), _NNS_END);
-  EXPECT_EQ (gst_tensor_get_type (NULL), _NNS_END);
+  EXPECT_EQ (gst_tensor_get_type (""), _NNS_NONE);
+  EXPECT_EQ (gst_tensor_get_type (NULL), _NNS_NONE);
 }
 
 /**
@@ -46,8 +46,8 @@ TEST (common_get_tensor_type, int32)
  */
 TEST (common_get_tensor_type, int32_n)
 {
-  EXPECT_EQ (gst_tensor_get_type ("InT322"), _NNS_END);
-  EXPECT_EQ (gst_tensor_get_type ("int3"), _NNS_END);
+  EXPECT_EQ (gst_tensor_get_type ("InT322"), _NNS_NONE);
+  EXPECT_EQ (gst_tensor_get_type ("int3"), _NNS_NONE);
 }
 
 /**
@@ -66,8 +66,8 @@ TEST (common_get_tensor_type, int16)
  */
 TEST (common_get_tensor_type, int16_n)
 {
-  EXPECT_EQ (gst_tensor_get_type ("InT162"), _NNS_END);
-  EXPECT_EQ (gst_tensor_get_type ("int1"), _NNS_END);
+  EXPECT_EQ (gst_tensor_get_type ("InT162"), _NNS_NONE);
+  EXPECT_EQ (gst_tensor_get_type ("int1"), _NNS_NONE);
 }
 
 /**
@@ -86,8 +86,8 @@ TEST (common_get_tensor_type, int8)
  */
 TEST (common_get_tensor_type, int8_n)
 {
-  EXPECT_EQ (gst_tensor_get_type ("InT82"), _NNS_END);
-  EXPECT_EQ (gst_tensor_get_type ("int3"), _NNS_END);
+  EXPECT_EQ (gst_tensor_get_type ("InT82"), _NNS_NONE);
+  EXPECT_EQ (gst_tensor_get_type ("int3"), _NNS_NONE);
 }
 
 /**
@@ -106,8 +106,8 @@ TEST (common_get_tensor_type, uint32)
  */
 TEST (common_get_tensor_type, uint32_n)
 {
-  EXPECT_EQ (gst_tensor_get_type ("UInT322"), _NNS_END);
-  EXPECT_EQ (gst_tensor_get_type ("uint3"), _NNS_END);
+  EXPECT_EQ (gst_tensor_get_type ("UInT322"), _NNS_NONE);
+  EXPECT_EQ (gst_tensor_get_type ("uint3"), _NNS_NONE);
 }
 
 /**
@@ -126,8 +126,8 @@ TEST (common_get_tensor_type, uint16)
  */
 TEST (common_get_tensor_type, uint16_n)
 {
-  EXPECT_EQ (gst_tensor_get_type ("UInT162"), _NNS_END);
-  EXPECT_EQ (gst_tensor_get_type ("uint1"), _NNS_END);
+  EXPECT_EQ (gst_tensor_get_type ("UInT162"), _NNS_NONE);
+  EXPECT_EQ (gst_tensor_get_type ("uint1"), _NNS_NONE);
 }
 
 /**
@@ -146,8 +146,8 @@ TEST (common_get_tensor_type, uint8)
  */
 TEST (common_get_tensor_type, uint8_n)
 {
-  EXPECT_EQ (gst_tensor_get_type ("UInT82"), _NNS_END);
-  EXPECT_EQ (gst_tensor_get_type ("uint3"), _NNS_END);
+  EXPECT_EQ (gst_tensor_get_type ("UInT82"), _NNS_NONE);
+  EXPECT_EQ (gst_tensor_get_type ("uint3"), _NNS_NONE);
 }
 
 /**
@@ -166,8 +166,8 @@ TEST (common_get_tensor_type, float32)
  */
 TEST (common_get_tensor_type, float32_n)
 {
-  EXPECT_EQ (gst_tensor_get_type ("FloaT322"), _NNS_END);
-  EXPECT_EQ (gst_tensor_get_type ("float3"), _NNS_END);
+  EXPECT_EQ (gst_tensor_get_type ("FloaT322"), _NNS_NONE);
+  EXPECT_EQ (gst_tensor_get_type ("float3"), _NNS_NONE);
 }
 
 /**
@@ -186,8 +186,8 @@ TEST (common_get_tensor_type, float64)
  */
 TEST (common_get_tensor_type, float64_n)
 {
-  EXPECT_EQ (gst_tensor_get_type ("FloaT642"), _NNS_END);
-  EXPECT_EQ (gst_tensor_get_type ("float6"), _NNS_END);
+  EXPECT_EQ (gst_tensor_get_type ("FloaT642"), _NNS_NONE);
+  EXPECT_EQ (gst_tensor_get_type ("float6"), _NNS_NONE);
 }
 
 /**
@@ -206,8 +206,8 @@ TEST (common_get_tensor_type, int64)
  */
 TEST (common_get_tensor_type, int64_n)
 {
-  EXPECT_EQ (gst_tensor_get_type ("InT642"), _NNS_END);
-  EXPECT_EQ (gst_tensor_get_type ("int6"), _NNS_END);
+  EXPECT_EQ (gst_tensor_get_type ("InT642"), _NNS_NONE);
+  EXPECT_EQ (gst_tensor_get_type ("int6"), _NNS_NONE);
 }
 
 /**
@@ -226,8 +226,8 @@ TEST (common_get_tensor_type, uint64)
  */
 TEST (common_get_tensor_type, uint64_n)
 {
-  EXPECT_EQ (gst_tensor_get_type ("UInT642"), _NNS_END);
-  EXPECT_EQ (gst_tensor_get_type ("uint6"), _NNS_END);
+  EXPECT_EQ (gst_tensor_get_type ("UInT642"), _NNS_NONE);
+  EXPECT_EQ (gst_tensor_get_type ("uint6"), _NNS_NONE);
 }
 
 /**

--- a/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
+++ b/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
@@ -97,6 +97,9 @@ TEST (nnstreamer_filter_armnn, get_dimension)
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   GstTensorsInfo info, res;
 
+  gst_tensors_info_init (&info);
+  gst_tensors_info_init (&res);
+
   ASSERT_NE (root_path, nullptr);
 
   /** armnn needs a directory with model file and metadata in that directory */
@@ -257,6 +260,9 @@ TEST (nnstreamer_filter_armnn, invoke_advanced)
   ssize_t data_read;
   size_t max_idx;
   gboolean status;
+
+  gst_tensors_info_init (&info);
+  gst_tensors_info_init (&res);
 
   ASSERT_NE (root_path, nullptr);
 

--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
@@ -148,6 +148,8 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, get_dimension_fail_n)
   GstTensorsInfo res;
   gchar **model_files;
 
+  gst_tensors_info_init (&res);
+
   model_files = get_model_files ();
   ASSERT_TRUE (model_files != nullptr);
 
@@ -194,6 +196,8 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, get_dimension)
   GstTensorsInfo res;
   gchar **model_files;
 
+  gst_tensors_info_init (&res);
+
   model_files = get_model_files ();
   ASSERT_TRUE (model_files != nullptr);
 
@@ -237,6 +241,8 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, set_dimension_fail_n)
   void *data = NULL;
   GstTensorsInfo set;
   gchar **model_files;
+
+  gst_tensors_info_init (&set);
 
   model_files = get_model_files ();
   ASSERT_TRUE (model_files != nullptr);
@@ -286,6 +292,9 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, set_dimension)
   void *data = NULL;
   GstTensorsInfo set, get;
   gchar **model_files;
+
+  gst_tensors_info_init (&set);
+  gst_tensors_info_init (&get);
 
   model_files = get_model_files ();
   ASSERT_TRUE (model_files != nullptr);
@@ -427,6 +436,9 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, invoke)
   gchar **model_files;
   GstTensorsInfo input_info, output_info;
   guint i;
+
+  gst_tensors_info_init (&input_info);
+  gst_tensors_info_init (&output_info);
 
   model_files = get_model_files ();
   ASSERT_TRUE (model_files != nullptr);

--- a/tests/nnstreamer_filter_openvino/unittest_openvino.cc
+++ b/tests/nnstreamer_filter_openvino/unittest_openvino.cc
@@ -1082,7 +1082,7 @@ TEST (tensor_filter_openvino, convertFromIETypeStr_1_n)
     tensor_type ret_type;
 
     ret_type = tfOvTest.convertFromIETypeStr (ie_suport_type_str);
-    EXPECT_EQ (_NNS_END, ret_type);
+    EXPECT_EQ (_NNS_NONE, ret_type);
   }
 
   g_free (test_model_xml);

--- a/tests/nnstreamer_filter_openvino/unittest_openvino.cc
+++ b/tests/nnstreamer_filter_openvino/unittest_openvino.cc
@@ -593,6 +593,8 @@ TEST (tensor_filter_openvino, getTensorDim_0)
   gchar *test_model;
   gint ret;
 
+  gst_tensors_info_init (&nns_tensors_info);
+
   /* Check if mandatory methods are contained */
   ASSERT_TRUE (fw && fw->open && fw->close);
 
@@ -671,6 +673,8 @@ TEST (tensor_filter_openvino, getTensorDim_0_n)
   gchar *test_model_bin;
   gint ret;
 
+  gst_tensors_info_init (&nns_tensors_info);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -746,6 +750,8 @@ TEST (tensor_filter_openvino, getTensorDim_1_n)
   gchar *test_model_bin;
   gint ret;
 
+  gst_tensors_info_init (&nns_tensors_info);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -819,6 +825,8 @@ TEST (tensor_filter_openvino, getTensorDim_2_n)
   gchar *test_model_bin;
   gint ret;
 
+  gst_tensors_info_init (&nns_tensors_info);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -890,6 +898,8 @@ TEST (tensor_filter_openvino, getTensorDim_3_n)
   gchar *test_model_xml;
   gchar *test_model_bin;
   gint ret;
+
+  gst_tensors_info_init (&nns_tensors_info);
 
   /* supposed to run test in build directory */
   if (root_path == NULL)

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -64,6 +64,7 @@
       g_object_set (h->element, "mode", GTT_TYPECAST, "option", str_to_t, NULL);  \
       g_object_set (h->element, "acceleration", (gboolean) accel, NULL);  \
       /** input tensor info */ \
+      gst_tensor_config_init (&config); \
       config.info.type = from_nns_t; \
       gst_tensor_parse_dimension (str(size), config.info.dimension); \
       config.rate_n = 0; \
@@ -506,6 +507,7 @@ TEST (test_tensor_transform, arithmetic_1)
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_FLOAT32;
   gst_tensor_parse_dimension ("5", config.info.dimension);
   config.rate_n = 0;
@@ -576,6 +578,7 @@ TEST (test_tensor_transform, arithmetic_1_accel)
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_FLOAT32;
   gst_tensor_parse_dimension ("5", config.info.dimension);
   config.rate_n = 0;
@@ -646,6 +649,7 @@ TEST (test_tensor_transform, arithmetic_2)
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_FLOAT64;
   gst_tensor_parse_dimension ("5", config.info.dimension);
   config.rate_n = 0;
@@ -716,6 +720,7 @@ TEST (test_tensor_transform, arithmetic_2_accel)
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_FLOAT64;
   gst_tensor_parse_dimension ("5", config.info.dimension);
   config.rate_n = 0;
@@ -787,6 +792,7 @@ TEST (test_tensor_transform, arithmetic_3)
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_UINT8;
   gst_tensor_parse_dimension ("5", config.info.dimension);
   config.rate_n = 0;
@@ -861,6 +867,7 @@ TEST (test_tensor_transform, arithmetic_3_accel)
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_UINT8;
   gst_tensor_parse_dimension ("5", config.info.dimension);
   config.rate_n = 0;
@@ -935,6 +942,7 @@ TEST (test_tensor_transform, arithmetic_4)
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_UINT8;
   gst_tensor_parse_dimension ("5", config.info.dimension);
   config.rate_n = 0;
@@ -1009,6 +1017,7 @@ TEST (test_tensor_transform, arithmetic_4_accel)
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_UINT8;
   gst_tensor_parse_dimension ("5", config.info.dimension);
   config.rate_n = 0;
@@ -1083,6 +1092,7 @@ TEST (test_tensor_transform, arithmetic_5)
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_UINT8;
   gst_tensor_parse_dimension ("5", config.info.dimension);
   config.rate_n = 0;
@@ -1157,6 +1167,7 @@ TEST (test_tensor_transform, arithmetic_5_accel)
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_UINT8;
   gst_tensor_parse_dimension ("5", config.info.dimension);
   config.rate_n = 0;
@@ -1228,6 +1239,7 @@ TEST (test_tensor_transform, arithmetic_change_option_string)
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_FLOAT32;
   gst_tensor_parse_dimension ("5", config.info.dimension);
   config.rate_n = 0;
@@ -1408,6 +1420,7 @@ TEST (test_tensor_aggregator, aggregate_1)
   g_object_set (h->element, "frames-out", 2, "frames-dim", 3, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_INT32;
   gst_tensor_parse_dimension ("3:4:2:2", config.info.dimension);
   config.rate_n = 0;
@@ -1484,6 +1497,7 @@ TEST (test_tensor_aggregator, aggregate_2)
   g_object_set (h->element, "frames-out", 2, "frames-dim", 2, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_INT32;
   gst_tensor_parse_dimension ("3:4:2:2", config.info.dimension);
   config.rate_n = 0;
@@ -1560,6 +1574,7 @@ TEST (test_tensor_aggregator, aggregate_3)
   g_object_set (h->element, "frames-out", 2, "frames-dim", 1, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_INT32;
   gst_tensor_parse_dimension ("3:4:2:2", config.info.dimension);
   config.rate_n = 0;
@@ -1636,6 +1651,7 @@ TEST (test_tensor_aggregator, aggregate_4)
   g_object_set (h->element, "frames-out", 2, "frames-dim", 0, NULL);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_INT32;
   gst_tensor_parse_dimension ("3:4:2:2", config.info.dimension);
   config.rate_n = 0;
@@ -1712,6 +1728,7 @@ TEST (test_tensor_aggregator, aggregate_5)
   g_object_set (h->element, "concat", (gboolean) FALSE, NULL);
 
   /* in/out tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_INT32;
   gst_tensor_parse_dimension ("3:4:2:2", config.info.dimension);
   config.rate_n = 0;
@@ -3503,6 +3520,7 @@ TEST (test_tensor_filter, reopen_tflite_01_p)
   g_free (str_launch_line);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_UINT8;
   gst_tensor_parse_dimension ("3:224:224:1", config.info.dimension);
   config.rate_n = 0;
@@ -3633,6 +3651,7 @@ TEST (test_tensor_filter, reload_tflite_set_property)
   g_free (str_launch_line);
 
   /* input tensor info */
+  gst_tensor_config_init (&config);
   config.info.type = _NNS_UINT8;
   gst_tensor_parse_dimension ("3:224:224:1", config.info.dimension);
   config.rate_n = 0;

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -1792,6 +1792,9 @@ TEST (nnstreamer_capi_util, info_create_2_n)
 {
   GstTensorsInfo gi;
   ml_tensors_info_h i;
+
+  gst_tensors_info_init (&gi);
+
   int status = ml_tensors_info_create_from_gst (&i, nullptr);
   ASSERT_EQ (status, ML_ERROR_INVALID_PARAMETER);
   status = ml_tensors_info_create_from_gst (nullptr, &gi);

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -66,6 +66,9 @@ TEST (nnstreamer_nnfw_runtime_raw_functions, get_dimension)
   GstTensorsInfo info, res;
   gchar *model_file;
 
+  gst_tensors_info_init (&info);
+  gst_tensors_info_init (&res);
+
   model_file = get_model_file ();
   ASSERT_TRUE (model_file != nullptr);
   const gchar *model_files[] = {
@@ -128,6 +131,10 @@ TEST (nnstreamer_nnfw_runtime_raw_functions, DISABLED_set_dimension)
   GstTensorMemory input, output;
   gchar *model_file;
   int tensor_size;
+
+  gst_tensors_info_init (&in_info);
+  gst_tensors_info_init (&out_info);
+  gst_tensors_info_init (&res);
 
   model_file = get_model_file ();
   ASSERT_TRUE (model_file != nullptr);
@@ -305,6 +312,9 @@ TEST (nnstreamer_nnfw_runtime_raw_functions, DISABLED_invoke_advanced)
   gsize data_read;
   size_t max_idx;
   gboolean status;
+
+  gst_tensors_info_init (&info);
+  gst_tensors_info_init (&res);
 
   ASSERT_NE (root_path, nullptr);
 


### PR DESCRIPTION
This patch replaces `info->num_tensors` to `NNS_TENSOR_SIZE_LIMIT`
in `gst_tensors_info_free` like capi impl.

Also, it changes the invalid tensor type to `_NNS_NONE`, which is 0.
(Related issue: #2563)

CC: @jaeyun-jung 

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
