### PR TITLE
[TESTS/CAPI] Seperate negative TC as single test case

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -8422,6 +8422,222 @@ TEST (nnstreamer_capi_custom, register_filter_01_p)
  */
 TEST (nnstreamer_capi_custom, register_filter_02_n)
 {
+  ml_custom_easy_filter_h custom;
+  ml_tensors_info_h in_info, out_info;
+  int status;
+  ml_tensor_dimension dim = { 2, 1, 1, 1 };
+
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
+
+
+  ml_tensors_info_set_count (in_info, 1);
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT8);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, dim);
+
+  ml_tensors_info_set_count (out_info, 1);
+  ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);
+  ml_tensors_info_set_tensor_dimension (out_info, 0, dim);
+
+  /* test code with null param */
+  status = ml_pipeline_custom_easy_filter_register (NULL,
+      in_info, out_info, test_custom_easy_cb, NULL, &custom);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
+}
+
+/**
+ * @brief Test for custom-easy registration.
+ * @detail Invalid params.
+ */
+TEST (nnstreamer_capi_custom, register_filter_03_n)
+{
+  const char test_custom_filter[] = "test-custom-filter";
+  ml_custom_easy_filter_h custom;
+  ml_tensors_info_h out_info;
+  int status;
+  ml_tensor_dimension dim = { 2, 1, 1, 1 };
+
+  ml_tensors_info_create (&out_info);
+
+  ml_tensors_info_set_count (out_info, 1);
+  ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);
+  ml_tensors_info_set_tensor_dimension (out_info, 0, dim);
+
+  /* test code with null param */
+  status = ml_pipeline_custom_easy_filter_register (test_custom_filter,
+      NULL, out_info, test_custom_easy_cb, NULL, &custom);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  ml_tensors_info_destroy (out_info);
+}
+
+/**
+ * @brief Test for custom-easy registration.
+ * @detail Invalid params.
+ */
+TEST (nnstreamer_capi_custom, register_filter_04_n)
+{
+  const char test_custom_filter[] = "test-custom-filter";
+  ml_custom_easy_filter_h custom;
+  ml_tensors_info_h in_info;
+  int status;
+  ml_tensor_dimension dim = { 2, 1, 1, 1 };
+
+  ml_tensors_info_create (&in_info);
+
+  ml_tensors_info_set_count (in_info, 1);
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT8);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, dim);
+
+  /* test code with null param */
+  status = ml_pipeline_custom_easy_filter_register (test_custom_filter,
+      in_info, NULL, test_custom_easy_cb, NULL, &custom);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  ml_tensors_info_destroy (in_info);
+}
+
+/**
+ * @brief Test for custom-easy registration.
+ * @detail Invalid params.
+ */
+TEST (nnstreamer_capi_custom, register_filter_05_n)
+{
+  const char test_custom_filter[] = "test-custom-filter";
+  ml_custom_easy_filter_h custom;
+  ml_tensors_info_h in_info, out_info;
+  int status;
+  ml_tensor_dimension dim = { 2, 1, 1, 1 };
+
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
+
+  ml_tensors_info_set_count (in_info, 1);
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT8);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, dim);
+
+  ml_tensors_info_set_count (out_info, 1);
+  ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);
+  ml_tensors_info_set_tensor_dimension (out_info, 0, dim);
+
+  /* test code with null param */
+  status = ml_pipeline_custom_easy_filter_register (test_custom_filter,
+      in_info, out_info, NULL, NULL, &custom);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
+}
+
+/**
+ * @brief Test for custom-easy registration.
+ * @detail Invalid params.
+ */
+TEST (nnstreamer_capi_custom, register_filter_06_n)
+{
+  const char test_custom_filter[] = "test-custom-filter";
+  ml_tensors_info_h in_info, out_info;
+  int status;
+  ml_tensor_dimension dim = { 2, 1, 1, 1 };
+
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
+
+  ml_tensors_info_set_count (in_info, 1);
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT8);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, dim);
+
+  ml_tensors_info_set_count (out_info, 1);
+  ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);
+  ml_tensors_info_set_tensor_dimension (out_info, 0, dim);
+
+  /* test code with null param */
+  status = ml_pipeline_custom_easy_filter_register (test_custom_filter,
+      in_info, out_info, test_custom_easy_cb, NULL, NULL);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
+}
+
+/**
+ * @brief Test for custom-easy registration.
+ * @detail Invalid params.
+ */
+TEST (nnstreamer_capi_custom, register_filter_07_n)
+{
+  int status;
+
+  /* test code with null param */
+  status = ml_pipeline_custom_easy_filter_unregister (NULL);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test for custom-easy registration.
+ * @detail Invalid params.
+ */
+TEST (nnstreamer_capi_custom, register_filter_08_n)
+{
+  const char test_custom_filter[] = "test-custom-filter";
+  ml_custom_easy_filter_h custom;
+  ml_tensors_info_h in_info, out_info;
+  ml_tensor_dimension dim = { 2, 1, 1, 1 };
+  int status;
+
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
+
+  /* test code with invalid output info */
+  ml_tensors_info_set_count (in_info, 1);
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT8);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, dim);
+
+  status = ml_pipeline_custom_easy_filter_register (test_custom_filter,
+      in_info, out_info, test_custom_easy_cb, NULL, &custom);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
+}
+
+/**
+ * @brief Test for custom-easy registration.
+ * @detail Invalid params.
+ */
+TEST (nnstreamer_capi_custom, register_filter_09_n)
+{
+  const char test_custom_filter[] = "test-custom-filter";
+  ml_custom_easy_filter_h custom;
+  ml_tensors_info_h in_info, out_info;
+  ml_tensor_dimension dim = { 2, 1, 1, 1 };
+  int status;
+
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
+
+  /* test code with invalid input info */
+  ml_tensors_info_set_count (out_info, 1);
+  ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);
+  ml_tensors_info_set_tensor_dimension (out_info, 0, dim);
+
+  status = ml_pipeline_custom_easy_filter_register (test_custom_filter,
+      in_info, out_info, test_custom_easy_cb, NULL, &custom);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
+}
+
+/**
+ * @brief Test for custom-easy registration.
+ * @detail Invalid params.
+ */
+TEST (nnstreamer_capi_custom, register_filter_10_n)
+{
   const char test_custom_filter[] = "test-custom-filter";
   ml_custom_easy_filter_h custom, custom2;
   ml_tensors_info_h in_info, out_info;
@@ -8431,43 +8647,9 @@ TEST (nnstreamer_capi_custom, register_filter_02_n)
   ml_tensors_info_create (&in_info);
   ml_tensors_info_create (&out_info);
 
-  /* test code with null param */
-  status = ml_pipeline_custom_easy_filter_register (NULL,
-      in_info, out_info, test_custom_easy_cb, NULL, &custom);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_custom_easy_filter_register (test_custom_filter,
-      NULL, out_info, test_custom_easy_cb, NULL, &custom);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_custom_easy_filter_register (test_custom_filter,
-      in_info, NULL, test_custom_easy_cb, NULL, &custom);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_custom_easy_filter_register (test_custom_filter,
-      in_info, out_info, NULL, NULL, &custom);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_custom_easy_filter_register (test_custom_filter,
-      in_info, out_info, test_custom_easy_cb, NULL, NULL);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_custom_easy_filter_unregister (NULL);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  /* test code with invalid input info */
-  status = ml_pipeline_custom_easy_filter_register (test_custom_filter,
-      in_info, out_info, test_custom_easy_cb, NULL, &custom);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   ml_tensors_info_set_count (in_info, 1);
   ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT8);
   ml_tensors_info_set_tensor_dimension (in_info, 0, dim);
-
-  /* test code with invalid output info */
-  status = ml_pipeline_custom_easy_filter_register (test_custom_filter,
-      in_info, out_info, test_custom_easy_cb, NULL, &custom);
-  EXPECT_NE (status, ML_ERROR_NONE);
 
   ml_tensors_info_set_count (out_info, 1);
   ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -5560,7 +5560,7 @@ TEST (nnstreamer_capi_element, release_handle_03_n)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_bool()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_bool_04_p)
+TEST (nnstreamer_capi_element, set_property_bool_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h selector_h = nullptr;
@@ -5597,7 +5597,20 @@ TEST (nnstreamer_capi_element, set_property_bool_04_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_bool()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_bool_05_n)
+TEST (nnstreamer_capi_element, set_property_bool_02_n)
+{
+  int status;
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_bool(nullptr, "sync-streams", FALSE);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_bool()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_bool_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h selector_h = nullptr;
@@ -5615,9 +5628,6 @@ TEST (nnstreamer_capi_element, set_property_bool_05_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_set_property_bool(nullptr, "sync-streams", FALSE);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_set_property_bool(selector_h, "WRONG_PROPERTY", TRUE);
   EXPECT_NE (status, ML_ERROR_NONE);
 
@@ -5632,9 +5642,43 @@ TEST (nnstreamer_capi_element, set_property_bool_05_n)
 
 /**
  * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_bool()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_bool_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vscale_h = nullptr;
+  int status;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vscale", &vscale_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_bool (vscale_h, "sharpness", 10);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (vscale_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_bool()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_bool_06_p)
+TEST (nnstreamer_capi_element, get_property_bool_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h selector_h = nullptr;
@@ -5680,13 +5724,26 @@ TEST (nnstreamer_capi_element, get_property_bool_06_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_bool()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_bool_07_n)
+TEST (nnstreamer_capi_element, get_property_bool_02_n)
+{
+  int ret_sync_streams;
+  int status;
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_bool (nullptr, "sync-streams", &ret_sync_streams);
+  ASSERT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_bool()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_bool_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h selector_h = nullptr;
   gchar *pipeline;
   int ret_sync_streams;
-  int ret_wrong_type;
   int status;
 
   pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
@@ -5703,16 +5760,7 @@ TEST (nnstreamer_capi_element, get_property_bool_07_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_get_property_bool (nullptr, "sync-streams", &ret_sync_streams);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_get_property_bool (selector_h, "WRONG_NAME", &ret_sync_streams);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_element_get_property_bool (selector_h, "sync-streams", nullptr);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_element_get_property_int32 (selector_h, "sync-streams", &ret_wrong_type);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (selector_h);
@@ -5726,9 +5774,82 @@ TEST (nnstreamer_capi_element, get_property_bool_07_n)
 
 /**
  * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_bool()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_bool_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h selector_h = nullptr;
+  gchar *pipeline;
+  int status;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "is01", &selector_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_bool(selector_h, "sync-streams", FALSE);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_bool (selector_h, "sync-streams", nullptr);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (selector_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_bool()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_bool_05_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h udpsrc_h = nullptr;
+  int status;
+  int wrong_type;
+  gchar *pipeline;
+
+  pipeline = g_strdup("udpsrc name=usrc port=5555 caps=application/x-rtp ! queue ! fakesink");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "usrc", &udpsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_uint64 (udpsrc_h, "timeout", 123456789123456789ULL);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_bool (udpsrc_h, "timeout", &wrong_type);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (udpsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_string()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_string_08_p)
+TEST (nnstreamer_capi_element, set_property_string_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h demux_h = nullptr;
@@ -5761,7 +5882,20 @@ TEST (nnstreamer_capi_element, set_property_string_08_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_string()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_string_09_n)
+TEST (nnstreamer_capi_element, set_property_string_02_n)
+{
+  int status;
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_string (nullptr, "tensorpick", "1,2");
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_string()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_string_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h demux_h = nullptr;
@@ -5778,9 +5912,6 @@ TEST (nnstreamer_capi_element, set_property_string_09_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_set_property_string (nullptr, "tensorpick", "1,2");
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_set_property_string (demux_h, "WRONG_NAME", "1,2");
   EXPECT_NE (status, ML_ERROR_NONE);
 
@@ -5795,9 +5926,43 @@ TEST (nnstreamer_capi_element, set_property_string_09_n)
 
 /**
  * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_string()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_string_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h selector_h = nullptr;
+  gchar *pipeline;
+  int status;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "is01", &selector_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_string(selector_h, "sync-streams", "TRUE");
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (selector_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_string()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_string_10_p)
+TEST (nnstreamer_capi_element, get_property_string_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h demux_h = nullptr;
@@ -5844,13 +6009,26 @@ TEST (nnstreamer_capi_element, get_property_string_10_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_string()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_string_11_n)
+TEST (nnstreamer_capi_element, get_property_string_02_n)
+{
+  int status;
+  gchar *ret_tensorpick;
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_string (nullptr, "tensorpick", &ret_tensorpick);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_string()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_string_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h demux_h = nullptr;
   gchar *pipeline;
   gchar *ret_tensorpick;
-  int ret_wrong_type;
   int status;
 
   pipeline = g_strdup("videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! videorate max-rate=1 ! " \
@@ -5866,16 +6044,7 @@ TEST (nnstreamer_capi_element, get_property_string_11_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_get_property_string (nullptr, "tensorpick", &ret_tensorpick);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_get_property_string (demux_h, "WRONG_NAME", &ret_tensorpick);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_element_get_property_string (demux_h, "tensorpick", nullptr);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_element_get_property_int32 (demux_h, "tensorpick", &ret_wrong_type);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (demux_h);
@@ -5889,9 +6058,83 @@ TEST (nnstreamer_capi_element, get_property_string_11_n)
 
 /**
  * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_string()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_string_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h demux_h = nullptr;
+  gchar *pipeline;
+  int status;
+
+  pipeline = g_strdup("videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! videorate max-rate=1 ! " \
+    "tensor_converter ! tensor_mux ! tensor_demux name=demux ! tensor_sink");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "demux", &demux_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_string (demux_h, "tensorpick", "1,2");
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_string (demux_h, "tensorpick", nullptr);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (demux_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_string()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_string_05_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h selector_h = nullptr;
+  gchar *pipeline;
+  gchar *ret_wrong_type;
+  int status;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "is01", &selector_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_bool(selector_h, "sync-streams", FALSE);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_string (selector_h, "sync-streams", &ret_wrong_type);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (selector_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_int32()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_int32_12_p)
+TEST (nnstreamer_capi_element, set_property_int32_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
@@ -5928,7 +6171,20 @@ TEST (nnstreamer_capi_element, set_property_int32_12_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_int32()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_int32_13_n)
+TEST (nnstreamer_capi_element, set_property_int32_02_n)
+{
+  int status;
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_int32 (nullptr, "kx", 10);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_int32()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_int32_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
@@ -5946,13 +6202,7 @@ TEST (nnstreamer_capi_element, set_property_int32_13_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_set_property_int32 (nullptr, "kx", 10);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_set_property_int32 (vsrc_h, "WRONG_NAME", 10);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_element_set_property_uint32 (vsrc_h, "kx", 10U);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vsrc_h);
@@ -5966,9 +6216,42 @@ TEST (nnstreamer_capi_element, set_property_int32_13_n)
 
 /**
  * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_int32()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_int32_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h demux_h = nullptr;
+  gchar *pipeline;
+  int status;
+
+  pipeline = g_strdup("videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! videorate max-rate=1 ! " \
+    "tensor_converter ! tensor_mux ! tensor_demux name=demux ! tensor_sink");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "demux", &demux_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_int32 (demux_h, "tensorpick", 1);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (demux_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_int32()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_int32_14_p)
+TEST (nnstreamer_capi_element, get_property_int32_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
@@ -6014,13 +6297,26 @@ TEST (nnstreamer_capi_element, get_property_int32_14_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_int32()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_int32_15_n)
+TEST (nnstreamer_capi_element, get_property_int32_02_n)
+{
+  int status;
+  int32_t ret_kx;
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_int32 (nullptr, "kx", &ret_kx);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_int32()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_int32_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
   int status;
   int32_t ret_kx;
-  uint32_t ret_wrong_type;
   gchar *pipeline;
 
   pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
@@ -6037,13 +6333,7 @@ TEST (nnstreamer_capi_element, get_property_int32_15_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_get_property_int32 (nullptr, "kx", &ret_kx);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_get_property_int32 (vsrc_h, "WRONG_NAME", &ret_kx);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_element_get_property_uint32 (vsrc_h, "kx", &ret_wrong_type);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vsrc_h);
@@ -6057,9 +6347,84 @@ TEST (nnstreamer_capi_element, get_property_int32_15_n)
 
 /**
  * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_int32()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_int32_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vsrc_h = nullptr;
+  int status;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vsrc", &vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_int32 (vsrc_h, "kx", 10);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_int32 (vsrc_h, "kx", nullptr);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_int32()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_int32_05_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vscale_h = nullptr;
+  int status;
+  int wrong_type;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vscale", &vscale_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_double (vscale_h, "sharpness", 0.72);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_int32 (vscale_h, "sharpness", &wrong_type);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (vscale_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_int64()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_int64_16_p)
+TEST (nnstreamer_capi_element, set_property_int64_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
@@ -6096,7 +6461,20 @@ TEST (nnstreamer_capi_element, set_property_int64_16_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_int64()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_int64_17_n)
+TEST (nnstreamer_capi_element, set_property_int64_02_n)
+{
+  int status;
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_int64 (nullptr, "timestamp-offset", 1234567891234LL);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_int64()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_int64_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
@@ -6114,13 +6492,41 @@ TEST (nnstreamer_capi_element, set_property_int64_17_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_set_property_int64 (nullptr, "timestamp-offset", 1234567891234LL);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_set_property_int64 (vsrc_h, "WRONG_NAME", 1234567891234LL);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_element_set_property_int32 (vsrc_h, "timestamp-offset", 12LL);
+  status = ml_pipeline_element_release_handle (vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_int64()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_int64_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vsrc_h = nullptr;
+  int status;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vsrc", &vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_int64 (vsrc_h, "foreground-color", 123456);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vsrc_h);
@@ -6136,7 +6542,7 @@ TEST (nnstreamer_capi_element, set_property_int64_17_n)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_int64()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_int64_18_p)
+TEST (nnstreamer_capi_element, get_property_int64_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
@@ -6182,13 +6588,26 @@ TEST (nnstreamer_capi_element, get_property_int64_18_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_int64()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_int64_19_n)
+TEST (nnstreamer_capi_element, get_property_int64_02_n)
+{
+  int status;
+  int64_t ret_timestame_offset;
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_int64 (nullptr, "timestamp-offset", &ret_timestame_offset);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_int64()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_int64_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
   int status;
   int64_t ret_timestame_offset;
-  int wrong_type;
   gchar *pipeline;
 
   pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
@@ -6205,13 +6624,82 @@ TEST (nnstreamer_capi_element, get_property_int64_19_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_get_property_int64 (nullptr, "timestamp-offset", &ret_timestame_offset);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_get_property_int64 (vsrc_h, "WRONG_NAME", &ret_timestame_offset);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_element_get_property_int32 (vsrc_h, "timestamp-offset", &wrong_type);
+  status = ml_pipeline_element_release_handle (vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_int64()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_int64_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vsrc_h = nullptr;
+  int status;
+  int64_t wrong_type;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vsrc", &vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_uint32 (vsrc_h, "foreground-color", 123456U);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_int64 (vsrc_h, "foreground-color", &wrong_type);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_int64()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_int64_05_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vsrc_h = nullptr;
+  int status;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vsrc", &vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_int64 (vsrc_h, "timestamp-offset", 1234567891234LL);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_int64 (vsrc_h, "timestamp-offset", nullptr);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vsrc_h);
@@ -6227,7 +6715,7 @@ TEST (nnstreamer_capi_element, get_property_int64_19_n)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_uint32()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_uint32_20_p)
+TEST (nnstreamer_capi_element, set_property_uint32_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
@@ -6264,7 +6752,20 @@ TEST (nnstreamer_capi_element, set_property_uint32_20_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_uint32()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_uint32_21_n)
+TEST (nnstreamer_capi_element, set_property_uint32_02_n)
+{
+  int status;
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_uint32 (nullptr, "foreground-color", 123456U);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_uint32()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_uint32_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
@@ -6282,13 +6783,41 @@ TEST (nnstreamer_capi_element, set_property_uint32_21_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_set_property_uint32 (nullptr, "foreground-color", 123456U);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_set_property_uint32 (vsrc_h, "WRONG_NAME", 123456U);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_element_set_property_int32 (vsrc_h, "foreground-color", 123456);
+  status = ml_pipeline_element_release_handle (vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_uint32()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_uint32_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vsrc_h = nullptr;
+  int status;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vsrc", &vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_uint32 (vsrc_h, "kx", 10U);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vsrc_h);
@@ -6304,7 +6833,7 @@ TEST (nnstreamer_capi_element, set_property_uint32_21_n)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_uint32()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_uint32_22_p)
+TEST (nnstreamer_capi_element, get_property_uint32_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
@@ -6350,13 +6879,26 @@ TEST (nnstreamer_capi_element, get_property_uint32_22_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_uint32()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_uint32_23_n)
+TEST (nnstreamer_capi_element, get_property_uint32_02_n)
+{
+  int status;
+  uint32_t ret_foreground_color;
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_uint32 (nullptr, "foreground-color", &ret_foreground_color);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_uint32()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_uint32_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
   int status;
   uint32_t ret_foreground_color;
-  int32_t wrong_type;
   gchar *pipeline;
 
   pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
@@ -6373,13 +6915,82 @@ TEST (nnstreamer_capi_element, get_property_uint32_23_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_get_property_uint32 (nullptr, "foreground-color", &ret_foreground_color);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_get_property_uint32 (vsrc_h, "WRONG_NAME", &ret_foreground_color);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_element_get_property_int32 (vsrc_h, "foreground-color", &wrong_type);
+  status = ml_pipeline_element_release_handle (vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_uint32()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_uint32_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vsrc_h = nullptr;
+  int status;
+  uint32_t ret_wrong_type;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vsrc", &vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_int32 (vsrc_h, "kx", 10);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_uint32 (vsrc_h, "kx", &ret_wrong_type);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_uint32()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_uint32_05_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vsrc_h = nullptr;
+  int status;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vsrc", &vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_uint32 (vsrc_h, "foreground-color", 123456U);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_uint32 (vsrc_h, "foreground-color", nullptr);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vsrc_h);
@@ -6395,7 +7006,7 @@ TEST (nnstreamer_capi_element, get_property_uint32_23_n)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_uint64()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_uint64_24_p)
+TEST (nnstreamer_capi_element, set_property_uint64_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h udpsrc_h = nullptr;
@@ -6430,7 +7041,20 @@ TEST (nnstreamer_capi_element, set_property_uint64_24_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_uint64()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_uint64_25_n)
+TEST (nnstreamer_capi_element, set_property_uint64_02_n)
+{
+  int status;
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_uint64 (nullptr, "timeout", 123456789123456789ULL);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_uint64()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_uint64_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h udpsrc_h = nullptr;
@@ -6446,13 +7070,7 @@ TEST (nnstreamer_capi_element, set_property_uint64_25_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_set_property_uint64 (nullptr, "timeout", 123456789123456789ULL);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_set_property_uint64 (udpsrc_h, "WRONG_NAME", 123456789123456789ULL);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_element_set_property_uint32 (udpsrc_h, "timeout", 123456789ULL);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (udpsrc_h);
@@ -6466,9 +7084,43 @@ TEST (nnstreamer_capi_element, set_property_uint64_25_n)
 
 /**
  * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_uint64()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_uint64_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vsrc_h = nullptr;
+  int status;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vsrc", &vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_uint64 (vsrc_h, "timestamp-offset", 12ULL);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_uint64()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_uint64_26_p)
+TEST (nnstreamer_capi_element, get_property_uint64_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h udpsrc_h = nullptr;
@@ -6512,13 +7164,26 @@ TEST (nnstreamer_capi_element, get_property_uint64_26_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_uint64()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_uint64_27_n)
+TEST (nnstreamer_capi_element, get_property_uint64_02_n)
+{
+  int status;
+  uint64_t ret_timeout;
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_uint64 (nullptr, "timeout", &ret_timeout);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_uint64()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_uint64_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h udpsrc_h = nullptr;
   int status;
   uint64_t ret_timeout;
-  uint32_t wrong_type;
   gchar *pipeline;
 
   pipeline = g_strdup("udpsrc name=usrc port=5555 caps=application/x-rtp ! queue ! fakesink");
@@ -6533,13 +7198,80 @@ TEST (nnstreamer_capi_element, get_property_uint64_27_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_get_property_uint64 (nullptr, "timeout", &ret_timeout);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_get_property_uint64 (udpsrc_h, "WRONG_NAME", &ret_timeout);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_element_get_property_uint32 (udpsrc_h, "timeout", &wrong_type);
+  status = ml_pipeline_element_release_handle (udpsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_uint64()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_uint64_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vsrc_h = nullptr;
+  int status;
+  uint64_t wrong_type;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vsrc", &vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_int64 (vsrc_h, "timestamp-offset", 1234567891234LL);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_uint64 (vsrc_h, "timestamp-offset", &wrong_type);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (vsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_uint64()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_uint64_05_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h udpsrc_h = nullptr;
+  int status;
+  gchar *pipeline;
+
+  pipeline = g_strdup("udpsrc name=usrc port=5555 caps=application/x-rtp ! queue ! fakesink");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "usrc", &udpsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_uint64 (udpsrc_h, "timeout", 123456789123456789ULL);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_uint64 (udpsrc_h, "timeout", nullptr);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (udpsrc_h);
@@ -6555,7 +7287,7 @@ TEST (nnstreamer_capi_element, get_property_uint64_27_n)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_double()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_double_28_p)
+TEST (nnstreamer_capi_element, set_property_double_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vscale_h = nullptr;
@@ -6592,7 +7324,20 @@ TEST (nnstreamer_capi_element, set_property_double_28_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_double()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_double_29_n)
+TEST (nnstreamer_capi_element, set_property_double_02_n)
+{
+  int status;
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_double (nullptr, "sharpness", 0.72);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_double()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_double_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vscale_h = nullptr;
@@ -6610,13 +7355,41 @@ TEST (nnstreamer_capi_element, set_property_double_29_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_set_property_double (nullptr, "sharpness", 0.72);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_set_property_double (vscale_h, "WRONG_NAME", 1.43);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_element_set_property_int32 (vscale_h, "sharpness", 10);
+  status = ml_pipeline_element_release_handle (vscale_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_double()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_double_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vscale_h = nullptr;
+  int status;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vscale", &vscale_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_double (vscale_h, "method", 3.0);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vscale_h);
@@ -6632,7 +7405,7 @@ TEST (nnstreamer_capi_element, set_property_double_29_n)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_double()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_double_30_p)
+TEST (nnstreamer_capi_element, get_property_double_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vscale_h = nullptr;
@@ -6678,13 +7451,26 @@ TEST (nnstreamer_capi_element, get_property_double_30_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_double()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_double_31_n)
+TEST (nnstreamer_capi_element, get_property_double_02_n)
+{
+  int status;
+  double ret_sharpness;
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_double (nullptr, "sharpness", &ret_sharpness);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_double()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_double_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vscale_h = nullptr;
   int status;
   double ret_sharpness;
-  int wrong_type;
   gchar *pipeline;
 
   pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
@@ -6701,13 +7487,82 @@ TEST (nnstreamer_capi_element, get_property_double_31_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_get_property_double (nullptr, "sharpness", &ret_sharpness);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_get_property_double (vscale_h, "WRONG_NAME", &ret_sharpness);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_element_get_property_int32 (vscale_h, "sharpness", &wrong_type);
+  status = ml_pipeline_element_release_handle (vscale_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_double()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_double_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vscale_h = nullptr;
+  int status;
+  double wrong_type;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vscale", &vscale_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_enum (vscale_h, "method", 3U);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_double (vscale_h, "method", &wrong_type);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (vscale_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_double()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_double_05_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vscale_h = nullptr;
+  int status;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vscale", &vscale_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_double (vscale_h, "sharpness", 0.72);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_double (vscale_h, "sharpness", nullptr);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vscale_h);
@@ -6723,7 +7578,7 @@ TEST (nnstreamer_capi_element, get_property_double_31_n)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_enum()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_enum_32_p)
+TEST (nnstreamer_capi_element, set_property_enum_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vscale_h = nullptr;
@@ -6766,7 +7621,20 @@ TEST (nnstreamer_capi_element, set_property_enum_32_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_set_property_enum()` API and check its results.
  */
-TEST (nnstreamer_capi_element, set_property_enum_33_n)
+TEST (nnstreamer_capi_element, set_property_enum_02_n)
+{
+  int status;
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_enum (nullptr, "method", 3U);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_enum()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_enum_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vscale_h = nullptr;
@@ -6784,13 +7652,7 @@ TEST (nnstreamer_capi_element, set_property_enum_33_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_set_property_enum (nullptr, "method", 3U);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_set_property_enum (vscale_h, "WRONG_NAME", 3U);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
-  status = ml_pipeline_element_set_property_double (vscale_h, "method", 3.0);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vscale_h);
@@ -6804,9 +7666,41 @@ TEST (nnstreamer_capi_element, set_property_enum_33_n)
 
 /**
  * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_set_property_enum()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, set_property_enum_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h udpsrc_h = nullptr;
+  int status;
+  gchar *pipeline;
+
+  pipeline = g_strdup("udpsrc name=usrc port=5555 caps=application/x-rtp ! queue ! fakesink");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "usrc", &udpsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_set_property_enum (udpsrc_h, "timeout", 12345);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (udpsrc_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_enum()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_enum_34_p)
+TEST (nnstreamer_capi_element, get_property_enum_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vscale_h = nullptr;
@@ -6867,13 +7761,27 @@ TEST (nnstreamer_capi_element, get_property_enum_34_p)
  * @brief Test case of Element Property Control.
  * @detail Run the `ml_pipeline_element_get_property_enum()` API and check its results.
  */
-TEST (nnstreamer_capi_element, get_property_enum_35_n)
+TEST (nnstreamer_capi_element, get_property_enum_02_n)
+{
+
+  int status;
+  uint32_t ret_method;
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_enum (nullptr, "method", &ret_method);
+  EXPECT_NE (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_enum()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_enum_03_n)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vscale_h = nullptr;
   int status;
   uint32_t ret_method;
-  double wrong_type;
   gchar *pipeline;
 
   pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
@@ -6890,13 +7798,81 @@ TEST (nnstreamer_capi_element, get_property_enum_35_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Test Code */
-  status = ml_pipeline_element_get_property_enum (nullptr, "method", &ret_method);
-  EXPECT_NE (status, ML_ERROR_NONE);
-
   status = ml_pipeline_element_get_property_enum (vscale_h, "WRONG_NAME", &ret_method);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_element_get_property_double (vscale_h, "method", &wrong_type);
+  status = ml_pipeline_element_release_handle (vscale_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_enum()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_enum_04_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h demux_h = nullptr;
+  gchar *pipeline;
+  uint32_t ret_wrong_type;
+  int status;
+
+  pipeline = g_strdup("videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! videorate max-rate=1 ! " \
+    "tensor_converter ! tensor_mux ! tensor_demux name=demux ! tensor_sink");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "demux", &demux_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_string (demux_h, "tensorpick", "1,2");
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_enum (demux_h, "tensorpick", &ret_wrong_type);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_release_handle (demux_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free(pipeline);
+}
+
+/**
+ * @brief Test case of Element Property Control.
+ * @detail Run the `ml_pipeline_element_get_property_enum()` API and check its results.
+ */
+TEST (nnstreamer_capi_element, get_property_enum_05_n)
+{
+  ml_pipeline_h handle = nullptr;
+  ml_pipeline_element_h vscale_h = nullptr;
+  int status;
+  gchar *pipeline;
+
+  pipeline = g_strdup("videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " \
+    "video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! " \
+    "valve name=valvex ! input-selector name=is01 ! tensor_sink name=sinkx");
+
+  status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_get_handle (handle, "vscale", &vscale_h);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_element_set_property_enum (vscale_h, "method", 3U);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* Test Code */
+  status = ml_pipeline_element_get_property_enum (vscale_h, "method", nullptr);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_element_release_handle (vscale_h);
@@ -6912,7 +7888,7 @@ TEST (nnstreamer_capi_element, get_property_enum_35_n)
  * @brief Test case of Element Property Control.
  * @detail Construct the pipeline and run it during updating elements' property.
  */
-TEST (nnstreamer_capi_element, scenario_36_p)
+TEST (nnstreamer_capi_element, scenario_01_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_element_h vsrc_h = nullptr;
@@ -6978,7 +7954,7 @@ TEST (nnstreamer_capi_element, scenario_36_p)
  * @brief Test case of Element Property Control.
  * @detail Construct the pipeline and run it during updating elements' property.
  */
-TEST (nnstreamer_capi_element, scenario_37_p)
+TEST (nnstreamer_capi_element, scenario_02_p)
 {
   ml_pipeline_h handle = nullptr;
   ml_pipeline_sink_h sinkhandle = nullptr;


### PR DESCRIPTION
Negative TCs has multiple tests, separate them as single test cases.

 After this PR:
     - Total TCs: 458
     - Positive TCs: 250
     - Negative TCs: 208

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped