### PR TITLE
[test/fix] Fix signed-unsigned compare

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi_latency.cc
+++ b/tests/tizen_capi/unittest_tizen_capi_latency.cc
@@ -167,7 +167,7 @@ class nnstreamer_capi_singleshot_latency : public ::testing::Test
     if (fd >= 0) {
       resetDataFile ();
       data_read = read (fd, data, data_size);
-      EXPECT_EQ (data_read, data_size);
+      EXPECT_EQ ((size_t) data_read, data_size);
     }
 
     /** Benchmark the invoke duration */


### PR DESCRIPTION
- Fix build fail issue when build with capi

Previous build result:
```bash
../tests/tizen_capi/unittest_tizen_capi_latency.cc:170:7:   required from here
/usr/src/gtest/include/gtest/gtest.h:1392:11: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
cc1plus: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```
Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped