### PR TITLE
Test/CAPI: Type mismatch warning

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -5638,7 +5638,7 @@ TEST (nnstreamer_capi_element, set_property_04_n)
     "sync-mode", &ret_sync_mode, NULL);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (ret_buffer_status, TRUE);
-  EXPECT_EQ (ret_sync_mode, 1);
+  EXPECT_EQ (ret_sync_mode, 1U);
 
   status = ml_pipeline_element_release_handle (selector_h);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -5780,7 +5780,7 @@ TEST (nnstreamer_capi_element, get_property_01_p)
     "sync-mode", &ret_sync_mode, NULL);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (ret_buffer_status, TRUE);
-  EXPECT_EQ (ret_sync_mode, 1);
+  EXPECT_EQ (ret_sync_mode, 1U);
 
   /* Set "drop" property as FALSE */
   status = ml_pipeline_element_set_property(valve_h, "drop", FALSE, NULL);


### PR DESCRIPTION
ret_sync_mode is unsigned.
If it is compiled with more strict compilers,
it emits errors. Fix it by adding U.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

