### PR TITLE
Revert "[Android/NNFW] change nnfw version" / Emergency

### DIFF
--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -64,7 +64,7 @@ enable_tflite="yes"
 tf_lite_ver="1.13.1"
 
 # Set NNFW version (https://github.com/Samsung/ONE/releases)
-nnfw_ver="1.6.1"
+nnfw_ver="1.6.0"
 
 # Parse args
 for arg in "$@"; do


### PR DESCRIPTION
This reverts commit 5eefd5119550bbd19c351ecfb04bef1d589b72bd.

PM has decided to keep using 1.6.0 for this release.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
