### PR TITLE
[Repo] Fix the assertion error when executing `gst-inspect-1.0 command

### DIFF
--- a/gst/nnstreamer/tensor_repo/tensor_reposrc.c
+++ b/gst/nnstreamer/tensor_repo/tensor_reposrc.c
@@ -53,6 +53,7 @@ enum
 
 #define DEFAULT_SILENT TRUE
 #define DEFAULT_INDEX 0
+#define INVALID_INDEX G_MAXUINT
 
 static void gst_tensor_reposrc_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec);
@@ -97,7 +98,7 @@ gst_tensor_reposrc_class_init (GstTensorRepoSrcClass * klass)
 
   g_object_class_install_property (gobject_class, PROP_SLOT_ID,
       g_param_spec_uint ("slot-index", "Slot Index", "repository slot index",
-          0, UINT_MAX, DEFAULT_INDEX,
+          0, INVALID_INDEX - 1, DEFAULT_INDEX,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   basesrc_class->get_caps = gst_tensor_reposrc_getcaps;
@@ -130,6 +131,7 @@ gst_tensor_reposrc_init (GstTensorRepoSrc * self)
   gst_tensors_config_init (&self->config);
   self->caps = NULL;
   self->set_startid = FALSE;
+  self->myid = INVALID_INDEX;
 }
 
 /**
@@ -140,7 +142,8 @@ gst_tensor_reposrc_dispose (GObject * object)
 {
   GstTensorRepoSrc *self = GST_TENSOR_REPOSRC (object);
 
-  if (!gst_tensor_repo_remove_repodata (self->myid))
+  if (self->myid != INVALID_INDEX
+      && !gst_tensor_repo_remove_repodata (self->myid))
     GST_ELEMENT_ERROR (self, RESOURCE, WRITE,
         ("Cannot remove [key: %d] in repo", self->myid), NULL);
 


### PR DESCRIPTION
When executing `gst-inspect-1.0 tensor_reposrc` command, below error
occurs.
```bash
$ gst-inspect-1.0 tensor_reposrc
...

** (gst-inspect-1.0:29483): CRITICAL **:
gst_tensor_repo_remove_repodata: assertion '_repo.initialized' failed
```

The main reason that the disposal callback always try to remove the repodata
even though it is not initialized and it causes the assertion error.
This patch fixes that bug.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed []Skipped
2. Run test: [X]Passed [ ]Failed []Skipped


