### PR TITLE
[TF-lite] Check flatbuffer dependency when tf-lite is enabled.

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -85,6 +85,12 @@ if tf_support_is_available
 endif
 
 if tflite_support_is_available
+  if not get_option('flatbuf-support').disabled()
+    if not flatbuf_dep.found()
+      error ('flatbuf devel package should be install to build the tensorflow lite.')
+    endif
+  endif
+
   filter_sub_tflite_sources = ['tensor_filter_tensorflow_lite.cc']
 
   nnstreamer_filter_tflite_sources = []


### PR DESCRIPTION
This patch adds the dependency check of flatbuffer when tf-lite filter
is enabled. It shows developers more detailed information instead of a
simple build break log.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

### Current Problem ###
If tf-lite filter is enabled, then `flatbuffers-dev` package also should be installed.
However, there is no dependency check for this so below error occurs.
```bash
$ meson build
..
$ ninja -C build
...
In file included from /usr/include/tensorflow/lite/core/api/op_resolver.h:20:0,
                 from /usr/include/tensorflow/lite/model.h:39,
                 from /home/again4you/nnstreamer_work/flatbuffer_dependency/nnstreamer/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc:36:
/usr/include/tensorflow/lite/schema/schema_generated.h:21:10: fatal error: flatbuffers/flatbuffers.h: No such file or directory
 #include "flatbuffers/flatbuffers.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[90/169] Linking target ext/nnstreamer/tensor_decoder/libnnstreamer_decoder_image_segment.so.
ninja: build stopped: subcommand failed.
```

### After applying this PR ###
```bash
$ meson build
...
Dependency gstreamer-1.0 found: YES (cached)
Configuring nnstreamer_version.h using configuration
Library flatbuffers found: NO

ext/nnstreamer/tensor_filter/meson.build:91:6: ERROR: Problem encountered: flatbuf devel package should be install to build the tensorflow lite.

A full log can be found at /home/again4you/nnstreamer_work/flatbuffer_dependency/nnstreamer/build/meson-logs/meson-log.txt
```


