### PR TITLE
[TensorRate/Filter] Skip inference when QoS events arrive

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -890,6 +890,11 @@ gst_tensor_filter_common_init_property (GstTensorFilterPrivate * priv)
   priv->combi.out_combi_o_defined = FALSE;
   gst_tensors_config_init (&priv->in_config);
   gst_tensors_config_init (&priv->out_config);
+
+  /* init qos properties */
+  priv->prev_ts = GST_CLOCK_TIME_NONE;
+  priv->throttling_delay = 0;
+  priv->throttling_accum = 0;
 }
 
 /**

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -120,6 +120,10 @@ typedef struct _GstTensorFilterPrivate
   gint latency_mode;     /**< latency profiling mode (0: off, 1: on, ...) */
   gint throughput_mode;  /**< throughput profiling mode (0: off, 1: on, ...) */
 
+  GstClockTime prev_ts;  /**< previous timestamp */
+  GstClockTimeDiff throttling_delay;  /**< throttling delay from tensor rate */
+  GstClockTimeDiff throttling_accum;  /**< accumulated frame durations for throttling */
+
   GstTensorFilterCombination combi;
 } GstTensorFilterPrivate;
 

--- a/gst/nnstreamer/tensor_rate/gsttensorrate.c
+++ b/gst/nnstreamer/tensor_rate/gsttensorrate.c
@@ -326,6 +326,8 @@ gst_tensor_rate_reset (GstTensorRate * self)
   self->next_ts = GST_CLOCK_TIME_NONE;
   self->last_ts = GST_CLOCK_TIME_NONE;
 
+  self->sent_qos_on_passthrough = FALSE;
+
   gst_tensor_rate_swap_prev (self, NULL, 0);
 }
 
@@ -524,7 +526,10 @@ gst_tensor_rate_transform_ip (GstBaseTransform * trans, GstBuffer * buffer)
 
   /* let's send a QoS event even if pass-through is used on the same caps */
   if (gst_base_transform_is_passthrough (trans)) {
-    gst_tensor_rate_send_qos_throttle (self, intime);
+    if (!self->sent_qos_on_passthrough) {
+      self->sent_qos_on_passthrough = TRUE;
+      gst_tensor_rate_send_qos_throttle (self, intime);
+    }
     return GST_FLOW_OK;
   }
 

--- a/gst/nnstreamer/tensor_rate/gsttensorrate.h
+++ b/gst/nnstreamer/tensor_rate/gsttensorrate.h
@@ -42,6 +42,8 @@ struct _GstTensorRate
   GstSegment segment;           /**< current segment */
   guint64 out_frame_count;      /**< number of frames output */
 
+  gboolean sent_qos_on_passthrough; /**< qos event on passthrough */
+
   /** Caps negotiation */
   gint from_rate_numerator;     /**< framerate numerator (From) */
   gint from_rate_denominator;   /**< framerate denominator (From) */


### PR DESCRIPTION
This patch implements a simple QoS mechanism which skips
inference when QoS events arrive from tensor_rate.      

The below shows test results using tflite object detection example

- Without throttling (original pipeline, eventually saturated 10 FPS due to tensor filter's performance)
```
...
  ! queue leaky=2 max-size-buffers=2 ! videoscale ! video/x-raw,width=640,height=480 ! tensor_converter
  ! tensor_transform mode=arithmetic option=typecast:float32,add:-127.5,div:127.5
  ! tensor_filter framework=tensorflow-lite model=...
...
```
![without throttling](https://user-images.githubusercontent.com/48666767/95434212-f32f4e80-098b-11eb-8a1c-a49e9ecd0c51.png)


- With throttling (`tensor_rate` added, and no `max-size-buffer` setting, we want to limit framerate to 5 FPS)
```
...
  ! queue ! videoscale ! video/x-raw,width=640,height=480 ! tensor_converter
  ! tensor_transform mode=arithmetic option=typecast:float32,add:-127.5,div:127.5
  ! tensor_filter framework=tensorflow-lite model=...
  ! tensor_rate framerate=5/1 throttle=true
...
```

![with throttling](https://user-images.githubusercontent.com/48666767/95844426-df1c9000-0d83-11eb-9536-6b3baea2ea8f.png)

In short, even without limiting queue's max buffers, we can adjust a frame rate to 5 FPS, and effectively reduces CPU consumption.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com> 