### PR TITLE
[C-API] int32/uint32 get/set functions support enum type.

### DIFF
--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -715,7 +715,6 @@ int ml_pipeline_element_set_property_int32 (ml_pipeline_element_h elem_h, const 
 /**
  * @brief Sets the integer 64bit value of element's property in NNStreamer pipelines.
  * @since_tizen 6.0
- * @remarks This function supports both Integer64 and Long.
  * @param[in] elem_h The target element handle.
  * @param[in] property_name The name of the property.
  * @param[in] value The integer value to be set.
@@ -741,7 +740,6 @@ int ml_pipeline_element_set_property_uint32 (ml_pipeline_element_h elem_h, const
 /**
  * @brief Sets the unsigned integer 64bit value of element's property in NNStreamer pipelines.
  * @since_tizen 6.0
- * @remarks This function supports both Unsigned Integer64 and Unsigned Long.
  * @param[in] elem_h The target element handle.
  * @param[in] property_name The name of the property.
  * @param[in] value The unsigned integer 64bit value to be set.
@@ -822,7 +820,6 @@ int ml_pipeline_element_get_property_int32 (ml_pipeline_element_h elem_h, const 
 /**
  * @brief Gets the integer 64bit value of element's property in NNStreamer pipelines.
  * @since_tizen 6.0
- * @remarks This function supports both Integer64 and Long.
  * @param[in] elem_h The target element handle.
  * @param[in] property_name The name of the property.
  * @param[out] value The integer 64bit value of given property.
@@ -832,7 +829,6 @@ int ml_pipeline_element_get_property_int32 (ml_pipeline_element_h elem_h, const 
  * @retval #ML_ERROR_INVALID_PARAMETER Given property name does not exist or the third parameter is NULL.
  */
 int ml_pipeline_element_get_property_int64 (ml_pipeline_element_h elem_h, const char *property_name, int64_t *value);
-
 
 /**
  * @brief Gets the unsigned integer value of element's property in NNStreamer pipelines.
@@ -850,7 +846,6 @@ int ml_pipeline_element_get_property_uint32 (ml_pipeline_element_h elem_h, const
 /**
  * @brief Gets the unsigned integer 64bit value of element's property in NNStreamer pipelines.
  * @since_tizen 6.0
- * @remarks This function supports both Unsigned Integer64 and Unsigned Long.
  * @param[in] elem_h The target element handle.
  * @param[in] property_name The name of the property.
  * @param[out] value The unsigned integer 64bit value of given property.

--- a/api/capi/src/nnstreamer-capi-pipeline.c
+++ b/api/capi/src/nnstreamer-capi-pipeline.c
@@ -1701,6 +1701,8 @@ ml_pipeline_element_check_property (GObjectClass *class, const char *property_na
     (type == G_TYPE_ENUM && G_TYPE_IS_ENUM (pspec->value_type)) ||
     (type == G_TYPE_INT64 && pspec->value_type == G_TYPE_LONG) ||
     (type == G_TYPE_UINT64 && pspec->value_type == G_TYPE_ULONG) ||
+    (type == G_TYPE_INT && G_TYPE_IS_ENUM (pspec->value_type)) ||
+    (type == G_TYPE_UINT && G_TYPE_IS_ENUM (pspec->value_type)) ||
     (type == G_TYPE_DOUBLE && pspec->value_type == G_TYPE_FLOAT))) {
     ml_loge ("The type of property name [%s] is '%s'", property_name, g_type_name(pspec->value_type));
     return FALSE;

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -6609,6 +6609,12 @@ TEST (nnstreamer_capi_element, set_property_enum_32_p)
   status = ml_pipeline_element_set_property_enum (vscale_h, "method", 5U);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
+  status = ml_pipeline_element_set_property_int32 (vscale_h, "method", 4);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_uint32 (vscale_h, "method", 2U);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
   status = ml_pipeline_element_release_handle (vscale_h);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
@@ -6646,7 +6652,7 @@ TEST (nnstreamer_capi_element, set_property_enum_33_n)
   status = ml_pipeline_element_set_property_enum (vscale_h, "WRONG_NAME", 3U);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_element_set_property_uint32 (vscale_h, "method", 3U);
+  status = ml_pipeline_element_set_property_double (vscale_h, "method", 3.0);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vscale_h);
@@ -6668,6 +6674,7 @@ TEST (nnstreamer_capi_element, get_property_enum_34_p)
   ml_pipeline_element_h vscale_h = nullptr;
   int status;
   uint32_t ret_method;
+  int32_t ret_signed_method;
   gchar *pipeline;
 
   pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
@@ -6695,6 +6702,20 @@ TEST (nnstreamer_capi_element, get_property_enum_34_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (ret_method, 5U);
 
+  status = ml_pipeline_element_set_property_uint32 (vscale_h, "method", 2U);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_property_uint32 (vscale_h, "method", &ret_method);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (ret_method, 2U);
+
+  status = ml_pipeline_element_set_property_int32 (vscale_h, "method", 4);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_property_int32 (vscale_h, "method", &ret_signed_method);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (ret_signed_method, 4);
+
   status = ml_pipeline_element_release_handle (vscale_h);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
@@ -6714,7 +6735,7 @@ TEST (nnstreamer_capi_element, get_property_enum_35_n)
   ml_pipeline_element_h vscale_h = nullptr;
   int status;
   uint32_t ret_method;
-  uint32_t wrong_type;
+  double wrong_type;
   gchar *pipeline;
 
   pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
@@ -6737,7 +6758,7 @@ TEST (nnstreamer_capi_element, get_property_enum_35_n)
   status = ml_pipeline_element_get_property_enum (vscale_h, "WRONG_NAME", &ret_method);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_element_get_property_uint32 (vscale_h, "method", &wrong_type);
+  status = ml_pipeline_element_get_property_double (vscale_h, "method", &wrong_type);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vscale_h);

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -6475,11 +6475,14 @@ TEST (nnstreamer_capi_element, set_property_double_29_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_set_property_double (vscale_h, "sharpness", 0.72);
-  EXPECT_EQ (status, ML_ERROR_NONE);
+  status = ml_pipeline_element_set_property_double (nullptr, "sharpness", 0.72);
+  EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_element_set_property_double (vscale_h, "sharpness", 1.43);
-  EXPECT_EQ (status, ML_ERROR_NONE);
+  status = ml_pipeline_element_set_property_double (vscale_h, "WRONG_NAME", 1.43);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_int32 (vscale_h, "sharpness", 10);
+  EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vscale_h);
   EXPECT_EQ (status, ML_ERROR_NONE);


### PR DESCRIPTION
This patch makes int32/uint32 element-wise getter/setter functions
support Enumeration type. It is much natural and easy to use for
developers. I also add related test cases.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped


### Submit history

#### Submit v2
* Remove remark section related with long and enum type.
* Update the negative test case of element-wise control function.

#### Submit v1
* First draft