### PR TITLE
[Android] deallocate direct buffer

### DIFF
--- a/api/android/api/src/main/java/org/nnsuite/nnstreamer/TensorsData.java
+++ b/api/android/api/src/main/java/org/nnsuite/nnstreamer/TensorsData.java
@@ -113,13 +113,18 @@ public final class TensorsData implements AutoCloseable {
     private void addTensorData(@NonNull ByteBuffer data) {
         int index = getTensorsCount();
 
-        if (data.isDirect() && data.order() != ByteOrder.nativeOrder()) {
-            /* From native function NewDirectByteBuffer(), we should change the byte order. */
-            data = data.order(ByteOrder.nativeOrder());
-        }
-
         checkByteBuffer(index, data);
         mDataList.add(data);
+    }
+
+    /**
+     * Internal method called from native to add tensor.
+     */
+    private void addTensorFromNative(byte[] data) {
+        ByteBuffer buffer = allocateByteBuffer(data.length);
+        buffer.put(data);
+
+        addTensorData(buffer);
     }
 
     /**

--- a/api/android/api/src/main/jni/nnstreamer-native-singleshot.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-singleshot.c
@@ -242,9 +242,9 @@ nns_native_single_invoke (JNIEnv * env, jobject thiz, jlong handle, jobject in)
   }
 
 done:
-  /* do not free input/output tensors (direct access from object) */
+  /* do not free input tensors (direct access from object) */
   g_free (in_data);
-  g_free (out_data);
+  ml_tensors_data_destroy (out_data);
   return result;
 }
 

--- a/api/android/api/src/main/jni/nnstreamer-native.h
+++ b/api/android/api/src/main/jni/nnstreamer-native.h
@@ -200,7 +200,6 @@ nns_add_element_handle (pipeline_info_s * pipe_info, const gchar * name, element
 
 /**
  * @brief Convert tensors data to TensorsData object.
- * @note This function will create new direct buffer object with tensors. You should not release the tensor data in data_h.
  */
 extern gboolean
 nns_convert_tensors_data (pipeline_info_s * pipe_info, JNIEnv * env, ml_tensors_data_h data_h, jobject obj_info, jobject * result);


### PR DESCRIPTION
Direct buffer allocated from native will not release the buffer.
Create instance in java and set byte array, then call method to add tensor data.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
