### PR TITLE
[C-API] Allocate memory at once for tensor in tensors

### DIFF
--- a/api/capi/include/tensor_filter_single.h
+++ b/api/capi/include/tensor_filter_single.h
@@ -52,6 +52,8 @@ typedef struct _GTensorFilterSingleClass GTensorFilterSingleClass;
 struct _GTensorFilterSingle
 {
   GObject element;     /**< This is the parent object */
+  size_t total_output_size;     /**< Total size of the output tensor data */
+  size_t output_offset[NNS_TENSOR_SIZE_LIMIT];  /**< Offset of each output from base memory */
 
   GstTensorFilterPrivate priv; /**< Internal properties for tensor-filter */
 };

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -4806,6 +4806,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_02)
   in_dim[2] = 1;
   in_dim[3] = 1;
   ml_tensors_info_set_count (in_info, 1);
+  ml_tensors_info_set_tensor_name (in_info, 0, "input");
   ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_FLOAT32);
   ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
 
@@ -4814,6 +4815,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_02)
   out_dim[2] = 1;
   out_dim[3] = 1;
   ml_tensors_info_set_count (out_info, 1);
+  ml_tensors_info_set_tensor_name (out_info, 0, "output");
   ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);
   ml_tensors_info_set_tensor_dimension (out_info, 0, out_dim);
 


### PR DESCRIPTION
This patch changes the semantics of memory allocation for tensor data.
Tensor data is now allocated for all the tensor in tensors.
This reduces the multiple calls to malloc/free to 1, thus reducing the latency.
The final location of the memory in the tensor data is set with the offset.
This updates the memory allocated ml_tensors_data_create() and memory allocated
internally in single API tensor filter.
Correspondongly ml_tensors_data_destroy is also correspondingly update.

Note that this does not update the memory allocation by the pipeline API elements.
The tensor filter in the pipeline API retains its original behavior.

This patch exposes 2 bugs :

1. Memory allocated by the tensor filters inside them (which support allocate_in_invoke)
is not freed appropriately. When using the single API, this memory is wrapped with ml_tensors_data
and freed wtih ml_tensors_data_destroy. However, these memories allocated by the tensor filter itself
must be destroyed with destroyer of the tensor filter extension (issue #2593).
This will be fixed in a different patch.

2. Single API sets the input/output tensors info provided by the user.
However, it sets all the info with empty string which is might not be even provided.
tensor_filter set_property() ignores empty properties for most of the times.
However it updates the number of tensors even with empty properties (issue #2594).
The failing unittest (nnstreamer_capi_singleshot.set_input_info_success_02) has been
fixed for now. A proper fix to the internals will be done in a different patch.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>