### PR TITLE
[tensor_filter] Improve subplugin initialization

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -750,10 +750,15 @@ static GstTensorFilterFramework NNS_support_armnn = {
       .allocate_in_invoke = FALSE,
       .run_without_model = FALSE,
       .verify_model_path = FALSE,
+      .statistics = nullptr,
       .invoke_NN = armnn_invoke,
       .getInputDimension = armnn_getInputDim,
       .getOutputDimension = armnn_getOutputDim,
+      .setInputDimension = nullptr,
+      .destroyNotify = nullptr,
+      .reloadModel = nullptr,
       .checkAvailability = armnn_checkAvailability,
+      .allocateInInvoke = nullptr,
     }
   }
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -35,9 +35,9 @@
 #include <armnnCaffeParser/ICaffeParser.hpp>
 
 #include <nnstreamer_log.h>
-#define __NO_ANONYMOUS_NESTED_STRUCT
+#define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
-#undef __NO_ANONYMOUS_NESTED_STRUCT
+#undef NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api.h>
 #include <nnstreamer_conf.h>
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -35,7 +35,9 @@
 #include <armnnCaffeParser/ICaffeParser.hpp>
 
 #include <nnstreamer_log.h>
+#define __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
+#undef __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api.h>
 #include <nnstreamer_conf.h>
 
