### PR TITLE
[Dist/debian] Fix nnstreamer install files

### DIFF
--- a/debian/nnstreamer.install
+++ b/debian/nnstreamer.install
@@ -1,4 +1,8 @@
-/usr/lib/nnstreamer/decoders/libnnstreamer_decoder_*.so
+/usr/lib/nnstreamer/decoders/libnnstreamer_decoder_bounding_boxes.so
+/usr/lib/nnstreamer/decoders/libnnstreamer_decoder_pose_estimation.so
+/usr/lib/nnstreamer/decoders/libnnstreamer_decoder_image_segment.so
+/usr/lib/nnstreamer/decoders/libnnstreamer_decoder_image_labeling.so
+/usr/lib/nnstreamer/decoders/libnnstreamer_decoder_direct_video.so
 /usr/lib/nnstreamer/filters/libnnstreamer_filter_cpp.so
 /usr/lib/*/gstreamer-1.0/*.so
 /usr/lib/*/libcapi-*.so


### PR DESCRIPTION
Since nnstreamer-protobuf and nnstreamer-flatbuf packages are separated from nnstreamer package, fix the SO installation list of nnstreamer.

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped