### PR TITLE
[Android] method to set surface

### DIFF
--- a/api/android/api/src/main/jni/nnstreamer-native-api.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-api.c
@@ -133,6 +133,9 @@ nns_free_element_data (gpointer data)
       case NNS_ELEMENT_TYPE_SWITCH:
         ml_pipeline_switch_release_handle ((ml_pipeline_switch_h) item->handle);
         break;
+      case NNS_ELEMENT_TYPE_VIDEO_SINK:
+        ml_pipeline_element_release_handle ((ml_pipeline_element_h) item->handle);
+        break;
 #endif
       default:
         nns_logw ("Given element type %d is unknown.", item->type);

--- a/api/android/api/src/main/jni/nnstreamer-native.h
+++ b/api/android/api/src/main/jni/nnstreamer-native.h
@@ -25,8 +25,11 @@
 #define __NNSTREAMER_ANDROID_NATIVE_H__
 
 #include <jni.h>
+#include <android/native_window.h>
+#include <android/native_window_jni.h>
 
 #include <gst/gst.h>
+#include <gst/video/video.h>
 
 #include "nnstreamer.h"
 #include "nnstreamer-single.h"
@@ -80,6 +83,7 @@ typedef enum
   NNS_ELEMENT_TYPE_SINK,
   NNS_ELEMENT_TYPE_VALVE,
   NNS_ELEMENT_TYPE_SWITCH,
+  NNS_ELEMENT_TYPE_VIDEO_SINK,
 
   NNS_ELEMENT_TYPE_UNKNOWN
 } nns_element_type_e;


### PR DESCRIPTION
Add new method to set a surface to video-sink element.
In Android application, developer can simply set SurfaceHolder object to glimagesink.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
