### PR TITLE
[unittest] Bug fix for c-api unittest

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -2342,12 +2342,13 @@ TEST (nnstreamer_capi_singleshot, invoke_01)
   status = ml_single_close (single);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
+  ml_tensors_info_destroy (in_res);
+  ml_tensors_info_destroy (out_res);
+
 skip_test:
   g_free (test_model);
   ml_tensors_info_destroy (in_info);
   ml_tensors_info_destroy (out_info);
-  ml_tensors_info_destroy (in_res);
-  ml_tensors_info_destroy (out_res);
 }
 
 /**


### PR DESCRIPTION
Bug fix for c-api unittest when tensorflow-lite is not present
Bug of destroy info without create in invoke_01

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>