@@ -741,22 +743,25 @@ static GstTensorFilterFramework NNS_support_armnn = {
   .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = armnn_open,
   .close = armnn_close,
-  .checkAvailability = armnn_checkAvailability,
+  {
+    .v0 = {
+      .name = filter_subplugin_armnn,
+      .allow_in_place = FALSE,  /** @todo: support this to optimize performance later. */
+      .allocate_in_invoke = FALSE,
+      .run_without_model = FALSE,
+      .verify_model_path = FALSE,
+      .invoke_NN = armnn_invoke,
+      .getInputDimension = armnn_getInputDim,
+      .getOutputDimension = armnn_getOutputDim,
+      .checkAvailability = armnn_checkAvailability,
+    }
+  }
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_armnn (void)
 {
-  NNS_support_armnn.name = filter_subplugin_armnn;
-  NNS_support_armnn.allow_in_place = FALSE;      /** @todo: support this to optimize performance later. */
-  NNS_support_armnn.allocate_in_invoke = FALSE;
-  NNS_support_armnn.run_without_model = FALSE;
-  NNS_support_armnn.verify_model_path = FALSE;
-  NNS_support_armnn.invoke_NN = armnn_invoke;
-  NNS_support_armnn.getInputDimension = armnn_getInputDim;
-  NNS_support_armnn.getOutputDimension = armnn_getOutputDim;
-
   nnstreamer_filter_probe (&NNS_support_armnn);
 }
 
@@ -764,5 +769,5 @@ init_filter_armnn (void)
 void
 fini_filter_armnn (void)
 {
-  nnstreamer_filter_exit (NNS_support_armnn.name);
+  nnstreamer_filter_exit (NNS_support_armnn.v0.name);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
@@ -31,7 +31,9 @@
 
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
+#define __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
+#undef __NO_ANONYMOUS_NESTED_STRUCT
 
 #include <caffe2/core/workspace.h>
 #include <caffe2/core/init.h>
@@ -597,23 +599,26 @@ static GstTensorFilterFramework NNS_support_caffe2 = {
   .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = caffe2_open,
   .close = caffe2_close,
+  {
+    .v0 = {
+      .name = filter_subplugin_caffe2,
+      .allow_in_place = FALSE,  /** @todo: support this to optimize performance later. */
+      .allocate_in_invoke = TRUE,
+      .run_without_model = FALSE,
+      .verify_model_path = FALSE,
+      .invoke_NN = caffe2_run,
+      .getInputDimension = caffe2_getInputDim,
+      .getOutputDimension = caffe2_getOutputDim,
+      .destroyNotify = caffe2_destroyNotify,
+      .checkAvailability = caffe2_checkAvailability,
+    }
+  }
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_caffe2 (void)
 {
-  NNS_support_caffe2.name = filter_subplugin_caffe2;
-  NNS_support_caffe2.allow_in_place = FALSE;      /** @todo: support this to optimize performance later. */
-  NNS_support_caffe2.allocate_in_invoke = TRUE;
-  NNS_support_caffe2.run_without_model = FALSE;
-  NNS_support_caffe2.verify_model_path = FALSE;
-  NNS_support_caffe2.invoke_NN = caffe2_run;
-  NNS_support_caffe2.getInputDimension = caffe2_getInputDim;
-  NNS_support_caffe2.getOutputDimension = caffe2_getOutputDim;
-  NNS_support_caffe2.destroyNotify = caffe2_destroyNotify;
-  NNS_support_caffe2.checkAvailability = caffe2_checkAvailability;
-
   nnstreamer_filter_probe (&NNS_support_caffe2);
 }
 
@@ -621,5 +626,5 @@ init_filter_caffe2 (void)
 void
 fini_filter_caffe2 (void)
 {
-  nnstreamer_filter_exit (NNS_support_caffe2.name);
+  nnstreamer_filter_exit (NNS_support_caffe2.v0.name);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
@@ -31,9 +31,9 @@
 
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
-#define __NO_ANONYMOUS_NESTED_STRUCT
+#define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
-#undef __NO_ANONYMOUS_NESTED_STRUCT
+#undef NO_ANONYMOUS_NESTED_STRUCT
 
 #include <caffe2/core/workspace.h>
 #include <caffe2/core/init.h>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
@@ -606,11 +606,15 @@ static GstTensorFilterFramework NNS_support_caffe2 = {
       .allocate_in_invoke = TRUE,
       .run_without_model = FALSE,
       .verify_model_path = FALSE,
+      .statistics = nullptr,
       .invoke_NN = caffe2_run,
       .getInputDimension = caffe2_getInputDim,
       .getOutputDimension = caffe2_getOutputDim,
+      .setInputDimension = nullptr,
       .destroyNotify = caffe2_destroyNotify,
+      .reloadModel = nullptr,
       .checkAvailability = caffe2_checkAvailability,
+      .allocateInInvoke = nullptr,
     }
   }
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
@@ -35,9 +35,9 @@
 #include <gmodule.h>
 
 #include <nnstreamer_log.h>
-#define __NO_ANONYMOUS_NESTED_STRUCT
+#define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
-#undef __NO_ANONYMOUS_NESTED_STRUCT
+#undef NO_ANONYMOUS_NESTED_STRUCT
 
 #include "tensor_filter_cpp.hh"
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
@@ -59,10 +59,15 @@ static GstTensorFilterFramework NNS_support_cpp = {
       .allocate_in_invoke = FALSE,
       .run_without_model = FALSE,
       .verify_model_path = FALSE,
+      .statistics = nullptr,
       .invoke_NN = tensor_filter_cpp::invoke,
       .getInputDimension = tensor_filter_cpp::getInputDim,
       .getOutputDimension = tensor_filter_cpp::getOutputDim,
       .setInputDimension = tensor_filter_cpp::setInputDim,
+      .destroyNotify = nullptr,
+      .reloadModel = nullptr,
+      .checkAvailability = nullptr,
+      .allocateInInvoke = nullptr,
     }
   }
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
@@ -32,9 +32,9 @@
 #include <gst/gst.h>
 #include <mvnc2/mvnc.h>
 #include <nnstreamer_log.h>
-#define __NO_ANONYMOUS_NESTED_STRUCT
+#define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
-#undef __NO_ANONYMOUS_NESTED_STRUCT
+#undef NO_ANONYMOUS_NESTED_STRUCT
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
@@ -32,7 +32,9 @@
 #include <gst/gst.h>
 #include <mvnc2/mvnc.h>
 #include <nnstreamer_log.h>
+#define __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
+#undef __NO_ANONYMOUS_NESTED_STRUCT
 #include <sys/types.h>
 #include <sys/stat.h>
 
@@ -437,21 +439,24 @@ static GstTensorFilterFramework NNS_support_movidius_ncsdk2 = {
   .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = _mvncsdk2_open,
   .close = _mvncsdk2_close,
-  .checkAvailability = _mvncsdk2_checkAvailability,
+  {
+    .v0 = {
+      .name = filter_subplugin_movidius_ncsdk2,
+      .allow_in_place = FALSE,
+      .allocate_in_invoke = FALSE,
+      .verify_model_path = FALSE,
+      .invoke_NN = _mvncsdk2_invoke,
+      .getInputDimension = _mvncsdk2_getInputDim,
+      .getOutputDimension = _mvncsdk2_getOutputDim,
+      .checkAvailability = _mvncsdk2_checkAvailability,
+    }
+  }
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_mvncsdk2 (void)
 {
-  NNS_support_movidius_ncsdk2.name = filter_subplugin_movidius_ncsdk2;
-  NNS_support_movidius_ncsdk2.allow_in_place = FALSE;
-  NNS_support_movidius_ncsdk2.allocate_in_invoke = FALSE;
-  NNS_support_movidius_ncsdk2.verify_model_path = FALSE;
-  NNS_support_movidius_ncsdk2.invoke_NN = _mvncsdk2_invoke;
-  NNS_support_movidius_ncsdk2.getInputDimension = _mvncsdk2_getInputDim;
-  NNS_support_movidius_ncsdk2.getOutputDimension = _mvncsdk2_getOutputDim;
-
   nnstreamer_filter_probe (&NNS_support_movidius_ncsdk2);
 }
 
@@ -459,5 +464,5 @@ init_filter_mvncsdk2 (void)
 void
 fini_filter_mvncsdk2 (void)
 {
-  nnstreamer_filter_exit (NNS_support_movidius_ncsdk2.name);
+  nnstreamer_filter_exit (NNS_support_movidius_ncsdk2.v0.name);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
@@ -444,11 +444,17 @@ static GstTensorFilterFramework NNS_support_movidius_ncsdk2 = {
       .name = filter_subplugin_movidius_ncsdk2,
       .allow_in_place = FALSE,
       .allocate_in_invoke = FALSE,
+      .run_without_model = FALSE,
       .verify_model_path = FALSE,
+      .statistics = NULL,
       .invoke_NN = _mvncsdk2_invoke,
       .getInputDimension = _mvncsdk2_getInputDim,
       .getOutputDimension = _mvncsdk2_getOutputDim,
+      .setInputDimension = NULL,
+      .destroyNotify = NULL,
+      .reloadModel = NULL,
       .checkAvailability = _mvncsdk2_checkAvailability,
+      .allocateInInvoke = NULL,
     }
   }
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -32,7 +32,9 @@
 #include <glib-object.h>
 
 #include <tensor_common.h>
+#define __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
+#undef __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnfw.h>
 
 /** backends supported by nnfw */
@@ -664,6 +666,21 @@ static GstTensorFilterFramework NNS_support_nnfw = {
   .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = nnfw_open,
   .close = nnfw_close,
+  {
+    .v0 = {
+      .name = filter_subplugin_nnfw,
+      .allow_in_place = FALSE,
+      .allocate_in_invoke = FALSE,
+      .run_without_model = FALSE,
+      .verify_model_path = FALSE,
+      .statistics = &nnfw_internal_stats,
+      .invoke_NN = nnfw_invoke,
+      .getInputDimension = nnfw_getInputDim,
+      .getOutputDimension = nnfw_getOutputDim,
+      .setInputDimension = nnfw_setInputDim,
+      .checkAvailability = nnfw_checkAvailability,
+    }
+  }
 };
 
 /**@brief Initialize this object for tensor_filter subplugin runtime register */
@@ -674,18 +691,6 @@ init_filter_nnfw (void)
   nnfw_internal_stats.total_invoke_latency = 0;
   nnfw_internal_stats.total_overhead_latency = 0;
 
-  NNS_support_nnfw.name = filter_subplugin_nnfw;
-  NNS_support_nnfw.allow_in_place = FALSE;
-  NNS_support_nnfw.allocate_in_invoke = FALSE;
-  NNS_support_nnfw.run_without_model = FALSE;
-  NNS_support_nnfw.verify_model_path = FALSE;
-  NNS_support_nnfw.invoke_NN = nnfw_invoke;
-  NNS_support_nnfw.getInputDimension = nnfw_getInputDim;
-  NNS_support_nnfw.getOutputDimension = nnfw_getOutputDim;
-  NNS_support_nnfw.setInputDimension = nnfw_setInputDim;
-  NNS_support_nnfw.checkAvailability = nnfw_checkAvailability;
-  NNS_support_nnfw.statistics = &nnfw_internal_stats;
-
   nnstreamer_filter_probe (&NNS_support_nnfw);
 }
 
@@ -693,5 +698,5 @@ init_filter_nnfw (void)
 void
 fini_filter_nnfw (void)
 {
-  nnstreamer_filter_exit (NNS_support_nnfw.name);
+  nnstreamer_filter_exit (NNS_support_nnfw.v0.name);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -63,7 +63,11 @@ static const gchar *nnfw_accl_default = ACCL_CPU_STR;
 void init_filter_nnfw (void) __attribute__ ((constructor));
 void fini_filter_nnfw (void) __attribute__ ((destructor));
 
-static GstTensorFilterFrameworkStatistics nnfw_internal_stats;
+static GstTensorFilterFrameworkStatistics nnfw_internal_stats = {
+  .total_invoke_num = 0,
+  .total_invoke_latency = 0,
+  .total_overhead_latency = 0,
+};
 
 /**
  * @brief private data structure for the nnfw framework
@@ -690,10 +694,6 @@ static GstTensorFilterFramework NNS_support_nnfw = {
 void
 init_filter_nnfw (void)
 {
-  nnfw_internal_stats.total_invoke_num = 0;
-  nnfw_internal_stats.total_invoke_latency = 0;
-  nnfw_internal_stats.total_overhead_latency = 0;
-
   nnstreamer_filter_probe (&NNS_support_nnfw);
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -678,7 +678,10 @@ static GstTensorFilterFramework NNS_support_nnfw = {
       .getInputDimension = nnfw_getInputDim,
       .getOutputDimension = nnfw_getOutputDim,
       .setInputDimension = nnfw_setInputDim,
+      .destroyNotify = NULL,
+      .reloadModel = NULL,
       .checkAvailability = nnfw_checkAvailability,
+      .allocateInInvoke = NULL,
     }
   }
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -32,9 +32,9 @@
 #include <glib-object.h>
 
 #include <tensor_common.h>
-#define __NO_ANONYMOUS_NESTED_STRUCT
+#define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
-#undef __NO_ANONYMOUS_NESTED_STRUCT
+#undef NO_ANONYMOUS_NESTED_STRUCT
 #include <nnfw.h>
 
 /** backends supported by nnfw */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
@@ -655,10 +655,15 @@ static GstTensorFilterFramework NNS_support_openvino = {
       .allocate_in_invoke = FALSE,
       .run_without_model = FALSE,
       .verify_model_path = FALSE,
+      .statistics = nullptr,
       .invoke_NN = ov_invoke,
       .getInputDimension = ov_getInputDim,
       .getOutputDimension = ov_getOutputDim,
+      .setInputDimension = nullptr,
+      .destroyNotify = nullptr,
+      .reloadModel = nullptr,
       .checkAvailability = ov_checkAvailability,
+      .allocateInInvoke = nullptr,
     }
   }
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
@@ -26,7 +26,9 @@
 
 #include <glib.h>
 #include <nnstreamer_log.h>
+#define __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
+#undef __NO_ANONYMOUS_NESTED_STRUCT
 #include <tensor_common.h>
 #ifdef __OPENVINO_CPU_EXT__
 #include <ext_list.hpp>
@@ -646,6 +648,19 @@ static GstTensorFilterFramework NNS_support_openvino = {
   .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = ov_open,
   .close = ov_close,
+  {
+    .v0 = {
+      .name = filter_subplugin_openvino,
+      .allow_in_place = FALSE,
+      .allocate_in_invoke = FALSE,
+      .run_without_model = FALSE,
+      .verify_model_path = FALSE,
+      .invoke_NN = ov_invoke,
+      .getInputDimension = ov_getInputDim,
+      .getOutputDimension = ov_getOutputDim,
+      .checkAvailability = ov_checkAvailability,
+    }
+  }
 };
 
 /**
@@ -654,16 +669,6 @@ static GstTensorFilterFramework NNS_support_openvino = {
 void
 init_filter_openvino (void)
 {
-  NNS_support_openvino.name = filter_subplugin_openvino;
-  NNS_support_openvino.allow_in_place = FALSE;
-  NNS_support_openvino.allocate_in_invoke = FALSE;
-  NNS_support_openvino.run_without_model = FALSE;
-  NNS_support_openvino.verify_model_path = FALSE;
-  NNS_support_openvino.invoke_NN = ov_invoke;
-  NNS_support_openvino.getInputDimension = ov_getInputDim;
-  NNS_support_openvino.getOutputDimension = ov_getOutputDim;
-  NNS_support_openvino.checkAvailability = ov_checkAvailability;
-
   nnstreamer_filter_probe (&NNS_support_openvino);
 }
 
@@ -673,5 +678,5 @@ init_filter_openvino (void)
 void
 fini_filter_openvino (void)
 {
-  nnstreamer_filter_exit (NNS_support_openvino.name);
+  nnstreamer_filter_exit (NNS_support_openvino.v0.name);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
@@ -26,9 +26,9 @@
 
 #include <glib.h>
 #include <nnstreamer_log.h>
-#define __NO_ANONYMOUS_NESTED_STRUCT
+#define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
-#undef __NO_ANONYMOUS_NESTED_STRUCT
+#undef NO_ANONYMOUS_NESTED_STRUCT
 #include <tensor_common.h>
 #ifdef __OPENVINO_CPU_EXT__
 #include <ext_list.hpp>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -975,13 +975,16 @@ static GstTensorFilterFramework NNS_support_python = {
       .allocate_in_invoke = TRUE,
       .run_without_model = FALSE,
       .verify_model_path = FALSE,
+      .statistics = nullptr,
       .invoke_NN = py_run,
       /** dimension-related callbacks are dynamically updated */
       .getInputDimension = py_getInputDim,
       .getOutputDimension = py_getOutputDim,
       .setInputDimension = py_setInputDim,
       .destroyNotify = py_destroyNotify,
+      .reloadModel = nullptr,
       .checkAvailability = py_checkAvailability,
+      .allocateInInvoke = nullptr,
     }
   }
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -60,9 +60,9 @@
 
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
-#define __NO_ANONYMOUS_NESTED_STRUCT
+#define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
-#undef __NO_ANONYMOUS_NESTED_STRUCT
+#undef NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_conf.h>
 
 #include <vector>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -60,7 +60,9 @@
 
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
+#define __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
+#undef __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_conf.h>
 
 #include <vector>
