### PR TITLE
[TensorIF] Support generic type for comapred and supplied value

### DIFF
--- a/gst/nnstreamer/tensor_if/gsttensorif.h
+++ b/gst/nnstreamer/tensor_if/gsttensorif.h
@@ -89,6 +89,25 @@ typedef enum {
 } tensor_if_behavior;
 
 /**
+ * @brief Internal data structure for value
+ */
+typedef struct
+{
+  tensor_type type;
+  tensor_element data;
+} tensor_if_data_s;
+
+/**
+ * @brief Internal data structure for supplied value
+ */
+typedef struct
+{
+  guint32 num;
+  tensor_type type;
+  tensor_element data[2];
+} tensor_if_sv_s;
+
+/**
  * @brief Tensor If data structure
  */
 struct _GstTensorIf
@@ -108,8 +127,8 @@ struct _GstTensorIf
   tensor_if_operator op;
   tensor_if_behavior act_then;
   tensor_if_behavior act_else;
+  tensor_if_sv_s sv[2];
   GList *cv_option;
-  GList *sv;
   GList *then_option;
   GList *else_option;
 };


### PR DESCRIPTION
 Support generic type for compared value and supplied value
    
float type is availabe for supplied value.
      - e.g., supplied-value=2.23e+1,22.3
    
 -  Supported operator: All
 -  Supported data type: All
 -  @todo: Supported action: Not given. Just operate as passthrough(TRUE) and skip(FALSE)
    
Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped
