### PR TITLE
[single] Resolve tensor filter memory leak

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -148,6 +148,7 @@ typedef struct {
 typedef struct {
   unsigned int num_tensors; /**< The number of tensors. */
   ml_tensor_data_s tensors[ML_TENSOR_SIZE_LIMIT]; /**< The list of tensor data. NULL for unused tensors. */
+  void *handle; /**< The handle which owns this buffer and will be used to de-alloc the data */
 } ml_tensors_data_s;
 
 /**
@@ -389,6 +390,8 @@ const char* ml_get_nnfw_subplugin_name (ml_nnfw_type_e nnfw);
  * @return The reference of pipeline itself. Null if the pipeline is not constructed or closed.
  */
 GstElement* ml_pipeline_get_gst_element (ml_pipeline_h pipe);
+
+int ml_single_destroy_notify (ml_single_h single, ml_tensors_data_s *data);
 
 #if defined (__TIZEN__)
 /**

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -96,6 +96,7 @@ int ml_single_close (ml_single_h single);
  * @param[in] input The input data to be inferred.
  * @param[out] output The allocated output buffer. The caller is responsible for freeing the output buffer with ml_tensors_data_destroy().
  * @return @c 0 on success. Otherwise a negative error value.
+ * @note If the data for the output buffer is allocated by the neural network framework (ML_NNFW_TYPE_CUSTOM_FILTER supports this), then this data will be freed when closing the @a single automatically by the neural network framework, and will not available for use later. It is recommended to copy the data from @a output if it is required to use it after the @a single handle is closed.
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.

--- a/api/capi/include/tensor_filter_single.h
+++ b/api/capi/include/tensor_filter_single.h
@@ -78,6 +78,10 @@ struct _GTensorFilterSingleClass
   /** Set the info about the input tensor */
   gint (*set_input_info) (GTensorFilterSingle * self,
       const GstTensorsInfo * in_info, GstTensorsInfo * out_info);
+  /** Check if the filter performs allocate_in_invoke */
+  gboolean (*allocate_in_invoke) (GTensorFilterSingle * self);
+  /** Free the data allocated by the tensor filter in invoke */
+  void (*destroy_notify) (GTensorFilterSingle * self, GstTensorMemory * mem);
 };
 
 /**

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -540,6 +540,7 @@ ml_tensors_info_free (ml_tensors_info_s * info)
 int
 ml_tensors_data_destroy (ml_tensors_data_h data)
 {
+  gint status = ML_ERROR_NONE;
   ml_tensors_data_s *_data;
   guint i;
 
@@ -550,15 +551,19 @@ ml_tensors_data_destroy (ml_tensors_data_h data)
 
   _data = (ml_tensors_data_s *) data;
 
-  for (i = 0; i < ML_TENSOR_SIZE_LIMIT; i++) {
-    if (_data->tensors[i].tensor) {
-      g_free (_data->tensors[i].tensor);
-      _data->tensors[i].tensor = NULL;
+  if (_data->handle != NULL) {
+    status = ml_single_destroy_notify (_data->handle, _data);
+  } else {
+    for (i = 0; i < ML_TENSOR_SIZE_LIMIT; i++) {
+      if (_data->tensors[i].tensor) {
+        g_free (_data->tensors[i].tensor);
+        _data->tensors[i].tensor = NULL;
+      }
     }
   }
 
   g_free (_data);
-  return ML_ERROR_NONE;
+  return status;
 }
 
 /**
@@ -587,6 +592,7 @@ ml_tensors_data_create_no_alloc (const ml_tensors_info_h info,
     return ML_ERROR_OUT_OF_MEMORY;
   }
 
+  _data->handle = NULL;
   _info = (ml_tensors_info_s *) info;
   if (_info != NULL) {
     _data->num_tensors = _info->num_tensors;
@@ -624,6 +630,7 @@ ml_tensors_data_clone_no_alloc (const ml_tensors_data_s * data_src,
     return ML_ERROR_OUT_OF_MEMORY;
   }
 
+  _data->handle = NULL;
   _data->num_tensors = data_src->num_tensors;
   memcpy(_data->tensors, data_src->tensors,
       sizeof (ml_tensor_data_s) * data_src->num_tensors);

--- a/api/capi/src/tensor_filter_single.c
+++ b/api/capi/src/tensor_filter_single.c
@@ -271,6 +271,7 @@ g_tensor_filter_destroy_notify (GTensorFilterSingle * self,
 
   for (i = 0; i < priv->prop.output_meta.num_tensors; i++) {
     gst_tensor_filter_destroy_notify_util (priv, mem[i].data);
+    mem[i].data = NULL;
   }
 }
 
@@ -310,9 +311,6 @@ g_tensor_filter_single_invoke (GTensorFilterSingle * self,
   }
 
   GST_TF_FW_INVOKE_COMPAT (priv, status, input, output);
-
-  if (self->allocate_in_invoke) {
-  }
 
   if (status == 0)
     return TRUE;

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -312,22 +312,10 @@ gst_tensor_filter_destroy_notify (void *data)
 {
   GPtrArray *array = (GPtrArray *) data;
   GstTensorFilter *self = (GstTensorFilter *) g_ptr_array_index (array, 0);
-  GstTensorFilterPrivate *priv = &self->priv;
   void *tensor_data = (void *) g_ptr_array_index (array, 1);
-  GstTensorFilterFrameworkEventData event_data;
   g_ptr_array_free (array, TRUE);
 
-  if (GST_TF_FW_V0 (priv->fw) && priv->fw->destroyNotify) {
-    priv->fw->destroyNotify (&priv->privateData, tensor_data);
-  } else if (GST_TF_FW_V1 (priv->fw)) {
-    event_data.data = tensor_data;
-    if (priv->fw->eventHandler (priv->fw, &priv->prop, priv->privateData,
-            DESTROY_NOTIFY, &event_data) == -ENOENT) {
-      g_free (tensor_data);
-    }
-  } else {
-    g_free (tensor_data);
-  }
+  gst_tensor_filter_destroy_notify_util (&self->priv, tensor_data);
 }
 
 /**

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -558,6 +558,30 @@ gst_tensor_filter_allocate_in_invoke (GstTensorFilterPrivate * priv)
 }
 
 /**
+ * @brief Free the data allocated for tensor filter output
+ * @param[in] priv Struct containing the properties of the object
+ * @param[in] data Data to be freed
+ */
+void
+gst_tensor_filter_destroy_notify_util (GstTensorFilterPrivate * priv,
+    void *data)
+{
+  GstTensorFilterFrameworkEventData event_data;
+
+  if (GST_TF_FW_V0 (priv->fw) && priv->fw->destroyNotify) {
+    priv->fw->destroyNotify (&priv->privateData, data);
+  } else if (GST_TF_FW_V1 (priv->fw)) {
+    event_data.data = data;
+    if (priv->fw->eventHandler (priv->fw, &priv->prop, priv->privateData,
+            DESTROY_NOTIFY, &event_data) == -ENOENT) {
+      g_free (data);
+    }
+  } else {
+    g_free (data);
+  }
+}
+
+/**
  * @brief Printout the comparison results of two tensors.
  * @param[in] info1 The tensors to be shown on the left hand side
  * @param[in] info2 The tensors to be shown on the right hand side

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -210,4 +210,10 @@ extern gboolean
 gst_tensor_filter_check_hw_availability (const GstTensorFilterFramework *fw,
     accl_hw hw);
 
+/**
+ * @brief Free the data allocated for tensor filter output
+ */
+extern void
+gst_tensor_filter_destroy_notify_util (GstTensorFilterPrivate *priv, void *data);
+
 #endif /* __G_TENSOR_FILTER_COMMON_H__ */

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,7 +26,7 @@ option('enable-mediapipe', type: 'boolean', value: false)
 option('install-example', type: 'boolean', value: false)
 option('enable-env-var', type: 'boolean', value: true)
 option('enable-symbolic-link', type: 'boolean', value: true)
