### PR TITLE
[Filter/NNFW] directory as model parameter

### DIFF
--- a/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestCommon.java
+++ b/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestCommon.java
@@ -180,13 +180,21 @@ public class APITestCommon {
     }
 
     /**
-     * Gets the File object of tensorflow-lite model.
+     * Gets the path string of tensorflow-lite add.tflite model.
+     */
+    public static String getTFLiteAddModelPath() {
+        String root = Environment.getExternalStorageDirectory().getAbsolutePath();
+        return root + "/nnstreamer/test/add";
+    }
+
+    /**
+     * Gets the File object of tensorflow-lite add.tflite model.
      * Note that, to invoke model in the storage, the permission READ_EXTERNAL_STORAGE is required.
      */
     public static File getTFLiteAddModel() {
-        String root = Environment.getExternalStorageDirectory().getAbsolutePath();
-        File model = new File(root + "/nnstreamer/test/add/add.tflite");
-        File meta = new File(root + "/nnstreamer/test/add/metadata/MANIFEST");
+        String path = getTFLiteAddModelPath();
+        File model = new File(path + "/add.tflite");
+        File meta = new File(path + "/metadata/MANIFEST");
 
         if (!model.exists() || !meta.exists()) {
             fail();

--- a/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
+++ b/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
@@ -776,6 +776,39 @@ public class APITestSingleShot {
     }
 
     @Test
+    public void testNNFWOpenDir() {
+        if (!NNStreamer.isAvailable(NNStreamer.NNFWType.NNFW)) {
+            /* cannot run the test */
+            return;
+        }
+
+        try {
+            File model = new File(APITestCommon.getTFLiteAddModelPath());
+
+            new SingleShot(model, NNStreamer.NNFWType.NNFW);
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testNNFWOpenInvalidDir_n() {
+        if (!NNStreamer.isAvailable(NNStreamer.NNFWType.NNFW)) {
+            /* cannot run the test */
+            return;
+        }
+
+        try {
+            File model = new File(APITestCommon.getTFLiteAddModelPath() + "/invaliddir");
+
+            new SingleShot(model, NNStreamer.NNFWType.NNFW);
+            fail();
+        } catch (Exception e) {
+            /* expected */
+        }
+    }
+
+    @Test
     public void testSNPE() {
         if (!NNStreamer.isAvailable(NNStreamer.NNFWType.SNPE)) {
             /* cannot run the test */

--- a/api/android/api/src/main/jni/Android.mk
+++ b/api/android/api/src/main/jni/Android.mk
@@ -136,7 +136,7 @@ GSTREAMER_NDK_BUILD_PATH := $(GSTREAMER_ROOT)/share/gst-android/ndk-build/
 include $(LOCAL_PATH)/Android-gst-plugins.mk
 
 GSTREAMER_PLUGINS        := $(GST_REQUIRED_PLUGINS)
-GSTREAMER_EXTRA_DEPS     := $(GST_REQUIRED_DEPS) gio-2.0 gmodule-2.0 json-glib-1.0
+GSTREAMER_EXTRA_DEPS     := $(GST_REQUIRED_DEPS) gio-2.0 gmodule-2.0
 GSTREAMER_EXTRA_LIBS     := $(GST_REQUIRED_LIBS) -liconv
 
 ifeq ($(NNSTREAMER_API_OPTION),all)

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -30,7 +30,6 @@
 #include <string.h>
 #include <glib.h>
 #include <glib-object.h>
-#include <json-glib/json-glib.h>
 
 #include <tensor_common.h>
 #include <nnstreamer_plugin_api_filter.h>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -153,8 +153,13 @@ nnfw_open (const GstTensorFilterProperties * prop, void **private_data)
     goto unalloc_exit;
   }
 
-  /** @note nnfw opens the first model listed in the MANIFEST file */
-  model_path = g_path_get_dirname (prop->model_files[0]);
+  /** @todo NNFW now uses package path. Fix when file path is available to open NNFW. */
+  if (g_file_test (prop->model_files[0], G_FILE_TEST_IS_DIR)) {
+    model_path = g_strdup (prop->model_files[0]);
+  } else {
+    model_path = g_path_get_dirname (prop->model_files[0]);
+  }
+
   status = nnfw_load_model_from_file (pdata->session, model_path);
   g_free (model_path);
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -849,6 +849,12 @@ gst_tensor_filter_framework_auto_detection (const gchar ** model_files,
   gchar **fw_priority_str_arr;
   guint i;
 
+  /* supposed it is ONE if given model is directory */
+  if (g_file_test (model_files[0], G_FILE_TEST_IS_DIR)) {
+    detected_fw = g_strdup ("nnfw");
+    goto done;
+  }
+
   file_extension = strrchr (model_files[0], '.');
 
   /* Detect framework based on file extension */
@@ -909,13 +915,13 @@ gst_tensor_filter_framework_auto_detection (const gchar ** model_files,
     g_strfreev (fw_priority_str_arr);
   }
 
+done:
   if (detected_fw) {
     nns_logi ("Automatically detected framework is %s.", detected_fw);
     nns_logd
         ("If you want to change priority of framework for auto detection, Please edit meson_option.txt. You can find the file at root path of nnstreamer. \n");
   } else {
-    nns_logw ("Cannot get any neural network framework of %s. \n",
-        file_extension);
+    nns_logw ("Cannot get any neural network framework for given model");
   }
 
   return detected_fw;

--- a/meson.build
+++ b/meson.build
@@ -150,8 +150,6 @@ fb_comp = find_program('flatc', required : get_option('flatbuf-support'))
 # Protobuf compiler
 pb_comp = find_program('protoc', required: get_option('protobuf-support'))
 
-json_glib_dep = dependency('json-glib-1.0', required: get_option('nnfw-runtime-support'))
-
 #orc
 pg_orcc = find_program('orcc', required: get_option('orcc-support'))
 orc_dep = dependency('orc-0.4', version: '>= 0.4.17', required: get_option('orcc-support'))
@@ -223,7 +221,7 @@ features = {
     'project_args': { 'ENABLE_MOVIDIUS_NCSDK2' : 1}
   },
   'nnfw-runtime-support': {
-    'extra_deps': [ nnfw_dep, json_glib_dep ],
+    'extra_deps': [ nnfw_dep ],
     'project_args': { 'ENABLE_NNFW_RUNTIME': 1 }
   },
   'tflite-nnapi-delegation': {


### PR DESCRIPTION
Support model path as model property for NNFW.

NNFW requires model path to open model.
Current tensor-filter and API does not allow directory string.
Check the model property and if it is directory, set framework to NNFW.

cc @lemmaa @chunseoklee 

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
