### PR TITLE
[Log/TF-lite] print average invoke time

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -239,6 +239,10 @@ TFLiteInterpreter::invoke (const GstTensorMemory * input,
 #if (DBG)
   g_critical ("Invoke() is finished: %" G_GINT64_FORMAT,
       (stop_time - start_time));
+  g_critical ("%ld invoke average %" G_GINT64_FORMAT ", total overhead %" G_GINT64_FORMAT,
+      tflite_internal_stats.total_invoke_num,
+      (tflite_internal_stats.total_invoke_latency / tflite_internal_stats.total_invoke_num),
+      tflite_internal_stats.total_overhead_latency);
 #endif
 
   if (status != kTfLiteOk) {


### PR DESCRIPTION
add debug log in invoke function to print average time.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
