### PR TITLE
[TensorCommon] Add get tensors cap common function @open sesame 11/18 16:59 

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -352,6 +352,23 @@ extern const gchar *
 gst_tensor_get_type_string (tensor_type type);
 
 /**
+ * @brief Get tensors caps from tensors config and peer caps of the src pad
+ * @param config tensors config structure
+ * @param pad GstPad to check if it supports other/tensor
+ * @return caps for given config and pad. Caller is responsible for unreffing the returned caps.
+ */
+extern GstCaps *
+gst_tensors_get_caps (GstPad * pad, const GstTensorsConfig * config);
+
+/**
+ * @brief Check whether pad's caps support other/tensor or not
+ * @param pad GstPad to check if it supports other/tensor
+ * @return TRUE if other/tensor, FALSE if not
+ */
+extern gboolean
+gst_pad_has_tensor_caps (GstPad * pad);
+
+/**
  * @brief Find the index value of the given key string array
  * @return Corresponding index
  * @param strv Null terminated array of gchar *

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -858,6 +858,60 @@ gst_tensors_config_from_structure (GstTensorsConfig * config,
 }
 
 /**
+ * @brief Get tensors caps from tensors config and caps of the src pad
+ * @param pad GstPad to check if it supports other/tensor
+ * @param config tensors config structure
+ * @return caps for given config and pad
+ */
+GstCaps *
+gst_tensors_get_caps (GstPad * pad, const GstTensorsConfig * config)
+{
+  GstCaps *caps = NULL;
+
+  if (config->info.num_tensors == 1 && gst_pad_has_tensor_caps (pad)) {
+    GstTensorConfig tensor_config;
+    tensor_config.info = config->info.info[0];
+    tensor_config.rate_n = config->rate_n;
+    tensor_config.rate_d = config->rate_d;
+    caps = gst_tensor_caps_from_config (&tensor_config);
+  } else {
+    caps = gst_tensors_caps_from_config (config);
+  }
+  return caps;
+}
+
+/**
+ * @brief Check whether pad's caps support other/tensor or not
+ * @param pad GstPad to check if it supports other/tensor
+ * @return TRUE if other/tensor, FALSE if not
+ */
+gboolean
+gst_pad_has_tensor_caps (GstPad * pad)
+{
+  GstCaps *peer_caps;
+  gboolean ret = TRUE;
+
+  peer_caps = gst_pad_peer_query_caps (pad, NULL);
+  /**
+   * supposed other/tensor If peer caps is NULL or the lengh of the peer caps is zero.
+   */
+  if (peer_caps) {
+    GstCaps *caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT);
+    GstCaps *intersection =
+        gst_caps_intersect_full (caps, peer_caps, GST_CAPS_INTERSECT_FIRST);
+
+    if (gst_caps_is_empty (intersection))
+      ret = FALSE;
+
+    gst_caps_unref (caps);
+    gst_caps_unref (intersection);
+  }
+  gst_caps_unref (peer_caps);
+
+  return ret;
+}
+
+/**
  * @brief Get caps from tensors config (for other/tensors)
  * @param config tensors config info
  * @return caps for given config

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -1757,36 +1757,9 @@ static gboolean
 gst_tensor_converter_update_caps (GstTensorConverter * self,
     GstPad * pad, GstTensorsConfig * config)
 {
-  GstStructure *st;
   GstCaps *curr_caps, *out_caps = NULL;
 
-  if (config->info.num_tensors == 1) {
-    GstCaps *peer_caps = gst_pad_peer_query_caps (pad, NULL);
-
-    if (peer_caps == NULL) {
-      GST_WARNING_OBJECT (self, "Failed to get peer caps \n");
-      return FALSE;
-    }
-
-    if (gst_caps_get_size (peer_caps) > 0) {
-      st = gst_caps_get_structure (peer_caps, 0);
-
-      if (g_strcmp0 (gst_structure_get_name (st), "other/tensor") == 0) {
-        GstTensorConfig tensor_config;
-
-        tensor_config.info = config->info.info[0];
-        tensor_config.rate_n = config->rate_n;
-        tensor_config.rate_d = config->rate_d;
-        out_caps = gst_tensor_caps_from_config (&tensor_config);
-      }
-    }
-    gst_caps_unref (peer_caps);
-  }
-
-  /* caps for tensors */
-  if (out_caps == NULL)
-    out_caps = gst_tensors_caps_from_config (config);
-  silent_debug_caps (out_caps, "out-caps");
+  out_caps = gst_tensors_get_caps (pad, config);
 
   /* Update pad caps. If it is different */
   curr_caps = gst_pad_get_current_caps (pad);

--- a/gst/nnstreamer/tensor_demux/gsttensordemux.c
+++ b/gst/nnstreamer/tensor_demux/gsttensordemux.c
@@ -295,27 +295,6 @@ gst_tensor_demux_get_tensor_config (GstTensorDemux * tensor_demux,
 }
 
 /**
- * @brief Check whether caps is other/tensor or not
- * @return TRUE if other/tensor, FALSE if not
- */
-static gboolean
-gst_tensor_demux_is_tensor_caps (GstCaps * caps)
-{
-  GstStructure *caps_s;
-  guint i, caps_len;
-
-  caps_len = gst_caps_get_size (caps);
-
-  for (i = 0; i < caps_len; i++) {
-    caps_s = gst_caps_get_structure (caps, i);
-    if (gst_structure_has_name (caps_s, "other/tensor")) {
-      return TRUE;
-    }
-  }
-  return FALSE;
-}
-
-/**
  * @brief Checking if the source pad is created and if not, create TensorPad
  * @param tesnor_demux TensorDemux Object
  * @param[out] created will be updated in this function
@@ -398,16 +377,14 @@ gst_tensor_demux_get_tensor_pad (GstTensorDemux * tensor_demux,
     gchar *seleted_tensor;
     gchar **strv;
     guint num;
-    GstCaps *peer_caps;
 
     g_assert (g_list_length (tensor_demux->tensorpick) >= nth);
 
     seleted_tensor = (gchar *) g_list_nth_data (tensor_demux->tensorpick, nth);
     strv = g_strsplit_set (seleted_tensor, ":+", -1);
     num = g_strv_length (strv);
-    peer_caps = gst_pad_peer_query_caps (pad, NULL);
 
-    if (num == 1 && gst_tensor_demux_is_tensor_caps (peer_caps)) {
+    if (num == 1 && gst_pad_has_tensor_caps (pad)) {
       GstTensorConfig config;
       gint64 idx = g_ascii_strtoll (strv[0], NULL, 10);
       gst_tensor_demux_get_tensor_config (tensor_demux, &config, idx);
@@ -426,7 +403,6 @@ gst_tensor_demux_get_tensor_pad (GstTensorDemux * tensor_demux,
       caps = gst_tensors_caps_from_config (&config);
     }
     g_strfreev (strv);
-    gst_caps_unref (peer_caps);
   } else {
     GstTensorConfig config;
     gst_tensor_demux_get_tensor_config (tensor_demux, &config, nth);

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -832,26 +832,12 @@ static GstCaps *
 gst_tensor_filter_caps_from_config (GstTensorFilter * self,
     GstTensorsConfig * config)
 {
-  GstCaps *caps;
+  GstPad *src_pad;
 
   g_return_val_if_fail (config != NULL, NULL);
+  src_pad = GST_BASE_TRANSFORM_SRC_PAD (&self->element);
 
-  if (config->info.num_tensors < 2) {
-    GstTensorConfig c;
-
-    /**
-     * supposed other/tensor if the number of tensor is less than 2.
-     */
-    c.info = config->info.info[0];
-    c.rate_n = config->rate_n;
-    c.rate_d = config->rate_d;
-
-    caps = gst_tensor_caps_from_config (&c);
-  } else {
-    caps = gst_tensors_caps_from_config (config);
-  }
-
-  return caps;
+  return gst_tensors_get_caps (src_pad, config);
 }
 
 /**

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -54,7 +54,7 @@ if gtest_dep.found()
   # Run unittest_common
   unittest_common = executable('unittest_common',
     join_paths('common', 'unittest_common.cc'),
-    dependencies: [nnstreamer_unittest_deps],
+    dependencies: [nnstreamer_unittest_deps, unittest_util_dep],
     install: get_option('install-test'),
     install_dir: unittest_install_dir
   )


### PR DESCRIPTION
Add get tensors cap common function.
If the number of tensors is 1, it is to cover the case that only othenr/tensors is supported by peer pad.

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped