### PR TITLE
[Clamp] Support 'clamp' as tensor_transform's option

### DIFF
--- a/gst/nnstreamer/tensor_transform/tensor_transform.h
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.h
@@ -60,6 +60,7 @@ typedef enum _tensor_transform_mode
   GTT_ARITHMETIC,     /* Arithmetic. "arithmetic" */
   GTT_TRANSPOSE,      /* Transpose. "transpose" */
   GTT_STAND,          /* Standardization. "stand" */
+  GTT_CLAMP,          /* Clamp, "clamp" */
 
   GTT_UNKNOWN = -1,   /* Unknown/Not-implemented-yet Mode. "unknown" */
 } tensor_transform_mode;
@@ -135,6 +136,13 @@ typedef struct _tensor_transform_stand {
 } tensor_transform_stand;
 
 /**
+ * @brief Internal data structure for clamp mode.
+ */
+typedef struct _tensor_transform_clamp {
+  double min, max;
+} tensor_transform_clamp;
+
+/**
  * @brief Internal data structure for tensor_transform instances.
  */
 struct _GstTensorTransform
@@ -150,6 +158,7 @@ struct _GstTensorTransform
     tensor_transform_arithmetic data_arithmetic; /**< Parsed option value for "arithmetic" mode. */
     tensor_transform_transpose data_transpose; /**< Parsed option value for "transpose" mode. */
     tensor_transform_stand data_stand; /**< Parsed option value for "stand" mode. */
+    tensor_transform_clamp data_clamp; /**< Parsed option value for "clamp" mode. */
   };
   gboolean loaded; /**< TRUE if mode & option are loaded */
   gboolean acceleration; /**< TRUE to set orc acceleration */

--- a/tests/transform_clamp/generateTest.py
+++ b/tests/transform_clamp/generateTest.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Copyright (C) 2020 Samsung Electronics
+#
+# @file generateTest.py
+# @brief Generate golden test results for clamp test cases
+# @author Dongju Chae <dongju.chae@samsung.com>
+
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+from struct import pack
+import numpy as np
+
+def saveTestData(filename, dtype, cmin, cmax):
+  data = np.random.randint(-100, 100, size=[100, 50]).astype(dtype)
+  with open (filename, 'wb') as file:
+    file.write (data)
+
+  np.clip (data, cmin, cmax, out=data)
+  with open (filename + ".golden", 'wb') as file:
+    file.write (data)
+
+saveTestData("test_00.dat", np.int8, -50, 50)
+saveTestData("test_01.dat", np.uint32, 20, 80)
+saveTestData("test_02.dat", np.float32, -33.3, 77.7)

--- a/tests/transform_clamp/runTest.sh
+++ b/tests/transform_clamp/runTest.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
+## @file runTest.sh
+## @author Dongju Chae <dongju.chae@samsung.com>
+## @date Sep 02 2020
+## @brief SSAT Test Cases for transform clamp
+##
+
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
+"
+fi
+
+# This is compatible with SSAT (https://github.com/myungjoo/SSAT)
+testInit $1
+
+PATH_TO_PLUGIN="../../build"
+
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
+else
+    echo "Test Case Generation Started"
+    python generateTest.py
+    sopath=$1
+fi
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=\"test_00.dat\" blocksize=-1 ! application/octet-stream ! tensor_converter input-dim=50:100:1:1 input-type=int8 ! tensor_transform mode=clamp option=-50:50 ! filesink location=\"./result_00.dat\" sync=true" 1 0 0 $PERFORMANCE
+callCompareTest result_00.dat test_00.dat.golden 1 "Golden test comparison 1" 1 0
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=\"test_01.dat\" blocksize=-1 ! application/octet-stream ! tensor_converter input-dim=50:100:1:1 input-type=uint32 ! tensor_transform mode=clamp option=+20:80 ! filesink location=\"./result_01.dat\" sync=true" 2 0 0 $PERFORMANCE
+callCompareTest result_01.dat test_01.dat.golden 2 "Golden test comparison 2" 1 0
+
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=\"test_02.dat\" blocksize=-1 ! application/octet-stream ! tensor_converter input-dim=50:100:1:1 input-type=float32 ! tensor_transform mode=clamp option=-33.3:+77.7 ! filesink location=\"./result_02.dat\" sync=true" 3 0 0 $PERFORMANCE
+callCompareTest result_02.dat test_02.dat.golden 3 "Golden test comparison 3" 1 0
+
+report


### PR DESCRIPTION
This patch supports 'clamp' as tensor_transform's option.
It requires min/max values to apply clamp for input tensor data.

The usage is like below:
```
... ! tensor_transform mode=clamp option=-123.902313:150.837601 ! ...
```

It resolves https://github.com/nnstreamer/nnstreamer/issues/2675

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

