### PR TITLE
[Meson] Merge install-example into install-test @open sesame 9/24 16:02

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -38,7 +38,7 @@ override_dh_auto_clean:
 override_dh_auto_configure:
 	mkdir -p build
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
-	-Dinstall-example=true -Dtf-support=$(enable_tf) -Dtflite-support=enabled -Dpytorch-support=enabled -Dcaffe2-support=enabled \
+	-Dtf-support=$(enable_tf) -Dtflite-support=enabled -Dpytorch-support=enabled -Dcaffe2-support=enabled \
 	-Dpython2-support=enabled -Dpython3-support=enabled -Denable-capi=true -Denable-edgetpu=true -Denable-tizen=false \
 	-Denable-openvino=true build
 	cd tools/development/confchk && meson --prefix=/usr build && cd ../../..

--- a/meson.build
+++ b/meson.build
@@ -464,13 +464,11 @@ subdir('ext')
 # Build API
 subdir('api')
 
-# Build nnstreamer examples
-if get_option('enable-test') or get_option('install-example')
-  subdir('nnstreamer_example')
-endif
-
 # Build unittests
 if get_option('enable-test')
+  # Build nnstreamer examples
+  subdir('nnstreamer_example')
+
   # temporary ini file for test, enable env variables.
   nnstreamer_test_conf = configuration_data()
   nnstreamer_test_conf.merge_from(nnstreamer_conf)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -23,7 +23,6 @@ option('enable-test', type: 'boolean', value: true)
 option('install-test', type: 'boolean', value: false)
 option('enable-pytorch-use-gpu', type: 'boolean', value: false) # default value, can be specified at run time
 option('enable-mediapipe', type: 'boolean', value: false)
-option('install-example', type: 'boolean', value: false)
 option('enable-env-var', type: 'boolean', value: true)
 option('enable-symbolic-link', type: 'boolean', value: true)
 option('enable-capi', type: 'boolean', value: true)

--- a/nnstreamer_example/custom_example_LSTM/meson.build
+++ b/nnstreamer_example/custom_example_LSTM/meson.build
@@ -2,6 +2,6 @@ library('dummyLSTM',
   'dummy_LSTM.c',
   dependencies: [libm_dep, glib_dep],
   include_directories: nnstreamer_inc,
-  install: get_option('install-example'),
+  install: get_option('install-test'),
   install_dir: customfilter_install_dir
 )

--- a/nnstreamer_example/custom_example_RNN/meson.build
+++ b/nnstreamer_example/custom_example_RNN/meson.build
@@ -1,6 +1,6 @@
 library('dummyRNN',
   'dummy_RNN.c',
   include_directories: nnstreamer_inc,
-  install: get_option('install-example'),
+  install: get_option('install-test'),
   install_dir: customfilter_install_dir
 )

--- a/nnstreamer_example/custom_example_average/meson.build
+++ b/nnstreamer_example/custom_example_average/meson.build
@@ -1,6 +1,6 @@
 library('nnstreamer_customfilter_average',
   'nnstreamer_customfilter_example_average.c',
   include_directories: nnstreamer_inc,
-  install: get_option('install-example'),
+  install: get_option('install-test'),
   install_dir: customfilter_install_dir
 )

--- a/nnstreamer_example/custom_example_opencv/meson.build
+++ b/nnstreamer_example/custom_example_opencv/meson.build
@@ -4,14 +4,14 @@ if opencv_dep.found()
   library('nnstreamer_customfilter_opencv_scaler',
     'nnstreamer_customfilter_opencv_scaler.cc',
     dependencies: [glib_dep, gst_dep, nnstreamer_dep, opencv_dep],
-    install: get_option('install-example'),
+    install: get_option('install-test'),
     install_dir: customfilter_install_dir
   )
 
   library('nnstreamer_customfilter_opencv_average',
     'nnstreamer_customfilter_opencv_average.cc',
     dependencies: [glib_dep, gst_dep, nnstreamer_dep, opencv_dep],
-    install: get_option('install-example'),
+    install: get_option('install-test'),
     install_dir: customfilter_install_dir
   )
 endif

