### PR TITLE
[C-API] Bugfix for abnormal accessing of the callback function

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -194,16 +194,13 @@ struct _ml_pipeline {
 };
 
 /**
- * @brief Internal private representation of sink handle of GstTensorSink and GstAppSink
+ * @brief Internal private representation sink callback function for GstTensorSink and GstAppSink
  * @details This represents a single instance of callback registration. This should not be exposed to applications.
  */
-typedef struct _ml_pipeline_sink {
-  ml_pipeline *pipe; /**< The pipeline, which is the owner of this ml_pipeline_sink */
-  ml_pipeline_element *element;
-  guint32 id;
+typedef struct {
   ml_pipeline_sink_cb cb;
   void *pdata;
-} ml_pipeline_sink;
+} callback_info_s;
 
 /**
  * @brief Internal private representation of common element handle (All GstElement except AppSink and TensorSink)
@@ -213,6 +210,7 @@ typedef struct _ml_pipeline_common_elem {
   ml_pipeline *pipe;
   ml_pipeline_element *element;
   guint32 id;
+  callback_info_s *callback_info;   /** < Callback function information, If element is not GstTensorSink or GstAppSink, then it should be NULL */
 } ml_pipeline_common_elem;
 
 /**


### PR DESCRIPTION
If the handle of sink-type element (i.e. tensor_sink and app_sink) is fetched by calling both `ml_pipeline_element_get_handle()` and `ml_pipeline_sink_register()` functions, segmantation fault occurs because of abnormal accessing for callback function. This PR adds this case and fixes this bug

It contains the following patches.
* Bugfix for abnormal accessing of the callback function
* Add test case for abnormal accessing of callback function

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped


### Submit history
#### Submit v2
* Use `g_list_free_full()` and `GDestroyNotify` instead of iteration of GList.
#### Submit v1
* First draft