### PR TITLE
[dist/debian] Package c-api headers

### DIFF
--- a/debian/nnstreamer-dev.install
+++ b/debian/nnstreamer-dev.install
@@ -8,5 +8,8 @@
 /usr/include/nnstreamer/tensor_typedef.h
 /usr/include/nnstreamer/tensor_filter_cpp.hh
 /usr/include/nnstreamer/nnstreamer_cppplugin_api_filter.hh
+/usr/include/nnstreamer/nnstreamer.h
+/usr/include/nnstreamer/nnstreamer-single.h
+/usr/include/nnstreamer/ml-api-common.h
 /usr/lib/*/pkgconfig/*.pc
 /usr/lib/*/*.a


### PR DESCRIPTION
Debian packaging of nnstreamer packages nnstreamer and capi-nnstreamer shared libraries
The corresponding headers are packaged as part of dev package. However, the headers
of c-api are not packaged. This patch packages the missing c-api headers.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>