### PR TITLE
[Single] invoke with pre-allocated output data

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -263,6 +263,13 @@ typedef struct {
 int ml_single_open_custom (ml_single_h *single, ml_single_preset *info);
 
 /**
+ * @brief Invokes the model with the given input data.
+ * This function does not allocate data handle and updates output data.
+ * @todo consider to open new api (invoke with preallocated output handle)
+ */
+int ml_single_invoke_no_alloc (ml_single_h single, const ml_tensors_data_h input, ml_tensors_data_h output);
+
+/**
  * @brief Macro to check the availability of given NNFW.
  */
 #define ml_nnfw_is_available(f,h) ({bool a; (ml_check_nnfw_availability ((f), (h), &a) == ML_ERROR_NONE && a);})

--- a/api/capi/include/tensor_filter_single.h
+++ b/api/capi/include/tensor_filter_single.h
@@ -66,7 +66,7 @@ struct _GTensorFilterSingleClass
 
   /** Invoke the filter for execution. */
   gboolean (*invoke) (GTensorFilterSingle * self, const GstTensorMemory * input,
-      GstTensorMemory * output);
+      GstTensorMemory * output, gboolean allocate);
   /** Start the filter, must be called before invoke. */
   gboolean (*start) (GTensorFilterSingle * self);
   /** Stop the filter.*/

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -237,7 +237,8 @@ __invoke (ml_single * single_h)
   out_tensors = (GstTensorMemory *) out_data->tensors;
 
   /** invoke the thread */
-  if (!single_h->klass->invoke (single_h->filter, in_tensors, out_tensors)) {
+  if (!single_h->klass->invoke (single_h->filter, in_tensors, out_tensors,
+      single_h->free_output)) {
     status = ML_ERROR_STREAMS_PIPE;
     if (single_h->free_output)
       ml_tensors_data_destroy (single_h->output);
@@ -1002,7 +1003,6 @@ _ml_single_invoke_internal (ml_single_h single,
     if (status != ML_ERROR_NONE)
       goto exit;
   } else {
-    /** @todo implement no-alloc (invoke with allocated output data) */
     single_h->output = *output;
   }
 
@@ -1065,6 +1065,17 @@ ml_single_invoke (ml_single_h single,
     const ml_tensors_data_h input, ml_tensors_data_h * output)
 {
   return _ml_single_invoke_internal (single, input, output, TRUE);
+}
+
+/**
+ * @brief Invokes the model with the given input data.
+ * This function does not allocate data handle and updates output data.
+ */
+int
+ml_single_invoke_no_alloc (ml_single_h single,
+    const ml_tensors_data_h input, ml_tensors_data_h output)
+{
+  return _ml_single_invoke_internal (single, input, &output, FALSE);
 }
 
 /**


### PR DESCRIPTION
Add new function to invoke the model with pre-allocated output data handle.
This may reduce single-shot invoke latency in Android Java API.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
