### PR TITLE
[Api/Single] default no timeout when invoking model

### DIFF
--- a/api/android/api/src/main/java/org/nnsuite/nnstreamer/SingleShot.java
+++ b/api/android/api/src/main/java/org/nnsuite/nnstreamer/SingleShot.java
@@ -142,7 +142,7 @@ public final class SingleShot implements AutoCloseable {
      * input data frames of an instance of a model should share the same dimension.
      * To change the input information, you should call {@link #setInputInfo(TensorsInfo)} before calling invoke method.
      *
-     * Note that this has a default timeout of 3 seconds.
+     * Note that this will wait for the result until the invoke process is done.
      * If an application wants to change the time to wait for an output,
      * set the timeout using {@link #setTimeout(int)}.
      *

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -90,7 +90,7 @@ int ml_single_close (ml_single_h single);
  * @brief Invokes the model with the given input data.
  * @details Even if the model has flexible input data dimensions,
  *          input data frames of an instance of a model should share the same dimension.
- *          Note that this has a default timeout of 3 seconds. If an application wants to change the time to wait for an output, set the timeout using ml_single_set_timeout().
+ *          Note that this will wait for the result until the invoke process is done. If an application wants to change the time to wait for an output, set the timeout using ml_single_set_timeout().
  * @since_tizen 5.5
  * @param[in] single The model handle to be inferred.
  * @param[in] input The input data to be inferred.
@@ -109,7 +109,7 @@ int ml_single_invoke (ml_single_h single, const ml_tensors_data_h input, ml_tens
  * @brief Invokes the model with the given input data with the given tensors information.
  * @details This function changes the input tensors information for the model, and returns the corresponding output data.
  *          A model/framework may not support changing the information.
- *          Note that this has a default timeout of 3 seconds. If an application wants to change the time to wait for an output, set the timeout using ml_single_set_timeout().
+ *          Note that this will wait for the result until the invoke process is done. If an application wants to change the time to wait for an output, set the timeout using ml_single_set_timeout().
  * @since_tizen 6.0
  * @param[in] single The model handle to be inferred.
  * @param[in] input The input data to be inferred.

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -31,9 +31,9 @@
 #define ML_SINGLE_MAGIC 0xfeedfeed
 
 /**
- * @brief Default time to wait for an output (3 seconds).
+ * @brief Default time to wait for an output in milliseconds (0 will wait for the output).
  */
-#define SINGLE_DEFAULT_TIMEOUT 3000
+#define SINGLE_DEFAULT_TIMEOUT 0
 
 /**
  * @brief Global lock for single shot API
@@ -839,27 +839,38 @@ ml_single_invoke (ml_single_h single,
   single_h->state = RUNNING;
   single_h->ignore_output = FALSE;
 
-  end_time = g_get_monotonic_time () +
-      single_h->timeout * G_TIME_SPAN_MILLISECOND;
-
   g_cond_broadcast (&single_h->cond);
-  if (g_cond_wait_until (&single_h->cond, &single_h->mutex, end_time)) {
-    status = single_h->status;
-  } else {
-    ml_logw ("Wait for invoke has timed out");
-    status = ML_ERROR_TIMED_OUT;
-    /** This is set to notify invoke_thread to not process if timedout */
-    single_h->ignore_output = TRUE;
 
-    /** Free if any output memory was allocated */
-    if (*single_h->output != NULL) {
-      ml_tensors_data_destroy ((ml_tensors_data_h) * single_h->output);
-      *single_h->output = NULL;
+  if (single_h->timeout > 0) {
+    /* set timeout */
+    end_time = g_get_monotonic_time () +
+        single_h->timeout * G_TIME_SPAN_MILLISECOND;
+
+    if (g_cond_wait_until (&single_h->cond, &single_h->mutex, end_time)) {
+      status = single_h->status;
+    } else {
+      ml_logw ("Wait for invoke has timed out");
+      status = ML_ERROR_TIMED_OUT;
+      /** This is set to notify invoke_thread to not process if timedout */
+      single_h->ignore_output = TRUE;
+
+      /** Free if any output memory was allocated */
+      if (*single_h->output != NULL) {
+        ml_tensors_data_destroy ((ml_tensors_data_h) *single_h->output);
+        *single_h->output = NULL;
+      }
     }
+  } else {
+    /** @todo calling klass->invoke() may suspend current thread */
+    g_cond_wait (&single_h->cond, &single_h->mutex);
+    status = single_h->status;
   }
 
 exit:
   ML_SINGLE_HANDLE_UNLOCK (single_h);
+
+  if (status != ML_ERROR_NONE)
+    ml_loge ("Failed to invoke the model.");
   return status;
 }
 


### PR DESCRIPTION
If user does not set the timeout, single-invoke function will wait for the output till the invoke is done.
This requires another ACR.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
