### PR TITLE
NNStreamer-Check Utility

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -113,3 +113,11 @@ Description: NNStreamer development package
  Gstreamer plugins, "NNStreamer", provides access to neural network frameworks for media streams.
  This is development package for nnstreamer.
  If you want to develop Android applications with nnstreamer+gstreamer, you need the libnnstreamer.a from this package.
+
+Package: nnstreamer-util
+Architecture: any
+Multi-Arch: same
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer utility
+ Gstreamer plugins, "NNStreamer", provides access to neural network frameworks for media streams.
+ This is a configuration checker utility for nnstreamer.

--- a/debian/nnstreamer-util.install
+++ b/debian/nnstreamer-util.install
@@ -1,0 +1,1 @@
+/usr/bin/nnstreamer-check

--- a/debian/rules
+++ b/debian/rules
@@ -41,9 +41,11 @@ override_dh_auto_configure:
 	-Dinstall-example=true -Dtf-support=$(enable_tf) -Dtflite-support=enabled -Dpytorch-support=enabled -Dcaffe2-support=enabled \
 	-Dpython2-support=enabled -Dpython3-support=enabled -Denable-capi=true -Denable-edgetpu=true -Denable-tizen=false \
 	-Denable-openvino=true build
+	cd tools/development/confchk && meson --prefix=/usr build && cd ../../..
 
 override_dh_auto_build:
 	ninja -C build
+	cd tools/development/confchk && ninja -C build && cd ../../..
 
 override_dh_auto_test:
 	./packaging/run_unittests_binaries.sh ./tests
@@ -56,6 +58,7 @@ override_dh_link:
 
 override_dh_auto_install:
 	DESTDIR=$(CURDIR)/debian/tmp ninja -C build install
+	cd tools/development/confchk && DESTDIR=$(CURDIR)/debian/tmp ninja -C build install && cd ../../..
 
 override_dh_install:
 	dh_install --sourcedir=debian/tmp --list-missing

--- a/gst/nnstreamer/nnstreamer_conf.h
+++ b/gst/nnstreamer/nnstreamer_conf.h
@@ -163,5 +163,13 @@ nnsconf_get_custom_value_string (const gchar * group, const gchar * key);
 extern gboolean
 nnsconf_get_custom_value_bool (const gchar * group, const gchar * key, gboolean def);
 
+/**
+ * @brief NNStreamer configuration dump as string.
+ * @param[out] str Preallocated string for the output (dump).
+ * @param[in] size The size of given str.
+ */
+extern void
+nnsconf_dump (gchar * str, gulong size);
+
 G_END_DECLS
 #endif /* __GST_NNSTREAMER_CONF_H__ */

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -431,6 +431,11 @@ Requires:	nnstreamer = %{version}-%{release}
 Package containing various unittests of the nnstreamer.
 %endif
 
+%package util
+Summary:	NNStreamer developer utilities
+%description util
+NNStreamer developer utilities include nnstreamer configuration checker.
+
 ## Define build options ##
 %define enable_tizen -Denable-tizen=false
 %define enable_tizen_sensor -Denable-tizen-sensor=false
@@ -608,8 +613,17 @@ export NNSTREAMER_CONVERTERS=$(pwd)/build/ext/nnstreamer/tensor_converter
 
 python tools/development/count_test_cases.py build tests/summary.txt
 
+pushd tools/development/confchk
+    rm -rf build
+    meson --prefix=%{_prefix} build
+    ninja -C build
+popd
+
 %install
 DESTDIR=%{buildroot} ninja -C build %{?_smp_mflags} install
+pushd tools/development/confchk
+DESTDIR=%{buildroot} ninja -C build install
+popd
 
 pushd %{buildroot}%{_libdir}
 ln -sf %{gstlibdir}/libnnstreamer.so libnnstreamer.so
@@ -838,6 +852,9 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %license LICENSE
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_openvino.so
 %endif
+
+%files util
+%{_bindir}/nnstreamer-check
 
 %changelog
 * Thu Jun 04 2020 MyungJoo Ham <myungjoo.ham@samsung.com>

