### PR TITLE
[Common] Add rank field to GstTensorInfo

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.cc
@@ -79,6 +79,8 @@ gst_tensor_decoder_protobuf (const GstTensorsConfig * config,
       tensor->add_dimension (config->info.info[i].dimension[j]);
     }
 
+    tensor->set_rank (config->info.info[i].rank);
+
     tensor->set_data (input[i].data, (int) input[i].size);
   }
 
@@ -144,6 +146,7 @@ gst_tensor_converter_protobuf (GstBuffer * in_buf, gsize * frame_size,
     const nnstreamer::protobuf::Tensor *tensor = &tensors.tensor (i);
     config->info.info[i].name = g_strdup (tensor->name ().c_str ());
     config->info.info[i].type = (tensor_type) tensor->type ();
+    config->info.info[i].rank = tensor->rank ();
     for (guint j = 0; j < NNS_TENSOR_RANK_LIMIT; j++) {
       config->info.info[i].dimension[j] = tensor->dimension (j);
     }

--- a/ext/nnstreamer/include/nnstreamer.fbs
+++ b/ext/nnstreamer/include/nnstreamer.fbs
@@ -33,6 +33,7 @@ table Tensor {
   name  : string;
   type : Tensor_type = NNS_END;
   dimension : [uint32]; // support up to 4th ranks.
+  rank : uint32;
   data : [ubyte]; 
 }
 

--- a/ext/nnstreamer/include/nnstreamer.proto
+++ b/ext/nnstreamer/include/nnstreamer.proto
@@ -18,7 +18,8 @@ message Tensor {
   }
   Tensor_type type = 2;
   repeated uint32 dimension = 3;
-  bytes data = 4;
+  uint32 rank = 4;
+  bytes data = 5;
 }
 
 message Tensors {

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
@@ -63,8 +63,9 @@ fbc_get_out_config (const GstCaps * in_cap, GstTensorsConfig * config)
   /* All tensor info should be updated later in chain function. */
   config->info.info[0].type = _NNS_UINT8;
   config->info.num_tensors = 1;
-  if (gst_tensor_parse_dimension ("1:1:1:1",
-          config->info.info[0].dimension) == 0) {
+  config->info.info[0].rank = gst_tensor_parse_dimension ("1:1:1:1", config->info.info[0].dimension);
+
+  if (config->info.info[0].rank == 0) {
     ml_loge ("Failed to set initial dimension for subplugin");
     return FALSE;
   }

--- a/ext/nnstreamer/tensor_converter/tensor_converter_protobuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_protobuf.cc
@@ -58,10 +58,11 @@ pbc_get_out_config (const GstCaps * in_cap, GstTensorsConfig * config)
   g_return_val_if_fail (structure != NULL, FALSE);
 
   /* All tensor info should be updated later in chain function. */
-    config->info.info[0].type = _NNS_UINT8;
-    config->info.num_tensors = 1;
-  if (gst_tensor_parse_dimension ("1:1:1:1",
-          config->info.info[0].dimension) == 0) {
+  config->info.info[0].type = _NNS_UINT8;
+  config->info.num_tensors = 1;
+  config->info.info[0].rank = gst_tensor_parse_dimension ("1:1:1:1", config->info.info[0].dimension);
+
+  if (config->info.info[0].rank == 0) {
     ml_loge ("Failed to set initial dimension for subplugin");
     return FALSE;
   }

--- a/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
@@ -70,6 +70,7 @@ fb_decode (void **pdata, const GstTensorsConfig * config,
 {
   char *name;
   Tensor_type type;
+  guint rank;
   GstMapInfo out_info;
   GstMemory *out_mem;
   unsigned int i, num_tensors = config->info.num_tensors;
@@ -96,13 +97,14 @@ fb_decode (void **pdata, const GstTensorsConfig * config,
       tensor_name = builder.CreateString (name);
 
     type = (Tensor_type) config->info.info[i].type;
+    rank = config->info.info[i].rank;
 
     /* Create the vector first, and fill in data later */
     /** @todo Consider to remove memcpy */
     input_vector = builder.CreateUninitializedVector<unsigned char> (input[i].size, &tmp_buf);
     memcpy (tmp_buf, input[i].data, input[i].size);
 
-    tensor = CreateTensor (builder, tensor_name, type, dim, input_vector);
+    tensor = CreateTensor (builder, tensor_name, type, dim, rank, input_vector);
     tensor_vector.push_back (tensor);
   }
 

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -172,6 +172,7 @@ typedef struct
                    and some (tensorflow-lite) do not need this. */
   tensor_type type; /**< Type of each element in the tensor. User must designate this. */
   tensor_dim dimension; /**< Dimension. We support up to 4th ranks.  */
+  unsigned int rank; /** < Rank of the tensor. */
 } GstTensorInfo;
 
 /**

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -242,7 +242,7 @@ gst_tensor_info_get_rank (const GstTensorInfo * info)
       break;
   }
 
-  return idx + 1;
+  return NNS_TENSOR_RANK_LIMIT - idx;
 }
 
 /**

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -108,6 +108,7 @@ gst_tensor_info_init (GstTensorInfo * info)
 
   info->name = NULL;
   info->type = _NNS_END;
+  info->rank = 0;
 
   for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
     info->dimension[i] = 0;
@@ -208,6 +209,9 @@ gst_tensor_info_copy_n (GstTensorInfo * dest, const GstTensorInfo * src,
 
   dest->name = g_strdup (src->name);
   dest->type = src->type;
+
+  if (src->rank > 0 && src->rank <= NNS_TENSOR_RANK_LIMIT)
+    dest->rank = src->rank;
 
   for (i = 0; i < n; i++) {
     dest->dimension[i] = src->dimension[i];
@@ -403,7 +407,8 @@ gst_tensors_info_parse_dimensions_string (GstTensorsInfo * info,
     }
 
     for (i = 0; i < num_dims; i++) {
-      gst_tensor_parse_dimension (str_dims[i], info->info[i].dimension);
+      info->info[i].rank =
+          gst_tensor_parse_dimension (str_dims[i], info->info[i].dimension);
     }
 
     g_strfreev (str_dims);
@@ -677,7 +682,7 @@ gst_tensor_config_from_structure (GstTensorConfig * config,
 
   if (gst_structure_has_field (structure, "dimension")) {
     const gchar *dim_str = gst_structure_get_string (structure, "dimension");
-    gst_tensor_parse_dimension (dim_str, info->dimension);
+    info->rank = gst_tensor_parse_dimension (dim_str, info->dimension);
   }
 
   if (gst_structure_has_field (structure, "type")) {

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -789,6 +789,37 @@ TEST (common_tensors_info_string, names)
 }
 
 /**
+ * @brief Test for rank in tensors info, which is based on dimensions string.
+ */
+TEST (common_tensors_info_string, rank)
+{
+  GstTensorsInfo info;
+
+  gst_tensors_info_init (&info);
+
+  /* Default rank: 0 */
+  EXPECT_EQ (info.info[0].rank, 0U);
+
+  /* The rank of single tensor: 2 */
+  gst_tensors_info_parse_dimensions_string (&info, "1024:768");
+  EXPECT_EQ (info.info[0].rank, 2U);
+
+  /* The rank of single tensor: 4 */
+  gst_tensors_info_parse_dimensions_string (&info, "1:2:3:4");
+  EXPECT_EQ (info.info[0].rank, 4U);
+
+  /* The rank of 4 tensors: 1, 2, 3 and 4 */
+  gst_tensors_info_parse_dimensions_string (&info, "1, 2:2, 3:3:3, 4:4:4:4");
+  for (unsigned int i = 1; i <= 4; ++i)
+    EXPECT_EQ (info.info[i-1].rank, i);
+
+  /* All rank of 4 tensors: 4 */
+  gst_tensors_info_parse_dimensions_string (&info, "1:1:1:1, 2:2:2:2, 3:3:3:3, 4:4:4:4");
+  for (unsigned int i = 1; i <= 4; ++i)
+    EXPECT_EQ (info.info[i-1].rank, 4U);
+}
+
+/**
  * @brief Test to replace string.
  */
 TEST (common_string_util, replace_str_01)


### PR DESCRIPTION
This patch newly adds the rank field to GstTensorInfo structure. 
When passing the dimension string in tensor filter, the rank value is automatically set. 
For example, the rank value of the dimension string '1:10:1:1' is 4. This rank field is not used in cap-negotiation phase.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

This PR contains the below patches.
* Add rank field to GstTensorInfo
* bugfix: Fix the wrong rank of gst_tensor_info_get_rank()


**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped


