### PR TITLE
Update dimension string when it is explicitly given in Pipeline @open sesame 10/20 18:25

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -313,6 +313,17 @@ extern gchar *
 gst_tensor_get_dimension_string (const tensor_dim dim);
 
 /**
+ * @brief Get dimension string from given tensor dimension and rank count.
+ * @param dim tensor dimension
+ * @param rank rank count of given tensor dimension
+ * @return Formatted string of given dimension
+ * @note If rank count is 3, then returned string is 'd1:d2:d3`.
+ * The returned value should be freed with g_free().
+ */
+extern gchar *
+gst_tensor_get_rank_dimension_string (const tensor_dim dim, const unsigned int rank);
+
+/**
  * @brief Count the number of elements of a tensor
  * @return The number of elements. 0 if error.
  * @param dim The tensor dimension

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -982,6 +982,40 @@ gst_tensor_get_dimension_string (const tensor_dim dim)
 }
 
 /**
+ * @brief Get dimension string from given tensor dimension and rank count.
+ * @param dim tensor dimension
+ * @param rank rank count of given tensor dimension
+ * @return Formatted string of given dimension
+ * @note If rank count is 3, then returned string is 'd1:d2:d3`.
+ * The returned value should be freed with g_free().
+ */
+gchar *
+gst_tensor_get_rank_dimension_string (const tensor_dim dim,
+    const unsigned int rank)
+{
+  guint i;
+  GString *dim_str;
+  guint actual_rank;
+
+  dim_str = g_string_new (NULL);
+
+  if (rank == 0 || rank > NNS_TENSOR_RANK_LIMIT)
+    actual_rank = NNS_TENSOR_RANK_LIMIT;
+  else
+    actual_rank = rank;
+
+  for (i = 0; i < actual_rank; i++) {
+    g_string_append_printf (dim_str, "%d", dim[i]);
+
+    if (i < actual_rank - 1) {
+      g_string_append (dim_str, ":");
+    }
+  }
+
+  return g_string_free (dim_str, FALSE);
+}
+
+/**
  * @brief Count the number of elements of a tensor
  * @return The number of elements. 0 if error.
  * @param dim The tensor dimension

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -267,6 +267,41 @@ gst_tensors_get_rank_string (const GstTensorFilterProperties * prop,
 }
 
 /**
+ * @brief Get the dimension string of tensors considering rank count.
+ * @param[in] prop GstTensorFilterProperties object
+ * @param isInput TRUE if target is input tensors
+ * @return dimension string of tensors
+ * @note If rank count is 3, then returned string is 'd1:d2:d3`.
+ */
+static gchar *
+gst_tensor_filter_get_dimensions_string (GstTensorFilterProperties * prop,
+    const gboolean isInput)
+{
+  gchar *dim_str = NULL;
+  GstTensorsInfo *tinfo = isInput ? &prop->input_meta : &prop->output_meta;
+
+  if (tinfo->num_tensors > 0) {
+    guint i;
+    GString *dimensions = g_string_new (NULL);
+
+    unsigned int *_rank = (isInput) ? prop->input_ranks : prop->output_ranks;
+    for (i = 0; i < tinfo->num_tensors; ++i) {
+      dim_str =
+          gst_tensor_get_rank_dimension_string (tinfo->info[i].dimension,
+          *(_rank + i));
+      g_string_append (dimensions, dim_str);
+
+      if (i < tinfo->num_tensors - 1) {
+        g_string_append (dimensions, ",");
+      }
+      g_free (dim_str);
+    }
+    dim_str = g_string_free (dimensions, FALSE);
+  }
+  return dim_str;
+}
+
+/**
  * @brief Get layout string of tensor layout.
  * @param layout layout of the tensor
  * @return string of layout in tensor
@@ -1729,6 +1764,7 @@ gst_tensor_filter_common_set_property (GstTensorFilterPrivate * priv,
   return TRUE;
 }
 
+
 /**
  * @brief Get the properties for tensor_filter
  * @param[in] priv Struct containing the properties of the object
@@ -1775,7 +1811,7 @@ gst_tensor_filter_common_get_property (GstTensorFilterPrivate * priv,
       if (prop->input_meta.num_tensors > 0) {
         gchar *dim_str;
 
-        dim_str = gst_tensors_info_get_dimensions_string (&prop->input_meta);
+        dim_str = gst_tensor_filter_get_dimensions_string (prop, TRUE);
 
         g_value_take_string (value, dim_str);
       } else {
@@ -1786,7 +1822,7 @@ gst_tensor_filter_common_get_property (GstTensorFilterPrivate * priv,
       if (prop->output_meta.num_tensors > 0) {
         gchar *dim_str;
 
-        dim_str = gst_tensors_info_get_dimensions_string (&prop->output_meta);
+        dim_str = gst_tensor_filter_get_dimensions_string (prop, FALSE);
 
         g_value_take_string (value, dim_str);
       } else {

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -4359,12 +4359,13 @@ TEST (test_tensor_filter, property_rank_01_p)
   filter = gst_harness_find_element (hrnss, "tensor_filter");
   ASSERT_TRUE (filter != NULL);
 
+  /* Check input dimension '3:224:224' */
   gchar * input_dim;
   g_object_get (filter, "input", &input_dim, NULL);
-  EXPECT_STREQ (input_dim, "3:224:224:1");
+  EXPECT_STREQ (input_dim, "3:224:224");
   g_free (input_dim);
 
-  /* Rank should be 3 since dimension string of the output is explicitly '3:224:224'. */
+  /* Rank should be 3 since dimension string of the input is explicitly '3:224:224'. */
   gchar * input_ranks;
   g_object_get (filter, "inputranks", &input_ranks, NULL);
   EXPECT_STREQ (input_ranks, "3");
@@ -4420,6 +4421,7 @@ TEST (test_tensor_filter, property_rank_02_p)
   EXPECT_STREQ (input_dim, "3:224:224:1");
   g_free (input_dim);
 
+  /* Rank should be 3 since input dimension string is not given. */
   gchar * input_ranks;
   g_object_get (filter, "inputranks", &input_ranks, NULL);
   EXPECT_STREQ (input_ranks, "3");
@@ -4430,10 +4432,63 @@ TEST (test_tensor_filter, property_rank_02_p)
   EXPECT_STREQ (output_dim, "1001:1:1:1");
   g_free (output_dim);
 
-  /* Rank should be 1 since dimension string is not given. */
+  /* Rank should be 1 since output dimension string is not given. */
   gchar * output_ranks;
   g_object_get (filter, "outputranks", &output_ranks, NULL);
   EXPECT_STREQ (output_ranks, "1");
+  g_free (output_ranks);
+
+  g_object_unref (filter);
+  gst_harness_teardown (hrnss);
+}
+
+/**
+ * @brief Test for inputranks and outputranks property of the tensor_filter
+ * @details Given dimension string, check its rank value.
+ */
+TEST (test_tensor_filter, property_rank_03_n)
+{
+  gchar *str_launch_line;
+  GstHarness *hrnss;
+  GstElement *filter;
+  gchar *test_model;
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+
+  /* supposed to run test in build directory */
+  if (root_path == NULL)
+    root_path = "..";
+
+  test_model = g_build_filename (root_path, "tests", "test_models", "models",
+      "mobilenet_v1_1.0_224_quant.tflite", NULL);
+  ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
+
+  hrnss = gst_harness_new_empty ();
+  ASSERT_TRUE (hrnss != NULL);
+
+  str_launch_line = g_strdup_printf ("tensor_filter framework=auto model=%s input=3:224:224 inputtype=uint8 \
+      output=1001:1 outputtype=uint8 ", test_model);
+  gst_harness_add_parse (hrnss,  str_launch_line);
+  g_free (str_launch_line);
+
+  filter = gst_harness_find_element (hrnss, "tensor_filter");
+  ASSERT_TRUE (filter != NULL);
+
+  /* The input dimension string should be '3:224:224' since it is given in the pipeline. */
+  gchar * input_dim;
+  g_object_get (filter, "input", &input_dim, NULL);
+  EXPECT_STRNE (input_dim, "3:224:224:1");
+  g_free (input_dim);
+
+  /* The input dimension string should be '1001:1' since it is given in the pipeline. */
+  gchar * output_dim;
+  g_object_get (filter, "output", &output_dim, NULL);
+  EXPECT_STRNE (output_dim, "1001:1:1:1");
+  g_free (output_dim);
+
+  /* Rank should be 2 since dimension string of the output is explicitly '1000:1:1:1'. */
+  gchar * output_ranks;
+  g_object_get (filter, "outputranks", &output_ranks, NULL);
+  EXPECT_STREQ (output_ranks, "2");
   g_free (output_ranks);
 
   g_object_unref (filter);


### PR DESCRIPTION
Even though the dimension string of the input tensor is given in the
pipeline, the `input` property is always fixed 4 dimensions (i.e.
d1:d2:d3:d4). This patch returns the dimension string considering tensor
dimension and rank count.

For example, given tensor filter parameters
'tensor_filter input=3:224:224', the returned dimension string is
`__3:224:224__` instead of `3:224:224:1`.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped


### Submit history
#### v2
* Rebase previous patches
* According to Jaeyun's advice, make a simple logic

#### v1
* first draft
