### PR TITLE
[C-API] add the EOS push at the destroy moment

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -88,6 +88,8 @@ typedef enum { MM_RESOURCE_MANAGER_RES_TYPE_MAX } mm_resource_manager_res_type_e
 #define TIZEN5PLUS 0
 #endif  /* __TIZEN__ */
 
+#define EOS_MESSAGE_TIME_LIMIT 100
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -205,6 +207,7 @@ struct _ml_pipeline {
   GstBus *bus;            /**< The bus of the pipeline */
   gulong signal_msg;      /**< The message signal (connected to bus) */
   GMutex lock;            /**< Lock for pipeline operations */
+  gboolean isEOS;         /**< The pipeline is EOS state */
   GHashTable *namednodes; /**< hash table of "element"s. */
   GHashTable *resources;  /**< hash table of resources to construct the pipeline */
   pipeline_state_cb_s state_cb; /**< Callback to notify the change of pipeline state */


### PR DESCRIPTION
for the specific situation, tensor_mux(refresh), the EOS buffer has to be inserted to make the pipeline state as NULL

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped