### PR TITLE
Filter/TF2-Lite: remove unnecessary if in meson @open sesame 10/28 15:05

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -179,7 +179,7 @@ if tflite2_support_is_available
     nnstreamer_filter_tflite2_sources += join_paths(meson.current_source_dir(), s)
   endforeach
 
-  nnstreamer_filter_tflite2_deps = tflite_support_deps + [thread_dep, libdl_dep, glib_dep, gst_dep, nnstreamer_dep]
+  nnstreamer_filter_tflite2_deps = tflite2_support_deps + [thread_dep, libdl_dep, glib_dep, gst_dep, nnstreamer_dep]
 
   tflite2_compile_args = []
   if cxx.has_type('kTfLiteInt8', prefix : '#include <tensorflow2/contrib/lite/model.h>')

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -182,18 +182,10 @@ if tflite2_support_is_available
   nnstreamer_filter_tflite2_deps = tflite2_support_deps + [thread_dep, libdl_dep, glib_dep, gst_dep, nnstreamer_dep]
 
   tflite2_compile_args = []
-  if cxx.has_type('kTfLiteInt8', prefix : '#include <tensorflow2/contrib/lite/model.h>')
-    tflite2_compile_args += '-DTFLITE_INT8=1'
-  endif
-  if cxx.has_type('kTfLiteInt16', prefix : '#include <tensorflow2/contrib/lite/model.h>')
-    tflite2_compile_args += '-DTFLITE_INT16=1'
-  endif
-  if cxx.has_type('kTfLiteFloat16', prefix : '#include <tensorflow2/contrib/lite/model.h>')
-    tflite2_compile_args += '-DTFLITE_FLOAT16=1'
-  endif
-  if cxx.has_type('kTfLiteComplex64', prefix : '#include <tensorflow2/contrib/lite/model.h>')
-    tflite2_compile_args += '-DTFLITE_COMPLEX64=1'
-  endif
+  tflite2_compile_args += '-DTFLITE_INT8=1'
+  tflite2_compile_args += '-DTFLITE_INT16=1'
+  tflite2_compile_args += '-DTFLITE_FLOAT16=1'
+  tflite2_compile_args += '-DTFLITE_COMPLEX64=1'
 
   tflite2_extra_dep = declare_dependency(
     compile_args : tflite2_compile_args


### PR DESCRIPTION
TF2-Lite has all such data types enabled.
We do not need to check them.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