@@ -966,25 +968,28 @@ static GstTensorFilterFramework NNS_support_python = {
   .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = py_open,
   .close = py_close,
+  {
+    .v0 = {
+      .name = filter_subplugin_python,
+      .allow_in_place = FALSE, /** @todo: support this to optimize performance later. */
+      .allocate_in_invoke = TRUE,
+      .run_without_model = FALSE,
+      .verify_model_path = FALSE,
+      .invoke_NN = py_run,
+      /** dimension-related callbacks are dynamically updated */
+      .getInputDimension = py_getInputDim,
+      .getOutputDimension = py_getOutputDim,
+      .setInputDimension = py_setInputDim,
+      .destroyNotify = py_destroyNotify,
+      .checkAvailability = py_checkAvailability,
+    }
+  }
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_py (void)
 {
-  NNS_support_python.name = filter_subplugin_python;
-  NNS_support_python.allow_in_place = FALSE;      /** @todo: support this to optimize performance later. */
-  NNS_support_python.allocate_in_invoke = TRUE;
-  NNS_support_python.run_without_model = FALSE;
-  NNS_support_python.verify_model_path = FALSE;
-  NNS_support_python.invoke_NN = py_run;
-  /** dimension-related callbacks are dynamically updated */
-  NNS_support_python.getInputDimension = py_getInputDim;
-  NNS_support_python.getOutputDimension = py_getOutputDim;
-  NNS_support_python.setInputDimension = py_setInputDim;
-  NNS_support_python.destroyNotify = py_destroyNotify;
-  NNS_support_python.checkAvailability = py_checkAvailability;
-
   nnstreamer_filter_probe (&NNS_support_python);
   /** Python should be initialized and finalized only once */
   Py_Initialize();
@@ -996,5 +1001,5 @@ fini_filter_py (void)
 {
   /** Python should be initialized and finalized only once */
   Py_Finalize();
-  nnstreamer_filter_exit (NNS_support_python.name);
+  nnstreamer_filter_exit (NNS_support_python.v0.name);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -691,10 +691,15 @@ static GstTensorFilterFramework NNS_support_pytorch = {
       .allocate_in_invoke = FALSE,
       .run_without_model = FALSE,
       .verify_model_path = FALSE,
+      .statistics = nullptr,
       .invoke_NN = torch_invoke,
       .getInputDimension = torch_getInputDim,
       .getOutputDimension = torch_getOutputDim,
+      .setInputDimension = nullptr,
+      .destroyNotify = nullptr,
+      .reloadModel = nullptr,
       .checkAvailability = torch_checkAvailability,
+      .allocateInInvoke = nullptr,
     }
   }
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -28,9 +28,9 @@
 
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
-#define __NO_ANONYMOUS_NESTED_STRUCT
+#define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
-#undef __NO_ANONYMOUS_NESTED_STRUCT
+#undef NO_ANONYMOUS_NESTED_STRUCT
 
 #include <nnstreamer_conf.h>
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -28,7 +28,9 @@
 
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
+#define __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
+#undef __NO_ANONYMOUS_NESTED_STRUCT
 
 #include <nnstreamer_conf.h>
 
@@ -682,22 +684,25 @@ static GstTensorFilterFramework NNS_support_pytorch = {
   .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = torch_open,
   .close = torch_close,
+  {
+    .v0 = {
+      .name = filter_subplugin_pytorch,
+      .allow_in_place = FALSE, /** @todo: support this to optimize performance later. */
+      .allocate_in_invoke = FALSE,
+      .run_without_model = FALSE,
+      .verify_model_path = FALSE,
+      .invoke_NN = torch_invoke,
+      .getInputDimension = torch_getInputDim,
+      .getOutputDimension = torch_getOutputDim,
+      .checkAvailability = torch_checkAvailability,
+    }
+  }
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_torch (void)
 {
-  NNS_support_pytorch.name = filter_subplugin_pytorch;
-  NNS_support_pytorch.allow_in_place = FALSE;
-  NNS_support_pytorch.allocate_in_invoke = FALSE;
-  NNS_support_pytorch.run_without_model = FALSE;
-  NNS_support_pytorch.verify_model_path = FALSE;
-  NNS_support_pytorch.invoke_NN = torch_invoke;
-  NNS_support_pytorch.getInputDimension = torch_getInputDim;
-  NNS_support_pytorch.getOutputDimension = torch_getOutputDim;
-  NNS_support_pytorch.checkAvailability = torch_checkAvailability;
-
   nnstreamer_filter_probe (&NNS_support_pytorch);
 }
 
@@ -705,5 +710,5 @@ init_filter_torch (void)
 void
 fini_filter_torch (void)
 {
-  nnstreamer_filter_exit (NNS_support_pytorch.name);
+  nnstreamer_filter_exit (NNS_support_pytorch.v0.name);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
@@ -773,11 +773,15 @@ static GstTensorFilterFramework NNS_support_tensorflow = {
       .allocate_in_invoke = TRUE,
       .run_without_model = FALSE,
       .verify_model_path = FALSE,
+      .statistics = nullptr,
       .invoke_NN = tf_run,
       .getInputDimension = tf_getInputDim,
       .getOutputDimension = tf_getOutputDim,
+      .setInputDimension = nullptr,
       .destroyNotify = tf_destroyNotify,
+      .reloadModel = nullptr,
       .checkAvailability = tf_checkAvailability,
+      .allocateInInvoke = nullptr,
     }
   }
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
@@ -29,7 +29,9 @@
 
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
+#define __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
+#undef __NO_ANONYMOUS_NESTED_STRUCT
 
 #include <iostream>
 #include <fstream>
@@ -764,23 +766,26 @@ static GstTensorFilterFramework NNS_support_tensorflow = {
   .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = tf_open,
   .close = tf_close,
+  {
+    .v0 = {
+      .name = filter_subplugin_tensorflow,
+      .allow_in_place = FALSE, /** @todo: support this to optimize performance later. */
+      .allocate_in_invoke = TRUE,
+      .run_without_model = FALSE,
+      .verify_model_path = FALSE,
+      .invoke_NN = tf_run,
+      .getInputDimension = tf_getInputDim,
+      .getOutputDimension = tf_getOutputDim,
+      .destroyNotify = tf_destroyNotify,
+      .checkAvailability = tf_checkAvailability,
+    }
+  }
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_tf (void)
 {
-  NNS_support_tensorflow.name = filter_subplugin_tensorflow;
-  NNS_support_tensorflow.allow_in_place = FALSE;      /** @todo: support this to optimize performance later. */
-  NNS_support_tensorflow.allocate_in_invoke = TRUE;
-  NNS_support_tensorflow.run_without_model = FALSE;
-  NNS_support_tensorflow.verify_model_path = FALSE;
-  NNS_support_tensorflow.invoke_NN = tf_run;
-  NNS_support_tensorflow.getInputDimension = tf_getInputDim;
-  NNS_support_tensorflow.getOutputDimension = tf_getOutputDim;
-  NNS_support_tensorflow.destroyNotify = tf_destroyNotify;
-  NNS_support_tensorflow.checkAvailability = tf_checkAvailability;
-
   nnstreamer_filter_probe (&NNS_support_tensorflow);
 }
 
@@ -788,5 +793,5 @@ init_filter_tf (void)
 void
 fini_filter_tf (void)
 {
-  nnstreamer_filter_exit (NNS_support_tensorflow.name);
+  nnstreamer_filter_exit (NNS_support_tensorflow.v0.name);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
@@ -29,9 +29,9 @@
 
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
-#define __NO_ANONYMOUS_NESTED_STRUCT
+#define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
-#undef __NO_ANONYMOUS_NESTED_STRUCT
+#undef NO_ANONYMOUS_NESTED_STRUCT
 
 #include <iostream>
 #include <fstream>
@@ -781,7 +781,7 @@ static GstTensorFilterFramework NNS_support_tensorflow = {
       .destroyNotify = tf_destroyNotify,
       .reloadModel = nullptr,
       .checkAvailability = tf_checkAvailability,
-      .allocateInInvoke = nullptr,
+      .allocateInInvoke = nullptr, // TODO: what, it's allocate_in_invoke
     }
   }
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -63,7 +63,11 @@ static const gchar *tflite_accl_auto = ACCL_CPU_STR;
 #endif
 static const gchar *tflite_accl_default = ACCL_CPU_STR;
 
-static GstTensorFilterFrameworkStatistics tflite_internal_stats;
+static GstTensorFilterFrameworkStatistics tflite_internal_stats = {
+  .total_invoke_num = 0,
+  .total_invoke_latency = 0,
+  .total_overhead_latency = 0,
+};
 
 /**
  * @brief Wrapper class for TFLite Interpreter to support model switching
@@ -1112,10 +1116,6 @@ static GstTensorFilterFramework NNS_support_tensorflow_lite = {
 void
 init_filter_tflite (void)
 {
-  tflite_internal_stats.total_invoke_num = 0;
-  tflite_internal_stats.total_invoke_latency = 0;
-  tflite_internal_stats.total_overhead_latency = 0;
-
   nnstreamer_filter_probe (&NNS_support_tensorflow_lite);
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -32,7 +32,9 @@
 
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
+#define __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
+#undef __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_conf.h>
 
 #include <tensorflow/contrib/lite/model.h>
@@ -1086,6 +1088,22 @@ static GstTensorFilterFramework NNS_support_tensorflow_lite = {
   .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = tflite_open,
   .close = tflite_close,
+  {
+    .v0 = {
+      .name = filter_subplugin_tensorflow_lite,
+      .allow_in_place = FALSE,  /** @todo: support this to optimize performance later. */
+      .allocate_in_invoke = FALSE,
+      .run_without_model = FALSE,
+      .verify_model_path = TRUE,
+      .statistics = &tflite_internal_stats,
+      .invoke_NN = tflite_invoke,
+      .getInputDimension = tflite_getInputDim,
+      .getOutputDimension = tflite_getOutputDim,
+      .setInputDimension = tflite_setInputDim,
+      .reloadModel = tflite_reloadModel,
+      .checkAvailability = tflite_checkAvailability,
+    }
+  }
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */
@@ -1096,18 +1114,6 @@ init_filter_tflite (void)
   tflite_internal_stats.total_invoke_latency = 0;
   tflite_internal_stats.total_overhead_latency = 0;
 
-  NNS_support_tensorflow_lite.name = filter_subplugin_tensorflow_lite;
-  NNS_support_tensorflow_lite.allow_in_place = FALSE;      /** @todo: support this to optimize performance later. */
-  NNS_support_tensorflow_lite.allocate_in_invoke = FALSE;
-  NNS_support_tensorflow_lite.run_without_model = FALSE;
-  NNS_support_tensorflow_lite.verify_model_path = TRUE;
-  NNS_support_tensorflow_lite.invoke_NN = tflite_invoke;
-  NNS_support_tensorflow_lite.getInputDimension = tflite_getInputDim;
-  NNS_support_tensorflow_lite.getOutputDimension = tflite_getOutputDim;
-  NNS_support_tensorflow_lite.setInputDimension = tflite_setInputDim;
-  NNS_support_tensorflow_lite.reloadModel = tflite_reloadModel;
-  NNS_support_tensorflow_lite.checkAvailability = tflite_checkAvailability;
-  NNS_support_tensorflow_lite.statistics = &tflite_internal_stats;
   nnstreamer_filter_probe (&NNS_support_tensorflow_lite);
 }
 
@@ -1115,5 +1121,5 @@ init_filter_tflite (void)
 void
 fini_filter_tflite (void)
 {
-  nnstreamer_filter_exit (NNS_support_tensorflow_lite.name);
+  nnstreamer_filter_exit (NNS_support_tensorflow_lite.v0.name);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -1100,8 +1100,10 @@ static GstTensorFilterFramework NNS_support_tensorflow_lite = {
       .getInputDimension = tflite_getInputDim,
       .getOutputDimension = tflite_getOutputDim,
       .setInputDimension = tflite_setInputDim,
+      .destroyNotify = nullptr,
       .reloadModel = tflite_reloadModel,
       .checkAvailability = tflite_checkAvailability,
+      .allocateInInvoke = nullptr,
     }
   }
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -32,9 +32,9 @@
 
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
-#define __NO_ANONYMOUS_NESTED_STRUCT
+#define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
-#undef __NO_ANONYMOUS_NESTED_STRUCT
+#undef NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_conf.h>
 
 #include <tensorflow/contrib/lite/model.h>

--- a/ext/nnstreamer/tensor_filter/vivante/tensor_filter_subplugin.c
+++ b/ext/nnstreamer/tensor_filter/vivante/tensor_filter_subplugin.c
@@ -72,7 +72,9 @@
 #include <glib.h>
 #include <errno.h>
 
+#define __NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
+#undef __NO_ANONYMOUS_NESTED_STRUCT
 
 #include <dlfcn.h>
 
@@ -581,19 +583,23 @@ static GstTensorFilterFramework NNS_support_vivante = {
 #endif
   .open = vivante_open,
   .close = vivante_close,
+  {
+    .v0 = {
+      .name = filter_subplugin_vivante,
+      .allow_in_place = FALSE,
+      .allocate_in_invoke = FALSE,
+      .run_without_model = FALSE,
+      .invoke_NN = vivante_invoke,
+      .getInputDimension = vivante_getInputDim,
+      .getOutputDimension = vivante_getOutputDim,
+    }
+  }
 };
 
 /**@brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_vivante (void)
 {
-  NNS_support_vivante.name = filter_subplugin_vivante;
-  NNS_support_vivante.allow_in_place = FALSE;
-  NNS_support_vivante.allocate_in_invoke = FALSE;
-  NNS_support_vivante.run_without_model = FALSE;
-  NNS_support_vivante.invoke_NN = vivante_invoke;
-  NNS_support_vivante.getInputDimension = vivante_getInputDim;
-  NNS_support_vivante.getOutputDimension = vivante_getOutputDim;
   nnstreamer_filter_probe (&NNS_support_vivante);
 }
 
@@ -601,5 +607,5 @@ init_filter_vivante (void)
 void
 fini_filter_vivante (void)
 {
-  nnstreamer_filter_exit (NNS_support_vivante.name);
+  nnstreamer_filter_exit (NNS_support_vivante.v0.name);
 }

--- a/ext/nnstreamer/tensor_filter/vivante/tensor_filter_subplugin.c
+++ b/ext/nnstreamer/tensor_filter/vivante/tensor_filter_subplugin.c
@@ -589,9 +589,16 @@ static GstTensorFilterFramework NNS_support_vivante = {
       .allow_in_place = FALSE,
       .allocate_in_invoke = FALSE,
       .run_without_model = FALSE,
+      .verify_model_path = FALSE,
+      .statistics = NULL,
       .invoke_NN = vivante_invoke,
       .getInputDimension = vivante_getInputDim,
       .getOutputDimension = vivante_getOutputDim,
+      .setInputDimension = NULL,
+      .destroyNotify = NULL,
+      .reloadModel = NULL,
+      .checkAvailability = NULL,
+      .allocateInInvoke = NULL,
     }
   }
 };

--- a/ext/nnstreamer/tensor_filter/vivante/tensor_filter_subplugin.c
+++ b/ext/nnstreamer/tensor_filter/vivante/tensor_filter_subplugin.c
@@ -72,9 +72,9 @@
 #include <glib.h>
 #include <errno.h>
 
-#define __NO_ANONYMOUS_NESTED_STRUCT
+#define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
-#undef __NO_ANONYMOUS_NESTED_STRUCT
+#undef NO_ANONYMOUS_NESTED_STRUCT
 
 #include <dlfcn.h>
 

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -386,7 +386,7 @@ struct _GstTensorFilterFramework
         * @return 0 if supported. -errno if not supported.
         */
     }
