### PR TITLE
[C-API] Use typedef enum for feature_state

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -36,6 +36,13 @@
 #if defined (__TIZEN__)
 #include "nnstreamer-tizen-internal.h"
 
+typedef enum
+{
+  NOT_CHECKED_YET = -1,
+  NOT_SUPPORTED = 0,
+  SUPPORTED = 1
+} feature_state_t;
+
 #if defined (__FEATURE_CHECK_SUPPORT__)
 #define check_feature_state() \
   do { \

--- a/api/capi/src/nnstreamer-capi-tizen-feature-check.c
+++ b/api/capi/src/nnstreamer-capi-tizen-feature-check.c
@@ -42,7 +42,7 @@
 typedef struct
 {
   GMutex mutex;
-  int feature_state;
+  feature_state_t feature_state;
 } feature_info_s;
 
 static feature_info_s *feature_info = NULL;
@@ -58,7 +58,7 @@ ml_tizen_initialize_feature_state (void)
     g_assert (feature_info);
 
     g_mutex_init (&feature_info->mutex);
-    feature_info->feature_state = -1;
+    feature_info->feature_state = NOT_CHECKED_YET;
   }
 }
 
@@ -96,21 +96,21 @@ ml_tizen_get_feature_enabled (void)
   feature_enabled = feature_info->feature_state;
   g_mutex_unlock (&feature_info->mutex);
 
-  if (0 == feature_enabled) {
+  if (NOT_SUPPORTED == feature_enabled) {
     ml_loge ("machine_learning.inference NOT supported");
     return ML_ERROR_NOT_SUPPORTED;
-  } else if (-1 == feature_enabled) {
+  } else if (NOT_CHECKED_YET == feature_enabled) {
     bool ml_inf_supported = false;
     ret =
         system_info_get_platform_bool (ML_INF_FEATURE_PATH, &ml_inf_supported);
     if (0 == ret) {
       if (false == ml_inf_supported) {
         ml_loge ("machine_learning.inference NOT supported");
-        ml_tizen_set_feature_state (0);
+        ml_tizen_set_feature_state (NOT_SUPPORTED);
         return ML_ERROR_NOT_SUPPORTED;
       }
 
-      ml_tizen_set_feature_state (1);
+      ml_tizen_set_feature_state (SUPPORTED);
     } else {
       switch (ret) {
         case SYSTEM_INFO_ERROR_INVALID_PARAMETER:

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -7369,7 +7369,7 @@ main (int argc, char **argv)
   }
 
   /* ignore tizen feature status while running the testcases */
-  set_feature_state (1);
+  set_feature_state (SUPPORTED);
 
   try {
     result = RUN_ALL_TESTS ();
@@ -7377,7 +7377,7 @@ main (int argc, char **argv)
     g_warning ("catch `testing::internal::GoogleTestFailureException`");
   }
 
-  set_feature_state (-1);
+  set_feature_state (NOT_CHECKED_YET);
 
   return result;
 }

--- a/tests/tizen_capi/unittest_tizen_sensor.cc
+++ b/tests/tizen_capi/unittest_tizen_sensor.cc
@@ -517,7 +517,7 @@ int main (int argc, char **argv)
   }
 
   /* ignore tizen feature status while running the testcases */
-  set_feature_state (1);
+  set_feature_state (SUPPORTED);
 
   gst_init (&argc, &argv);
   try {
@@ -526,7 +526,7 @@ int main (int argc, char **argv)
     g_warning ("catch `testing::internal::GoogleTestFailureException`");
   }
 
-  set_feature_state (-1);
+  set_feature_state (NOT_CHECKED_YET);
 
   return result;
 }

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -1338,14 +1338,14 @@ main (int argc, char **argv)
     g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
   }
   /* ignore tizen feature status while running the testcases */
-  set_feature_state (1);
+  set_feature_state (SUPPORTED);
 
   try {
     result = RUN_ALL_TESTS ();
   } catch (...) {
     g_warning ("catch `testing::internal::GoogleTestFailureException`");
   }
-  set_feature_state (-1);
+  set_feature_state (NOT_CHECKED_YET);
 
   return result;
 }


### PR DESCRIPTION
For readability, use typedef enum.
Resolves: https://github.com/nnstreamer/nnstreamer/issues/2574

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


