### PR TITLE
[C-Api] define sub-plugin names

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -388,6 +388,11 @@ char* ml_nnfw_to_str_prop (ml_nnfw_hw_e hw);
 const char* ml_get_nnfw_subplugin_name (ml_nnfw_type_e nnfw);
 
 /**
+ * @brief Internal function to get the nnfw type.
+ */
+ml_nnfw_type_e ml_get_nnfw_type_by_subplugin_name (const char *name);
+
+/**
  * @brief Gets the element of pipeline itself (GstElement).
  * @details With the returned reference, you can use GStreamer functions to handle the element in pipeline.
  *          Note that caller should release the returned reference using gst_object_unref().

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -131,7 +131,7 @@ typedef void *ml_custom_easy_filter_h;
  * @since_tizen 5.5
  */
 typedef enum {
-  ML_NNFW_TYPE_ANY = 0,               /**< NNHW is not specified (Try to determine the NNFW with file extension). */
+  ML_NNFW_TYPE_ANY = 0,               /**< NNFW is not specified (Try to determine the NNFW with file extension). */
   ML_NNFW_TYPE_CUSTOM_FILTER = 1,     /**< Custom filter (Independent shared object). */
   ML_NNFW_TYPE_TENSORFLOW_LITE = 2,   /**< Tensorflow-lite (.tflite). */
   ML_NNFW_TYPE_TENSORFLOW = 3,        /**< Tensorflow (.pb). */

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -3128,6 +3128,34 @@ TEST (nnstreamer_capi_util, data_set_tdata_05_n)
 }
 
 /**
+ * @brief Test utility functions (private)
+ * @details check sub-plugin type and name
+ */
+TEST (nnstreamer_capi_util, nnfw_name_01_p)
+{
+  EXPECT_STREQ (ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_TENSORFLOW_LITE), "tensorflow-lite");
+  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name ("tensorflow-lite"), ML_NNFW_TYPE_TENSORFLOW_LITE);
+  EXPECT_STREQ (ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_TENSORFLOW), "tensorflow");
+  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name ("tensorflow"), ML_NNFW_TYPE_TENSORFLOW);
+  EXPECT_STREQ (ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_NNFW), "nnfw");
+  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name ("nnfw"), ML_NNFW_TYPE_NNFW);
+  EXPECT_STREQ (ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_VIVANTE), "vivante");
+  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name ("vivante"), ML_NNFW_TYPE_VIVANTE);
+  EXPECT_STREQ (ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_SNAP), "snap");
+  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name ("snap"), ML_NNFW_TYPE_SNAP);
+}
+
+/**
+ * @brief Test utility functions (private)
+ * @details check sub-plugin type and name
+ */
+TEST (nnstreamer_capi_util, nnfw_name_02_n)
+{
+  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name ("invalid-fw"), ML_NNFW_TYPE_ANY);
+  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name (NULL), ML_NNFW_TYPE_ANY);
+}
+
+/**
  * @brief Test NNStreamer single shot (tensorflow-lite)
  */
 TEST (nnstreamer_capi_singleshot, invoke_invalid_param_01_n)


### PR DESCRIPTION
Fix typo and add new function to get the nnfw type by subplugin name.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
