### PR TITLE
[docker] Add ubuntu16.04/18.04 devel Dockerfile

### DIFF
--- a/docker/devel/ubuntu16.04/Dockerfile
+++ b/docker/devel/ubuntu16.04/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:16.04
+
+RUN apt update
+RUN apt install -y software-properties-common
+RUN apt-add-repository ppa:nnstreamer
+RUN apt update
+
+RUN apt install -y git
+RUN git clone https://github.com/nnstreamer/nnstreamer.git /opt/nnstreamer
+
+RUN apt install -y \
+    meson \
+    ninja-build \
+    build-essential \
+    pkg-config \
+    cmake \
+    libglib2.0-dev \
+    libgstreamer1.0-0 \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav \
+    gstreamer1.0-doc \
+    gstreamer1.0-tools \
+    gstreamer1.0-x \
+    gstreamer1.0-alsa \
+    gstreamer1.0-pulseaudio \
+    libgstreamer-plugins-base1.0-dev \
+    libgtest-dev
+
+WORKDIR /opt/nnstreamer/
+RUN meson build
+RUN ninja -C build
+
+WORKDIR /opt/nnstreamer/build/
+RUN ninja install

--- a/docker/devel/ubuntu18.04/Dockerfile
+++ b/docker/devel/ubuntu18.04/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:18.04
+
+RUN apt update
+RUN apt install -y software-properties-common
+RUN apt-add-repository ppa:nnstreamer
+RUN apt update
+
+RUN apt install -y git
+RUN git clone https://github.com/nnstreamer/nnstreamer.git /opt/nnstreamer
+
+RUN apt install -y \
+    meson \
+    ninja-build \
+    build-essential \
+    pkg-config \
+    cmake \
+    libglib2.0-dev \
+    libgstreamer1.0-0 \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav \
+    gstreamer1.0-doc \
+    gstreamer1.0-tools \
+    gstreamer1.0-x \
+    gstreamer1.0-alsa \
+    gstreamer1.0-gl \
+    gstreamer1.0-gtk3 \
+    gstreamer1.0-qt5 \
+    gstreamer1.0-pulseaudio \
+    libgstreamer-plugins-base1.0-dev \
+    libgtest-dev
+
+WORKDIR /opt/nnstreamer/
+RUN meson build
+RUN ninja -C build
+
+WORKDIR /opt/nnstreamer/build/
+RUN ninja install

--- a/docker/runtime/ubuntu16.04/Dockerfile
+++ b/docker/runtime/ubuntu16.04/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:16.04
+
+RUN apt update
+RUN apt install -y software-properties-common
+RUN apt-add-repository ppa:nnstreamer/ppa
+RUN apt update
+RUN apt install -y nnstreamer

--- a/docker/runtime/ubuntu18.04/Dockerfile
+++ b/docker/runtime/ubuntu18.04/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:18.04
+
+RUN apt update
+RUN apt install -y software-properties-common
+RUN apt-add-repository ppa:nnstreamer/ppa
+RUN apt update
+RUN apt install -y nnstreamer


### PR DESCRIPTION
Adding docker container for nnstreamer runtime and development (meson/ninja build) in ubuntu 16.04/18.04.

I added my forked repository's Dockerfile to [Docker Hub](https://hub.docker.com/repository/docker/wisechang1/nnstreamer), and build was successful.
If this PR is merged, it may be useful to create a Docker Hub nnstreamer account and add a nnstreamer/nnstreamer repository to the Docker Hub.

For nnstreamer project, docker can an easiest way for setup. (Recent days, Tensorflow recommend to use docker container, too)
Is there a better location for the `docker/` directory?

Resolves: #2657 

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped