### PR TITLE
[Tools/Parser] Parser Rule #4: chain/openchain with URL

### DIFF
--- a/tools/development/parser/grammar.y
+++ b/tools/development/parser/grammar.y
@@ -816,15 +816,10 @@ morepads:	/* NOP */		      { $$ = NULL; }
 *       http://somesource.org ! fakesink
 **************************************************************/
 
-chain:	openchain link PARSE_URL	      { GstElement *element =
-							  gst_element_make_from_uri (GST_URI_SINK, $3, NULL, NULL);
-						/* FIXME: get and parse error properly */
-						if (!element) {
-						  SET_ERROR (graph->error, GST_PARSE_ERROR_NO_SUCH_ELEMENT,
-							  _("no sink element for URI \"%s\""), $3);
-						}
+chain:	openchain link PARSE_URL	      { _Element *element =
+							  nnstparser_element_from_uri (GST_URI_SINK, $3, NULL, NULL);
 						$$ = $1;
-						$2->sink.element = element?gst_object_ref(element):NULL;
+						$2->sink.element = element;
 						$2->src = $1->last;
 						TRY_SETUP_LINK($2);
 						$$->last.element = NULL;
@@ -836,21 +831,15 @@ chain:	openchain link PARSE_URL	      { GstElement *element =
 	;
 openchain:
 	PARSE_URL			      { GstElement *element =
-							  gst_element_make_from_uri (GST_URI_SRC, $1, NULL, NULL);
-						/* FIXME: get and parse error properly */
-						if (!element) {
-						  SET_ERROR (graph->error, GST_PARSE_ERROR_NO_SUCH_ELEMENT,
-						    _("no source element for URI \"%s\""), $1);
-						}
-						$$ = gst_parse_chain_new ();
-						/* g_print ("@%p: CHAINing srcURL\n", $$); */
+							  nnstparser_element_from_uri (GST_URI_SRC, $1, NULL, NULL);
+						$$ = g_slice_new0 (chain_t);
 						$$->first.element = NULL;
 						$$->first.name = NULL;
 						$$->first.pads = NULL;
 						$$->last.element = element ? gst_object_ref(element):NULL;
 						$$->last.name = NULL;
 						$$->last.pads = NULL;
-						$$->elements = element ? g_slist_prepend (NULL, element)  : NULL;
+						$$->elements = g_slist_prepend (NULL, element);
 						g_free($1);
 					      }
 	;

--- a/tools/development/parser/types.c
+++ b/tools/development/parser/types.c
@@ -35,8 +35,27 @@ _Element *
 nnstparser_element_make (const gchar * element, const gchar * name)
 {
   _Element ret = g_new0 (_Element, 1);
+  ret->specialType = eST_normal;
   ret->element = g_strdup (element);
   ret->name = g_strdup (name);
+
+  return ret;
+}
+
+/**
+ * @brief Create URL dummy element instead of gst_element_make_from_uri
+ */
+_Element *
+nnstparser_element_from_uri (_URIType type, const gchar * uri,
+    const gchar * elementname, void **error)
+{
+  _Element ret = g_malloc (sizeof (_Element));
+
+  g_assert (type == GST_URI_SINK || type == GST_URI_SRC);
+
+  ret->specialType = (type == GST_URI_SINK) ? eST_URI_SINK : eST_URI_SRC;
+  ret->element = g_strdup (url);
+  ret->name = g_strdup (elementname);
 
   return ret;
 }

--- a/tools/development/parser/types.h
+++ b/tools/development/parser/types.h
@@ -14,10 +14,17 @@
 
 #include <glib-object.h>
 
+typedef enum {
+  eST_normal = 0,
+  eST_URI_SINK,
+  eST_URI_SRC,
+} elementSpecialType;
+
 /** @brief Simplified GST-Element */
 typedef struct {
   gchar *element;
   gchar *name;
+  elementSpecialType specialType;
   GSList *properties; /**< List of key-value pairs (_Property), added for gst-pbtxt, except for name=.... */
 } _Element;
 
@@ -69,6 +76,23 @@ typedef enum
   __PARSE_FLAG_NO_SINGLE_ELEMENT_BINS = (1 << 1),
   __PARSE_FLAG_PLACE_IN_BIN = (1 << 2)
 } _ParseFlags;
+
+/**
+ * @brief A copy of GstURIType from gstreamer/gsturi
+ */
+typedef enum {
+  GST_URI_UNKNOWN,
+  GST_URI_SINK,
+  GST_URI_SRC
+} _URIType;
+
+/**
+ * @brief A dummy copy of gst_element_make_from_uri from gstreamer/gsturi
+ */
+extern _Element *
+nnstparser_element_from_uri (const _URIType type, const gchar *uri,
+    const gchar * elementname, void **error);
+
 
 typedef struct _graph_t graph_t;
 /** @brief The pipeline graph */


### PR DESCRIPTION


Replacing GST methods with parser-only logic:
Rule 4 includes:
chain: openchain link PARSE_URL
openchain: PARSE_URL

With Rule 4, uri-element make is created.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
