### PR TITLE
[Ext/Filter/Meson] Do not build tflite-extension without flatbuffers-dev

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -85,10 +85,9 @@ if tf_support_is_available
 endif
 
 if tflite_support_is_available
-  if not get_option('flatbuf-support').disabled()
-    if not flatbuf_dep.found()
-      error ('flatbuf devel package should be install to build the tensorflow lite.')
-    endif
+  if not flatbuf_support_is_available
+    flatbuf_dep = dependency('flatbuffers', required : true, \
+        not_found_message : 'flatbuf devel package should be install to build the tensorflow lite subplugin.')
   endif
 
   filter_sub_tflite_sources = ['tensor_filter_tensorflow_lite.cc']


### PR DESCRIPTION
This patch blocks the building of the TensorFlow-Lite subplugin without resolving the dependency on libflatbuffers-dev.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped