### PR TITLE
[Android] fix data conversion error

### DIFF
--- a/api/android/api/src/main/jni/nnstreamer-native-api.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-api.c
@@ -380,6 +380,7 @@ nns_add_element_handle (pipeline_info_s * pipe_info, const gchar * name,
 
 /**
  * @brief Convert tensors data to TensorsData object.
+ * @note This function will create new direct buffer object with tensors. You should not release the tensor data in data_h.
  */
 gboolean
 nns_convert_tensors_data (pipeline_info_s * pipe_info, JNIEnv * env,

--- a/api/android/api/src/main/jni/nnstreamer-native-singleshot.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-singleshot.c
@@ -242,9 +242,9 @@ nns_native_single_invoke (JNIEnv * env, jobject thiz, jlong handle, jobject in)
   }
 
 done:
-  /* do not free input tensors (direct access from object) */
+  /* do not free input/output tensors (direct access from object) */
   g_free (in_data);
-  ml_tensors_data_destroy (out_data);
+  g_free (out_data);
   return result;
 }
 

--- a/api/android/api/src/main/jni/nnstreamer-native.h
+++ b/api/android/api/src/main/jni/nnstreamer-native.h
@@ -200,6 +200,7 @@ nns_add_element_handle (pipeline_info_s * pipe_info, const gchar * name, element
 
 /**
  * @brief Convert tensors data to TensorsData object.
+ * @note This function will create new direct buffer object with tensors. You should not release the tensor data in data_h.
  */
 extern gboolean
 nns_convert_tensors_data (pipeline_info_s * pipe_info, JNIEnv * env, ml_tensors_data_h data_h, jobject obj_info, jobject * result);


### PR DESCRIPTION
The result of single-shot invoke is invalid.
Remove tensor data free after converting native handle to data object in single-shot.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
