### PR TITLE
[Filter] Add rank count logic to GstTensorFilterProperties @open sesame 10/14 13:28

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -142,10 +142,12 @@ typedef struct _GstTensorFilterProperties
   int input_configured; /**< TRUE if input tensor is configured. Use int instead of gboolean because this is refered by custom plugins. */
   GstTensorsInfo input_meta; /**< configured input tensor info */
   tensors_layout input_layout; /**< data layout info provided as a property to tensor_filter for the input, defaults to _NNS_LAYOUT_ANY for all the tensors */
+  unsigned int input_ranks[NNS_TENSOR_SIZE_LIMIT];  /**< the rank list of input tensors, it is calculated based on the dimension string. */
 
   int output_configured; /**< TRUE if output tensor is configured. Use int instead of gboolean because this is refered by custom plugins. */
   GstTensorsInfo output_meta; /**< configured output tensor info */
   tensors_layout output_layout; /**< data layout info provided as a property to tensor_filter for the output, defaults to _NNS_LAYOUT_ANY for all the tensors */
+  unsigned int output_ranks[NNS_TENSOR_SIZE_LIMIT];  /**< the rank list of output tensors, it is calculated based on the dimension string. */
 
   const char *custom_properties; /**< sub-plugin specific custom property values in string */
   union {

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -106,10 +106,12 @@ enum
   PROP_INPUTTYPE,
   PROP_INPUTNAME,
   PROP_INPUTLAYOUT,
+  PROP_INPUTRANKS,
   PROP_OUTPUT,
   PROP_OUTPUTTYPE,
   PROP_OUTPUTNAME,
   PROP_OUTPUTLAYOUT,
+  PROP_OUTPUTRANKS,
   PROP_CUSTOM,
   PROP_SUBPLUGINS,
   PROP_ACCELERATOR,
@@ -128,6 +130,18 @@ gst_tensors_layout_init (tensors_layout layout)
 
   for (i = 0; i < NNS_TENSOR_SIZE_LIMIT; i++) {
     layout[i] = _NNS_LAYOUT_ANY;
+  }
+}
+
+/**
+ * @brief Initialize the tensors ranks
+ */
+static void
+gst_tensors_rank_init (unsigned int ranks[])
+{
+  int i;
+  for (i = 0; i < NNS_TENSOR_SIZE_LIMIT; ++i) {
+    ranks[i] = 0;
   }
 }
 
@@ -204,6 +218,52 @@ gst_tensors_parse_layouts_string (tensors_layout layout,
   }
 
   return num_layouts;
