### PR TITLE
[nnfw] Support INT64 for nnfw

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -327,6 +327,9 @@ nnfw_tensor_type_to_gst (const NNFW_TYPE nnfw_type, tensor_type * type)
     case NNFW_TYPE_TENSOR_INT32:
       *type = _NNS_INT32;
       break;
+    case NNFW_TYPE_TENSOR_INT64:
+      *type = _NNS_INT64;
+      break;
     case NNFW_TYPE_TENSOR_QUANT8_ASYMM:
       /** @todo: update this to NNFW_TYPE_TENSOR_UINT8 type once nnfw is updated */
       *type = _NNS_UINT8;
@@ -577,6 +580,9 @@ nnfw_tensor_type_from_gst (const tensor_type type, NNFW_TYPE * nnfw_type)
       break;
     case _NNS_INT32:
       *nnfw_type = NNFW_TYPE_TENSOR_INT32;
+      break;
+    case _NNS_INT64:
+      *nnfw_type = NNFW_TYPE_TENSOR_INT64;
       break;
     case _NNS_UINT8:
       /** @todo: update this to NNFW_TYPE_TENSOR_UINT8 type once nnfw is updated */


### PR DESCRIPTION
Some models use INT64 type

Change-Id: I1009cc7ac845c1dbb20fbed36fc68b08f98e81dc
Signed-off-by: Semun Lee <semun.lee@samsung.com>


**Changes proposed in this PR:**
- Added INT64 case to nnfw_tensor_type_to_gst()

Resolves: #2643 

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed []Skipped
2. Run test: [ *]Passed [ ]Failed []Skipped

**How to evaluate:**
1. See if ml_single_open() succeed with nnfw and models with INT64 output.

```

