### PR TITLE
[Tizen/gRPC] check gRPC capability in nnstreamer.spec

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -64,7 +64,6 @@
 %define		mvncsdk2_support 0
 %define		edgetpu_support 0
 %define		openvino_support 0
-%define		grpc_support 0
 %endif
 
 %if !0%{?enable_extra_subplugins}
@@ -72,7 +71,6 @@
 %define		python_support 0
 %define		mvncsdk2_support 0
 %define		edgetpu_support 0
-%define		grpc_support 0
 %endif
 
 %if !0%{?check_test}


### PR DESCRIPTION
This patch enables gRPC plugin in DA profile.

The below shows gRPC deployment status in each profile.
- DA: gRPC 1.20.1 (same with the upstream)
- VD: None

It resolves https://github.com/nnstreamer/nnstreamer/issues/2861

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>
