### PR TITLE
Fix Ubuntu CI Build Error @open sesame 7/28 13:31

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_protobuf.h
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.h
@@ -16,6 +16,7 @@
 #ifndef __NNS_PROTOBUF_UTIL_H__
 #define __NNS_PROTOBUF_UTIL_H__
 
+#include <gst/gst.h>
 #include <nnstreamer_plugin_api.h>
 
 /**

--- a/ext/nnstreamer/tensor_decoder/tensordec-protobuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-protobuf.cc
@@ -15,7 +15,7 @@
  */
 
 #include <glib.h>
-#include <gst/gstinfo.h>
+#include <gst/gst.h>
 #include <tensor_typedef.h>
 #include <nnstreamer_plugin_api_decoder.h>
 #include <nnstreamer_plugin_api.h>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -65,6 +65,7 @@
 
 #include <vector>
 #include <map>
+#include <string>
 
 /**
  * @brief Macro for debug mode.


### PR DESCRIPTION
Having header inclusion with incorrect orders
may incur errors with older gcc of older Ubuntu distro.

You shouldn't omit headers only because they may be included
indirectly by other headers.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
