### PR TITLE
[android/build] Patch NDK source to prevent build error @open sesame 12/01 15:52

### DIFF
--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -205,6 +205,11 @@ fi
 echo "Android SDK: $android_sdk_dir"
 echo "Android NDK: $android_ndk_dir"
 
+echo "Patching NDK source"
+# See: https://github.com/nnstreamer/nnstreamer/issues/2899
+
+sed -z -i "s|struct AMediaCodecOnAsyncNotifyCallback {\n      AMediaCodecOnAsyncInputAvailable  onAsyncInputAvailable;\n      AMediaCodecOnAsyncOutputAvailable onAsyncOutputAvailable;\n      AMediaCodecOnAsyncFormatChanged   onAsyncFormatChanged;\n      AMediaCodecOnAsyncError           onAsyncError;\n};|typedef struct AMediaCodecOnAsyncNotifyCallback {\n      AMediaCodecOnAsyncInputAvailable  onAsyncInputAvailable;\n      AMediaCodecOnAsyncOutputAvailable onAsyncOutputAvailable;\n      AMediaCodecOnAsyncFormatChanged   onAsyncFormatChanged;\n      AMediaCodecOnAsyncError           onAsyncError;\n} AMediaCodecOnAsyncNotifyCallback;|" $android_ndk_dir/toolchains/llvm/prebuilt/*/sysroot/usr/include/media/NdkMediaCodec.h
+
 # GStreamer prebuilt libraries for Android
 # Download from https://gstreamer.freedesktop.org/data/pkg/android/
 if [[ -z "$gstreamer_dir" ]]; then


### PR DESCRIPTION
- After Android API level 28, the introduced
  `AMediaCodecOnAsyncNotifyCallback` make compile error.
- Make build script to patch this part after
    https://android.googlesource.com/platform/frameworks/av/+/master/media/ndk/include/media/NdkMediaCodec.h#117
- This resolves #2899 

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
