### PR TITLE
[Filter] Fix the omitted initialization of GstTensorFilterFrameworkInfo

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -394,7 +394,7 @@ gst_tensor_filter_framework_info_init (GstTensorFilterFrameworkInfo * info)
   info->allow_in_place = 0;
   info->allocate_in_invoke = 0;
   info->run_without_model = 0;
-  info->allocate_in_invoke = 0;
+  info->verify_model_path = 0;
   info->hw_list = NULL;
   info->accl_auto = -1;
   info->accl_default = -1;


### PR DESCRIPTION
This patch initializes the omitted 'verify_model_path' value instead of
'allocate_in_invoke', which is set twice.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

