### PR TITLE
[SPEC] Exclude device-dependent filters when checking testcase coverage

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -663,8 +663,8 @@ find . -name "CMakeCXXCompilerId*.gcda" -delete
 #find . -path "/build/*.j
 # Generate report
 lcov -t 'NNStreamer Unit Test Coverage' -o unittest.info -c -d . -b $(pwd) --no-external
-# Exclude generated files (Orc)
-lcov -r unittest.info "*/*-orc.*" "*/tests/*" "*/meson*/*" "*/*@sha/*" -o unittest-filtered.info
+# Exclude generated files (Orc) and device-dependent filters.
+lcov -r unittest.info "*/*-orc.*" "*/tests/*" "*/meson*/*" "*/*@sha/*" "*/*_openvino*" "*/*_edgetpu*" "*/*_movidius_ncsdk2*" -o unittest-filtered.info
 # Visualize the report
 genhtml -o result unittest-filtered.info -t "nnstreamer %{version}-%{release} ${VCS}" --ignore-errors source -p ${RPM_BUILD_DIR}
 


### PR DESCRIPTION
This patch excludes the device-dependent filters such as OpenVino and
EdgeTPU when checking testcase coverage.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped



