### PR TITLE
[TensorIF] Supports other/tensor(s) in output format

### DIFF
--- a/gst/nnstreamer/tensor_if/gsttensorif.h
+++ b/gst/nnstreamer/tensor_if/gsttensorif.h
@@ -89,6 +89,15 @@ typedef enum {
 } tensor_if_behavior;
 
 /**
+ * @brief Which src pad
+ */
+typedef enum
+{
+  TIFSP_THEN_PAD = 0,
+  TIFSP_ELSE_PAD,
+} tensor_if_srcpads;
+
+/**
  * @brief Internal data structure for value
  */
 typedef struct
@@ -118,7 +127,7 @@ struct _GstTensorIf
   gboolean silent;
 
   GstTensorsConfig in_config; /**< input tensor info */
-  GstTensorsConfig out_config; /**< output tensor info */
+  GstTensorsConfig out_config[2]; /**< output tensor info */
   guint32 num_srcpads;
   gboolean have_group_id;
   guint group_id;


### PR DESCRIPTION
Supports other/tensor(s) in output format.

      - Supported operator: All
      - Supported data type: All
      - Supported action: passthrough, skip, tensorpick. (Others will be added)
      - Output format: other/tensor or other/tensors
    
Test pipeline description
```
gst-launch-1.0 v4l2src ! videoconvert ! videoscale ! video/x-raw, format=RGB, width=640, height=480, framerate=30/1 ! tensor_converter ! mux.sink_0 \
               videotestsrc ! videoconvert ! videoscale ! video/x-raw, format=RGB, width=640, height=480, framerate=30/1 ! tensor_converter ! mux.sink_1 \
               tensor_mux name=mux ! tensor_if name=tif \
                                               compared_value=A_VALUE compared-value-option=0:0:0:0,0 \
                                               supplied-value=70,150 \
                                               operator=RANGE_INCLUSIVE \
                                               then = PASSTHROUGH\
                                               else = TENSORPICK \
                                               else-option= 1 \
                tif.src_0 ! tensor_demux name=demux \
                    demux.src_0 ! tensor_decoder mode=direct_video ! videoconvert ! ximagesink async=false sync=false \
                    demux.src_1 ! tensor_decoder mode=direct_video ! videoconvert ! ximagesink async=false sync=false \
                tif.src_1 ! tensor_decoder mode=direct_video ! videoconvert ! ximagesink async=false sync=false
```

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped