### PR TITLE
[filter/single] Optimize invoke path for tensor filter single

### DIFF
--- a/api/capi/include/tensor_filter_single.h
+++ b/api/capi/include/tensor_filter_single.h
@@ -51,7 +51,8 @@ typedef struct _GTensorFilterSingleClass GTensorFilterSingleClass;
  */
 struct _GTensorFilterSingle
 {
-  GObject element;     /**< This is the parent object */
+  GObject element;          /**< This is the parent object */
+  gboolean allocate_in_invoke;  /**< cached value after first invoke */
 
   GstTensorFilterPrivate priv; /**< Internal properties for tensor-filter */
 };

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -1885,6 +1885,7 @@ gst_tensor_filter_common_close_fw (GstTensorFilterPrivate * priv)
     priv->prop.fwname = NULL;
     priv->fw = NULL;
     priv->privateData = NULL;
+    priv->configured = FALSE;
   }
 }
 


### PR DESCRIPTION
Tensor filter single performs various check on invoke
However, these checks are done on properties which remain static after open and first invoke
So, these checks are now performed on the first invoke only
Further, some checks were being performed multiple times, which have now been removed.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>