### PR TITLE
[Meson] Enable fbs-support only if versions of flatc and libs are matched @open sesame 09/22 11:55

### DIFF
--- a/ext/nnstreamer/meson.build
+++ b/ext/nnstreamer/meson.build
@@ -1,7 +1,7 @@
 if flatbuf_support_is_available
   # Compile flatbuffers schema file
-  fb_gen = generator(fb_comp, output : '@BASENAME@_generated.h',
-                 arguments : ['--cpp', '-o', '@BUILD_DIR@', '@INPUT@'])
+  fb_gen = generator(flatc, output : '@BASENAME@_generated.h',
+      arguments : ['--cpp', '-o', '@BUILD_DIR@', '@INPUT@'])
   fb_gen_src = fb_gen.process('./include/nnstreamer.fbs')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -143,9 +143,14 @@ thread_dep = dependency('threads') # pthread for tensorflow-lite
 # Protobuf
 protobuf_dep = dependency('protobuf', version: '>= 3.6.1', required: false)
 
-# Flatbuffer compiler
-flatbuf_dep = cc.find_library('flatbuffers', required : get_option('flatbuf-support'))
-fb_comp = find_program('flatc', required : get_option('flatbuf-support'))
+# Flatbuffers compiler and libraries
+flatc = find_program('flatc', required : get_option('flatbuf-support'))
+flatbuf_dep = disabler()
+if flatc.found()
+  flatc_ver = run_command(flatc, '--version').stdout().split()[2]
+  flatbuf_dep = dependency('flatbuffers', version: flatc_ver,
+      required : get_option('flatbuf-support'))
+endif
 
 # Protobuf compiler
 pb_comp = find_program('protoc', required: get_option('protobuf-support'))
@@ -244,7 +249,7 @@ features = {
     'extra_args': { 'SNPE_ROOT': SNPE_ROOT }
   },
   'flatbuf-support': {
-    'extra_deps': [ fb_comp, flatbuf_dep ],
+    'extra_deps': [ flatc, flatbuf_dep ],
     'project_args': { 'ENABLE_FLATBUF': 1 }
   },
   'protobuf-support': {


### PR DESCRIPTION
This patch revises meson.build to enable the flatbuf-support only if the versions of flatc and libflatbuffers are matched.

FYI, there is no way to get the version of the library found using cc.find_library() in Meson.
Therefore, ```flatbuffers.pc``` has been included in the dev-kit packages for Ubuntu and Tizen before submitting this PR.

(Wait for deployment of https://review.tizen.org/gerrit/gitweb?p=platform/upstream/flatbuffers.git;a=commit;h=1bfa4ddaa8e39fc6b50f8b8e359aa0c32ef8ced1)

Resolves: #2711 

Signed-off-by: Wook Song <wook16.song@samsung.com>

