### PR TITLE
[Stand/Typo] Fix a minor typo in 'stand' transform description

### DIFF
--- a/gst/nnstreamer/tensor_transform/tensor_transform.h
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.h
@@ -128,7 +128,7 @@ typedef struct _tensor_transform_transpose {
 } tensor_transform_transpose;
 
 /**
- * @brief Internal data structure for arithmetic mode.
+ * @brief Internal data structure for stand mode.
  */
 typedef struct _tensor_transform_stand {
   tensor_transform_stand_mode mode;


### PR DESCRIPTION
This patch fixes a minor typo in 'stand' transform description.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

