### PR TITLE
[SPEC] Add capi-nnstreamer-devel Requires to capi-nnstreamer package

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -356,6 +356,10 @@ Summary:	Tizen Native API for NNStreamer
 Group:		Multimedia/Framework
 Requires:	%{name} = %{version}-%{release}
 Requires:	%{name}-misc = %{version}-%{release}
+# Workaround: Since the rootstrap of Tizen v6.5 is not ready,
+# some application built on v6.0 needs libcapi-nnstreamer.so file.
+# This code will be removed when the rootstrap of Tizen v6.5 is ready.
+Requires:	capi-nnstreamer-devel = %{version}-%{release}
 %if 0%{tizen_sensor_support}
 Requires:	%{name}-tizen-sensor = %{version}-%{release}
 %endif


### PR DESCRIPTION
Since the rootstrap of Tizen v6.5 is not ready, some application built on v6.0 needs libcapi-nnstreamer.so file.
Because of this reason, this patch temporarily adds the capi-nnstreamer-devel Requires to capi-nnstreamer package.
It will be removed when the rootstrap of Tizen v6.5 is ready.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed []Skipped
2. Run test: [X]Passed [ ]Failed []Skipped

### Related issue
* https://github.com/nnstreamer/nnstreamer/issues/2874

### Submit history
#### v2
* Add `capi-nnstreamer-devel` Requires to `capi-nnstreamer package` instead of making symlink.

#### v1
* First draft
