### PR TITLE
[Android] params to init nnstreamer

### DIFF
--- a/api/android/api/src/main/jni/nnstreamer-native-api.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-api.c
@@ -682,13 +682,22 @@ nnstreamer_native_initialize (JNIEnv * env, jobject context)
 
   G_LOCK (nns_native_lock);
 
-  if (!gst_is_initialized ())
-    gst_android_init (env, context);
+#if !defined (NNS_SINGLE_ONLY)
+  /* single-shot does not require gstreamer */
+  if (!gst_is_initialized ()) {
+    if (env && context) {
+      gst_android_init (env, context);
+    } else {
+      nns_loge ("Invalid params, cannot initialize GStreamer.");
+      goto done;
+    }
+  }
 
   if (!gst_is_initialized ()) {
     nns_loge ("GStreamer is not initialized.");
     goto done;
   }
+#endif
 
   if (nns_is_initilaized == FALSE) {
     /* register nnstreamer plugins */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
@@ -449,6 +449,9 @@ static gboolean _snpe_set_env (JNIEnv * env, jobject context)
   const gchar *native_library_dir_path_str;
   gchar *new_path;
 
+  g_return_val_if_fail (env != NULL, FALSE);
+  g_return_val_if_fail (context != NULL, FALSE);
+
   context_class = env->GetObjectClass (context);
   if (!context_class) {
     nns_loge ("Failed to get context class.");


### PR DESCRIPTION
Add condition to check params when initializing nnstreamer.
Also, single-shot does not need gstreamer initialization. Add feature for this.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
