### PR TITLE
[tizensensor] Add tolerance for sensor data check @open sesame 07/28 15:30

### DIFF
--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
@@ -1285,7 +1285,7 @@ gst_tensor_src_tizensensor_fill (GstBaseSrc * src, guint64 offset,
     /* 2-1. Find out the delay already occured */
     /* ts and event->timestamp are in microseconds */
     ts = g_get_monotonic_time ();
-    if (ts < event->timestamp) {
+    if ((ts + (((guint64) self->interval_ms) * 1000)) < event->timestamp) {
       GST_ERROR_OBJECT (self,
           "Timestamp of the Tizen sensor is from the future.");
       retval = GST_FLOW_ERROR;


### PR DESCRIPTION
Ease the future timestamp check:
- At the check time, the timestamp of event could be the "next" sample
- Add tolerance amount of sampling rate
- Change Error to Warning

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped