### PR TITLE
[Build/TF-Lite] Check tf-lite version and don't use contrib path @open sesame 9/24 16:03

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -84,7 +84,22 @@ if tf_support_is_available
   )
 endif
 
+tflite_ver_dep = disabler()
 if tflite_support_is_available
+  tflite_ver = tflite_support_deps[0].version()
+  tflite_ver_major = tflite_ver.split('.')[0]
+  tflite_ver_minor = tflite_ver.split('.')[1]
+  tflite_ver_micro = tflite_ver.split('.')[2]
+
+  tflite_ver_dep = declare_dependency (
+    compile_args : [
+      '-DTFLITE_VERSION=' + tflite_ver,
+      '-DTFLITE_VERSION_MAJOR=' + tflite_ver_major,
+      '-DTFLITE_VERSION_MINOR=' + tflite_ver_minor,
+      '-DTFLITE_VERSION_MICRO=' + tflite_ver_micro,
+    ],
+  )
+
   if not flatbuf_support_is_available
     flatbuf_dep = dependency('flatbuffers', required : true, \
         not_found_message : 'flatbuf devel package should be install to build the tensorflow lite subplugin.')
@@ -99,27 +114,32 @@ if tflite_support_is_available
 
   nnstreamer_filter_tflite_deps = tflite_support_deps + [thread_dep, libdl_dep, glib_dep, gst_dep, nnstreamer_dep]
 
-  tflite_compile_args = []
+  # Since tf-1.13, tflite has moved from contrib to core
+  tflite_h_prefix='#include <tensorflow/lite/model.h>'
+  if tflite_ver_minor.to_int() < 13
+    tflite_h_prefix='#include <tensorflow/contrib/lite/model.h>'
+  endif
 
-  if cxx.has_type('kTfLiteInt8', prefix : '#include <tensorflow/contrib/lite/model.h>')
+  tflite_compile_args = []
+  if cxx.has_type('kTfLiteInt8', prefix : tflite_h_prefix)
     tflite_compile_args += '-DTFLITE_INT8=1'
   endif
-  if cxx.has_type('kTfLiteInt16', prefix : '#include <tensorflow/contrib/lite/model.h>')
+  if cxx.has_type('kTfLiteInt16', prefix : tflite_h_prefix)
     tflite_compile_args += '-DTFLITE_INT16=1'
   endif
-  if cxx.has_type('kTfLiteFloat16', prefix : '#include <tensorflow/contrib/lite/model.h>')
+  if cxx.has_type('kTfLiteFloat16', prefix : tflite_h_prefix)
     tflite_compile_args += '-DTFLITE_FLOAT16=1'
   endif
-  if cxx.has_type('kTfLiteComplex64', prefix : '#include <tensorflow/contrib/lite/model.h>')
+  if cxx.has_type('kTfLiteComplex64', prefix : tflite_h_prefix)
     tflite_compile_args += '-DTFLITE_COMPLEX64=1'
   endif
-  tflite_compile_args += '-DTFLITE_VERSION=1'
 
   tflite_extra_dep = declare_dependency(
-    compile_args : tflite_compile_args,
+    compile_args : tflite_compile_args
   )
 
   nnstreamer_filter_tflite_deps += tflite_extra_dep
+  nnstreamer_filter_tflite_deps += tflite_ver_dep
 
   shared_library('nnstreamer_filter_tensorflow-lite',
     nnstreamer_filter_tflite_sources,
@@ -136,7 +156,22 @@ if tflite_support_is_available
   )
 endif
 
+tflite2_ver_dep = disabler()
 if tflite2_support_is_available
+  tflite2_ver = tflite2_support_deps[0].version()
+  tflite2_ver_major = tflite2_ver.split('.')[0]
+  tflite2_ver_minor = tflite2_ver.split('.')[1]
+  tflite2_ver_micro = tflite2_ver.split('.')[2]
+
+  tflite2_ver_dep = declare_dependency (
+    compile_args : [
+      '-DTFLITE_VERSION=' + tflite2_ver,
+      '-DTFLITE_VERSION_MAJOR=' + tflite2_ver_major,
+      '-DTFLITE_VERSION_MINOR=' + tflite2_ver_minor,
+      '-DTFLITE_VERSION_MICRO=' + tflite2_ver_micro,
+    ],
+  )
+
   filter_sub_tflite2_sources = ['tensor_filter_tensorflow_lite.cc']
 
   nnstreamer_filter_tflite2_sources = []
@@ -147,7 +182,6 @@ if tflite2_support_is_available
   nnstreamer_filter_tflite2_deps = tflite_support_deps + [thread_dep, libdl_dep, glib_dep, gst_dep, nnstreamer_dep]
 
   tflite2_compile_args = []
-
   if cxx.has_type('kTfLiteInt8', prefix : '#include <tensorflow2/contrib/lite/model.h>')
     tflite2_compile_args += '-DTFLITE_INT8=1'
   endif
@@ -160,13 +194,13 @@ if tflite2_support_is_available
   if cxx.has_type('kTfLiteComplex64', prefix : '#include <tensorflow2/contrib/lite/model.h>')
     tflite2_compile_args += '-DTFLITE_COMPLEX64=1'
   endif
-  tflite2_compile_args += '-DTFLITE_VERSION=2'
 
   tflite2_extra_dep = declare_dependency(
-    compile_args : tflite2_compile_args,
+    compile_args : tflite2_compile_args
   )
 
   nnstreamer_filter_tflite2_deps += tflite2_extra_dep
+  nnstreamer_filter_tflite2_deps += tflite2_ver_dep
 
   shared_library('nnstreamer_filter_tensorflow2-lite',
     nnstreamer_filter_tflite2_sources,
@@ -388,9 +422,6 @@ if get_option('enable-edgetpu')
 
     endif
 
-    tflite_ver_dep = declare_dependency (
-      compile_args : ['-DTFLITE_VER="' + tflite_support_deps[0].version() +'"', ],
-    )
     shared_library('nnstreamer_filter_edgetpu',
       nnstreamer_filter_edgetpu_sources,
       dependencies: tflite_support_deps + [glib_dep, gst_dep, nnstreamer_dep, edgetpu_dep, libdl_dep, tflite_ver_dep],

--- a/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
@@ -39,8 +39,8 @@
 using nnstreamer::tensor_filter_subplugin;
 using edgetpu::EdgeTpuContext;
 
-#if defined (TFLITE_VER)
-constexpr char tflite_ver[] = TFLITE_VER;
+#if defined (TFLITE_VERSION)
+constexpr char tflite_ver[] = G_STRINGIFY(TFLITE_VERSION);
 #else
 constexpr char tflite_ver[] = "1.x";
 #endif /* defined (TFLITE_VER) */
@@ -51,7 +51,7 @@ namespace tensorfilter_edgetpu {
 void _init_filter_edgetpu (void) __attribute__ ((constructor));
 void _fini_filter_edgetpu (void) __attribute__ ((destructor));
 
-
+/** @brief enum for edgetpu device type */
 enum class edgetpu_subplugin_device_type : uint32_t {
   USB = static_cast<uint32_t>(edgetpu::DeviceType::kApexUsb),
   PCI = static_cast<uint32_t>(edgetpu::DeviceType::kApexPci),
@@ -59,6 +59,7 @@ enum class edgetpu_subplugin_device_type : uint32_t {
   DUMMY = 99,
 };
 
+/** @brief get device typename */
 static const std::string edgetpu_subplugin_device_type_name (
     edgetpu_subplugin_device_type t)
 {
@@ -74,6 +75,7 @@ static const std::string edgetpu_subplugin_device_type_name (
     }
 }
 
+/** @brief edgetpu subplugin class */
 class edgetpu_subplugin final : public tensor_filter_subplugin {
 private:
   bool empty_model;
@@ -129,6 +131,7 @@ public:
 const char *edgetpu_subplugin::name = "edgetpu";
 const accl_hw edgetpu_subplugin::hw_list[] = { ACCL_NPU_EDGE_TPU };
 
+/** @brief edgetpu class constructor */
 edgetpu_subplugin::edgetpu_subplugin () :
     tensor_filter_subplugin (),
     empty_model (true),
@@ -143,6 +146,7 @@ edgetpu_subplugin::edgetpu_subplugin () :
   /** Nothing to do. Just let it have an empty instance */
 }
 
+/** @brief cleanup resources used by edgetpu subplugin */
 void edgetpu_subplugin::cleanup ()
 {
   if (empty_model)
@@ -171,11 +175,13 @@ void edgetpu_subplugin::cleanup ()
   empty_model = true;
 }
 
+/** @brief edgetpu class destructor */
 edgetpu_subplugin::~edgetpu_subplugin ()
 {
   cleanup ();
 }
 
+/** @brief get empty instance of edgetpu subplugin */
 tensor_filter_subplugin & edgetpu_subplugin::getEmptyInstance ()
 {
   return *(new edgetpu_subplugin());
@@ -240,6 +246,7 @@ edgetpu_subplugin_device_type edgetpu_subplugin::parse_custom_prop (
   return edgetpu_subplugin_device_type::DEFAULT;
 }
 
+/** @brief configure edgetpu instance */
 void edgetpu_subplugin::configure_instance (const GstTensorFilterProperties *prop)
 {
   const std::string _model_path = prop->model_files[0];
@@ -319,6 +326,7 @@ void edgetpu_subplugin::configure_instance (const GstTensorFilterProperties *pro
   empty_model = false;
 }
 
+/** @brief invoke using edgetpu */
 void edgetpu_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
 {
   unsigned int i;
@@ -389,6 +397,7 @@ void edgetpu_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *o
   }
 }
 
+/** @brief Get framework information */
 void edgetpu_subplugin::getFrameworkInfo (GstTensorFilterFrameworkInfo &info)
 {
   info.name = name;
@@ -400,6 +409,7 @@ void edgetpu_subplugin::getFrameworkInfo (GstTensorFilterFrameworkInfo &info)
   info.num_hw = num_hw;
 }
 
+/** @brief Get model information */
 int edgetpu_subplugin::getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info)
 {
   if (ops == GET_IN_OUT_INFO) {
@@ -412,6 +422,7 @@ int edgetpu_subplugin::getModelInfo (model_info_ops ops, GstTensorsInfo &in_info
   return -ENOENT;
 }
 
+/** @brief Event handler (TBD) */
 int edgetpu_subplugin::eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data)
 {
   return -ENOENT;
@@ -523,13 +534,14 @@ void edgetpu_subplugin::setTensorProp (tflite::Interpreter *interpreter,
 
 edgetpu_subplugin *edgetpu_subplugin::registeredRepresentation = nullptr;
 
-/**@brief Initialize this object for tensor_filter subplugin runtime register */
+/** @brief Initialize this object for tensor_filter subplugin runtime register */
 void edgetpu_subplugin::init_filter_edgetpu (void)
 {
   registeredRepresentation =
       tensor_filter_subplugin::register_subplugin<edgetpu_subplugin> ();
 }
 
+/** @brief initializer */
 void _init_filter_edgetpu ()
 {
   edgetpu_subplugin::init_filter_edgetpu();
@@ -542,6 +554,7 @@ void edgetpu_subplugin::fini_filter_edgetpu (void)
   tensor_filter_subplugin::unregister_subplugin (registeredRepresentation);
 }
 
+/** @brief finalizer */
 void _fini_filter_edgetpu ()
 {
   edgetpu_subplugin::fini_filter_edgetpu();

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -37,8 +37,13 @@
 #undef NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_conf.h>
 
+#if TFLITE_VERSION_MAJOR >= 2 || TFLITE_VERSION_MINOR >= 13
+#include <tensorflow/lite/model.h>
+#include <tensorflow/lite/kernels/register.h>
+#else
 #include <tensorflow/contrib/lite/model.h>
 #include <tensorflow/contrib/lite/kernels/register.h>
+#endif
 
 /**
  * @brief Macro for debug mode.
@@ -959,6 +964,9 @@ tflite_getOutputDim (const GstTensorFilterProperties * prop,
     } \
   } while (0)
 
+/**
+ * @brief A fallback function to recover input tensor dimensions
+ */
 static void
 tflite_setInputDim_recovery (TFLiteCore *core, GstTensorsInfo *cur_in_info,
     const char * reason, int mode)
@@ -1082,7 +1090,7 @@ tflite_checkAvailability (accl_hw hw)
   return -ENOENT;
 }
 
-#if TFLITE_VERSION == 1
+#if TFLITE_VERSION_MAJOR == 1
 static gchar filter_subplugin_tensorflow_lite[] = "tensorflow-lite";
 #else
 static gchar filter_subplugin_tensorflow_lite[] = "tensorflow2-lite";


### PR DESCRIPTION
This patch adds tf-lite version checking and makes it remove
'contrib' include path in tflite subplugin.

It resolves https://github.com/nnstreamer/nnstreamer/issues/2756.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped