### PR TITLE
[Dist/Tizen] Correct typo

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -396,7 +396,7 @@ NNStreamer's tensor_fliter subplugin of Intel Movidius Neural Compute stick SDK2
 
 %if 0%{openvino_support}
 %package	openvino
-Summary:	NNStreamer OpenVino support support
+Summary:	NNStreamer OpenVino support
 Requires:	nnstreamer = %{version}-%{release}
 Requires:	openvino
 Group:		Multimedia/Framework


### PR DESCRIPTION
A [comment](https://github.com/nnstreamer/nnstreamer/pull/2537#pullrequestreview-467332430) from @helloahn was not applied in #2537.

This patch applies that comment by correcting typo in the rpm spec file.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
