### PR TITLE
[Android] new function to create data object

### DIFF
--- a/api/android/api/src/main/jni/nnstreamer-native.h
+++ b/api/android/api/src/main/jni/nnstreamer-native.h
@@ -199,6 +199,12 @@ extern gboolean
 nns_add_element_handle (pipeline_info_s * pipe_info, const gchar * name, element_data_s * item);
 
 /**
+ * @brief Create new data object with given tensors info. Caller should unref the result object.
+ */
+extern gboolean
+nns_create_tensors_data_object (pipeline_info_s * pipe_info, JNIEnv * env, jobject obj_info, jobject * result);
+
+/**
  * @brief Convert tensors data to TensorsData object.
  */
 extern gboolean


### PR DESCRIPTION
Prepare next version to reduce latency while converting the tensors.
Add new native function to create data object.

After implementing new single-shot API (no data alloc in invoke API), I will update Java invoke method to remove memcpy.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
