### PR TITLE
[Android] handle invalid context

### DIFF
--- a/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestCommon.java
+++ b/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestCommon.java
@@ -338,6 +338,16 @@ public class APITestCommon {
     }
 
     @Test
+    public void testInitWithInvalidCtx_n() {
+        try {
+            NNStreamer.initialize(null);
+            fail();
+        } catch (Exception e) {
+            /* expected */
+        }
+    }
+
+    @Test
     public void enumTensorType() {
         assertEquals(NNStreamer.TensorType.INT32, NNStreamer.TensorType.valueOf("INT32"));
         assertEquals(NNStreamer.TensorType.UINT32, NNStreamer.TensorType.valueOf("UINT32"));

--- a/api/android/api/src/main/java/org/nnsuite/nnstreamer/NNStreamer.java
+++ b/api/android/api/src/main/java/org/nnsuite/nnstreamer/NNStreamer.java
@@ -47,6 +47,8 @@ public final class NNStreamer {
 
     /**
      * The enumeration for supported frameworks in NNStreamer.
+     *
+     * @see #isAvailable(NNFWType)
      */
     public enum NNFWType {
         /**
@@ -116,8 +118,14 @@ public final class NNStreamer {
      * @param context The application context
      *
      * @return true if successfully initialized
+     *
+     * @throws IllegalArgumentException if given param is invalid
      */
     public static boolean initialize(Context context) {
+        if (context == null) {
+            throw new IllegalArgumentException("Given context is invalid");
+        }
+
         try {
             System.loadLibrary("gstreamer_android");
             System.loadLibrary("nnstreamer-native");


### PR DESCRIPTION
Handle invalid param case -init nnstreamer with invalid context.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
