### PR TITLE
[pytorch/caffe2] Update extensions for v1.6.0-rc1

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -140,6 +140,20 @@ if pytorch_support_is_available
 
   nnstreamer_filter_torch_deps = pytorch_support_deps + [glib_dep, gst_dep, nnstreamer_dep]
 
+  pytorch_compile_args = []
+
+  torch_ver_dep = dependency('pytorch', version : '>=1.2.0', required : false)
+  if torch_ver_dep.found()
+
+    pytorch_compile_args += '-DPYTORCH_VER_ATLEAST_1_2_0=1'
+  endif
+
+  pytorch_extra_dep = declare_dependency(
+    compile_args : pytorch_compile_args,
+  )
+
+  nnstreamer_filter_torch_deps += pytorch_extra_dep
+
   shared_library('nnstreamer_filter_pytorch',
     nnstreamer_filter_torch_sources,
     dependencies: nnstreamer_filter_torch_deps,

--- a/meson.build
+++ b/meson.build
@@ -41,8 +41,8 @@ elif not meson.is_cross_build()
   endif
 endif
 
+# Define warning flags for c and cpp
 warning_flags = [
-  '-Wredundant-decls',
   '-Wwrite-strings',
   '-Wformat',
   '-Wformat-nonliteral',
@@ -64,6 +64,7 @@ warning_c_flags = [
   '-Wdeclaration-after-statement'
 ]
 
+# Setup warning flags for c anc cpp
 foreach extra_arg : warning_flags
   if cc.has_argument (extra_arg)
     add_project_arguments([extra_arg], language: 'c')
@@ -288,13 +289,23 @@ foreach feature_name, data : features
 
 endforeach
 
-
 #Definitions enabled by meson_options.txt
 message('Following project_args are going to be included')
 message(project_args)
 foreach name, value: project_args
   add_project_arguments('-D@0@=@1@'.format(name, value), language: ['c', 'cpp'])
 endforeach
+
+# Add redundant declaration flag when caffe2 and pytorch both are disabled
+if not (pytorch_support_is_available and caffe2_support_is_available)
+  redundant_decls_flag = '-Wredundant-decls'
+  if cc.has_argument (redundant_decls_flag)
+    add_project_arguments([redundant_decls_flag], language: 'c')
+  endif
+  if cxx.has_argument (redundant_decls_flag)
+    add_project_arguments([redundant_decls_flag], language: 'cpp')
+  endif
+endif
 
 # Python
 have_python2 = false


### PR DESCRIPTION
Update pytorch extension for pytorch v1.6.0-rc1
Also pytorch and caffe2 headers do not follow redundant declarations
So, remove redundant declaration warning flag when compiling with them

Update caffe2 extension to remove warning based on api update for version 1.6.0-rc1

Related issue : #2411

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>