### PR TITLE
[tensorfilter] Set default framework when no priority

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -959,11 +959,12 @@ gst_tensor_filter_framework_auto_detection (const gchar ** model_files,
 
   /* Detect framework based on file extension */
   if (num_models == 1) {
-    if (g_ascii_strcasecmp (file_extension, ".tflite") == 0)
+    if (g_ascii_strcasecmp (file_extension, ".tflite") == 0) {
+      detected_fw = g_strdup ("tensorflow-lite");
       fw_priority_str =
           nnsconf_get_custom_value_string ("filter",
           "framework_priority_tflite");
-    else if (g_ascii_strcasecmp (file_extension, ".pb") == 0)
+    } else if (g_ascii_strcasecmp (file_extension, ".pb") == 0)
       detected_fw = g_strdup ("tensorflow");
     else if (g_ascii_strcasecmp (file_extension, ".pt") == 0)
       detected_fw = g_strdup ("pytorch");
@@ -1003,6 +1004,8 @@ gst_tensor_filter_framework_auto_detection (const gchar ** model_files,
       fw = nnstreamer_filter_find (fw_priority_str_arr[i]);
 
       if (fw) {
+        if (detected_fw)
+          g_free (detected_fw);
         detected_fw = g_strdup (fw_priority_str_arr[i]);
         break;
       } else {


### PR DESCRIPTION
tensor_filter auto detection of framework takes in the extension
and for tflite extension tries to identify the framework using
a priority set with the configuration.
however, in case, the priority string is NULL, no tensor_filter
framework is set although multiple tensor_filters supporting
this extension can exist.

This patch sets a default framework for tflite extension which is
overwritten based on the priority if priority exists.

This bug shows when using ML_NNFW_TYPE_ANY with nnstreamer CAPI
for tflite extension files on TIZEN with gbs emulator where priority string
is read as NULL (happens in nntrainer).

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>