### PR TITLE
[Build/ExtPlugin] Add registerer for ext plugins (tizensensor, gRPC, ...)

### DIFF
--- a/ext/nnstreamer/meson.build
+++ b/ext/nnstreamer/meson.build
@@ -22,3 +22,26 @@ subdir('tensor_decoder')
 subdir('tensor_filter')
 subdir('tensor_source')
 subdir('tensor_converter')
+
+if get_option('enable-tizen-sensor')
+  tizensensor_registerer_source_files = ['registerer/tizensensor.c']
+  tizensensor_registerer_sources = []
+
+  foreach s : tizensensor_registerer_source_files
+    tizensensor_registerer_sources += join_paths(meson.current_source_dir(), s)
+  endforeach
+
+  tizensensor_lib = shared_library('nnstreamer-tizen-sensor',
+    tizensensor_registerer_sources,
+    dependencies: tensor_src_tizensensor_dep,
+    install: true,
+    install_dir: plugins_install_dir
+  )
+
+  tizensensor_static = static_library('nnstreamer-tizen-sensor',
+    tizensensor_registerer_sources,
+    dependencies: tensor_src_tizensensor_dep,
+    install: true,
+    install_dir: nnstreamer_libdir
+  )
+endif

--- a/ext/nnstreamer/registerer/tizensensor.c
+++ b/ext/nnstreamer/registerer/tizensensor.c
@@ -1,0 +1,60 @@
+/**
+ * nnstreamer registerer for tizen sensor plugin
+ * Copyright (C) 2020 Dongju Chae <dongju.chae@samsung.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ */
+
+/**
+ * @file	tizensensor.c
+ * @date	22 Oct 2020
+ * @brief	Registers nnstreamer extension plugin for tizen sensor
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Dongju Chae <dongju.chae@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <gst/gst.h>
+
+#include <tensor_source/tensor_src_tizensensor.h>
+
+#define NNSTREAMER_TIZEN_SENSOR_INIT(plugin,name,type) \
+  do { \
+    if (!gst_element_register (plugin, "tensor_" # name, GST_RANK_NONE, GST_TYPE_TENSOR_ ## type)) { \
+      GST_ERROR ("Failed to register nnstreamer plugin : tensor_" # name); \
+      return FALSE; \
+    } \
+  } while (0)
+
+/**
+ * @brief Function to initialize all nnstreamer elements
+ */
+static gboolean
+gst_nnstreamer_tizen_sensor_init (GstPlugin * plugin)
+{
+  NNSTREAMER_TIZEN_SENSOR_INIT (plugin, src_tizensensor, SRC_TIZENSENSOR);
+  return TRUE;
+}
+
+#ifndef PACKAGE
+#define PACKAGE "nnstreamer_tizen_sensor"
+#endif
+
+GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
+    GST_VERSION_MINOR,
+    nnstreamer_tizen_sensor,
+    "nnstreamer Tizen sensor framework extension",
+    gst_nnstreamer_tizen_sensor_init, VERSION, "LGPL", "nnstreamer",
+    "https://github.com/nnstreamer/nnstreamer");

--- a/ext/nnstreamer/tensor_source/meson.build
+++ b/ext/nnstreamer/tensor_source/meson.build
@@ -1,4 +1,3 @@
-
 if get_option('enable-tizen-sensor')
   tzn_tensor_src_source_files = ['tensor_src_tizensensor.c']
   tzn_tensor_src_sources = []
@@ -8,19 +7,9 @@ if get_option('enable-tizen-sensor')
   endforeach
 
   tznsensor_dep = dependency('capi-system-sensor', required: true)
-  tensor_src_tizensensor_deps = [glib_dep, gst_dep, nnstreamer_dep, tznsensor_dep]
 
-  tensor_src_tizensensor_lib = shared_library('nnstreamer-tizen-sensor',
-    tzn_tensor_src_sources,
-    dependencies: tensor_src_tizensensor_deps,
-    install: true,
-    install_dir: plugins_install_dir
-  )
-
-  tensor_src_tizensensor_static = static_library('nnstreamer-tizen-sensor',
-    tzn_tensor_src_sources,
-    dependencies: tensor_src_tizensensor_deps,
-    install: true,
-    install_dir: nnstreamer_libdir
+  tensor_src_tizensensor_dep = declare_dependency(
+    sources : tzn_tensor_src_sources,
+    dependencies : [glib_dep, gst_dep, nnstreamer_dep, tznsensor_dep]
   )
 endif

--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
@@ -1308,30 +1308,3 @@ exit:
   _UNLOCK (self);
   return retval;
 }
-
-/**
- * @brief Register the plugin for GStreamer. This is an independent plugin.
- */
-static gboolean
-gst_nnstreamer_tizen_sensor_init (GstPlugin * plugin)
-{
-  if (!gst_element_register (plugin, "tensor_src_tizensensor",
-          GST_RANK_NONE, GST_TYPE_TENSOR_SRC_TIZENSENSOR)) {
-    GST_ERROR
-        ("Failed to register nnstreamer's tensor_src_tizensensor plugin.");
-    return FALSE;
-  }
-
-  return TRUE;
-}
-
-#ifndef PACKAGE
-#define PACKAGE "nnstreamer_tizen_sensor"
-#endif
-
-GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
-    GST_VERSION_MINOR,
-    nnstreamer_tizen_sensor,
-    "nnstreamer Tizen sensor framework extension",
-    gst_nnstreamer_tizen_sensor_init, VERSION, "LGPL", "nnstreamer",
-    "https://github.com/nnstreamer/nnstreamer");

--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.h
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.h
@@ -28,6 +28,8 @@
 #include <gst/gst.h>
 #include <gst/base/gstbasesrc.h>
 
+#include <tensor_typedef.h> /* GstTensorInfo */
+
 #ifndef __TIZEN__
 #error This plugin requires TIZEN packages.
 #endif

--- a/meson.build
+++ b/meson.build
@@ -492,7 +492,7 @@ if get_option('enable-test')
   path_nns_plugin_converters = join_paths(path_nns_plugin_prefix, 'tensor_converter')
 
   testenv = environment()
-  testenv.set('GST_PLUGIN_PATH', path_gst_plugin)
+  testenv.set('GST_PLUGIN_PATH', path_gst_plugin + ':' + path_nns_plugin_prefix)
   testenv.set('NNSTREAMER_CONF', path_nns_conf)
   testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
   testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -605,7 +605,7 @@ ninja -C build %{?_smp_mflags}
 
 export NNSTREAMER_SOURCE_ROOT_PATH=$(pwd)
 export NNSTREAMER_BUILD_ROOT_PATH=$(pwd)/build
-export GST_PLUGIN_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/gst/nnstreamer
+export GST_PLUGIN_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/gst/nnstreamer:${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer
 export NNSTREAMER_CONF=${NNSTREAMER_BUILD_ROOT_PATH}/nnstreamer-test.ini
 export NNSTREAMER_FILTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_filter
 export NNSTREAMER_DECODERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_decoder
@@ -615,7 +615,7 @@ export NNSTREAMER_CONVERTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor
 
 %if %{with tizen}
     bash %{test_script} ./tests/tizen_nnfw_runtime/unittest_nnfw_runtime_raw
-    GST_PLUGIN_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_source:${GST_PLUGIN_PATH} bash %{test_script} ./tests/tizen_capi/unittest_tizen_sensor
+    bash %{test_script} ./tests/tizen_capi/unittest_tizen_sensor
 %endif #if tizen
 %if 0%{?unit_test}
     bash %{test_script} ./tests

--- a/tests/tizen_capi/meson.build
+++ b/tests/tizen_capi/meson.build
@@ -45,14 +45,6 @@ if get_option('enable-tizen-sensor')
     install: get_option('install-test'),
     install_dir: unittest_install_dir
   )
-  tizen_sensor_testenv = environment()
-  tizen_sensor_testenv.set('GST_PLUGIN_PATH', \
-      join_paths(meson.build_root(), 'ext', 'nnstreamer', 'tensor_source'), \
-      path_gst_plugin)
-  tizen_sensor_testenv.set('NNSTREAMER_CONF', path_nns_conf)
-  tizen_sensor_testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
-  tizen_sensor_testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
-  tizen_sensor_testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
-  tizen_sensor_testenv.set('NNSTREAMER_SOURCE_ROOT_PATH', meson.source_root())
-  test('unittest_tizen_sensor', unittest_tizen_sensor, env: tizen_sensor_testenv)
+
+  test('unittest_tizen_sensor', unittest_tizen_sensor, env: testenv)
 endif


### PR DESCRIPTION
This patch adds registerer for ext plugins to register multiple elements for ext plugins.

For example, 
- tizensensor plugin
  --> tensor_src_tizensensor
- grpc plugin (TBA)
  --> tensor_src_grpc
  --> tensor_sink_grpc

@myungjoo Please take a look at this proposal.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>