### PR TITLE
[meson] Disable pytorch+caffe2 support for ubuntu <18.04

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -188,6 +188,20 @@ if not get_option('snpe-support').disabled()
   endif
 endif
 
+# Disable pytorch and caffe2 for ubuntu version less than 18.04
+pytorch_dep = dependency('', required: false)
+caffe2_dep = dependency('', required: false)
+if (not get_option('pytorch-support').disabled()) or (not get_option('caffe2-support').disabled())
+  os_name = run_command('sed', ['-n', '-e', '/\<NAME\>/ s/.*\= *//p', '/etc/os-release']).stdout()
+  os_version = run_command('sed', ['-n', '-e', '/VERSION_ID/ s/.*\= *//p', '/etc/os-release']).stdout()
+  if os_name.contains('Ubuntu') and os_version.version_compare('<16.04')
+    message('pytorch and caffe2 support is only for Ubuntu version 18.04 or higher')
+  else
+    pytorch_dep = declare_dependency()
+    caffe2_dep = declare_dependency()
+  endif
+endif
+
 # features registration to be controlled
 #
 # register feature as follows
@@ -212,10 +226,12 @@ features = {
   },
   'pytorch-support': {
     'target': 'pytorch',
+    'extra_deps': [ pytorch_dep ],
     'project_args': { 'ENABLE_PYTORCH': 1 }
   },
   'caffe2-support': {
     'target': 'caffe2',
+    'extra_deps': [ caffe2_dep ],
     'project_args': { 'ENABLE_CAFFE2': 1 }
   },
   'mvncsdk2-support': {


### PR DESCRIPTION
Disable support for pytorch and caffe2 filters for ubuntu version < 18.04
This is because pytorch and caffe2 are not independent of the protobuf version
they are compiled with.
With 18.04 ubuntu, 1.6.0 version of pytorch/caffe2 is compiled with protobuf version 3.12.3
However, with 16.04, 1.1.0 version of pytorch/caffe2 is compiled with protobuf version 3.6.1
(compiling 1.1.0 version of pytorch/caffe2 with protobuf version >3.6 fails)

So, for using pytorch/caffe2 on ubuntu 16.04, use old version (1.1.0) of pytorch/caffe2, and
build nnstreamer locally with protobuf version 3.6.1

See also #2411

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>