### PR TITLE
[TensorIF] Implement basic operation with uint8 type data @open sesame 9/24 16:05

### DIFF
--- a/gst/nnstreamer/tensor_if/gsttensorif.h
+++ b/gst/nnstreamer/tensor_if/gsttensorif.h
@@ -84,6 +84,7 @@ typedef enum {
   TIFB_FILL_WITH_FILE_RPT,	/**< Fill output frame with a user given file (a raw data of tensor/tensors)
 				     If the filesize is smally, the file is repeatedly used */
   TIFB_REPEAT_PREVIOUS_FRAME,	/**< Resend the previous output frame. If this is the first, send ZERO values. */
+  TIFB_TENSORPICK, /**< Choose nth tensor (or tensors) among tensors */
   TIFB_END,
 } tensor_if_behavior;
 
@@ -93,8 +94,24 @@ typedef enum {
 struct _GstTensorIf
 {
   GstBaseTransform element;     /**< This is the parent object */
-
+  GstPad *sinkpad;
+  GSList *srcpads;
   gboolean silent;
+
+  GstTensorsConfig in_config; /**< input tensor info */
+  GstTensorsConfig out_config; /**< output tensor info */
+  guint32 num_srcpads;
+  gboolean have_group_id;
+  guint group_id;
+
+  tensor_if_compared_value cv; /**< compared value */
+  tensor_if_operator op;
+  tensor_if_behavior act_then;
+  tensor_if_behavior act_else;
+  GList *cv_option;
+  GList *sv;
+  GList *then_option;
+  GList *else_option;
 };
 
 /**


### PR DESCRIPTION
Implemen basic operation of tensor_if element with uint8 type data.
Other PRs will be added soon to support generic type and remain actions.
   - Supported operator: All
   - Suppoted data type: uint8 (need to make it as generic type)
   - Supported action: Not given. Just operate as passthrough(TRUE) and skip(FALSE)

How to test tensor_if element?
If the value of [0][0][0][0] of the first tensor is less than 60, the buffer is dropped.

```
gst-launch-1.0 v4l2src ! videoconvert ! videoscale ! video/x-raw, format=RGB, width=640, height=480, framerate=30/1 ! tensor_converter ! mux.sink_0 \
               videotestsrc ! videoconvert ! videoscale ! video/x-raw, format=RGB, width=640, height=480, framerate=30/1 ! tensor_converter ! mux.sink_1 \
               tensor_mux name=mux ! tensor_if name=tif \
                                               compared_value=A_VALUE compared-value-option=0:0:0:0,0 \
                                               supplied-value=60 \
                                               operator=GE \
                tif.src_0 ! queue ! tensor_decoder mode=direct_video ! videoconvert ! ximagesink \
                tif.src_1 ! queue ! tensor_decoder mode=direct_video ! videoconvert ! ximagesink
```