### PR TITLE
[tensor_filter_common] Fix a wrong example in accelerator prop spec

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -712,7 +712,8 @@ gst_tensor_filter_install_properties (GObjectClass * gobject_class)
           "(true/false):(comma separated ACCELERATOR(s)). "
           "true/false determines if accelerator is to be used. "
           "list of accelerators determines the backend (ignored with false). "
-          "Example, if GPU, NPU can be used but not CPU - true:(GPU,NPU,!CPU). "
+          "Example, if GPU, NPU can be used but not CPU - true:npu,gpu,!cpu. "
+          "The full list of accelerators can be found in nnstreamer_plugin_api_filter.h. "
           "Note that only a few subplugins support this property.",
           "", G_PARAM_READWRITE));
   g_object_class_install_property (gobject_class, PROP_IS_UPDATABLE,


### PR DESCRIPTION
This patch fixes the wrong accelerator example in the prop spec.
This helps other developers to avoid confusions.
In actual tests, the true:(GPU,NPU,!CPU) format fails to be accepted so
that it switches to default mode. Also test cases do not cover such
format as well [1].

It also adds a note where to find available accelerator names.

[1]
https://github.com/nnstreamer/nnstreamer/blob/main/tests/nnstreamer_filter_tensorflow_lite/runTest.sh#L108

Signed-off-by: Bumsik Kim <k.bumsik@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nnstreamer/nnstreamer/2834)
<!-- Reviewable:end -->
