### PR TITLE
[Dist/Debian] Move libcapi-nnstreamer.a and .so to the development package

### DIFF
--- a/debian/nnstreamer-dev.install
+++ b/debian/nnstreamer-dev.install
@@ -14,3 +14,4 @@
 /usr/include/nnstreamer/nnstreamer-single.h
 /usr/lib/*/pkgconfig/*.pc
 /usr/lib/*/*.a
+/usr/lib/*/libcapi-*.so

--- a/debian/nnstreamer.install
+++ b/debian/nnstreamer.install
@@ -5,5 +5,5 @@
 /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_direct_video.so
 /usr/lib/nnstreamer/filters/libnnstreamer_filter_cpp.so
 /usr/lib/*/gstreamer-1.0/*.so
-/usr/lib/*/libcapi-*
+/usr/lib/*/libcapi-*.so.*
 /etc/nnstreamer.ini


### PR DESCRIPTION
This patch removes libcapi-nnstreamer.a from the main package and moves libcapi-nnstreamer.so to the development package.

Signed-off-by: Wook Song <wook16.song@samsung.com>

Resolves: #2836 

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped