### PR TITLE
[Docs] Add a '%' before http @open sesame 8/27 18:30

### DIFF
--- a/api/capi/doc/nnstreamer_doc.h
+++ b/api/capi/doc/nnstreamer_doc.h
@@ -59,7 +59,7 @@
  * features, please define the features in your manifest file using the manifest
  * editor in the SDK.\n
  * For example, your application accesses to the camera device,
- * then you have to add 'http://tizen.org/privilege/camera' into the manifest of your application.\n
+ * then you have to add '%http://tizen.org/privilege/camera' into the manifest of your application.\n
  * More details on featuring your application can be found from
  * <a href="https://docs.tizen.org/application/tizen-studio/native-tools/manifest-text-editor#feature-element">
  *    <b>Feature Element</b>.
@@ -100,7 +100,7 @@
  * features, please define the features in your manifest file using the manifest
  * editor in the SDK.\n
  * For example, your application accesses to the camera device,
- * then you have to add 'http://tizen.org/privilege/camera' into the manifest of your application.\n
+ * then you have to add '%http://tizen.org/privilege/camera' into the manifest of your application.\n
  * More details on featuring your application can be found from
  * <a href="https://docs.tizen.org/application/tizen-studio/native-tools/manifest-text-editor#feature-element">
  *    <b>Feature Element</b>.

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -50,8 +50,8 @@ typedef void *ml_single_h;
  * @details Even if the model has flexible input data dimensions,
  *          input data frames of an instance of a model should share the same dimension.
  * @since_tizen 5.5
- * @remarks http://tizen.org/privilege/mediastorage is needed if @a model is relevant to media storage.
- * @remarks http://tizen.org/privilege/externalstorage is needed if @a model is relevant to external storage.
+ * @remarks %http://tizen.org/privilege/mediastorage is needed if @a model is relevant to media storage.
+ * @remarks %http://tizen.org/privilege/externalstorage is needed if @a model is relevant to external storage.
  * @param[out] single This is the model handle opened. Users are required to close
  *                   the given instance with ml_single_close().
  * @param[in] model This is the path to the neural network model file.

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -40,7 +40,7 @@ extern "C" {
 /**
  * @brief The virtual name to set the video source of camcorder in Tizen.
  * @details If an application needs to access the camera device to construct the pipeline, set the virtual name as a video source element.
- *          Note that you have to add 'http://tizen.org/privilege/camera' into the manifest of your application.
+ *          Note that you have to add '%http://tizen.org/privilege/camera' into the manifest of your application.
  * @since_tizen 5.5
  */
 #define ML_TIZEN_CAM_VIDEO_SRC "tizencamvideosrc"
@@ -48,7 +48,7 @@ extern "C" {
 /**
  * @brief The virtual name to set the audio source of camcorder in Tizen.
  * @details If an application needs to access the recorder device to construct the pipeline, set the virtual name as an audio source element.
- *          Note that you have to add 'http://tizen.org/privilege/recorder' into the manifest of your application.
+ *          Note that you have to add '%http://tizen.org/privilege/recorder' into the manifest of your application.
  * @since_tizen 5.5
  */
 #define ML_TIZEN_CAM_AUDIO_SRC "tizencamaudiosrc"
@@ -258,10 +258,10 @@ typedef int (*ml_custom_easy_invoke_cb) (const ml_tensors_data_h in, ml_tensors_
  * @details Use this function to create gst_parse_launch compatible NNStreamer pipelines.
  * @since_tizen 5.5
  * @remarks If the function succeeds, @a pipe handle must be released using ml_pipeline_destroy().
- * @remarks http://tizen.org/privilege/mediastorage is needed if @a pipeline_description is relevant to media storage.
- * @remarks http://tizen.org/privilege/externalstorage is needed if @a pipeline_description is relevant to external storage.
- * @remarks http://tizen.org/privilege/camera is needed if @a pipeline_description accesses the camera device.
- * @remarks http://tizen.org/privilege/recorder is needed if @a pipeline_description accesses the recorder device.
+ * @remarks %http://tizen.org/privilege/mediastorage is needed if @a pipeline_description is relevant to media storage.
+ * @remarks %http://tizen.org/privilege/externalstorage is needed if @a pipeline_description is relevant to external storage.
+ * @remarks %http://tizen.org/privilege/camera is needed if @a pipeline_description accesses the camera device.
+ * @remarks %http://tizen.org/privilege/recorder is needed if @a pipeline_description accesses the recorder device.
  * @param[in] pipeline_description The pipeline description compatible with GStreamer gst_parse_launch(). Refer to GStreamer manual or NNStreamer (https://github.com/nnstreamer/nnstreamer) documentation for examples and the grammar.
  * @param[in] cb The function to be called when the pipeline state is changed. You may set NULL if it's not required.
  * @param[in] user_data Private data for the callback. This value is passed to the callback when it's invoked.


### PR DESCRIPTION
This patch adds a '%' before http to avoid html link. It is related to
Tizen public header issue.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

