### PR TITLE
[Fix/Debian] Add missing installation files (nnstreamer-check/capi)

### DIFF
--- a/debian/nnstreamer-dev.install
+++ b/debian/nnstreamer-dev.install
@@ -8,5 +8,9 @@
 /usr/include/nnstreamer/tensor_typedef.h
 /usr/include/nnstreamer/tensor_filter_cpp.hh
 /usr/include/nnstreamer/nnstreamer_cppplugin_api_filter.hh
+/usr/include/nnstreamer/ml-api-common.h
+/usr/include/nnstreamer/tizen_error.h
+/usr/include/nnstreamer/nnstreamer.h
+/usr/include/nnstreamer/nnstreamer-single.h
 /usr/lib/*/pkgconfig/*.pc
 /usr/lib/*/*.a

--- a/debian/nnstreamer.install
+++ b/debian/nnstreamer.install
@@ -5,5 +5,5 @@
 /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_direct_video.so
 /usr/lib/nnstreamer/filters/libnnstreamer_filter_cpp.so
 /usr/lib/*/gstreamer-1.0/*.so
-/usr/lib/*/libcapi-*.so
+/usr/lib/*/libcapi-*
 /etc/nnstreamer.ini

--- a/debian/rules
+++ b/debian/rules
@@ -37,6 +37,7 @@ endif
 
 override_dh_auto_clean:
 	rm -rf ${BUILDDIR}
+	rm -rf tools/development/confchk/${BUILDDIR}
 
 override_dh_auto_configure:
 	mkdir -p ${BUILDDIR}
@@ -44,7 +45,7 @@ override_dh_auto_configure:
 	-Dtf-support=$(enable_tf) -Dtflite-support=enabled -Dpytorch-support=enabled -Dcaffe2-support=enabled \
 	-Dpython2-support=enabled -Dpython3-support=enabled -Denable-capi=true -Denable-edgetpu=true -Denable-tizen=false \
 	-Denable-openvino=true ${BUILDDIR}
-	cd tools/development/confchk && meson --prefix=/usr ${BUILDDIR} && cd ../../..
+	cd tools/development/confchk && meson --prefix=/usr --bindir=bin ${BUILDDIR} && cd ../../..
 
 override_dh_auto_build:
 	ninja -C ${BUILDDIR}


### PR DESCRIPTION
This patch adds missing installation files on Ubuntu packaging,
mostly related to capi and nnstreamer-check.

It resolves #2822

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>