### PR TITLE
[single] Enable setting timeout to 0

### DIFF
--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -943,7 +943,7 @@ ml_single_set_timeout (ml_single_h single, unsigned int timeout)
 
   check_feature_state ();
 
-  if (!single || timeout == 0)
+  if (!single)
     return ML_ERROR_INVALID_PARAMETER;
 
   ML_SINGLE_GET_VALID_HANDLE_LOCKED (single_h, single, 0);


### PR DESCRIPTION
Enable setting timeout to 0
timeout 0 now has significance and re-setting timeout to 0 should be allowed

Related issue: #2568

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>