### PR TITLE
[Filter/tflite] Support GPU Delegate on Tizen

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -187,6 +187,13 @@ if tflite2_support_is_available
   tflite2_compile_args += '-DTFLITE_FLOAT16=1'
   tflite2_compile_args += '-DTFLITE_COMPLEX64=1'
 
+  if get_option('tflite2-gpu-delegate-support')
+    # GLES dependency for tflite GPU delegate
+    gles_dep = dependency('gles20', required: true)
+    nnstreamer_filter_tflite2_deps += gles_dep
+    tflite2_compile_args += '-DTFLITE_GPU_DELEGATE_SUPPORTED'
+  endif
+
   tflite2_extra_dep = declare_dependency(
     compile_args : tflite2_compile_args
   )

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -341,6 +341,14 @@ TFLiteInterpreter::loadModel (int num_threads, accl_hw accelerator)
     options.experimental_flags = TFLITE_GPU_EXPERIMENTAL_FLAGS_NONE;
     options.experimental_flags |= TFLITE_GPU_EXPERIMENTAL_FLAGS_ENABLE_QUANT;
 
+    /** NNStreamer filter for TFLite2 GPU delegate only supports OpenCL backend
+     * since GLES v3.1 backend has a constraint that
+     * Invoke() must be called from the same EGLContext. */
+    options.experimental_flags |= TFLITE_GPU_EXPERIMENTAL_FLAGS_CL_ONLY;
+    options.inference_priority1 = TFLITE_GPU_INFERENCE_PRIORITY_MIN_LATENCY;
+    options.inference_priority2 = TFLITE_GPU_INFERENCE_PRIORITY_MIN_MEMORY_USAGE;
+    options.inference_priority3 = TFLITE_GPU_INFERENCE_PRIORITY_MAX_PRECISION;
+
     gpu_delegate.reset (TfLiteGpuDelegateV2Create (&options));
     setDelegate (gpu_delegate.get ());
 #else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -23,6 +23,7 @@ option('grpc-support', type: 'feature', value: 'auto')
 option('enable-test', type: 'boolean', value: true)
 option('install-test', type: 'boolean', value: false)
 option('enable-pytorch-use-gpu', type: 'boolean', value: false) # default value, can be specified at run time
+option('tflite2-gpu-delegate-support', type: 'boolean', value: 'false')
 option('enable-mediapipe', type: 'boolean', value: false)
 option('enable-env-var', type: 'boolean', value: true)
 option('enable-symbolic-link', type: 'boolean', value: true)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -5,6 +5,7 @@
 %define		tensorflow_support 0
 %define		tensorflow_lite_support	1
 %define		tensorflow2_lite_support 1
+%define		tensorflow2_gpu_delegate_support 1
 %define		armnn_support 0
 %define		vivante_support 0
 %define		flatbuf_support 1
@@ -137,6 +138,9 @@ BuildRequires: tensorflow-lite-devel
 %if 0%{?tensorflow2_lite_support}
 # for tensorflow2-lite
 BuildRequires: tensorflow2-lite-devel
+%if 0%{?tensorflow2_gpu_delegate_support}
+BuildRequires: pkgconfig(gles20)
+%endif
 %endif
 # custom_example_opencv filter requires opencv-devel
 BuildRequires: opencv-devel
@@ -540,7 +544,11 @@ Provides additional gstreamer plugins for nnstreamer pipelines
 
 # Support tensorflow2-lite
 %if 0%{?tensorflow2_lite_support}
-%define enable_tf2_lite -Dtflite2-support=enabled
+%if 0%{?tensorflow2_gpu_delegate_support}
+%define enable_tf2_lite -Dtflite2-support=enabled -Dtflite2-gpu-delegate-support=true
+%else
+%define enable_tf2_lite -Dtflite2-support=enabled -Dtflite2-gpu-delegate-support=false
+%endif
 %else
 %define enable_tf2_lite -Dtflite2-support=disabled
 %endif


### PR DESCRIPTION
This patch supports the GPU Delegate functionality on Tizen platform.

NNStreamer filter for TFLite2 GPU delegate only supports OpenCL backend
since GLES v3.1 backend has a constraint that Invoke() must be called
from the same EGLContext.

If both tensorflow2_lite_support and tensorflow2_gpu_delegate_support
are set as 1 in nnstreamer.spec, GPU Delegate functionality is enabled.
If tensorflow2_gpu_delegate_support is set but tensorflow2_lite_support
is 0, then tensorflow2_gpu_delegate_support option is ignored.

~~Since Tensorflow2 GPU delegate is not ready,
tensorflow2_gpu_delegate_support is set as 0 in this patch.~~

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed []Skipped
2. Run test: [X]Passed [ ]Failed []Skipped



### Submit history
#### v3
* Enable `tensorflow2_gpu_delegate_support` as default since Tensorflow2 GPU delegate is ready,

#### v2
* Use the `boolean` type option instead of `feature` since it is more natural.

#### v1
* First draft


### Test Result
#### TM4 Device (OpenCL is supported)
* Use CPU accelerator(Default): Run without any errors.
* Use GPU Delegate: `accelerator=true:gpu`
```Bash
sh-3.2# gst-launch-1.0  filesrc location=/root/orange.png ! \
> pngdec ! videoscale ! imagefreeze ! videoconvert ! \
> video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! queue ! \
> tensor_filter framework=tensorflow2-lite accelerator=true:gpu model=/root/mobilenet_v1_1.0_224_quant.tflite ! \
> filesink location=/root/tflite2.out.log 
** Message: 20:01:02.909: accl = gpu
INFO: Created TensorFlow Lite delegate for GPU.
ERROR: Following operations are not supported by GPU delegate:
SQUEEZE: Operation is not supported.
29 operations will run on the GPU, and the remaining 2 operations will run on the CPU.
INFO: Initialized OpenCL-based API.
INFO: Created 1 GPU delegate kernels.
Setting pipeline to PAUSED ...
Pipeline is PREROLLING ...
Pipeline is PREROLLED ...
Setting pipeline to PLAYING ...
New clock: GstSystemClock
Got EOS from element "pipeline0".
Execution ended after 0:00:00.000626693
Setting pipeline to PAUSED ...
Setting pipeline to READY ...
Setting pipeline to NULL ...
Freeing pipeline ...
```

#### TM1 Device (OpenCL is not supported)
* Use CPU accelerator(Default): Run without any errors.
* Forcly use GPU accelerator: Error occurs because of no libOpenCL.so.
```bash
sh-3.2# gst-launch-1.0  filesrc location=/root/orange.png ! \
> pngdec ! videoscale ! imagefreeze ! videoconvert ! \
> video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! queue ! \
> tensor_filter framework=tensorflow2-lite accelerator=true:gpu model=/root/mobilenet_v1_1.0_224_quant.tflite ! \
> filesink location=/root/tflite2.out.log 
** Message: 09:23:59.971: accl = gpu
INFO: Created TensorFlow Lite delegate for GPU.
ERROR: Following operations are not supported by GPU delegate:
SQUEEZE: Operation is not supported.
29 operations will run on the GPU, and the remaining 2 operations will run on the CPU.
ERROR: TfLiteGpuDelegate Init: Can not open OpenCL library on this device - libOpenCL.so: cannot open shared object file: No such file or directory
INFO: Created 0 GPU delegate kernels.
ERROR: TfLiteGpuDelegate Prepare: delegate is not initialized
ERROR: Node number 31 (TfLiteGpuDelegateV2) failed to prepare.
```