### PR TITLE
[android] Set `extractNativeLibs` true to use snpe dsp/npu runtimes

### DIFF
--- a/api/android/api/src/main/AndroidManifest.xml
+++ b/api/android/api/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
+        android:extractNativeLibs="true"
         android:largeHeap="true" >
     </application>
 </manifest>


### PR DESCRIPTION
- For Android Gradle Plugin 3.6.0 or higher, the property is set to "false" by default,
- It makes snpe sub-plugin unable to use dsp/npu runtime, so set it to "true"

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
