### PR TITLE
[Android/NNFW] nnfw prebuilt libs

### DIFF
--- a/api/android/api/build.gradle
+++ b/api/android/api/build.gradle
@@ -66,6 +66,11 @@ android {
                 jniLibs.srcDirs += project.properties['SNPE_DSP_LIBRARY_PATH']
                 println 'Set jniLibs.srcDirs includes libraries for SNPE DSP runtime'
             }
+
+            if (project.hasProperty('NNFW_EXT_LIBRARY_PATH')) {
+                jniLibs.srcDirs += project.properties['NNFW_EXT_LIBRARY_PATH']
+                println 'Set jniLibs.srcDirs includes libraries for NNFW'
+            }
         }
     }
     packagingOptions {

--- a/api/android/api/src/main/jni/Android-nnfw-prebuilt.mk
+++ b/api/android/api/src/main/jni/Android-nnfw-prebuilt.mk
@@ -12,66 +12,13 @@ ifndef NNFW_LIB_PATH
 $(error NNFW_LIB_PATH is not defined!)
 endif
 
-# include EXT
-ENABLE_NNFW_EXT := false
-
 NNFW_PREBUILT_LIBS :=
 
 #------------------------------------------------------
 # nnfw prebuilt shared libraries
 #------------------------------------------------------
 include $(CLEAR_VARS)
-LOCAL_MODULE := nnfw-libbackend_cpu
-LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libbackend_cpu.so
-include $(PREBUILT_SHARED_LIBRARY)
-NNFW_PREBUILT_LIBS += nnfw-libbackend_cpu
-
-ifeq ($(ENABLE_NNFW_EXT),true)
-include $(CLEAR_VARS)
-LOCAL_MODULE := nnfw-libbackend_cpu-boost
-LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libbackend_cpu-boost.so
-include $(PREBUILT_SHARED_LIBRARY)
-NNFW_PREBUILT_LIBS += nnfw-libbackend_cpu-boost
-endif
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := nnfw-libcircle_loader
-LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libcircle_loader.so
-include $(PREBUILT_SHARED_LIBRARY)
-NNFW_PREBUILT_LIBS += nnfw-libcircle_loader
-
-#include $(CLEAR_VARS)
-#LOCAL_MODULE := nnfw-libneuralnetworks
-#LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libneuralnetworks.so
-#include $(PREBUILT_SHARED_LIBRARY)
-#NNFW_PREBUILT_LIBS += nnfw-libneuralnetworks
-
-include $(CLEAR_VARS)
 LOCAL_MODULE := nnfw-libnnfw-dev
 LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libnnfw-dev.so
 include $(PREBUILT_SHARED_LIBRARY)
 NNFW_PREBUILT_LIBS += nnfw-libnnfw-dev
-
-#include $(CLEAR_VARS)
-#LOCAL_MODULE := nnfw-libnnfw_lib_benchmark
-#LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libnnfw_lib_benchmark.so
-#include $(PREBUILT_SHARED_LIBRARY)
-#NNFW_PREBUILT_LIBS += nnfw-libnnfw_lib_benchmark
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := nnfw-libonert_core
-LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libonert_core.so
-include $(PREBUILT_SHARED_LIBRARY)
-NNFW_PREBUILT_LIBS += nnfw-libonert_core
-
-#include $(CLEAR_VARS)
-#LOCAL_MODULE := nnfw-libtensorflowlite_jni
-#LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libtensorflowlite_jni.so
-#include $(PREBUILT_SHARED_LIBRARY)
-#NNFW_PREBUILT_LIBS += nnfw-libtensorflowlite_jni
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := nnfw-libtflite_loader
-LOCAL_SRC_FILES := $(NNFW_LIB_PATH)/libtflite_loader.so
-include $(PREBUILT_SHARED_LIBRARY)
-NNFW_PREBUILT_LIBS += nnfw-libtflite_loader

--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -287,13 +287,25 @@ fi
 if [[ $enable_nnfw == "yes" ]]; then
     sed -i "s|ENABLE_NNFW := false|ENABLE_NNFW := true|" api/src/main/jni/Android-nnstreamer-prebuilt.mk
     sed -i "s|ENABLE_NNFW := false|ENABLE_NNFW := true|" api/src/main/jni/Android.mk
-    mkdir -p api/src/main/jni/nnfw
-    tar -zxf ./external/nnfw-$nnfw_ver-android-aarch64.tar.gz -C ./api/src/main/jni/nnfw
+    sed -i "$ a NNFW_EXT_LIBRARY_PATH=src/main/jni/nnfw/ext" gradle.properties
+
+    mkdir -p external/nnfw
+    tar -zxf external/nnfw-$nnfw_ver-android-aarch64.tar.gz -C external/nnfw
 
     if [[ $enable_nnfw_ext == "yes" ]]; then
-        sed -i "s|ENABLE_NNFW_EXT := false|ENABLE_NNFW_EXT := true|" api/src/main/jni/Android-nnfw-prebuilt.mk
-        tar -zxf ./external/nnfw-ext-$nnfw_ver-android-aarch64.tar.gz -C ./api/src/main/jni/nnfw
+        tar -zxf external/nnfw-ext-$nnfw_ver-android-aarch64.tar.gz -C external/nnfw
     fi
+
+    # Remove duplicated file c++shared.so
+    if [[ -e external/nnfw/lib/libc++_shared.so ]]; then
+        rm external/nnfw/lib/libc++_shared.so
+    fi
+
+    mkdir -p api/src/main/jni/nnfw/include api/src/main/jni/nnfw/lib
+    mkdir -p api/src/main/jni/nnfw/ext/arm64-v8a
+    mv external/nnfw/include/* api/src/main/jni/nnfw/include
+    mv external/nnfw/lib/libnnfw-dev.so api/src/main/jni/nnfw/lib
+    mv external/nnfw/lib/* api/src/main/jni/nnfw/ext/arm64-v8a
 fi
 
 # Update SNPE option

--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -250,6 +250,7 @@ fi
 
 if [[ $enable_nnfw == "yes" ]]; then
     wget --directory-prefix=./$build_dir/external https://github.com/Samsung/ONE/releases/download/$nnfw_ver/nnfw-$nnfw_ver-android-aarch64.tar.gz
+    wget --directory-prefix=./$build_dir/external https://github.com/Samsung/ONE/releases/download/$nnfw_ver/nnfw-devel-$nnfw_ver.tar.gz
 
    # You should get ONE-EXT release and copy it into NNFW_DIRECTORY.
    if [[ $enable_nnfw_ext == "yes" ]]; then
@@ -291,6 +292,7 @@ if [[ $enable_nnfw == "yes" ]]; then
 
     mkdir -p external/nnfw
     tar -zxf external/nnfw-$nnfw_ver-android-aarch64.tar.gz -C external/nnfw
+    tar -zxf external/nnfw-devel-$nnfw_ver.tar.gz -C external/nnfw
 
     if [[ $enable_nnfw_ext == "yes" ]]; then
         tar -zxf external/nnfw-ext-$nnfw_ver-android-aarch64.tar.gz -C external/nnfw


### PR DESCRIPTION
It is unnecessary to link all nnfw prebuilt libs. Only nnfw-dev requires to build aar.
This may fix unexpected error in nnfw runtime env.

cc @chunseoklee 

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