--- a/nnstreamer_example/custom_example_passthrough/meson.build
+++ b/nnstreamer_example/custom_example_passthrough/meson.build
@@ -1,13 +1,13 @@
 library('nnstreamer_customfilter_passthrough',
   'nnstreamer_customfilter_example_passthrough.c',
   dependencies: [glib_dep, gst_dep, nnstreamer_dep],
-  install: get_option('install-example'),
+  install: get_option('install-test'),
   install_dir: customfilter_install_dir
 )
 
 library('nnstreamer_customfilter_passthrough_variable',
   'nnstreamer_customfilter_example_passthrough_variable.c',
   dependencies: [glib_dep, gst_dep, nnstreamer_dep],
-  install: get_option('install-example'),
+  install: get_option('install-test'),
   install_dir: customfilter_install_dir
 )

--- a/nnstreamer_example/custom_example_scaler/meson.build
+++ b/nnstreamer_example/custom_example_scaler/meson.build
@@ -1,13 +1,13 @@
 library('nnstreamer_customfilter_scaler',
   'nnstreamer_customfilter_example_scaler.c',
   dependencies: [glib_dep, gst_dep, nnstreamer_dep],
-  install: get_option('install-example'),
+  install: get_option('install-test'),
   install_dir: customfilter_install_dir
 )
 
 library('nnstreamer_customfilter_scaler_allocator',
   'nnstreamer_customfilter_example_scaler_allocator.c',
   dependencies: [glib_dep, gst_dep, nnstreamer_dep],
-  install: get_option('install-example'),
+  install: get_option('install-test'),
   install_dir: customfilter_install_dir
 )

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -337,13 +337,6 @@ Requires:   devel = %{version}-%{release}
 %description devel-static
 Static library package of nnstreamer-devel.
 
-%package custom-filter-example
-Summary:	NNStreamer example custom plugins and test plugins
-Requires:	nnstreamer = %{version}-%{release}
-%description custom-filter-example
-Example custom tensor_filter subplugins and
-plugins created for test purpose.
-
 %if 0%{?testcoverage}
 %package unittest-coverage
 Summary:	NNStreamer UnitTest Coverage Analysis Result
@@ -444,7 +437,7 @@ You may enable this package to use Google Edge TPU with NNStreamer and Tizen ML 
 Summary:	NNStreamer unittests for core, API and plugins
 Requires:	nnstreamer = %{version}-%{release}
 %description unittests
-Package containing various unittests of the nnstreamer.
+Various unit test cases and custom subplugin examples for NNStreamer.
 %endif
 
 %package util
@@ -601,7 +594,7 @@ CXXFLAGS=`echo $CXXFLAGS | sed -e "s|-Wp,-D_FORTIFY_SOURCE=[1-9]||g"`
 mkdir -p build
 
 meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir=%{_libdir} \
-	--bindir=%{nnstexampledir} --includedir=%{_includedir} -Dinstall-example=true \
+	--bindir=%{nnstexampledir} --includedir=%{_includedir} \
 	%{enable_api} %{enable_tizen} %{element_restriction} -Denable-env-var=false -Denable-symbolic-link=false \
 	%{enable_tf_lite} %{enable_tf2_lite} %{enable_tf} %{enable_pytorch} %{enable_caffe2} %{enable_python} \
 	%{enable_nnfw_runtime} %{enable_mvncsdk2} %{enable_openvino} %{enable_armnn} %{enable_edgetpu}  %{enable_vivante} %{enable_flatbuf} \
@@ -801,12 +794,6 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{_datadir}/nnstreamer/unittest/*
 %endif
 
-%files custom-filter-example
-%manifest nnstreamer.manifest
-%defattr(-,root,root,-)
-%license LICENSE
-%{_prefix}/lib/nnstreamer/customfilters/*.so
-
 %if %{with tizen}
 %files -n capi-nnstreamer
 %manifest capi-nnstreamer.manifest
@@ -876,6 +863,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %files unittests
 %manifest nnstreamer.manifest
 %{_libdir}/libnnstreamer_unittest_util.so
+%{_prefix}/lib/nnstreamer/customfilters/*.so
 %{_prefix}/lib/nnstreamer/unittest
 %endif
 


### PR DESCRIPTION
Since there are test cases that require custom-filters, the install-example option should be set to true as well as the
install-test option to make the installed test cases fully work. To avoid such tangled dependencies between these meson options, this patch merges install-example into install-test.

Signed-off-by: Wook Song <wook16.song@samsung.com>

Resolves: #2761

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped