### PR TITLE
[Tools/Confchk] Show custom property description for sub-plugins @open sesame 10/15 19:48

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api_converter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_converter.h
@@ -87,6 +87,12 @@ extern int registerExternalConverter (NNStreamerExternalConverter * ex);
  */
 extern void unregisterExternalConverter (const char *prefix);
 
+/**
+ * @brief set custom property description for tensor converter sub-plugin
+ */
+extern void
+nnstreamer_converter_set_custom_property_desc (const char *name, const char *prop, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_decoder.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_decoder.h
@@ -120,6 +120,12 @@ nnstreamer_decoder_exit (const char *name);
 extern const GstTensorDecoderDef *
 nnstreamer_decoder_find (const char *name);
 
+/**
+ * @brief set custom property description for tensor decoder sub-plugin
+ */
+extern void
+nnstreamer_decoder_set_custom_property_desc (const char *name, const char *prop, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -501,6 +501,12 @@ extern const GstTensorFilterFramework *
 nnstreamer_filter_find (const char *name);
 
 /**
+ * @brief set custom property description for tensor filter sub-plugin
+ */
+extern void
+nnstreamer_filter_set_custom_property_desc (const char *name, const char *prop, ...);
+
+/**
  * @brief return accl_hw type from string
  */
 extern accl_hw

--- a/gst/nnstreamer/nnstreamer_conf.h
+++ b/gst/nnstreamer/nnstreamer_conf.h
@@ -171,5 +171,8 @@ nnsconf_get_custom_value_bool (const gchar * group, const gchar * key, gboolean 
 extern void
 nnsconf_dump (gchar * str, gulong size);
 
+extern void
+nnsconf_subplugin_dump (gchar * str, gulong size);
+
 G_END_DECLS
 #endif /* __GST_NNSTREAMER_CONF_H__ */

--- a/gst/nnstreamer/nnstreamer_subplugin.c
+++ b/gst/nnstreamer/nnstreamer_subplugin.c
@@ -40,6 +40,7 @@ typedef struct
 {
   char *name; /**< The name of subplugin */
   const void *data; /**< subplugin specific data forwarded from the subplugin */
+  GData *custom_dlist; /**< [OPTIONAL] subplugin specific custom property desc list */
 } subpluginData;
 
 static GHashTable *subplugins[NNS_SUBPLUGIN_END] = { 0 };
@@ -52,6 +53,9 @@ static void
 _spdata_destroy (gpointer _data)
 {
   subpluginData *data = _data;
+
+  g_datalist_clear (&data->custom_dlist);
+
   g_free (data->name);
   g_free (data);
 }
@@ -203,6 +207,7 @@ register_subplugin (subpluginType type, const char *name, const void *data)
 
   spdata->name = g_strdup (name);
   spdata->data = data;
+  g_datalist_init (&spdata->custom_dlist);
 
   G_LOCK (splock);
   ret = g_hash_table_insert (subplugins[type], g_strdup (name), spdata);
@@ -246,6 +251,54 @@ _close_handle (gpointer data)
 #else
   g_module_close ((GModule *) data);
 #endif
+}
+
+/**
+ * @brief common interface to set custom property description of a sub-plugin.
+ */
+void
+subplugin_set_custom_property_desc (subpluginType type, const char *name,
+    const gchar * prop, va_list varargs)
+{
+  subpluginData *spdata;
+
+  g_return_if_fail (name != NULL);
+  g_return_if_fail (subplugins[type] != NULL);
+
+  spdata = _get_subplugin_data (type, name);
+  g_return_if_fail (spdata != NULL);
+
+  g_datalist_clear (&spdata->custom_dlist);
+
+  while (prop) {
+    gchar *desc = va_arg (varargs, gchar *);
+
+    if (G_UNLIKELY (desc == NULL)) {
+      g_critical ("no description for %s", prop);
+      return;
+    }
+
+    g_datalist_set_data (&spdata->custom_dlist, prop, desc);
+    prop = va_arg (varargs, gchar *);
+  }
+}
+
+/**
+ * @brief common interface to get custom property description of a sub-plugin.
+ */
+GData *
+subplugin_get_custom_property_desc (subpluginType type, const char *name)
+{
+  subpluginData *spdata;
+
+  g_return_val_if_fail (name != NULL, NULL);
+  g_return_val_if_fail (subplugins[type] != NULL, NULL);
+
+  spdata = _get_subplugin_data (type, name);
+  if (spdata)
+    return spdata->custom_dlist;
+
+  return NULL;
 }
 
 /** @brief Create handles at the start of library */

--- a/gst/nnstreamer/nnstreamer_subplugin.h
+++ b/gst/nnstreamer/nnstreamer_subplugin.h
@@ -76,4 +76,11 @@ register_subplugin (subpluginType type, const char *name, const void *data);
 extern gboolean
 unregister_subplugin (subpluginType type, const char *name);
 
+extern void
+subplugin_set_custom_property_desc (subpluginType type, const char *name,
+    const gchar * prop, va_list varargs);
+
+extern GData *
+subplugin_get_custom_property_desc (subpluginType type, const char *name);
+
 #endif /* __GST_NNSTREAMER_SUBPLUGIN_H__ */

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -1854,3 +1854,18 @@ findExternalConverter (const char *media_type)
 
   return NULL;
 }
+
+/**
+ * @brief set custom property description for tensor converter sub-plugin
+ */
+void
+nnstreamer_converter_set_custom_property_desc (const char *name,
+    const char *prop, ...)
+{
+  va_list varargs;
+
+  va_start (varargs, prop);
+  subplugin_set_custom_property_desc (NNS_SUBPLUGIN_CONVERTER, name, prop,
+      varargs);
+  va_end (varargs);
+}

--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -202,6 +202,21 @@ nnstreamer_decoder_find (const char *name)
 }
 
 /**
+ * @brief set custom property description for tensor decoder sub-plugin
+ */
+void
+nnstreamer_decoder_set_custom_property_desc (const char *name, const char *prop,
+    ...)
+{
+  va_list varargs;
+
+  va_start (varargs, prop);
+  subplugin_set_custom_property_desc (NNS_SUBPLUGIN_DECODER, name, prop,
+      varargs);
+  va_end (varargs);
+}
+
+/**
  * @brief Macro to clean sub-plugin data
  */
 #define gst_tensor_decoder_clean_plugin(self) do { \

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -503,6 +503,21 @@ nnstreamer_filter_exit (const char *name)
 }
 
 /**
+ * @brief set custom property description for tensor filter sub-plugin
+ */
+void
+nnstreamer_filter_set_custom_property_desc (const char *name, const char *prop,
+    ...)
+{
+  va_list varargs;
+
+  va_start (varargs, prop);
+  subplugin_set_custom_property_desc (NNS_SUBPLUGIN_FILTER, name, prop,
+      varargs);
+  va_end (varargs);
+}
+
+/**
  * @brief Find filter sub-plugin with the name.
  * @param[in] name The name of filter sub-plugin.
  * @return NULL if not found or the sub-plugin object has an error.


### PR DESCRIPTION
This patch adds feature to show custom property description for
registered sub-plugins.

Related issue: #2782

Please share your opinions on better text formatting or recommended structure that contains related info.

For example, we can expect the following result
```
$ ./nnstreamer-check
...
NNStreamer registered sub-plugins:                                                           
============================================================                                 
                                                                                             
[Filter]                                                                                     
  cpp                                                                                        
    - No custom property found                                                               
  openvino                                                                                   
    - No custom property found                                                               
  tensorflow-lite                                                                            
    - Prop1: Descriptions1                                                                   
    - Prop2: Descriptions2                                                                   
  snpe                                                                                       
    - No custom property found                                                               
  caffe2                                                                                     
    - No custom property found                                                               
  python3                                                                                    
    - No custom property found                                                               
  python2                                                                                    
    - No custom property found                                                               
  edgetpu                                                                                    
    - No custom property found                                                               
  pytorch                                                                                    
    - No custom property found                                                               
  tensorflow                                                                                 
    - No custom property found                                                               
                                                                                             
[Decoder]                                                                                    
  image_segment                                                                              
    - No custom property found                                                               
  direct_video                                                                               
    - No custom property found                                                               
  flatbuf                                                                                    
    - No custom property found                                                               
  bounding_boxes                                                                             
    - No custom property found                                                               
  protobuf                                                                                   
    - Prop1: Descriptions1                                                                   
    - Prop2: Descriptions2                                                                   
  image_labeling                                                                             
    - No custom property found                                                               
  pose_estimation                                                                            
    - No custom property found                                                               
                                                                                             
[Conterver]                                                                                  
  libnnstreamer_converter_protobuf                                                           
    - No custom property found                                                               
  libnnstreamer_converter_flatbuf                                                            
    - Prop1: Descriptions1                                                                   
    - Prop2: Descriptions2                                                                   
```

if we add descriptions for custom properties like below
```
diff --git a/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc b/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
index 0a216f1..7f95711 100644
--- a/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
@@ -163,6 +163,10 @@ void
 init_fbc (void)
 {
   registerExternalConverter (&flatBuf);
+  nnstreamer_converter_set_custom_property_desc (converter_subplugin_flatbuf,
+      "Prop1", "Descriptions1",
+      "Prop2", "Descriptions2",
+      NULL);
 }
 
 /** @brief Destruct this object for tensor converter sub-plugin */
diff --git a/ext/nnstreamer/tensor_decoder/tensordec-protobuf.cc b/ext/nnstreamer/tensor_decoder/tensordec-protobuf.cc
index af3f726..a3fcc34 100644
--- a/ext/nnstreamer/tensor_decoder/tensordec-protobuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-protobuf.cc
@@ -95,6 +95,11 @@ void
 init_pb (void)
 {
   nnstreamer_decoder_probe (&protobuf);
+  nnstreamer_decoder_set_custom_property_desc (decoder_subplugin_protobuf,
+      "Prop1", "Descriptions1",
+      "Prop2", "Descriptions2",
+      NULL);
+
 }
 
 /** @brief Destruct this object for tensordec-plugin */
diff --git a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
index 0dac5f5..c40cc70 100644
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -1180,6 +1180,10 @@ void
 init_filter_tflite (void)
 {
   nnstreamer_filter_probe (&NNS_support_tensorflow_lite);
+  nnstreamer_filter_set_custom_property_desc (filter_subplugin_tensorflow_lite,
+      "Prop1", "Descriptions1",
+      "Prop2", "Descriptions2",
+      NULL);
 }
 
 /** @brief Destruct the subplugin */
```

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>


