### PR TITLE
[Ext/Filter] Set verify_model_path as TRUE for TF, PyTorch, and Python sub-plugins

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -974,7 +974,7 @@ static GstTensorFilterFramework NNS_support_python = {
       .allow_in_place = FALSE, /** @todo: support this to optimize performance later. */
       .allocate_in_invoke = TRUE,
       .run_without_model = FALSE,
-      .verify_model_path = FALSE,
+      .verify_model_path = TRUE,
       .statistics = nullptr,
       .invoke_NN = py_run,
       /** dimension-related callbacks are dynamically updated */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -183,8 +183,7 @@ TorchCore::getModelPath ()
  * @brief	load the torch model
  * @note	the model will be loaded
  * @return 0 if OK. non-zero if error.
- *        -1 if the modelfile is not valid(or not exist).
- *        -2 if the pt file is not loaded.
+ *        -1 if the pt file is not loaded.
  */
 int
 TorchCore::loadModel ()
@@ -192,12 +191,6 @@ TorchCore::loadModel ()
 #if (DBG)
   gint64 start_time = g_get_real_time ();
 #endif
-
-  if (!g_file_test (model_path, G_FILE_TEST_IS_REGULAR)) {
-    ml_loge ("the file of model_path (%s) is not valid (not regular).",
-        model_path);
-    return -1;
-  }
 
 #ifdef PYTORCH_VER_ATLEAST_1_2_0
   model = std::make_shared<torch::jit::script::Module>(torch::jit::load (model_path));
@@ -207,7 +200,7 @@ TorchCore::loadModel ()
 
   if (model == nullptr) {
     ml_loge ("Failed to read graph.");
-    return -2;
+    return -1;
   }
 
   if (use_gpu) {
@@ -690,7 +683,7 @@ static GstTensorFilterFramework NNS_support_pytorch = {
       .allow_in_place = FALSE, /** @todo: support this to optimize performance later. */
       .allocate_in_invoke = FALSE,
       .run_without_model = FALSE,
-      .verify_model_path = FALSE,
+      .verify_model_path = TRUE, /* check that the given .pt files are valid */
       .statistics = nullptr,
       .invoke_NN = torch_invoke,
       .getInputDimension = torch_getInputDim,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
@@ -219,13 +219,6 @@ TFCore::loadModel ()
   gchar *content = nullptr;
   GError *file_error = nullptr;
 
-  g_assert (model_path != nullptr);
-
-  if (!g_file_test (model_path, G_FILE_TEST_IS_REGULAR)) {
-    ml_loge ("the file of model_path (%s) is not valid (not regular)\n", model_path);
-    return -1;
-  }
-
   if (!g_file_get_contents (model_path, &content, &file_size, &file_error)) {
     ml_loge ("Error reading model file!! - %s", file_error->message);
     g_clear_error (&file_error);
@@ -772,7 +765,7 @@ static GstTensorFilterFramework NNS_support_tensorflow = {
       .allow_in_place = FALSE, /** @todo: support this to optimize performance later. */
       .allocate_in_invoke = TRUE,
       .run_without_model = FALSE,
-      .verify_model_path = FALSE,
+      .verify_model_path = TRUE, /* check that the given .pb files are valid */
       .statistics = nullptr,
       .invoke_NN = tf_run,
       .getInputDimension = tf_getInputDim,


### PR DESCRIPTION
This PR is about setting verify_model_path as TRUE to delegate the given model files' verification to the NNS common framework.
If such verification code is included in the tensor_filter sub-plugin, it is also removed from the sub-plugin.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
