### PR TITLE
[Coverity] Fix CWE-466 (Lock) in tizensensor_get_property

### DIFF
--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
@@ -825,10 +825,6 @@ gst_tensor_src_tizensensor_get_property (GObject * object,
       g_value_set_enum (value, self->mode);
       break;
     case PROP_FREQ:
-      if (self->freq_d < 1)
-        self->freq_d = 1;
-      if (self->freq_n < 0)
-        self->freq_n = 0;
       gst_value_set_fraction (value, self->freq_n, self->freq_d);
       break;
     default:


### PR DESCRIPTION
The conditions in `if` statements are guaranteed in the get_property function, so remove this part

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped