### PR TITLE
DIST/Tizen: enable flatbuf for VD

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -65,7 +65,6 @@
 %endif
 
 %if !0%{?enable_extra_subplugins}
-%define		flatbuf_support 0
 %define		protobuf_support 0
 %define		python_support 0
 %define		mvncsdk2_support 0


### PR DESCRIPTION
Flatbuf is required by tf-lite these days. Enable it.
Reported by Jongmin Lee.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

