### PR TITLE
[Tests] Eliminate hard-coded build root from source code

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,11 +16,14 @@
 ROOT_DIR:=$(shell pwd)
 export DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 export DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
-export GST_PLUGIN_PATH=${ROOT_DIR}/build/gst/nnstreamer
-export NNSTREAMER_CONF=${ROOT_DIR}/build/nnstreamer-test.ini
-export NNSTREAMER_FILTERS=${ROOT_DIR}/build/ext/nnstreamer/tensor_filter
-export NNSTREAMER_DECODERS=${ROOT_DIR}/build/ext/nnstreamer/tensor_decoder
-export NNSTREAMER_CONVERTERS=${ROOT_DIR}/build/ext/nnstreamer/tensor_converter
+export BUILDDIR=build
+export NNSTREAMER_SOURCE_ROOT_PATH=$(ROOT_DIR)
+export NNSTREAMER_BUILD_ROOT_PATH=${NNSTREAMER_SOURCE_ROOT_PATH}/${BUILDDIR}
+export GST_PLUGIN_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/gst/nnstreamer
+export NNSTREAMER_CONF=${NNSTREAMER_BUILD_ROOT_PATH}/nnstreamer-test.ini
+export NNSTREAMER_FILTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_filter
+export NNSTREAMER_DECODERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_decoder
+export NNSTREAMER_CONVERTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_converter
 export PYTHONIOENCODING=utf-8
 
 ifneq ($(filter $(DEB_HOST_ARCH),amd64),)
@@ -33,19 +36,19 @@ endif
 	dh $@ --parallel
 
 override_dh_auto_clean:
-	rm -rf build
+	rm -rf ${BUILDDIR}
 
 override_dh_auto_configure:
-	mkdir -p build
+	mkdir -p ${BUILDDIR}
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
 	-Dinstall-example=true -Dtf-support=$(enable_tf) -Dtflite-support=enabled -Dpytorch-support=enabled -Dcaffe2-support=enabled \
 	-Dpython2-support=enabled -Dpython3-support=enabled -Denable-capi=true -Denable-edgetpu=true -Denable-tizen=false \
-	-Denable-openvino=true build
-	cd tools/development/confchk && meson --prefix=/usr build && cd ../../..
+	-Denable-openvino=true ${BUILDDIR}
+	cd tools/development/confchk && meson --prefix=/usr ${BUILDDIR} && cd ../../..
 
 override_dh_auto_build:
-	ninja -C build
-	cd tools/development/confchk && ninja -C build && cd ../../..
+	ninja -C ${BUILDDIR}
+	cd tools/development/confchk && ninja -C ${BUILDDIR} && cd ../../..
 
 override_dh_auto_test:
 	./packaging/run_unittests_binaries.sh ./tests
@@ -57,8 +60,8 @@ override_dh_link:
 	dh_link /usr/lib/$(DEB_HOST_MULTIARCH)/gstreamer-1.0/libnnstreamer.so  /usr/lib/$(DEB_HOST_MULTIARCH)/libnnstreamer.so
 
 override_dh_auto_install:
-	DESTDIR=$(CURDIR)/debian/tmp ninja -C build install
-	cd tools/development/confchk && DESTDIR=$(CURDIR)/debian/tmp ninja -C build install && cd ../../..
+	DESTDIR=$(CURDIR)/debian/tmp ninja -C ${BUILDDIR} install
+	cd tools/development/confchk && DESTDIR=$(CURDIR)/debian/tmp ninja -C ${BUILDDIR} install && cd ../../..
 
 override_dh_install:
 	dh_install --sourcedir=debian/tmp --list-missing

--- a/meson.build
+++ b/meson.build
@@ -500,6 +500,7 @@ if get_option('enable-test')
   testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
   testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
   testenv.set('NNSTREAMER_SOURCE_ROOT_PATH', meson.source_root())
+  testenv.set('NNSTREAMER_BUILD_ROOT_PATH', meson.build_root())
 
   subdir('tests')
 endif

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -611,25 +611,26 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir
 ninja -C build %{?_smp_mflags}
 
 export NNSTREAMER_SOURCE_ROOT_PATH=$(pwd)
-export GST_PLUGIN_PATH=$(pwd)/build/gst/nnstreamer
-export NNSTREAMER_CONF=$(pwd)/build/nnstreamer-test.ini
-export NNSTREAMER_FILTERS=$(pwd)/build/ext/nnstreamer/tensor_filter
-export NNSTREAMER_DECODERS=$(pwd)/build/ext/nnstreamer/tensor_decoder
-export NNSTREAMER_CONVERTERS=$(pwd)/build/ext/nnstreamer/tensor_converter
+export NNSTREAMER_BUILD_ROOT_PATH=$(pwd)/build
+export GST_PLUGIN_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/gst/nnstreamer
+export NNSTREAMER_CONF=${NNSTREAMER_BUILD_ROOT_PATH}/nnstreamer-test.ini
+export NNSTREAMER_FILTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_filter
+export NNSTREAMER_DECODERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_decoder
+export NNSTREAMER_CONVERTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_converter
 
 %define test_script $(pwd)/packaging/run_unittests_binaries.sh
 
 %if %{with tizen}
     bash %{test_script} ./tests/tizen_nnfw_runtime/unittest_nnfw_runtime_raw
-    GST_PLUGIN_PATH=${NNSTREAMER_SOURCE_ROOT_PATH}/build/ext/nnstreamer/tensor_source:${GST_PLUGIN_PATH} bash %{test_script} ./tests/tizen_capi/unittest_tizen_sensor
+    GST_PLUGIN_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_source:${GST_PLUGIN_PATH} bash %{test_script} ./tests/tizen_capi/unittest_tizen_sensor
 %endif #if tizen
 %if 0%{?unit_test}
     bash %{test_script} ./tests
     bash %{test_script} ./tests/tizen_capi/unittest_tizen_capi
     bash %{test_script} ./tests/nnstreamer_filter_extensions_common
-    LD_LIBRARY_PATH=${NNSTREAMER_SOURCE_ROOT_PATH}/build/tests/nnstreamer_filter_mvncsdk2:. bash %{test_script} ./tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2
+    LD_LIBRARY_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/tests/nnstreamer_filter_mvncsdk2:. bash %{test_script} ./tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2
 %ifarch aarch64 x86_64
-    LD_LIBRARY_PATH=${NNSTREAMER_SOURCE_ROOT_PATH}/build/tests/nnstreamer_filter_edgetpu:. bash %{test_script} ./tests/nnstreamer_filter_edgetpu/unittest_edgetpu
+    LD_LIBRARY_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/tests/nnstreamer_filter_edgetpu:. bash %{test_script} ./tests/nnstreamer_filter_edgetpu/unittest_edgetpu
 %endif #ifarch 64
     pushd tests
     ssat -n --summary summary.txt -cn _n

--- a/packaging/run_unittests_binaries.sh
+++ b/packaging/run_unittests_binaries.sh
@@ -8,11 +8,13 @@
 ## @brief Runs all the unittests binaries in the specified folder or file
 input=$1
 
+export NNSTREAMER_SOURCE_ROOT_PATH=$(pwd)
 pushd build
-export NNSTREAMER_CONF=$(pwd)/nnstreamer-test.ini
-export NNSTREAMER_FILTERS=$(pwd)/ext/nnstreamer/tensor_filter
-export NNSTREAMER_DECODERS=$(pwd)/ext/nnstreamer/tensor_decoder
-export NNSTREAMER_CONVERTERS=$(pwd)/ext/nnstreamer/tensor_converter
+export NNSTREAMER_BUILD_ROOT_PATH=$(pwd)
+export NNSTREAMER_CONF=${NNSTREAMER_BUILD_ROOT_PATH}/nnstreamer-test.ini
+export NNSTREAMER_FILTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_filter
+export NNSTREAMER_DECODERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_decoder
+export NNSTREAMER_CONVERTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_converter
 export _PYTHONPATH=${PYTHONPATH}
 
 run_entry() {

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -10,9 +10,10 @@ tizen_apptest_deps = [
 # Format for adding subplugin into extensions -
 # [name, extension abbreviation, dependencies, model file name/folder path/file path, test name]
 extensions = []
-
-extensions += [['custom', 'custom', nnstreamer_unittest_deps, '../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough.' + so_ext, 'custom']]
-extensions += [['custom', 'custom', nnstreamer_unittest_deps, '../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough_variable.' + so_ext, 'custom-set']]
+custom_filter_path = join_paths(meson.build_root(), 'nnstreamer_example',
+    'custom_example_passthrough', 'libnnstreamer_customfilter_passthrough.' + so_ext)
+extensions += [['custom', 'custom', nnstreamer_unittest_deps, custom_filter_path, 'custom']]
+extensions += [['custom', 'custom', nnstreamer_unittest_deps, custom_filter_path, 'custom-set']]
 
 if tflite_support_is_available
   extensions += [['tensorflow-lite', 'tflite', nnstreamer_filter_tflite_deps, 'mobilenet_v1_1.0_224_quant.tflite', 'tensorflow_lite']]

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -3518,14 +3518,14 @@ TEST (nnstreamer_capi_singleshot, invoke_03)
   void *data_ptr;
   size_t data_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
 
-  test_model = g_build_filename (root_path, "build", "nnstreamer_example",
+  test_model = g_build_filename (root_path, "nnstreamer_example",
       "custom_example_passthrough", cf_name, NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
@@ -5803,14 +5803,14 @@ TEST (nnstreamer_capi_singleshot, invoke_10_p)
   void *data_ptr;
   size_t data_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
 
-  test_model = g_build_filename (root_path, "build", "nnstreamer_example",
+  test_model = g_build_filename (root_path, "nnstreamer_example",
       "custom_example_scaler", cf_name, NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
@@ -5885,14 +5885,14 @@ TEST (nnstreamer_capi_singleshot, invoke_11_p)
   void *data_ptr;
   size_t data_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
 
-  test_model = g_build_filename (root_path, "build", "nnstreamer_example",
+  test_model = g_build_filename (root_path, "nnstreamer_example",
       "custom_example_scaler", cf_name, NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
@@ -5969,14 +5969,14 @@ TEST (nnstreamer_capi_singleshot, invoke_12_p)
   void *data_ptr;
   size_t data_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
 
-  test_model = g_build_filename (root_path, "build", "nnstreamer_example",
+  test_model = g_build_filename (root_path, "nnstreamer_example",
       "custom_example_scaler", cf_name, NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
@@ -6056,7 +6056,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_02)
   unsigned int count = 0;
   int status, tensor_size;
 
-  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
@@ -6064,7 +6064,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_02)
     root_path = "..";
 
   /* custom-passthrough */
-  test_model = g_build_filename (root_path, "build", "nnstreamer_example",
+  test_model = g_build_filename (root_path, "nnstreamer_example",
       "custom_example_passthrough", cf_name, NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
@@ -9349,14 +9349,14 @@ TEST (nnstreamer_capi_internal, validate_model_file_01_n)
       NNSTREAMER_SO_FILE_EXTENSION;
   int status;
   ml_nnfw_type_e nnfw = ML_NNFW_TYPE_CUSTOM_FILTER;
-  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
   gchar *test_model;
 
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
 
-  test_model = g_build_filename (root_path, "build", "nnstreamer_example",
+  test_model = g_build_filename (root_path, "nnstreamer_example",
       "custom_example_passthrough", cf_name, NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
@@ -9382,17 +9382,20 @@ TEST (nnstreamer_capi_internal, validate_model_file_02_n)
       NNSTREAMER_SO_FILE_EXTENSION;
   int status;
   ml_nnfw_type_e nnfw;
-  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  const gchar *sroot_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  const gchar *broot_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
   gchar *test_model1, *test_model2;
   gchar *test_models[2];
 
   /* supposed to run test in build directory */
-  if (root_path == NULL)
-    root_path = "..";
+  if (sroot_path == NULL)
+    sroot_path = "..";
+  if (broot_path == NULL)
+    broot_path = ".";
 
-  test_model1 = g_build_filename (root_path, "build", "nnstreamer_example",
+  test_model1 = g_build_filename (broot_path, "nnstreamer_example",
       "custom_example_passthrough", cf_name, NULL);
-  test_model2 = g_build_filename (root_path, "tests", "test_models", "models",
+  test_model2 = g_build_filename (sroot_path, "tests", "test_models", "models",
       "mobilenet_v1_1.0_224_quant.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model1, G_FILE_TEST_EXISTS));
   ASSERT_TRUE (g_file_test (test_model2, G_FILE_TEST_EXISTS));

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -2217,7 +2217,7 @@ TEST (nnstreamer_capi_util, info_destroy_n)
   ASSERT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
-/*
+/**
  * @brief Test utility functions (internal)
  */
 TEST (nnstreamer_capi_util, info_init_n)
@@ -2259,7 +2259,7 @@ TEST (nnstreamer_capi_util, info_valid_02_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (internal)
  */
 TEST (nnstreamer_capi_util, info_comp_01_n)
@@ -2283,7 +2283,7 @@ TEST (nnstreamer_capi_util, info_comp_01_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (internal)
  */
 TEST (nnstreamer_capi_util, info_comp_02_n)
@@ -2308,7 +2308,7 @@ TEST (nnstreamer_capi_util, info_comp_02_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (internal)
  */
 TEST (nnstreamer_capi_util, info_comp_03_n)
@@ -2341,7 +2341,7 @@ TEST (nnstreamer_capi_util, info_comp_03_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (internal)
  */
 TEST (nnstreamer_capi_util, info_comp_0)
@@ -2369,7 +2369,7 @@ TEST (nnstreamer_capi_util, info_comp_0)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_set_count_n)
@@ -2378,7 +2378,7 @@ TEST (nnstreamer_capi_util, info_set_count_n)
   ASSERT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_get_count_n)
@@ -2387,7 +2387,7 @@ TEST (nnstreamer_capi_util, info_get_count_n)
   ASSERT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_set_tname_0_n)
@@ -2396,7 +2396,7 @@ TEST (nnstreamer_capi_util, info_set_tname_0_n)
   ASSERT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_set_tname_1_n)
@@ -2414,7 +2414,7 @@ TEST (nnstreamer_capi_util, info_set_tname_1_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_set_tname_1)
@@ -2434,7 +2434,7 @@ TEST (nnstreamer_capi_util, info_set_tname_1)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_get_tname_01_n)
@@ -2455,7 +2455,7 @@ TEST (nnstreamer_capi_util, info_get_tname_01_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_get_tname_02_n)
@@ -2475,7 +2475,7 @@ TEST (nnstreamer_capi_util, info_get_tname_02_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_get_tname_03_n)
@@ -2496,7 +2496,7 @@ TEST (nnstreamer_capi_util, info_get_tname_03_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_set_ttype_01_n)
@@ -2507,7 +2507,7 @@ TEST (nnstreamer_capi_util, info_set_ttype_01_n)
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_set_ttype_02_n)
@@ -2527,7 +2527,7 @@ TEST (nnstreamer_capi_util, info_set_ttype_02_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_set_ttype_03_n)
@@ -2547,7 +2547,7 @@ TEST (nnstreamer_capi_util, info_set_ttype_03_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_get_ttype_01_n)
@@ -2560,7 +2560,7 @@ TEST (nnstreamer_capi_util, info_get_ttype_01_n)
 
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_get_ttype_02_n)
@@ -2580,7 +2580,7 @@ TEST (nnstreamer_capi_util, info_get_ttype_02_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_get_ttype_03_n)
@@ -2601,7 +2601,7 @@ TEST (nnstreamer_capi_util, info_get_ttype_03_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_set_tdimension_01_n)
@@ -2613,7 +2613,7 @@ TEST (nnstreamer_capi_util, info_set_tdimension_01_n)
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_set_tdimension_02_n)
@@ -2634,7 +2634,7 @@ TEST (nnstreamer_capi_util, info_set_tdimension_02_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_get_tdimension_01_n)
@@ -2646,7 +2646,7 @@ TEST (nnstreamer_capi_util, info_get_tdimension_01_n)
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_get_tdimension_02_n)
@@ -2667,7 +2667,7 @@ TEST (nnstreamer_capi_util, info_get_tdimension_02_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_get_tsize_01_n)
@@ -2687,7 +2687,7 @@ TEST (nnstreamer_capi_util, info_get_tsize_01_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_get_tsize_02_n)
@@ -2699,7 +2699,7 @@ TEST (nnstreamer_capi_util, info_get_tsize_02_n)
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_get_tsize_03_n)
@@ -2722,7 +2722,7 @@ TEST (nnstreamer_capi_util, info_get_tsize_03_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_clone_01_n)
@@ -2740,7 +2740,7 @@ TEST (nnstreamer_capi_util, info_clone_01_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, info_clone_02_n)
@@ -2758,7 +2758,7 @@ TEST (nnstreamer_capi_util, info_clone_02_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, data_create_01_n)
@@ -2770,7 +2770,7 @@ TEST (nnstreamer_capi_util, data_create_01_n)
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, data_create_02_n)
@@ -2789,7 +2789,7 @@ TEST (nnstreamer_capi_util, data_create_02_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, data_create_03_n)
@@ -2823,7 +2823,7 @@ TEST (nnstreamer_capi_util, data_create_internal_n)
   EXPECT_NE (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, data_get_tdata_01_n)
@@ -2836,7 +2836,7 @@ TEST (nnstreamer_capi_util, data_get_tdata_01_n)
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, data_get_tdata_02_n)
@@ -2867,7 +2867,7 @@ TEST (nnstreamer_capi_util, data_get_tdata_02_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, data_get_tdata_03_n)
@@ -2898,7 +2898,7 @@ TEST (nnstreamer_capi_util, data_get_tdata_03_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, data_get_tdata_04_n)
@@ -2930,7 +2930,7 @@ TEST (nnstreamer_capi_util, data_get_tdata_04_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, data_set_tdata_01_n)
@@ -2946,7 +2946,7 @@ TEST (nnstreamer_capi_util, data_set_tdata_01_n)
   g_free (raw_data);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, data_set_tdata_02_n)
@@ -2976,7 +2976,7 @@ TEST (nnstreamer_capi_util, data_set_tdata_02_n)
   ASSERT_EQ (status, ML_ERROR_NONE);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, data_set_tdata_03_n)
@@ -3010,7 +3010,7 @@ TEST (nnstreamer_capi_util, data_set_tdata_03_n)
   g_free (raw_data);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, data_set_tdata_04_n)
@@ -3044,7 +3044,7 @@ TEST (nnstreamer_capi_util, data_set_tdata_04_n)
   g_free (raw_data);
 }
 
-/*
+/**
  * @brief Test utility functions (public)
  */
 TEST (nnstreamer_capi_util, data_set_tdata_05_n)


### PR DESCRIPTION
This patch eliminates hard-coded build root from source code. Instead of the hard-coded 'build', this patch introduces an environment variable, NNSTREAMER_BUILD_ROOT_PATH, which is provided by the meson build script. According to this change, packaging scripts are also updated.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped