### PR TITLE
[Android/Test] Add Test cases for SNPE Singleshot api

### DIFF
--- a/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
+++ b/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
@@ -831,4 +831,68 @@ public class APITestSingleShot {
             fail();
         }
     }
+
+    @Test
+    public void testInvalidSNPEOptionRuntime_n() {
+        if (!NNStreamer.isAvailable(NNStreamer.NNFWType.SNPE)) {
+            /* cannot run the test */
+            return;
+        }
+
+        String invalid_option = "Runtime:invalid_runtime";
+        try {
+            File model = APITestCommon.getSNPEModel();
+            new SingleShot(new File[] {model}, null, null, NNStreamer.NNFWType.SNPE, invalid_option);
+            fail();
+        } catch (Exception e) {
+            /* expected */
+        }
+    }
+
+    @Test
+    public void testInvalidSNPEOptionCPUFallback_n() {
+        if (!NNStreamer.isAvailable(NNStreamer.NNFWType.SNPE)) {
+            /* cannot run the test */
+            return;
+        }
+
+        String invalid_option = "CPUFallback:invalid_value";
+        try {
+            File model = APITestCommon.getSNPEModel();
+            new SingleShot(new File[] {model}, null, null, NNStreamer.NNFWType.SNPE, invalid_option);
+            fail();
+        } catch (Exception e) {
+            /* expected */
+        }
+    }
+
+    @Test
+    public void testSNPEClassificationResultWithRuntimeDSP() {
+        if (!NNStreamer.isAvailable(NNStreamer.NNFWType.SNPE)) {
+            /* cannot run the test */
+            return;
+        }
+
+        /* expected label is measuring_cup (648) */
+        final int expected_label = 648;
+        String option_string = "Runtime:DSP";
+        try {
+            File model = APITestCommon.getSNPEModel();
+            SingleShot single = new SingleShot(new File[] {model}, null, null, NNStreamer.NNFWType.SNPE, option_string);
+
+            /* single-shot invoke */
+            TensorsData in = APITestCommon.readRawImageDataSNPE();
+            TensorsData out = single.invoke(in);
+            int labelIndex = APITestCommon.getMaxScoreSNPE(out.getTensorData(0));
+
+            /* check label index (measuring cup) */
+            if (labelIndex != expected_label) {
+                fail();
+            }
+
+            single.close();
+        } catch (Exception e) {
+            fail();
+        }
+    }
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
@@ -272,7 +272,7 @@ void snpe_subplugin::configure_instance (const GstTensorFilterProperties *prop)
     zdl::SNPE::SNPEFactory::getLibraryVersion ().asString ().c_str ());
 
   if (!configure_option (prop)) {
-    nns_loge ("Failed to configure SNPE options.");
+    throw std::invalid_argument ("Failed to configure SNPE option.");
     return;
   }
 


### PR DESCRIPTION
- Throw invalid_argument exception when it fails to configure options
- Add two negative TCs for invalid custom properties
- Add a TC to test utilizing DSP runtime


**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped