### PR TITLE
[Android/NNFW] change nnfw version

### DIFF
--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -64,7 +64,7 @@ enable_tflite="yes"
 tf_lite_ver="1.13.1"
 
 # Set NNFW version (https://github.com/Samsung/ONE/releases)
-nnfw_ver="1.6.0"
+nnfw_ver="1.6.1"
 
 # Parse args
 for arg in "$@"; do


### PR DESCRIPTION
use nnfw 1.6.1 for android build and release.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
