### PR TITLE
[Meson] bugfixes: Add missing dependency in flatbuffer-support declaration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -244,7 +244,7 @@ features = {
     'extra_args': { 'SNPE_ROOT': SNPE_ROOT }
   },
   'flatbuf-support': {
-    'extra_deps': [ fb_comp ],
+    'extra_deps': [ fb_comp, flatbuf_dep ],
     'project_args': { 'ENABLE_FLATBUF': 1 }
   },
   'protobuf-support': {


### PR DESCRIPTION
This patch adds the missing dependency in the flatbuffer-support feature declaration.

Signed-off-by: Wook Song <wook16.song@samsung.com>