### PR TITLE
[Ext/Decoder] Support face detection models for OpenVino

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -93,6 +93,7 @@ typedef enum
   TFLITE_SSD_BOUNDING_BOX = 0,
   TF_SSD_BOUNDING_BOX = 1,
   OV_PERSON_DETECTION_BOUNDING_BOX = 2,
+  OV_FACE_DETECTION_BOUNDING_BOX = 3,
   BOUNDING_BOX_UNKNOWN,
 } bounding_box_modes;
 
@@ -103,6 +104,7 @@ static const char *bb_modes[] = {
   [TFLITE_SSD_BOUNDING_BOX] = "tflite-ssd",
   [TF_SSD_BOUNDING_BOX] = "tf-ssd",
   [OV_PERSON_DETECTION_BOUNDING_BOX] = "ov-person-detection",
+  [OV_FACE_DETECTION_BOUNDING_BOX] = "ov-face-detection",
   NULL,
 };
 
@@ -153,8 +155,6 @@ _init_modes (bounding_boxes * bdata)
     return TRUE;
   } else if (bdata->mode == TF_SSD_BOUNDING_BOX) {
     return TRUE;
-  } else if (bdata->mode == OV_PERSON_DETECTION_BOUNDING_BOX) {
-    return TRUE;
   }
   return TRUE;
 }
@@ -192,7 +192,6 @@ _exit_modes (bounding_boxes * bdata)
   if (bdata->mode == TFLITE_SSD_BOUNDING_BOX) {
     /* properties_TFLite_SSD *data = &bdata->tflite_ssd; */
   } else if (bdata->mode == TF_SSD_BOUNDING_BOX) {
-  } else if (bdata->mode == OV_PERSON_DETECTION_BOUNDING_BOX) {
   }
 }
 
@@ -546,7 +545,8 @@ bb_getOutCaps (void **pdata, const GstTensorsConfig * config)
     if (!_set_max_detection (data, max_detection, TF_SSD_DETECTION_MAX)) {
       return NULL;
     }
-  } else if (data->mode == OV_PERSON_DETECTION_BOUNDING_BOX) {
+  } else if ((data->mode == OV_PERSON_DETECTION_BOUNDING_BOX) ||
+      (data->mode == OV_FACE_DETECTION_BOUNDING_BOX)){
     const guint *dim;
 
     if (!_check_tensors (config, OV_PERSON_DETECTION_MAX_TENSORS))
@@ -1016,7 +1016,8 @@ bb_decode (void **pdata, const GstTensorsConfig * config,
       default:
         g_assert (0);
     }
-  } else if (bdata->mode == OV_PERSON_DETECTION_BOUNDING_BOX) {
+  } else if ((bdata->mode == OV_PERSON_DETECTION_BOUNDING_BOX) ||
+      (bdata->mode == OV_FACE_DETECTION_BOUNDING_BOX))  {
     results = g_array_sized_new (FALSE, TRUE, sizeof (detectedObject),
         OV_PERSON_DETECTION_MAX);
 


### PR DESCRIPTION
The output tensor description of face detection model for OpenVino is the same as that of person detection model for the same framework. This patch updates the bounding-boxes mode of tensor decoder to support face detection model by reusing the code for the person detection model support.

Signed-off-by: Wook Song <wook16.song@samsung.com>

#### How to test on AMD64 Ubuntu with Intel Movidius Neural Compute Stick 2 ####

1. Build 
```console
$ pwd
./nnstreamer
$ sudo apt install openvino-dev
$ meson build -Denable-openvino=true
$ ninja -C build
```
2. Prepare the running environment
```console
$ export GST_PLUGIN_PATH=$(pwd)/build/gst/nnstreamer
$ export NNSTREAMER_CONF=$(pwd)/build/nnstreamer-test.ini
$ export NNSTREAMER_FILTERS=$(pwd)/build/ext/nnstreamer/tensor_filter
$ export NNSTREAMER_DECODERS=$(pwd)/build/ext/nnstreamer/tensor_decoder
```
3. Launch the pipeline

You can get the model files from [here](https://download.01.org/opencv/2019/open_model_zoo/R3/20190905_163000_models_bin/face-detection-retail-0005/FP32/).

```console
$ gst-launch-1.0 filesrc location=/home/wook/Work/NNS/nnstreamer/ellen_s_oscar_selfie.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,height=300,width=300,format=BGR,framerate=0/1 ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tensor_transform mode=dimchg option=0:2 ! tensor_filter framework=openvino model=./face-detection-retail-0005.xml silent=false accelerator=true:npu ! tensor_decoder mode=bounding_boxes option1=ov-face-detection option4=600:450 option5=300:300 ! videoconvert ! video/x-raw,format=RGBA ! pngenc ! filesink location=./ellen_s_oscar_selfie-boxes.png
```

4. Results
- Source image
![ellen_s_oscar_selfie](https://user-images.githubusercontent.com/2772376/90464993-64e7da80-e149-11ea-9f34-3971b817e86f.png)


- The generated image containing bounding boxes
![ellen_s_oscar_selfie-boxes](https://user-images.githubusercontent.com/2772376/90465024-7335f680-e149-11ea-9cec-42081c4a9d00.png)