-option('enable-capi', type: 'boolean', value: false)
+option('enable-capi', type: 'boolean', value: true)
 option('enable-tizen', type: 'boolean', value: false)
 option('tizen-version-major', type: 'integer', min : 4, max : 9999, value: 9999) # 9999 means "not Tizen"
 option('enable-element-restriction', type: 'boolean', value: false) # true to restrict gst-elements in api

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -5759,6 +5759,259 @@ TEST (nnstreamer_capi_singleshot, invoke_09_n)
 
 /**
  * @brief Test NNStreamer single shot (custom filter)
+ * @detail Run pipeline with custom filter with allocate in invoke, handle multi tensors.
+ */
+TEST (nnstreamer_capi_singleshot, invoke_10_p)
+{
+  const gchar cf_name[] = "libnnstreamer_customfilter_scaler_allocator" \
+      NNSTREAMER_SO_FILE_EXTENSION;
+  ml_single_h single;
+  ml_tensors_info_h in_info, out_info;
+  ml_tensors_data_h input, output;
+  ml_tensor_dimension in_dim;
+  int status;
+  unsigned int i;
+  void *data_ptr;
+  size_t data_size;
+
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  gchar *test_model;
+
+  /* supposed to run test in build directory */
+  if (root_path == NULL)
+    root_path = "..";
+
+  test_model = g_build_filename (root_path, "build", "nnstreamer_example",
+      "custom_example_scaler", cf_name, NULL);
+  ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
+
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
+
+  ml_tensors_info_set_count (in_info, 1);
+
+  in_dim[0] = 10;
+  in_dim[1] = 1;
+  in_dim[2] = 1;
+  in_dim[3] = 1;
+
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT16);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
+
+  ml_tensors_info_clone (out_info, in_info);
+
+  status = ml_single_open (&single, test_model, in_info, out_info,
+      ML_NNFW_TYPE_CUSTOM_FILTER, ML_NNFW_HW_ANY);
+  ASSERT_EQ (status, ML_ERROR_NONE);
+
+  input = output = NULL;
+
+  /* generate input data */
+  status = ml_tensors_data_create (in_info, &input);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  ASSERT_TRUE (input != NULL);
+
+  status = ml_tensors_data_get_tensor_data (input, 0, &data_ptr, &data_size);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  for (i = 0; i < 10; i++) {
+    ((int16_t *) data_ptr)[i] = (int16_t) (i + 1);
+  }
+
+  status = ml_single_invoke (single, input, &output);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_TRUE (output != NULL);
+
+  /**
+   * since the output data was allocated by the tensor filter element in the single API,
+   * closing this single handle will also delete the data
+   */
+  status = ml_single_close (single);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_tensors_data_destroy (input);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free (test_model);
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
+
+  /** This will destroy twice resulting in UB */
+  // EXPECT_DEATH (ml_tensors_data_destroy (output), ".*");
+}
+
+/**
+ * @brief Test NNStreamer single shot (custom filter)
+ * @detail Run pipeline with custom filter with allocate in invoke, handle multi tensors.
+ */
+TEST (nnstreamer_capi_singleshot, invoke_11_p)
+{
+  const gchar cf_name[] = "libnnstreamer_customfilter_scaler_allocator" \
+      NNSTREAMER_SO_FILE_EXTENSION;
+  ml_single_h single;
+  ml_tensors_info_h in_info, out_info;
+  ml_tensors_data_h input, output;
+  ml_tensor_dimension in_dim;
+  int status;
+  unsigned int i;
+  void *data_ptr;
+  size_t data_size;
+
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  gchar *test_model;
+
+  /* supposed to run test in build directory */
+  if (root_path == NULL)
+    root_path = "..";
+
+  test_model = g_build_filename (root_path, "build", "nnstreamer_example",
+      "custom_example_scaler", cf_name, NULL);
+  ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
+
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
+
+  ml_tensors_info_set_count (in_info, 1);
+
+  in_dim[0] = 10;
+  in_dim[1] = 1;
+  in_dim[2] = 1;
+  in_dim[3] = 1;
+
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT16);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
+
+  ml_tensors_info_clone (out_info, in_info);
+
+  status = ml_single_open (&single, test_model, in_info, out_info,
+      ML_NNFW_TYPE_CUSTOM_FILTER, ML_NNFW_HW_ANY);
+  ASSERT_EQ (status, ML_ERROR_NONE);
+
+  input = output = NULL;
+
+  /* generate input data */
+  status = ml_tensors_data_create (in_info, &input);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  ASSERT_TRUE (input != NULL);
+
+  status = ml_tensors_data_get_tensor_data (input, 0, &data_ptr, &data_size);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  for (i = 0; i < 10; i++) {
+    ((int16_t *) data_ptr)[i] = (int16_t) (i + 1);
+  }
+
+  status = ml_single_invoke (single, input, &output);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_TRUE (output != NULL);
+
+  status = ml_tensors_data_destroy (input);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /** Access data before destroy works */
+  status = ml_tensors_data_get_tensor_data (output, 0, &data_ptr, &data_size);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /** User can destroy by themselves */
+  status = ml_tensors_data_destroy (output);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /** Close handle works normally */
+  status = ml_single_close (single);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free (test_model);
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
+}
+
+/**
+ * @brief Test NNStreamer single shot (custom filter)
+ * @detail Run pipeline with custom filter with allocate in invoke, handle multi tensors.
+ */
+TEST (nnstreamer_capi_singleshot, invoke_12_p)
+{
+  const gchar cf_name[] = "libnnstreamer_customfilter_scaler_allocator" \
+      NNSTREAMER_SO_FILE_EXTENSION;
+  ml_single_h single;
+  ml_tensors_info_h in_info, out_info;
+  ml_tensors_data_h input, output1, output2;
+  ml_tensor_dimension in_dim;
+  int status;
+  unsigned int i;
+  void *data_ptr;
+  size_t data_size;
+
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  gchar *test_model;
+
+  /* supposed to run test in build directory */
+  if (root_path == NULL)
+    root_path = "..";
+
+  test_model = g_build_filename (root_path, "build", "nnstreamer_example",
+      "custom_example_scaler", cf_name, NULL);
+  ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
+
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
+
+  ml_tensors_info_set_count (in_info, 1);
+
+  in_dim[0] = 10;
+  in_dim[1] = 1;
+  in_dim[2] = 1;
+  in_dim[3] = 1;
+
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT16);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
+
+  ml_tensors_info_clone (out_info, in_info);
+
+  status = ml_single_open (&single, test_model, in_info, out_info,
+      ML_NNFW_TYPE_CUSTOM_FILTER, ML_NNFW_HW_ANY);
+  ASSERT_EQ (status, ML_ERROR_NONE);
+
+  input = output1 = output2 = NULL;
+
+  /* generate input data */
+  status = ml_tensors_data_create (in_info, &input);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  ASSERT_TRUE (input != NULL);
+
+  status = ml_tensors_data_get_tensor_data (input, 0, &data_ptr, &data_size);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  for (i = 0; i < 10; i++) {
+    ((int16_t *) data_ptr)[i] = (int16_t) (i + 1);
+  }
+
+  status = ml_single_invoke (single, input, &output1);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_TRUE (output1 != NULL);
+
+  status = ml_single_invoke (single, input, &output2);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_TRUE (output2 != NULL);
+
+  status = ml_tensors_data_destroy (input);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /** Destroy one data by user */
+  status = ml_tensors_data_destroy (output1);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /** Destroy the other data by closing the handle */
+  status = ml_single_close (single);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  g_free (test_model);
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
+
+  /** This will destroy twice resulting in UB */
+  // EXPECT_DEATH (ml_tensors_data_destroy (output2), ".*");
+}
+
+/**
+ * @brief Test NNStreamer single shot (custom filter)
  * @detail Change the number of input tensors, run the model and verify output
  */
 TEST (nnstreamer_capi_singleshot, set_input_info_success_02)


### PR DESCRIPTION
Commit 1 : 
When tensor filter with `allocate_in_invoke` allocates the memory,
its memory should be destroyed with the filters destroy notify
However, this was ignored until now for the single API (#2593)

This patch fixes this
Single handle now creates a list of each such data buffer
as well as the single handle is stored in the data buffer.
If the data buffer is deallocated, then destroyNotify is called from the
single handle stored in it.
However, if the single handle is closed before the data buffer is freed,
then all the memory is freed from the list of the data buffers
stored in the single handle.

V2:
Added note to the description of `ml_single_invoke` about data not being available 
single handle is closed when memory is allocated by the framework.

Commit 2 :
Appropriate negative and positive unit tests are included to verify
that the data can be freed by the user before closing the filter or closing the filter frees the data
or partially both with multiple data points.
The negative tests were tried when destroying the data twice (destroying manually
after the single handle is closed) with `EXPECT_DEATH()`. However, the unit test
doesn't always die (modifying freed data is Undefined Behavior). So, it has been commented.
This as a side effect finally adds unit tests for custom framework
using allocate_in_invoke with the single API as well.

Resolves #2593

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>