### PR TITLE
[Android/SNPE] Modify SNPE prebuilt libs

### DIFF
--- a/api/android/api/build.gradle
+++ b/api/android/api/build.gradle
@@ -62,9 +62,9 @@ android {
     }
     sourceSets {
         main {
-            if (project.hasProperty('SNPE_DSP_LIBRARY_PATH')) {
-                jniLibs.srcDirs += project.properties['SNPE_DSP_LIBRARY_PATH']
-                println 'Set jniLibs.srcDirs includes libraries for SNPE DSP runtime'
+            if (project.hasProperty('SNPE_EXT_LIBRARY_PATH')) {
+                jniLibs.srcDirs += project.properties['SNPE_EXT_LIBRARY_PATH']
+                println 'Set jniLibs.srcDirs includes libraries for SNPE'
             }
         }
     }

--- a/api/android/api/src/main/jni/Android-snpe-prebuilt.mk
+++ b/api/android/api/src/main/jni/Android-snpe-prebuilt.mk
@@ -20,27 +20,3 @@ LOCAL_MODULE := libSNPE
 LOCAL_SRC_FILES := $(SNPE_LIB_PATH)/libSNPE.so
 include $(PREBUILT_SHARED_LIBRARY)
 SNPE_PREBUILT_LIBS += libSNPE
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := libsnpe_adsp
-LOCAL_SRC_FILES := $(SNPE_LIB_PATH)/libsnpe_adsp.so
-include $(PREBUILT_SHARED_LIBRARY)
-SNPE_PREBUILT_LIBS += libsnpe_adsp
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := libsnpe_dsp_domains
-LOCAL_SRC_FILES := $(SNPE_LIB_PATH)/libsnpe_dsp_domains.so
-include $(PREBUILT_SHARED_LIBRARY)
-SNPE_PREBUILT_LIBS += libsnpe_dsp_domains
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := libsnpe_dsp_domains_v2
-LOCAL_SRC_FILES := $(SNPE_LIB_PATH)/libsnpe_dsp_domains_v2.so
-include $(PREBUILT_SHARED_LIBRARY)
-SNPE_PREBUILT_LIBS += libsnpe_dsp_domains_v2
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := libhta
-LOCAL_SRC_FILES := $(SNPE_LIB_PATH)/libhta.so
-include $(PREBUILT_SHARED_LIBRARY)
-SNPE_PREBUILT_LIBS += libhta

--- a/api/android/api/src/main/jni/Android-snpe.mk
+++ b/api/android/api/src/main/jni/Android-snpe.mk
@@ -17,7 +17,7 @@ SNPE_DIR := $(LOCAL_PATH)/snpe
 SNPE_INCLUDES := $(SNPE_DIR)/include/zdl/
 
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
-SNPE_LIB_PATH := $(SNPE_DIR)/lib/aarch64-android-clang6.0
+SNPE_LIB_PATH := $(SNPE_DIR)/lib
 else
 $(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
 endif

--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -300,11 +300,16 @@ fi
 if [[ $enable_snpe == "yes" ]]; then
     sed -i "s|ENABLE_SNPE := false|ENABLE_SNPE := true|" api/src/main/jni/Android-nnstreamer-prebuilt.mk
     sed -i "s|ENABLE_SNPE := false|ENABLE_SNPE := true|" api/src/main/jni/Android.mk
-    sed -i "$ a SNPE_DSP_LIBRARY_PATH=src/main/jni/snpe/lib/dsp" gradle.properties
-    mkdir -p api/src/main/jni/snpe/lib/dsp/arm64-v8a
+    sed -i "$ a SNPE_EXT_LIBRARY_PATH=src/main/jni/snpe/lib/ext" gradle.properties
+
+    mkdir -p api/src/main/jni/snpe/lib/ext/arm64-v8a
     cp -r $SNPE_DIRECTORY/include api/src/main/jni/snpe
-    cp -r $SNPE_DIRECTORY/lib/aarch64-android-clang6.0 api/src/main/jni/snpe/lib/aarch64-android-clang6.0
-    cp $SNPE_DIRECTORY/lib/dsp/libsnpe*.so api/src/main/jni/snpe/lib/dsp/arm64-v8a
+    cp $SNPE_DIRECTORY/lib/aarch64-android-clang6.0/libSNPE.so api/src/main/jni/snpe/lib
+
+    # Copy external so files for SNPE
+    cp $SNPE_DIRECTORY/lib/aarch64-android-clang6.0/lib*dsp*.so api/src/main/jni/snpe/lib/ext/arm64-v8a
+    cp $SNPE_DIRECTORY/lib/aarch64-android-clang6.0/libhta.so api/src/main/jni/snpe/lib/ext/arm64-v8a
+    cp $SNPE_DIRECTORY/lib/dsp/libsnpe*.so api/src/main/jni/snpe/lib/ext/arm64-v8a
 fi
 
 # Update tf-lite option


### PR DESCRIPTION
- We do not need to link all snpe prebuilt libs: only libSNPE requires to build aar
- Move excluded libs to jniLibs

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
