### PR TITLE
[single] Reduce wrapper memcopy for invoke

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -335,6 +335,18 @@ void ml_tensors_info_copy_from_ml (GstTensorsInfo *gst_info, const ml_tensors_in
 int ml_tensors_data_create_no_alloc (const ml_tensors_info_h info, ml_tensors_data_h *data);
 
 /**
+ * @brief Creates a tensor data frame without allocating new buffer cloning the given tensors data.
+ * @details If @a data_src is null, this returns error.
+ * @param[in] data_src The handle of tensors data to be cloned.
+ * @param[out] data The handle of tensors data.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ * @retval #ML_ERROR_OUT_OF_MEMORY Failed to allocate required memory.
+ */
+int ml_tensors_data_clone_no_alloc (const ml_tensors_data_s * data_src, ml_tensors_data_h * data);
+
+/**
  * @brief Initializes the GStreamer library. This is internal function.
  */
 int ml_initialize_gstreamer (void);

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -601,6 +601,38 @@ ml_tensors_data_create_no_alloc (const ml_tensors_info_h info,
 }
 
 /**
+ * @brief Clones the given tensor data frame from the given tensors data. (more info in nnstreamer.h)
+ * @note Memory ptr for data buffer is copied. No new memory for data buffer is allocated.
+ */
+int
+ml_tensors_data_clone_no_alloc (const ml_tensors_data_s * data_src,
+    ml_tensors_data_h * data)
+{
+  ml_tensors_data_s *_data;
+
+  check_feature_state ();
+
+  if (data == NULL || data_src == NULL)
+    return ML_ERROR_INVALID_PARAMETER;
+
+  /* init null */
+  *data = NULL;
+
+  _data = g_try_new0 (ml_tensors_data_s, 1);
+  if (!_data) {
+    ml_loge ("Failed to allocate the tensors data handle.");
+    return ML_ERROR_OUT_OF_MEMORY;
+  }
+
+  _data->num_tensors = data_src->num_tensors;
+  memcpy(_data->tensors, data_src->tensors,
+      sizeof (ml_tensor_data_s) * data_src->num_tensors);
+
+  *data = _data;
+  return ML_ERROR_NONE;
+}
+
+/**
  * @brief Allocates a tensor data frame with the given tensors info. (more info in nnstreamer.h)
  */
 int


### PR DESCRIPTION
Reduced wrapper memcopy for invoke by typecasting ml_tensors_data_s->tensors to GstTensorMemory *
This reduces invoke latency

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>