### PR TITLE
[Android/AMC] start thread after the construction

### DIFF
--- a/ext/nnstreamer/android_source/gstamcsrc_looper.h
+++ b/ext/nnstreamer/android_source/gstamcsrc_looper.h
@@ -49,6 +49,7 @@ class Looper {
     Looper ();
 
     void loop (void);
+    void start (void);
     void exit (void);
     void post (gint cmd, void *data, bool flush);
     void add_msg (looper_message *new_msg, bool flush);


### PR DESCRIPTION
Fix exception case, start amcsrc-looper after calling the constructor.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