--- a/tools/development/confchk/confchk.c
+++ b/tools/development/confchk/confchk.c
@@ -1,0 +1,83 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * NNStreamer Configuration Checker Utility
+ * Copyright (C) 2020 MyungJoo Ham <myungjoo.ham@samsung.com>
+ */
+/**
+ * @file	confchk.c
+ * @date	13 Aug 2020
+ * @brief	NNStreamer configuration checker utility
+ * @see		http://github.com/nnstreamer/nnstreamer
+ * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ * This is a utility for nnstreamer developers.
+ * This shows the effective nnstreamer configurations.
+ *
+ * Internal mechanism:
+ *   Load up libnnstreamer.so with gstreamer
+ */
+#include <glib.h>
+#include <gst/gst.h>
+#include <dlfcn.h>
+
+#define STR_BOOL(x) ((x) ? "TRUE" : "FALSE")
+
+static int
+get_nnsconf_dump (const gchar * path)
+{
+  void *handle;
+  void (*nnsconf_dump) (gchar * str, gulong size);
+  gchar dump[8192];
+
+  handle = dlopen (path, RTLD_LAZY);
+  if (!handle) {
+    g_printerr ("Error opening %s: %s\n", path, dlerror ());
+    return -1;
+  }
+
+  nnsconf_dump = dlsym (handle, "nnsconf_dump");
+
+  if (!nnsconf_dump) {
+    g_printerr ("Error loading nnsconf_dump: %s\n", dlerror ());
+    dlclose (handle);
+    return -2;
+  }
+
+  nnsconf_dump (dump, 8192);
+
+  dlclose (handle);
+
+  g_print ("\n");
+  g_print ("NNStreamer configuration:\n");
+  g_print ("============================================================\n");
+  g_print ("%s\n", dump);
+  g_print ("============================================================\n");
+
+  return 0;
+}
+
+int
+main (int argc, char *argv[])
+{
+  GstPlugin *nnstreamer;
+
+  gst_init (&argc, &argv);
+
+  nnstreamer = gst_plugin_load_by_name ("nnstreamer");
+
+  if (!nnstreamer) {
+    g_printerr
+        ("Cannot load nnstreamer plugin. Please check if nnstreamer is installed and GST_PLUGIN_PATH is properly configured.\n");
+    return -1;
+  }
+
+  g_print ("NNStreamer version: %s\n", gst_plugin_get_version (nnstreamer));
+  g_print ("           loaded : %s\n",
+      STR_BOOL (gst_plugin_is_loaded (nnstreamer)));
+  g_print ("           path   : %s\n", gst_plugin_get_filename (nnstreamer));
+
+  get_nnsconf_dump (gst_plugin_get_filename (nnstreamer));
+
+  return 0;
+}

--- a/tools/development/confchk/meson.build
+++ b/tools/development/confchk/meson.build
@@ -1,0 +1,30 @@
+project('nnstreamer-check', 'c',
+  version: '1.0.0',
+  license: ['LGPL'],
+  meson_version: '>=0.50.0',
+  default_options: [
+    'werror=true',
+    'warning_level=1',
+    'c_std=gnu89',
+  ]
+)
+
+cc = meson.get_compiler('c')
+gst_api_verision = '1.0'
+glib_dep = dependency('glib-2.0')
+gst_dep = dependency('gstreamer-' + gst_api_verision)
+gst_base_dep = dependency('gstreamer-base-' + gst_api_verision)
+libdl_dep = cc.find_library('dl') # DL library
+
+nnstchk_deps = [
+  glib_dep,
+  gst_dep,
+  gst_base_dep,
+  libdl_dep,
+]
+
+nnstchk_exec = executable('nnstreamer-check',
+  'confchk.c',
+  dependencies: nnstchk_deps,
+  include_directories: ['../../../gst/nnstreamer', '../../../gst/nnstreamer/include'],
+)

--- a/tools/development/confchk/meson.build
+++ b/tools/development/confchk/meson.build
@@ -27,4 +27,6 @@ nnstchk_exec = executable('nnstreamer-check',
   'confchk.c',
   dependencies: nnstchk_deps,
   include_directories: ['../../../gst/nnstreamer', '../../../gst/nnstreamer/include'],
+  install: true,
+  install_dir: join_paths(get_option('prefix'), get_option('bindir')),
 )


### PR DESCRIPTION
Second commit (packaging):

    Dist/Tizen,Ubuntu: Add nnstreamer-util package
    
    Package nnstreamer-check at /usr/bin with "nnstreamer-util" package.
    Note that this does NOT require nnstreamer installation.
    If there is no nnstreamer detected, it will simply say that nnstreamer is not found.
    The utility, "nnstreamer-check", is supposed to search for nnstreamer installation with GStreamer infrastructure.
    
First commit (code):

    [Utility] NNStreamer-Check
    
    The new utility, "nnstreamer-check", shows
    NNStreamer configuration dump to stdout.
    This helps nnstreamer developers who suffer from
    installation paths and configuration paths.
    
    Fixes #2638
    
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


Example:
```bash
$ nnstreamer-check
NNStreamer version: 1.5.3
           loaded : TRUE
           path   : /source/AutoDrv/NNStreamer/build/gst/nnstreamer/libnnstreamer.so

** (nnstreamer-check:26399): WARNING **: 14:37:20.852: Failed to load the configuration, no config file found.

NNStreamer configuration:
============================================================
Configuration Loaded: TRUE
Configuration file path: <error> config file not loaded
    Candidates: envvar(NNSTREAMER_CONF): (null)
                build-config: etc/nnstreamer.ini
                hard-coded: /etc/nnstreamer.ini
[Common]
  Enable envvar: FALSE
  Enable sym-linked subplugins: FALSE
[Filter]
  Filter paths from .ini: (null)
             from envvar: <disabled>
         from hard-coded: /usr/lib/nnstreamer/filters/

============================================================

$
```

nnstreamer-check will have no dependency on nnstreamer so that it can be distributed independently.


Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
