### PR TITLE
[Filter/Python3] Make nnstreamer-python work with python 3.8 on macOS 

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -74,10 +74,15 @@
 #define DBG FALSE
 #endif
 
-#if PY_VERSION_HEX >= 0x03080000 || PY_VERSION_HEX < 0x03000000
-#define PYCORE_LIB_NAME_FORMAT "libpython%d.%d.so.1.0"
+#ifdef __MACOS__
+#define SO_EXT  "dylib"
 #else
-#define PYCORE_LIB_NAME_FORMAT "libpython%d.%dm.so.1.0"
+#define SO_EXT  "so.1.0"
+#endif
+#if PY_VERSION_HEX >= 0x03080000 || PY_VERSION_HEX < 0x03000000
+#define PYCORE_LIB_NAME_FORMAT "libpython%d.%d.%s"
+#else
+#define PYCORE_LIB_NAME_FORMAT "libpython%d.%dm.%s"
 #endif
 
 #define Py_ERRMSG(...) do {PyErr_Print(); ml_loge (__VA_ARGS__);} while (0);
@@ -171,7 +176,7 @@ PYCore::PYCore (const char* _script_path, const char* _custom)
   gchar libname[32] = { 0, };
 
   g_snprintf (libname, sizeof (libname), PYCORE_LIB_NAME_FORMAT,
-      PY_MAJOR_VERSION, PY_MINOR_VERSION);
+      PY_MAJOR_VERSION, PY_MINOR_VERSION, SO_EXT);
 
   handle = dlopen(libname, RTLD_LAZY | RTLD_GLOBAL);
   if (nullptr == handle)

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python_api.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python_api.c
@@ -246,6 +246,11 @@ initnnstreamer_python (void)
 #endif
   PyObject *type_object = (PyObject *) & TensorShapeType;
   PyObject *module;
+
+  /** Check TensorShape type */
+  if (PyType_Ready (&TensorShapeType) < 0)
+    return RETVAL (NULL);
+
 #if PY_VERSION_HEX >= 0x03000000
   module = PyModule_Create (&nnstreamer_python_module);
 #else
@@ -256,9 +261,6 @@ initnnstreamer_python (void)
 
   /** For numpy array init. */
   import_array ();
-
-  /** Check TensorShape type */
-  g_assert (!(PyType_Ready (&TensorShapeType) < 0));
 
   Py_INCREF (type_object);
   PyModule_AddObject (module, "TensorShape", type_object);

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ add_project_arguments('-DVERSION_MICRO="' + version_split[2] + '"', language: ['
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')
 build_platform = ''
+so_ext = 'so'
 
 if get_option('enable-tizen')
   # Pass __TIZEN__ to the compiler
@@ -45,6 +46,7 @@ elif not meson.is_cross_build()
       # Pass __MACOS__ to the compiler
       add_project_arguments('-D__MACOS__=1', language: ['c', 'cpp'])
       build_platform = 'macos'
+      so_ext = 'dylib'
     endif
   endif
 endif

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -11,8 +11,8 @@ tizen_apptest_deps = [
 # [name, extension abbreviation, dependencies, model file name/folder path/file path, test name]
 extensions = []
 
-extensions += [['custom', 'custom', nnstreamer_unittest_deps, '../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough.so', 'custom']]
-extensions += [['custom', 'custom', nnstreamer_unittest_deps, '../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough_variable.so', 'custom-set']]
+extensions += [['custom', 'custom', nnstreamer_unittest_deps, '../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough.' + so_ext, 'custom']]
+extensions += [['custom', 'custom', nnstreamer_unittest_deps, '../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough_variable.' + so_ext, 'custom-set']]
 
 if tflite_support_is_available
   extensions += [['tensorflow-lite', 'tflite', nnstreamer_filter_tflite_deps, 'mobilenet_v1_1.0_224_quant.tflite', 'tensorflow_lite']]
@@ -87,7 +87,7 @@ foreach ext : extensions
     run_command('rm', '-rf', py2_module_path, check : true)
     run_command('mkdir', '-p', py2_module_path, check : true)
     run_command('ln', '-sf',
-        join_paths(meson.build_root(), 'ext/nnstreamer/tensor_filter/nnstreamer_python2.so'),
+        join_paths(meson.build_root(), 'ext/nnstreamer/tensor_filter/nnstreamer_python2.' + so_ext),
         py2_module_path + '/nnstreamer_python.so', check : true)
     filter_ext_common_testenv.set('PYTHONPATH', py2_module_path)
   elif ext[0] == 'python3'
@@ -95,7 +95,7 @@ foreach ext : extensions
     run_command('rm', '-rf', py3_module_path, check : true)
     run_command('mkdir', '-p', py3_module_path, check : true)
     run_command('ln', '-sf',
-        join_paths(meson.build_root(), 'ext/nnstreamer/tensor_filter/nnstreamer_python3.so'),
+        join_paths(meson.build_root(), 'ext/nnstreamer/tensor_filter/nnstreamer_python3.' + so_ext),
         py3_module_path + '/nnstreamer_python.so', check : true)
     filter_ext_common_testenv.set('PYTHONPATH', py3_module_path)
   endif


### PR DESCRIPTION
In order to nnstreamer-python3 work with python 3.8 on macOS, this PR revises the libpython name and the hard-coded file extensions of shared libraries to fit macOS. In addition, PyType_Ready is moved to the location before PyModule_Create as the official tutorial [1, 2] guided. This is because PyType_Ready after PyModule_Create fails with returning -1 in some cases.

[1] https://docs.python.org/3/extending/newtypes_tutorial.html
[2] https://docs.python.org/2/extending/newtypes.html

Signed-off-by: Wook Song <wook16.song@samsung.com>
