### PR TITLE
C-API/ml_pipeline_src_input_data new enum for events suggstion.

### DIFF
--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -190,6 +190,7 @@ typedef enum {
   ML_PIPELINE_BUF_POLICY_AUTO_FREE      = 0, /**< Default. Application should not deallocate this buffer. NNStreamer will deallocate when the buffer is no more needed. */
   ML_PIPELINE_BUF_POLICY_DO_NOT_FREE    = 1, /**< This buffer is not to be freed by NNStreamer (i.e., it's a static object). However, be careful: NNStreamer might be accessing this object after the return of the API call. */
   ML_PIPELINE_BUF_POLICY_MAX,   /**< Max size of #ml_pipeline_buf_policy_e structure. */
+  ML_PIPELINE_BUF_SRC_EVENT_EOS         = 0x10000, /**< Trigger End-Of-Stream event for the corresponding appsrc and ignore the given input value. The correspnding appsrc will no longer accept new data after this. */
 } ml_pipeline_buf_policy_e;
 
 /**
@@ -417,7 +418,7 @@ int ml_pipeline_src_release_handle (ml_pipeline_src_h src_handle);
  * @param[in] src_handle The source handle returned by ml_pipeline_src_get_handle().
  * @param[in] data The handle of input tensors, in the format of tensors info given by ml_pipeline_src_get_tensors_info().
  *                 This function takes ownership of the data if @a policy is #ML_PIPELINE_BUF_POLICY_AUTO_FREE.
- * @param[in] policy The policy of buffer deallocation.
+ * @param[in] policy The policy of buffer deallocation. The policy value may include buffer deallocation mechanisms or event triggers for appsrc elements. If event triggers are provided, these functions will not give input data to the appsrc element, but will trigger the given event only.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_NOT_SUPPORTED Not supported.


### PR DESCRIPTION
In order to give events to appsrc via ml_pipeline_src_input_data,
I'd like to suggest to use "policy" argument to keep "data"
uncomplicated.

We can simply add non-policy enum values to have general
event support; if you need some value for an event, you can
keep using "data".

#2557 can coexist with this as a safety fall-back. (in case the user didn't call EOS before closing the pipeline.)
We just need to check if it is ok to call EOS twice for an appsrc.

Note that the implementation is not there and someone (@helloahn ?) needs to implement the function body: @helloahn 
We may need ACR as well: @again4you 

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
