### PR TITLE
[TEST] Fix duplicated test

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -2462,14 +2462,13 @@ TEST (nnstreamer_capi_util, info_get_tname_02_n)
 {
   int status;
   ml_tensors_info_h info;
-  char *name = NULL;
 
   status = ml_tensors_info_create (&info);
   ASSERT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_count (info, 1);
   ASSERT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_tensors_info_get_tensor_name (info, 2, &name);
+  status = ml_tensors_info_get_tensor_name (info, 0, nullptr);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   status = ml_tensors_info_destroy (info);


### PR DESCRIPTION
Fix duplicated test in unittest_tizen_capi.cc.
`info_get_tname_02_n` equals `info_get_tname_03_n`.

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped