### PR TITLE
[TESTS] Fix no assertion test

### DIFF
--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -1039,33 +1039,6 @@ TEST (version_control , get_ver_01)
 }
 
 /**
- * @brief Test version control (negative)
- */
-TEST (version_control , get_ver_02_n)
-{
-  guint major, minor, micro;
-  guint m1, m2;
-  nnstreamer_version_fetch (&major, &minor, &micro);
-  nnstreamer_version_fetch (&m1, &m2, nullptr);
-  EXPECT_EQ (m1, major);
-  EXPECT_EQ (m2, minor);
-  nnstreamer_version_fetch (&m1, nullptr, &m2);
-  EXPECT_EQ (m1, major);
-  EXPECT_EQ (m2, micro);
-  nnstreamer_version_fetch (nullptr, &m1, &m2);
-  EXPECT_EQ (m1, minor);
-  EXPECT_EQ (m2, micro);
-}
-
-/**
- * @brief Test version control (negative)
- */
-TEST (version_control , get_ver_03_n)
-{
-  nnstreamer_version_fetch (nullptr, nullptr, nullptr);
-}
-
-/**
  * @brief Main function for unit test.
  */
 int

--- a/tests/nnstreamer_filter_openvino/unittest_openvino.cc
+++ b/tests/nnstreamer_filter_openvino/unittest_openvino.cc
@@ -1110,8 +1110,8 @@ TEST (tensor_filter_openvino, convertGstTensorMemoryToBlobPtr_0)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   std::string str_test_model;
-  gchar *test_model_xml;
-  gchar *test_model_bin;
+  gchar *test_model_xml = NULL;
+  gchar *test_model_bin = NULL;
 
   /* supposed to run test in build directory */
   if (root_path == NULL)
@@ -1121,10 +1121,13 @@ TEST (tensor_filter_openvino, convertGstTensorMemoryToBlobPtr_0)
       "models", str_test_model.assign (MODEL_BASE_NAME_MOBINET_V2)
       .append (TensorFilterOpenvino::extXml).c_str (),
       NULL);
+  EXPECT_EQ (g_file_test (test_model_xml, G_FILE_TEST_IS_REGULAR), TRUE);
+
   test_model_bin = g_build_filename (root_path, "tests", "test_models",
       "models", str_test_model.assign (MODEL_BASE_NAME_MOBINET_V2)
       .append (TensorFilterOpenvino::extBin).c_str (),
       NULL);
+  EXPECT_EQ (g_file_test (test_model_bin, G_FILE_TEST_IS_REGULAR), TRUE);
 
   TEST_BLOB (InferenceEngine::Precision::FP32, _NNS_FLOAT32);
   TEST_BLOB (InferenceEngine::Precision::U8, _NNS_UINT8);


### PR DESCRIPTION
1. The TCM(test case manager) cannot check properly the test which is defined as a macro.
   Add assert test for unittest_plugins.cc
2. Remove the version control test. It's not a proper negative test.
3. tensor_filter_custom_easy.in_code_func_01 is False-negative.
   The test case contains assert_* and expect_*, it is detected as no assertion TC.

Related issue: #2633 

Results:
![캡처](https://user-images.githubusercontent.com/56856496/90098351-00a4cf80-dd73-11ea-9db4-97f650fc90a0.PNG)

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped