### PR TITLE
[Tools/Parser] Replace GST macros to dummy

### DIFF
--- a/tools/development/parser/grammar.y
+++ b/tools/development/parser/grammar.y
@@ -31,9 +31,9 @@
 
 #  define SET_ERROR(error, type, ...) \
 G_STMT_START { \
-  GST_CAT_ERROR (GST_CAT_PIPELINE, __VA_ARGS__); \
+  g_printerr (__VA_ARGS__); \
   if ((error) && !*(error)) { \
-    g_set_error ((error), GST_PARSE_ERROR, (type), __VA_ARGS__); \
+    g_set_error ((error), GST2PBTXT_PARSE_ERROR, (type), __VA_ARGS__); \
   } \
 } G_STMT_END
 
@@ -41,9 +41,9 @@ G_STMT_START { \
 
 #  define SET_ERROR(error, type, args...) \
 G_STMT_START { \
-  GST_CAT_ERROR (GST_CAT_PIPELINE, args ); \
+  g_printerr (args ); \
   if ((error) && !*(error)) { \
-    g_set_error ((error), GST_PARSE_ERROR, (type), args ); \
+    g_set_error ((error), GST2PBTXT_PARSE_ERROR, (type), args ); \
   } \
 } G_STMT_END
 
@@ -63,7 +63,7 @@ SET_ERROR (GError **error, gint type, const char *format, ...)
       string = g_strdup_vprintf (format, varargs);
       va_end (varargs);
 
-      g_set_error (error, GST_PARSE_ERROR, type, string);
+      g_set_error (error, GST2PBTXT_PARSE_ERROR, type, string);
 
       g_free (string);
     }
@@ -82,17 +82,17 @@ SET_ERROR (GError **error, gint type, const char *format, ...)
 
 #  ifdef G_HAVE_ISO_VARARGS
 
-/* #  define YYFPRINTF(a, ...) GST_CAT_DEBUG (GST_CAT_PIPELINE, __VA_ARGS__) */
+/* #  define YYFPRINTF(a, ...) g_printerr (__VA_ARGS__) */
 #    define YYFPRINTF(a, ...) \
 G_STMT_START { \
-     GST_CAT_LOG (GST_CAT_PIPELINE, __VA_ARGS__); \
+     g_print (__VA_ARGS__); \
 } G_STMT_END
 
 #  elif defined(G_HAVE_GNUC_VARARGS)
 
 #    define YYFPRINTF(a, args...) \
 G_STMT_START { \
-     GST_CAT_LOG (GST_CAT_PIPELINE, args); \
+     g_print (args); \
 } G_STMT_END
 
 #  else
@@ -105,7 +105,7 @@ YYPRINTF(const char *format, ...)
 
   va_start (varargs, format);
   temp = g_strdup_vprintf (format, varargs);
-  GST_CAT_LOG (GST_CAT_PIPELINE, "%s", temp);
+  g_print ("%s", temp);
   g_free (temp);
   va_end (varargs);
 }
@@ -139,12 +139,12 @@ static void  add_missing_element(graph_t *graph,gchar *name){
 
 #define TRY_SETUP_LINK(l) G_STMT_START { \
    if( (!(l)->src.element) && (!(l)->src.name) ){ \
-     SET_ERROR (graph->error, GST_PARSE_ERROR_LINK, _("link has no source [sink=%s@%p]"), \
+     SET_ERROR (graph->error, GST2PBTXT_PARSE_ERROR_LINK, _("link has no source [sink=%s@%p]"), \
 	(l)->sink.name ? (l)->sink.name : "", \
 	(l)->sink.element); \
      gst_parse_free_link (l); \
    }else if( (!(l)->sink.element) && (!(l)->sink.name) ){ \
-     SET_ERROR (graph->error, GST_PARSE_ERROR_LINK, _("link has no sink [source=%s@%p]"), \
+     SET_ERROR (graph->error, GST2PBTXT_PARSE_ERROR_LINK, _("link has no sink [source=%s@%p]"), \
 	(l)->src.name ? (l)->src.name : "", \
 	(l)->src.element); \
      gst_parse_free_link (l); \

--- a/tools/development/parser/types.c
+++ b/tools/development/parser/types.c
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer Pipeline from/to PBTxt Converter Parser
+ * Copyright (C) 2020 MyungJoo Ham <myungjoo.ham@samsung.com>
+ *
+ * @file  types.c
+ * @date  12 Nov 2020
+ * @brief Simplified Gstreamer's internal functions for gst2pbtxt parser (nnstreamer parser)
+ * @see https://github.com/nnstreamer/nnstreamer
+ * @author  MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <glib.h>
+#include "types.h"
+
+/**
+ * @brief Get the error quark used by the parsing subsystem.
+ *
+ * Returns: the quark of the parse errors.
+ */
+GQuark
+gst2pbtxt_parse_error_quark (void)
+{
+  static GQuark quark = 0;
+
+  if (!quark)
+    quark = g_quark_from_static_string ("gst_parse_error");
+  return quark;
+}
+
+/**
+ * @brief Replacement of gst_parse_element_make
+ */
+_Element *
+nnstparser_element_make (const gchar * element, const gchar * name)
+{
+  _Element ret = g_malloc (sizeof (_Element));
+  ret->element = g_strdup (element);
+  ret->name = g_strdup (name);
+
+  return ret;
+}

--- a/tools/development/parser/types.h
+++ b/tools/development/parser/types.h
@@ -21,6 +21,9 @@ typedef struct {
   GSList *properties; /**< List of key-value pairs (_Property), added for gst-pbtxt, except for name=.... */
 } _Element;
 
+extern _Element *
+nnstparser_element_make (const gchar *element, const gchar *name);
+
 /** @brief Simplified GObject Property for GST Element */
 typedef struct {
   gchar *name;
@@ -146,6 +149,22 @@ gst_parse_unescape (gchar *str)
   }
   *str = '\0';
 }
+
+GQuark gst2pbtxt_parse_error_quark (void);
+#define GST2PBTXT_PARSE_ERROR gst2pbtxt_parse_error_quark ()
+
+typedef enum
+{
+  GST2PBTXT_PARSE_ERROR_SYNTAX,
+  GST2PBTXT_PARSE_ERROR_NO_SUCH_ELEMENT,
+  GST2PBTXT_PARSE_ERROR_NO_SUCH_PROPERTY,
+  GST2PBTXT_PARSE_ERROR_LINK,
+  GST2PBTXT_PARSE_ERROR_COULD_NOT_SET_PROPERTY,
+  GST2PBTXT_PARSE_ERROR_EMPTY_BIN,
+  GST2PBTXT_PARSE_ERROR_EMPTY,
+  GST2PBTXT_PARSE_ERROR_DELAYED_LINK
+} Gst2PbtxtParseError;
+
 
 G_GNUC_INTERNAL _Element *priv_gst_parse_launch (const gchar      * str,
                                                    GError          ** err,


### PR DESCRIPTION

We do not need to create GST objects with this parser.
Do not use GST object invoking macros.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