+}
+
+/**
+ * @brief Get the rank string of the tensors
+ * @param prop GstTensorFilterProperties object
+ * @param isInput TRUE if target is input tensors
+ * @return rank string of the tensors
+ */
+static gchar *
+gst_tensors_get_rank_string (const GstTensorFilterProperties * prop,
+    gboolean isInput)
+{
+  gchar *rank_str = NULL;
+  guint i;
+  guint num_tenosrs;
+
+  g_return_val_if_fail (prop != NULL, NULL);
+
+  num_tenosrs =
+      isInput ? prop->input_meta.num_tensors : prop->output_meta.num_tensors;
+
+  if (num_tenosrs > 0) {
+    GString *rank = g_string_new (NULL);
+
+    for (i = 0; i < num_tenosrs; ++i) {
+      if (isInput) {
+        if (prop->input_ranks[i] != 0)
+          g_string_append_printf (rank, "%u", prop->input_ranks[i]);
+        else
+          g_string_append_printf (rank, "%d",
+              gst_tensor_info_get_rank (&prop->input_meta.info[i]));
+      } else {
+        if (prop->output_ranks[i] != 0)
+          g_string_append_printf (rank, "%u", prop->output_ranks[i]);
+        else
+          g_string_append_printf (rank, "%d",
+              gst_tensor_info_get_rank (&prop->output_meta.info[i]));
+      }
+
+      if (i < num_tenosrs - 1)
+        g_string_append_printf (rank, ",");
+    }
+    rank_str = g_string_free (rank, FALSE);
+  }
+
+  return rank_str;
 }
 
 /**
@@ -375,10 +435,12 @@ gst_tensor_filter_properties_init (GstTensorFilterProperties * prop)
   prop->input_configured = FALSE;
   gst_tensors_info_init (&prop->input_meta);
   gst_tensors_layout_init (prop->input_layout);
+  gst_tensors_rank_init (prop->input_ranks);
 
   prop->output_configured = FALSE;
   gst_tensors_info_init (&prop->output_meta);
   gst_tensors_layout_init (prop->output_layout);
+  gst_tensors_rank_init (prop->output_ranks);
 
   prop->custom_properties = NULL;
   prop->accl_str = NULL;
@@ -681,6 +743,10 @@ gst_tensor_filter_install_properties (GObjectClass * gobject_class)
           "Set channel first (NCHW) or channel last layout (NHWC) or None for input data. "
           "Layout of the data can be any or NHWC or NCHW or none for now. ",
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_INPUTRANKS,
+      g_param_spec_string ("inputranks", "Rank of Input Tensor",
+          "The Rank of the Input Tensor, which is separated with ',' in case of multiple Tensors",
+          "", G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_OUTPUTNAME,
       g_param_spec_string ("outputname", "Name of Output Tensor",
           "The Name of Output Tensor", "",
@@ -698,6 +764,10 @@ gst_tensor_filter_install_properties (GObjectClass * gobject_class)
           "Set channel first (NCHW) or channel last layout (NHWC) or None for output data. "
           "Layout of the data can be any or NHWC or NCHW or none for now. ",
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_OUTPUTRANKS,
+      g_param_spec_string ("outputranks", "Rank of Out Tensor",
+          "The Rank of the Out Tensor, which is separated with ',' in case of multiple Tensors",
+          "", G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_CUSTOM,
       g_param_spec_string ("custom", "Custom properties for subplugins",
           "Custom properties for subplugins ?", "",
@@ -1143,9 +1213,24 @@ _gtfc_setprop_INPUT (GstTensorFilterPrivate * priv,
 {
   if (!prop->input_configured && value) {
     guint num_dims;
+    gchar **str_dims;
+    guint i;
 
-    num_dims = gst_tensors_info_parse_dimensions_string (&prop->input_meta,
-        g_value_get_string (value));
+    str_dims = g_strsplit_set (g_value_get_string (value), ",.", -1);
+    num_dims = g_strv_length (str_dims);
+
+    if (num_dims > NNS_TENSOR_SIZE_LIMIT) {
+      GST_WARNING ("Invalid param, dimensions (%d) max (%d)\n",
+          num_dims, NNS_TENSOR_SIZE_LIMIT);
+
+      num_dims = NNS_TENSOR_SIZE_LIMIT;
+    }
+
+    for (i = 0; i < num_dims; ++i) {
+      prop->input_ranks[i] = gst_tensor_parse_dimension (str_dims[i],
+          prop->input_meta.info[i].dimension);
+    }
+    g_strfreev (str_dims);
 
     if (num_dims > 0) {
       if (prop->input_meta.num_tensors > 0 &&
@@ -1171,9 +1256,24 @@ _gtfc_setprop_OUTPUT (GstTensorFilterPrivate * priv,
 {
   if (!prop->output_configured && value) {
     guint num_dims;
+    gchar **str_dims;
+    guint i;
 
-    num_dims = gst_tensors_info_parse_dimensions_string (&prop->output_meta,
-        g_value_get_string (value));
+    str_dims = g_strsplit_set (g_value_get_string (value), ",.", -1);
+    num_dims = g_strv_length (str_dims);
+
+    if (num_dims > NNS_TENSOR_SIZE_LIMIT) {
+      GST_WARNING ("Invalid param, dimensions (%d) max (%d)\n",
+          num_dims, NNS_TENSOR_SIZE_LIMIT);
+
+      num_dims = NNS_TENSOR_SIZE_LIMIT;
+    }
+
+    for (i = 0; i < num_dims; ++i) {
+      prop->output_ranks[i] = gst_tensor_parse_dimension (str_dims[i],
+          prop->output_meta.info[i].dimension);
+    }
+    g_strfreev (str_dims);
 
     if (num_dims > 0) {
       if (prop->output_meta.num_tensors > 0 &&
@@ -1690,6 +1790,30 @@ gst_tensor_filter_common_get_property (GstTensorFilterPrivate * priv,
 
         g_value_set_string (value, dim_str);
         g_free (dim_str);
+      } else {
+        g_value_set_string (value, "");
+      }
+      break;
+    case PROP_INPUTRANKS:
+      if (prop->input_meta.num_tensors > 0) {
+        gchar *rank_str;
+
+        rank_str = gst_tensors_get_rank_string (prop, TRUE);
+
+        g_value_set_string (value, rank_str);
+        g_free (rank_str);
+      } else {
+        g_value_set_string (value, "");
+      }
+      break;
+    case PROP_OUTPUTRANKS:
+      if (prop->output_meta.num_tensors > 0) {
+        gchar *rank_str;
+
+        rank_str = gst_tensors_get_rank_string (prop, FALSE);
+
+        g_value_set_string (value, rank_str);
+        g_free (rank_str);
       } else {
         g_value_set_string (value, "");
       }

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -4329,6 +4329,118 @@ TEST (test_tensor_filter, framework_auto_ext_pt_pytorch_disabled_n)
 #endif /* ENABLE_PYTORCH */
 
 /**
+ * @brief Test for inputranks and outputranks property of the tensor_filter
+ * @details Given dimension string, check its rank value.
+ */
+TEST (test_tensor_filter, property_rank_01_p)
+{
+  gchar *str_launch_line;
+  GstHarness *hrnss;
+  GstElement *filter;
+  gchar *test_model;
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+
+  /* supposed to run test in build directory */
+  if (root_path == NULL)
+    root_path = "..";
+
+  test_model = g_build_filename (root_path, "tests", "test_models", "models",
+      "mobilenet_v1_1.0_224_quant.tflite", NULL);
+  ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
+
+  hrnss = gst_harness_new_empty ();
+  ASSERT_TRUE (hrnss != NULL);
+
+  str_launch_line = g_strdup_printf ("tensor_filter framework=auto model=%s input=3:224:224 inputtype=uint8 \
+      output=1001:1:1:1 outputtype=uint8 ", test_model);
+  gst_harness_add_parse (hrnss,  str_launch_line);
+  g_free (str_launch_line);
+
+  filter = gst_harness_find_element (hrnss, "tensor_filter");
+  ASSERT_TRUE (filter != NULL);
+
+  gchar * input_dim;
+  g_object_get (filter, "input", &input_dim, NULL);
+  EXPECT_STREQ (input_dim, "3:224:224:1");
+  g_free (input_dim);
+
+  /* Rank should be 3 since dimension string of the output is explicitly '3:224:224'. */
+  gchar * input_ranks;
+  g_object_get (filter, "inputranks", &input_ranks, NULL);
+  EXPECT_STREQ (input_ranks, "3");
+  g_free (input_ranks);
+
+  gchar * output_dim;
+  g_object_get (filter, "output", &output_dim, NULL);
+  EXPECT_STREQ (output_dim, "1001:1:1:1");
+  g_free (output_dim);
+
+  /* Rank should be 4 since dimension string of the output is explicitly '1000:1:1:1'. */
+  gchar * output_ranks;
+  g_object_get (filter, "outputranks", &output_ranks, NULL);
+  EXPECT_STREQ (output_ranks, "4");
+  g_free (output_ranks);
+
+  g_object_unref (filter);
+  gst_harness_teardown (hrnss);
+}
+
+/**
+ * @brief Test for inputranks and outputranks property of the tensor_filter
+ * @details Given dimension string, check its rank value.
+ */
+TEST (test_tensor_filter, property_rank_02_p)
+{
+  gchar *str_launch_line;
+  GstHarness *hrnss;
+  GstElement *filter;
+  gchar *test_model;
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+
+  /* supposed to run test in build directory */
+  if (root_path == NULL)
+    root_path = "..";
+
+  test_model = g_build_filename (root_path, "tests", "test_models", "models",
+      "mobilenet_v1_1.0_224_quant.tflite", NULL);
+  ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
+
+  hrnss = gst_harness_new_empty ();
+  ASSERT_TRUE (hrnss != NULL);
+
+  str_launch_line = g_strdup_printf ("tensor_filter framework=auto model=%s ", test_model);
+  gst_harness_add_parse (hrnss,  str_launch_line);
+  g_free (str_launch_line);
+
+  filter = gst_harness_find_element (hrnss, "tensor_filter");
+  ASSERT_TRUE (filter != NULL);
+
+  gchar * input_dim;
+  g_object_get (filter, "input", &input_dim, NULL);
+  EXPECT_STREQ (input_dim, "3:224:224:1");
+  g_free (input_dim);
+
+  gchar * input_ranks;
+  g_object_get (filter, "inputranks", &input_ranks, NULL);
+  EXPECT_STREQ (input_ranks, "3");
+  g_free (input_ranks);
+
+  gchar * output_dim;
+  g_object_get (filter, "output", &output_dim, NULL);
+  EXPECT_STREQ (output_dim, "1001:1:1:1");
+  g_free (output_dim);
+
+  /* Rank should be 1 since dimension string is not given. */
+  gchar * output_ranks;
+  g_object_get (filter, "outputranks", &output_ranks, NULL);
+  EXPECT_STREQ (output_ranks, "1");
+  g_free (output_ranks);
+
+  g_object_unref (filter);
+  gst_harness_teardown (hrnss);
+}
+
+/**
  * @brief Main function for unit test.
  */
 int


### PR DESCRIPTION
This patch newly adds the rank count logic to GstTensorFilterProperties.
The rank count is automatically calculated based on the given dimension
string and NNStreamer rank count rule.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

### Actual example
For example, given tensor filter parameters, input ranks are calculated as follows.

* `tensor_filter input=3:224:224`: input rank is 3.
* `tensor_filter input=3:224:224:1`: input rank is 4.
* `tensor_filter model=mobilenet_v1.tflite` : input rank is 3 since input dimension of given model is `3:224:224`.

### Rank counting rule
* https://github.com/nnstreamer/nnstreamer/wiki/Rank-counting-with-other-tensor-types

### Submit history

#### v3
* Set `outputranks` property as G_PARAM_READABLE.

#### v2
* Rank count is automatically calculated based on the given dimension and NNStreamer rank count rule
  * No writable property for rank.
* Add `inputranks` and `outputranks` properties to GstTensorFilterProperties with READONLY permission.
  * To get the rank value by calling `g_object_get()`.
* Filter developers can access the rank value via `GstTensorFilterProperties` struct.

#### v1
* First draft
* Add `inputranks` and `outputranks` properties to GstTensorFilterProperties with READ/WRITE permission


