### PR TITLE
[hw/accl] move h/w dependent code out of filter + Bug Fix

### DIFF
--- a/gst/nnstreamer/hw_accel.c
+++ b/gst/nnstreamer/hw_accel.c
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * NNStreamer hardware accelerator availability checking
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ */
+/**
+ * @file	hw_accel.c
+ * @date	8 September 2020
+ * @brief	Common hardware acceleration availability checks
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#include <hw_accel.h>
+#include <errno.h>
+
+#if defined(__aarch64__) || defined(__arm__)
+#if defined(__TIZEN__)
+#include <asm-arm/hwcap.h>
+#elif defined(__ANDROID__) || defined(__linux__)
+#include <asm/hwcap.h>
+#endif /* __TIZEN__ */
+#endif /* __arch64__ || __arm__ */
+
+#include <sys/auxv.h>
+
+/**
+ * @brief Check if neon is supported
+ * @retval 0 if supported, else -errno
+ */
+gint
+cpu_neon_accel_available (void)
+{
+  gint neon_available = 0;
+
+#if defined(__aarch64__) || defined(__arm__)
+  gulong hwcap_flag;
+
+#if defined(__aarch64__)
+  hwcap_flag = HWCAP_ASIMD;
+#elif defined(__arm__)
+  hwcap_flag = HWCAP_NEON;
+#endif /* __arch64 __ */
+
+  if (getauxval (AT_HWCAP) & hwcap_flag) {
+    neon_available = 0;
+  } else {
+    neon_available = -EINVAL;
+  }
+#endif /* __arch64__ || __arm__ */
+
+  return neon_available;
+}

--- a/gst/nnstreamer/hw_accel.h
+++ b/gst/nnstreamer/hw_accel.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * NNStreamer hardware accelerator availability checking
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ */
+/**
+ * @file	hw_accel.h
+ * @date	8 September 2020
+ * @brief	Common hardware acceleration availability header
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#ifndef __G_HW_ACCEL__
+#define __G_HW_ACCEL__
+
+#include <glib.h>
+
+/**
+ * @brief Check if neon is supported
+ * @retval 0 if supported, else -errno
+ */
+gint cpu_neon_accel_available (void);
+
+#endif /* __G_HW_ACCEL__ */

--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -29,6 +29,7 @@ nnstreamer_internal_deps = []
 # Add nnstreamer registerer and common sources
 nnst_common_sources = [
   'registerer/nnstreamer.c',
+  'hw_accel.c',
   'nnstreamer_conf.c',
   'nnstreamer_subplugin.c',
   'tensor_common.c',

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -24,15 +24,8 @@
  */
 
 #include <string.h>
-#if defined(__aarch64__) || defined(__arm__)
-#include <sys/auxv.h>
-#if defined(__ANDROID__)
-#include <asm/hwcap.h>
-#else /* __ANDROID __ */
-#include <asm-arm/hwcap.h>
-#endif /* __android __ */
-#endif /* __arch64__ __arm__ */
 
+#include <hw_accel.h>
 #include <nnstreamer_log.h>
 #include <tensor_common.h>
 
@@ -2117,23 +2110,7 @@ filter_supported_accelerators (const gchar ** supported_accelerators)
 {
   gint num_hw = 0, idx = 0;
   const gchar **accl_support;
-  gboolean neon_support = TRUE;
-
-#if defined(__aarch64__) || defined(__arm__)
-  glong hwcap_flag;
-
-#if defined(__aarch64__)
-  hwcap_flag = HWCAP_ASIMD;
-#elif defined(__arm__)
-  hwcap_flag = HWCAP_NEON;
-#endif
-
-  if (getauxval (AT_HWCAP) & hwcap_flag) {
-    neon_support = TRUE;
-  } else {
-    neon_support = FALSE;
-  }
-#endif
+  gint neon_available = cpu_neon_accel_available ();
 
   /** Count number of elements for the array */
   while (supported_accelerators[num_hw] != NULL) {
@@ -2147,8 +2124,8 @@ filter_supported_accelerators (const gchar ** supported_accelerators)
   idx = 0;
   num_hw = 0;
   while (supported_accelerators[idx] != NULL) {
-    if (get_accl_hw_type (supported_accelerators[idx]) == ACCL_CPU_NEON &&
-        !neon_support) {
+    if (g_ascii_strncasecmp (supported_accelerators[idx], ACCL_CPU_NEON_STR,
+            strlen (ACCL_CPU_NEON_STR)) == 0 && neon_available != 0) {
       g_critical ("Neon instructions are not available on this device.");
     } else {
       accl_support[num_hw] = supported_accelerators[idx];

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -32,6 +32,7 @@ NNSTREAMER_INCLUDES := \
 
 # nnstreamer common sources. (including tensor-filter common, custom filter)
 NNSTREAMER_COMMON_SRCS := \
+    $(NNSTREAMER_GST_HOME)/hw_accel.c \
     $(NNSTREAMER_GST_HOME)/nnstreamer_conf.c \
     $(NNSTREAMER_GST_HOME)/nnstreamer_subplugin.c \
     $(NNSTREAMER_GST_HOME)/tensor_common.c \


### PR DESCRIPTION
As per the comments received in #2651, this patch moves the hardware
dependent code out of the tensor filter.

V2:
Also updated bugfix for linux (non android, non tizen) arm build
for proper header inclusion.

Resolves #2704 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
