### PR TITLE
[Edge/Package] Prepare to implement the nnstreamer-edge plugin

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -113,6 +113,13 @@ Depends: nnstreamer, libgrpc7, libgrpc++1, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer gRPC tensor source/sink support
  This package allows nnstreamer to support gRPC tensor source/sink as a extra plugin
 
+Package: nnstreamer-edge
+Architecture: any
+MUlti-Arch: same
+Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer Edge-AI support
+ This package allows to efficiently perform Edge-AI computing in lightweight devices
+
 Package: nnstreamer-dev
 Architecture: any
 Multi-Arch: same

--- a/debian/nnstreamer-edge.install
+++ b/debian/nnstreamer-edge.install
@@ -1,0 +1,1 @@
+/usr/lib/*/gstreamer-1.0/libnnstreamer-edge.so

--- a/ext/nnstreamer/meson.build
+++ b/ext/nnstreamer/meson.build
@@ -46,6 +46,7 @@ subdir('tensor_filter')
 subdir('tensor_source')
 subdir('tensor_converter')
 subdir('tensor_sink')
+subdir('tensor_query')
 
 if get_option('enable-tizen-sensor')
   tizensensor_registerer_source_files = ['registerer/tizensensor.c']
@@ -81,6 +82,27 @@ if grpc_support_is_available
   grpc_lib = shared_library('nnstreamer-grpc',
     grpc_registerer_sources,
     dependencies: [tensor_src_grpc_dep, tensor_sink_grpc_dep],
+    install: true,
+    install_dir: plugins_install_dir
+  )
+endif
+
+if edge_support_is_available
+  edge_registerer_source_files = ['registerer/edge.c']
+  edge_registerer_sources = []
+
+  foreach s : edge_registerer_source_files
+    edge_registerer_sources += join_paths(meson.current_source_dir(), s)
+  endforeach
+
+  edge_deps = [
+    tensor_query_accept_dep,
+    tensor_query_reply_dep,
+    tensor_query_client_dep,
+  ]
+  edge_lib = shared_library('nnstreamer-edge',
+    edge_registerer_sources,
+    dependencies: edge_deps,
     install: true,
     install_dir: plugins_install_dir
   )

--- a/ext/nnstreamer/registerer/edge.c
+++ b/ext/nnstreamer/registerer/edge.c
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * nnstreamer registerer for Edge-AI plugin
+ * Copyright (C) 2020 Dongju Chae <dongju.chae@samsung.com>
+ */
+
+/**
+ * @file    edge.c
+ * @date    24 Nov 2020
+ * @brief   Registers nnstreamer extension plugin for Edge-AI
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Dongju Chae <dongju.chae@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <gst/gst.h>
+
+#define NNSTREAMER_EDGE_QUERY_IMPLEMENTED 0
+
+#define NNSTREAMER_EDGE_INIT(plugin,name,type) \
+  do { \
+    if (!gst_element_register (plugin, "tensor_" # name, GST_RANK_NONE, GST_TYPE_TENSOR_ ## type)) { \
+      GST_ERROR ("Failed to register nnstreamer plugin : tensor_" # name); \
+      return FALSE; \
+    } \
+  } while (0)
+
+/**
+ * @brief Function to initialize all nnstreamer elements
+ */
+static gboolean
+gst_nnstreamer_edge_init (GstPlugin * plugin)
+{
+#if NNSTREAMER_EDGE_QUERY_IMPLEMENTED
+  NNSTREAMER_EDGE_INIT (plugin, query_accept, QUERY_ACCEPT);
+  NNSTREAMER_EDGE_INIT (plugin, query_reply, QUERY_REPLY);
+  NNSTREAMER_EDGE_INIT (plugin, query_client, QUERY_CLIENT);
+#endif
+
+  return TRUE;
+}
+
+#ifndef PACKAGE
+#define PACKAGE "nnstreamer_edge"
+#endif
+
+GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
+    GST_VERSION_MINOR,
+    nnstreamer_edge,
+    "nnstreamer edge-ai framework extension",
+    gst_nnstreamer_edge_init, VERSION, "LGPL", "nnstreamer",
+    "https://github.com/nnstreamer/nnstreamer");

--- a/ext/nnstreamer/tensor_query/meson.build
+++ b/ext/nnstreamer/tensor_query/meson.build
@@ -1,0 +1,48 @@
+tensor_query_common_deps = [
+  nnstreamer_dep,
+  glib_dep,
+  gst_dep,
+  edge_support_deps,
+]
+
+tensor_query_accept_source_files = [
+  'tensor_query_accept.c',
+]
+tensor_query_accept_sources = []
+
+foreach s : tensor_query_accept_source_files
+  tensor_query_accept_sources += join_paths(meson.current_source_dir(), s)
+endforeach
+
+tensor_query_accept_dep = declare_dependency(
+  sources : tensor_query_accept_sources,
+  dependencies : tensor_query_common_deps,
+)
+
+tensor_query_reply_source_files = [
+  'tensor_query_reply.c',
+]
+tensor_query_reply_sources = []
+
+foreach s : tensor_query_reply_source_files
+  tensor_query_reply_sources += join_paths(meson.current_source_dir(), s)
+endforeach
+
+tensor_query_reply_dep = declare_dependency(
+  sources : tensor_query_reply_sources,
+  dependencies : tensor_query_common_deps,
+)
+
+tensor_query_client_source_files = [
+  'tensor_query_client.c',
+]
+tensor_query_client_sources = []
+
+foreach s : tensor_query_client_source_files
+  tensor_query_client_sources += join_paths(meson.current_source_dir(), s)
+endforeach
+
+tensor_query_client_dep = declare_dependency(
+  sources : tensor_query_client_sources,
+  dependencies : tensor_query_common_deps,
+)

--- a/ext/nnstreamer/tensor_query/tensor_query_accept.c
+++ b/ext/nnstreamer/tensor_query/tensor_query_accept.c
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer Tensor_Query_Accept
+ * Copyright (C) 2020 Dongju Chae <dongju.chae@samsung.com>
+ */
+/**
+ * @file    tensor_query_accept.c
+ * @date    25 Nov 2020
+ * @brief   GStreamer element to accept a query from another pipeline
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @author  Dongju Chae <dongju.chae@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */

--- a/ext/nnstreamer/tensor_query/tensor_query_client.c
+++ b/ext/nnstreamer/tensor_query/tensor_query_client.c
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer Tensor_Query_Client
+ * Copyright (C) 2020 Dongju Chae <dongju.chae@samsung.com>
+ */
+/**
+ * @file    tensor_query_client.c
+ * @date    25 Nov 2020
+ * @brief   GStreamer element to send a query with tensor data to another pipeline
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @author  Dongju Chae <dongju.chae@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */

--- a/ext/nnstreamer/tensor_query/tensor_query_reply.c
+++ b/ext/nnstreamer/tensor_query/tensor_query_reply.c
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer Tensor_Query_Reply
+ * Copyright (C) 2020 Dongju Chae <dongju.chae@samsung.com>
+ */
+/**
+ * @file    tensor_query_reply.c
+ * @date    25 Nov 2020
+ * @brief   GStreamer element to reply a query's result to the caller pipeline
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @author  Dongju Chae <dongju.chae@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */

--- a/meson.build
+++ b/meson.build
@@ -302,6 +302,9 @@ features = {
   },
   'grpc-support': {
     'extra_deps': [ grpc_dep, gpr_dep, grpcpp_dep ]
+  },
+  'edge-support': {
+    'extra_deps': [ flatbuf_dep ]
   }
 }
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,6 +18,7 @@ option('protobuf-support', type: 'feature', value: 'auto')
 option('flatbuf-support', type: 'feature', value: 'auto')
 option('tensorrt-support', type: 'feature', value: 'auto')
 option('grpc-support', type: 'feature', value: 'auto')
+option('edge-support', type: 'feature', value: 'auto')
 
 # booleans & other options
 option('enable-test', type: 'boolean', value: true)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -327,6 +327,13 @@ Requires:	flatbuffers
 NNStreamer's tensor_converter and decoder subplugin of flatbuf.
 %endif
 
+%package edge
+Summary:	NNStreamer Edge-AI Support
+Requires:	nnstreamer = %{version}-%{release}
+%description edge
+NNStreamer's Edge-AI support providing distributed pipeline elements.
+This contains tensor_server_accept, tensor_server_reply, and tensor_client_query.
+
 %package devel
 Summary:	Development package for custom tensor operator developers (tensor_filter/custom)
 Requires:	nnstreamer = %{version}-%{release}
@@ -907,6 +914,12 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %license LICENSE
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_openvino.so
 %endif
+
+%files edge
+%defattr(-,root,root,-)
+%manifest nnstreamer.manifest
+%license LICENSE
+%{gstlibdir}/libnnstreamer-edge.so
 
 %files util
 %{_bindir}/nnstreamer-check


### PR DESCRIPTION
This patch adds the registerer for nnstreamer-edge plugin.
It currently provides only skeleton codes for initial package.

Related issue: #2802 

The impl. for tensor_server_accept/reply and tensor_client_query
will be updated soon.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped