### PR TITLE
[API/Tizen] Add verson number to libcapi-nnstreamer.so

### DIFF
--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -95,6 +95,7 @@ shared_library ('capi-nnstreamer',
   include_directories: capi_inc,
   install: true,
   install_dir: nnstreamer_libdir,
+  version: meson.project_version(),
 )
 nnstreamer_capi_lib = static_library ('capi-nnstreamer',
   capi_main,

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -638,6 +638,11 @@ ln -sf %{_prefix}/lib/nnstreamer/filters/nnstreamer_python2.so nnstreamer_python
 popd
 %endif
 
+# Hotfix: Support the backward compatibility of the .Net APIs
+pushd %{buildroot}%{_libdir}
+ln -sf libcapi-nnstreamer.so.%{version} libcapi-nnstreamer.so.0
+popd
+
 %if 0%{?testcoverage}
 ##
 # The included directories are:

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -638,11 +638,6 @@ ln -sf %{_prefix}/lib/nnstreamer/filters/nnstreamer_python2.so nnstreamer_python
 popd
 %endif
 
-# Hotfix: Support backward compatibility
-pushd %{buildroot}%{_libdir}
-ln -sf ./libcapi-nnstreamer.so libcapi-nnstreamer.so.0
-popd
-
 %if 0%{?testcoverage}
 ##
 # The included directories are:
@@ -780,12 +775,12 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %files -n capi-nnstreamer
 %manifest capi-nnstreamer.manifest
 %license LICENSE
-%{_libdir}/libcapi-nnstreamer.so
 %{_libdir}/libcapi-nnstreamer.so.*
 
 %files -n capi-nnstreamer-devel
 %{_includedir}/nnstreamer/nnstreamer.h
 %{_includedir}/nnstreamer/nnstreamer-single.h
+%{_libdir}/libcapi-nnstreamer.so
 %{_libdir}/pkgconfig/capi-nnstreamer.pc
 
 %files -n capi-nnstreamer-devel-static


### PR DESCRIPTION
This patch adds the verson number to libcapi-nnstreamer.so and fixes the
packaging issue as follows:

```bash
$ rpm -qlp capi-nnstreamer-1.5.3-0.x86_64.rpm
/usr/lib64/libcapi-nnstreamer.so.0
/usr/lib64/libcapi-nnstreamer.so.1
/usr/lib64/libcapi-nnstreamer.so.1.5.3
/usr/share/licenses/capi-nnstreamer
/usr/share/licenses/capi-nnstreamer/LICENSE

$ rpm -qlp capi-nnstreamer-devel-1.5.3-0.x86_64.rpm
/usr/include/nnstreamer/nnstreamer-single.h
/usr/include/nnstreamer/nnstreamer.h
/usr/lib64/libcapi-nnstreamer.so
/usr/lib64/pkgconfig/capi-nnstreamer.pc
```

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped


### Submit history

#### Submit v2
* Add libcapi-nnstreamer.so.0 symlink to temporarily support the backward compatibility of the .Net APIs  and rootstrap

#### Submit v1
* First draft

### Notice 
~~DO NOT apply this patch only into review.tizen.org.~~

~~If this patch is merged, all .net test cases would be failed since it refers to `libcapi-nnstreamer.so.0` instead of `libcapi-nnstreamer.so.1`. So TizenFx should be fixed and merged it with the same SR tag.~~


