### PR TITLE
[tflite] Optimization for the invoke critical path @open sesame 07/28 15:00

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -187,7 +187,6 @@ TFLiteInterpreter::invoke (const GstTensorMemory * input,
     GstTensorMemory * output, bool use_nnapi)
 {
   int64_t start_time, stop_time;
-  std::vector <int> tensors_idx;
   int tensor_idx;
   TfLiteTensor *tensor_ptr;
   TfLiteStatus status;
@@ -201,7 +200,6 @@ TFLiteInterpreter::invoke (const GstTensorMemory * input,
     if (tensor_ptr->bytes != output[i].size)
       size_mismatch = TRUE;
     tensor_ptr->data.raw = (char *) output[i].data;
-    tensors_idx.push_back (tensor_idx);
   }
 
   for (unsigned int i = 0; i < inputTensorMeta.num_tensors; ++i) {
@@ -211,7 +209,6 @@ TFLiteInterpreter::invoke (const GstTensorMemory * input,
     if (tensor_ptr->bytes != input[i].size)
       size_mismatch = TRUE;
     tensor_ptr->data.raw = (char *) input[i].data;
-    tensors_idx.push_back (tensor_idx);
   }
   stop_time = g_get_monotonic_time ();
   tflite_internal_stats.total_overhead_latency += stop_time - start_time;

--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
@@ -528,6 +528,7 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, reload_model)
   int ret;
   void *data = NULL;
   gchar **model_files;
+  GstTensorsInfo info;
   GstTensorMemory input, output;
 
   model_files = get_model_files ();
@@ -555,7 +556,20 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, reload_model)
     ret = sp->reloadModel (&prop, &data);
     EXPECT_EQ (ret, 0);
 
-    output.size = input.size = gst_tensor_get_element_size (_NNS_FLOAT32) * 10;
+    gst_tensors_info_init (&info);
+    ret = sp->getInputDimension (&prop, &data, &info);
+    EXPECT_EQ (ret, 0);
+
+    input.size = gst_tensor_info_get_size (&info.info[0]);
+    gst_tensors_info_free (&info);
+
+    gst_tensors_info_init (&info);
+    ret = sp->getOutputDimension (&prop, &data, &info);
+    EXPECT_EQ (ret, 0);
+
+    output.size = gst_tensor_info_get_size (&info.info[0]);
+    gst_tensors_info_free (&info);
+
     input.data = g_malloc(input.size);
     output.data = g_malloc(output.size);
 


### PR DESCRIPTION
Tflite invoke stores evaluates and stores indexes of input and output tensors which is not needed
Remove it from critical path

Minimize invoke critical path for tflite extension:
1. Cache input and output tensor ptrs out of the invoke to the location where extension
stores input and output tensors info
2. Verification of output size also moved out of invoke as the output tensor memory is
allocated internally by nnstreamer and its size is verified by each of the single API
and by tensor_filter.c for pipeline

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped