### PR TITLE
[single] Bug fix for setting accelerator @open sesame 8/15 18:50

### DIFF
--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -666,7 +666,7 @@ ml_single_open_custom (ml_single_h * single, ml_single_preset * info)
   /* set accelerator, framework, model files and custom option */
   fw_name = ml_get_nnfw_subplugin_name (nnfw);
   hw_name = ml_nnfw_to_str_prop (hw);
-  g_object_set (filter_obj, "accelerator", hw_name, "framework", fw_name,
+  g_object_set (filter_obj, "framework", fw_name, "accelerator", hw_name,
       "model", info->models, NULL);
   g_free (hw_name);
 

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -463,7 +463,7 @@ TEST (nnstreamer_nnfw_mlapi, invoke_single_00)
   ml_tensors_info_set_tensor_dimension (out_info, 0, out_dim);
 
   status = ml_single_open (&single, test_model, in_info, out_info,
-      ML_NNFW_TYPE_NNFW, ML_NNFW_HW_AUTO);
+      ML_NNFW_TYPE_NNFW, ML_NNFW_HW_CPU);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* let's ignore timeout (30 sec) */


### PR DESCRIPTION
Bug fix for setting accelerator in the C-API.
When accelerator is set after the framework, tensor_filter does not know the framework
to check its version and store that information appropriately.
So, when framework version does not match, set property returns without setting the property.
This patch changes the order of setting this information for single API.

Related Issue: #2645 #2650

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>