### PR TITLE
[Android] mem ptr to byte-buffer

### DIFF
--- a/api/android/api/src/main/java/org/nnsuite/nnstreamer/TensorsData.java
+++ b/api/android/api/src/main/java/org/nnsuite/nnstreamer/TensorsData.java
@@ -105,25 +105,6 @@ public final class TensorsData implements AutoCloseable {
     /**
      * Adds a new tensor data.
      *
-     * @param data The byte array to be added
-     *
-     * @throws IllegalArgumentException if given data is invalid
-     * @throws IndexOutOfBoundsException when the maximum number of tensors in the list
-     */
-    private void addTensorData(@NonNull byte[] data) {
-        if (data == null) {
-            throw new IllegalArgumentException("Given data is null");
-        }
-
-        ByteBuffer buffer = allocateByteBuffer(data.length);
-        buffer.put(data);
-
-        addTensorData(buffer);
-    }
-
-    /**
-     * Adds a new tensor data.
-     *
      * @param data The tensor data to be added
      *
      * @throws IllegalArgumentException if given data is invalid
@@ -132,8 +113,12 @@ public final class TensorsData implements AutoCloseable {
     private void addTensorData(@NonNull ByteBuffer data) {
         int index = getTensorsCount();
 
-        checkByteBuffer(index, data);
+        if (data.isDirect() && data.order() != ByteOrder.nativeOrder()) {
+            /* From native function NewDirectByteBuffer(), we should change the byte order. */
+            data = data.order(ByteOrder.nativeOrder());
+        }
 
+        checkByteBuffer(index, data);
         mDataList.add(data);
     }
 

--- a/api/android/api/src/main/jni/nnstreamer-native-customfilter.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-customfilter.c
@@ -127,7 +127,7 @@ nns_customfilter_invoke (const ml_tensors_data_h in, ml_tensors_data_h out,
     goto done;
   }
 
-  if (!nns_parse_tensors_data (pipe_info, env, obj_out_data, &out, NULL)) {
+  if (!nns_parse_tensors_data (pipe_info, env, obj_out_data, TRUE, &out, NULL)) {
     nns_loge ("Failed to parse output data.");
     goto done;
   }

--- a/api/android/api/src/main/jni/nnstreamer-native-pipeline.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-pipeline.c
@@ -516,13 +516,13 @@ nns_native_pipe_input_data (JNIEnv * env, jobject thiz, jlong handle,
     goto done;
   }
 
-  if (!nns_parse_tensors_data (pipe_info, env, in, &in_data, NULL)) {
+  if (!nns_parse_tensors_data (pipe_info, env, in, FALSE, &in_data, NULL)) {
     nns_loge ("Failed to parse input data.");
     goto done;
   }
 
   status = ml_pipeline_src_input_data (src, in_data,
-      ML_PIPELINE_BUF_POLICY_AUTO_FREE);
+      ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
   if (status != ML_ERROR_NONE) {
     nns_loge ("Failed to input tensors data to source node %s.", element_name);
     goto done;
@@ -532,6 +532,8 @@ nns_native_pipe_input_data (JNIEnv * env, jobject thiz, jlong handle,
 
 done:
   (*env)->ReleaseStringUTFChars (env, name, element_name);
+  /* do not free input tensors (direct access from object) */
+  g_free (in_data);
   return res;
 }
 

--- a/api/android/api/src/main/jni/nnstreamer-native-singleshot.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-singleshot.c
@@ -225,7 +225,7 @@ nns_native_single_invoke (JNIEnv * env, jobject thiz, jlong handle, jobject in)
   single = pipe_info->pipeline_handle;
   in_data = out_data = NULL;
 
-  if (!nns_parse_tensors_data (pipe_info, env, in, &in_data, NULL)) {
+  if (!nns_parse_tensors_data (pipe_info, env, in, FALSE, &in_data, NULL)) {
     nns_loge ("Failed to parse input tensors data.");
     goto done;
   }
@@ -242,7 +242,8 @@ nns_native_single_invoke (JNIEnv * env, jobject thiz, jlong handle, jobject in)
   }
 
 done:
-  ml_tensors_data_destroy (in_data);
+  /* do not free input tensors (direct access from object) */
+  g_free (in_data);
   ml_tensors_data_destroy (out_data);
   return result;
 }

--- a/api/android/api/src/main/jni/nnstreamer-native.h
+++ b/api/android/api/src/main/jni/nnstreamer-native.h
@@ -208,7 +208,7 @@ nns_convert_tensors_data (pipeline_info_s * pipe_info, JNIEnv * env, ml_tensors_
  * @brief Parse tensors data from TensorsData object.
  */
 extern gboolean
-nns_parse_tensors_data (pipeline_info_s * pipe_info, JNIEnv * env, jobject obj_data, ml_tensors_data_h * data_h, ml_tensors_info_h * info_h);
+nns_parse_tensors_data (pipeline_info_s * pipe_info, JNIEnv * env, jobject obj_data, gboolean clone, ml_tensors_data_h * data_h, ml_tensors_info_h * info_h);
 
 /**
  * @brief Convert tensors info to TensorsInfo object.


### PR DESCRIPTION
In native code, we can get the mem ptr of byte-buffer.
Remove memcopy to convert tensors object and data struct in native.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