-#ifdef __NO_ANONYMOUS_NESTED_STRUCT
+#ifdef NO_ANONYMOUS_NESTED_STRUCT
         v0
 #endif
     ;
@@ -467,7 +467,7 @@ struct _GstTensorFilterFramework
        */
       void *subplugin_data; /**< This is used by tensor_filter infrastructure. Subplugin authors should NEVER update this. Only the files in /gst/nnstreamer/tensor_filter/ are allowed to access this. */
     }
-#ifdef __NO_ANONYMOUS_NESTED_STRUCT
+#ifdef NO_ANONYMOUS_NESTED_STRUCT
         v1
 #endif
     ;

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
@@ -36,9 +36,9 @@
 
 #include <system_error>
 
-#define __NO_ANONYMOUS_NESTED_STRUCT
+#define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
-#undef __NO_ANONYMOUS_NESTED_STRUCT
+#undef NO_ANONYMOUS_NESTED_STRUCT
 
 #include <nnstreamer_cppplugin_api_filter.hh>
 


### PR DESCRIPTION
This patch focuses on moving subplugin initialization from dlopen constructers to static definitions.
This also includes a minor macro rename (s/__NO_ANONYMOUS_NESTED_STRUCT/NO_ANONYMOUS_NESTED_STRUCT/g).

Please see commit messages for detail.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

**How to evaluate:**
1. Rebuilt library without error.
2. Run several examples and behaves the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nnstreamer/nnstreamer/2757)
<!-- Reviewable:end -->
