### PR TITLE
Debian: add flatbuf/protobuf packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -91,6 +91,20 @@ Depends: nnstreamer, openvino, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer OpenVino support
  This package allows nnstreamer to support OpenVino.
 
+Package: nnstreamer-protobuf
+Architecture: any
+MUlti-Arch: same
+Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer Protobuf converter/decoder support
+ This package allows to pack/unpack tensor streams to/from protobuf.
+
+Package: nnstreamer-flatbuf
+Architecture: any
+MUlti-Arch: same
+Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer Flatbuf converter/decoder support
+ This package allows to pack/unpack tensor streams to/from flatbuf.
+
 Package: nnstreamer-dev
 Architecture: any
 Multi-Arch: same

--- a/debian/nnstreamer-flatbuf.install
+++ b/debian/nnstreamer-flatbuf.install
@@ -1,0 +1,3 @@
+/usr/lib/nnstreamer/converters/libnnstreamer_converter_flatbuf.so
+/usr/lib/nnstreamer/decoders/libnnstreamer_decoder_flatbuf.so
+/usr/lib/*/libnnstreamer_protobuf.so

--- a/debian/nnstreamer-protobuf.install
+++ b/debian/nnstreamer-protobuf.install
@@ -1,0 +1,2 @@
+/usr/lib/nnstreamer/converters/libnnstreamer_converter_protobuf.so
+/usr/lib/nnstreamer/decoders/libnnstreamer_decoder_protobuf.so


### PR DESCRIPTION
nnstreamer-flatbuf and
nnstreamer-protobuf will be available for Ubuntu/Debian.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

This resolves the final subitem of #1919 