### PR TITLE
[Android/tflite] Support gpu delegate @open sesame 11/06 10:52 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ neural network developers to manage neural network pipelines and their filters e
 
 |     | [Tizen](http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/) | [Ubuntu](https://launchpad.net/~nnstreamer/+archive/ubuntu/ppa) | Android/NDK Build | Android/APK | Yocto | macOS |
 | :-- | :--: | :--: | :--: | :--: | :--: | :--: |
-|     | 5.5M2 and later | 16.04/18.04 | 7.0/N | 7.0/N | TBD |   |
+|     | 5.5M2 and later | 16.04/18.04 | 9/P | 9/P | TBD |   |
 | arm | [![armv7l badge](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/badge/armv7l_result_badge.svg)](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/build_result/) | Available  | Ready | Available| Ready | N/A |
 | arm64 |  [![aarch64 badge](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/badge/aarch64_result_badge.svg)](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/build_result/) | Available  | Ready | [![android badge](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/badge/android_result_badge.svg)](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/build_result/) | Planned | N/A |
 | x64 | [![x64 badge](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/badge/x86_64_result_badge.svg)](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/build_result/)  | [![ubuntu badge](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/badge/ubuntu_result_badge.svg)](http://nnsuite.mooo.com/nnstreamer/ci/taos/daily-build/build_result/)  | Ready  | Ready | Ready | Available |

--- a/api/android/README.md
+++ b/api/android/README.md
@@ -7,7 +7,7 @@ We assume that you already have experienced Android application developments wit
  * Host PC:
    * OS: Ubuntu 16.04 / 18.04 x86_64 LTS
    * Android Studio: Ubuntu version
-   * Android SDK: Min version 24 (Nougat)
+   * Android SDK: Min version 28 (Pie)
    * Android NDK: Use default ndk-bundle in Android Studio
    * GStreamer: gstreamer-1.0-android-universal-1.16.2
 

--- a/api/android/api/build.gradle
+++ b/api/android/api/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 28
     buildToolsVersion '28.0.3'
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 28
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/api/android/api/src/main/jni/Android-tensorflow-lite.mk
+++ b/api/android/api/src/main/jni/Android-tensorflow-lite.mk
@@ -65,6 +65,14 @@ LOCAL_MODULE := tensorflow-lite-subplugin
 LOCAL_SRC_FILES := $(NNSTREAMER_FILTER_TFLITE_SRCS)
 LOCAL_CXXFLAGS := -std=c++11 -O3 -fPIC -frtti -fexceptions $(NNS_API_FLAGS) $(TFLITE_FLAGS)
 LOCAL_C_INCLUDES := $(TF_LITE_INCLUDES) $(NNSTREAMER_INCLUDES) $(GST_HEADERS_COMMON)
+
+# Link gles for tflite v2.3.0 or higher for gpu delegate support
+ifeq ($(TFLITE_VERSION_MAJOR),2)
+ifeq ($(shell test $(TFLITE_VERSION_MINOR) -ge 3; echo $$?),0)
+LOCAL_EXPORT_LDLIBS := -lEGL -lGLESv2
+endif
+endif
+
 LOCAL_STATIC_LIBRARIES := tensorflow-lite-lib cpufeatures
 
 include $(BUILD_STATIC_LIBRARY)


### PR DESCRIPTION
- Tflite gpu delegate requires sdk version higher than 28. Bump up the minimum sdk version from 24 to 28
- Support gpu delegate for tflite-2.3.0
- Resolves #2852 
- REF: https://github.com/nnstreamer/nnstreamer-android-resource/pull/13

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
