### PR TITLE
[meson] Add deps declaration for tensorrt, grpc

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -608,7 +608,7 @@ if tensorrt_support_is_available
     nnstreamer_filter_tensorrt_sources += join_paths(meson.current_source_dir(), s)
   endforeach
 
-  nnstreamer_filter_tensorrt_deps = [glib_dep, gst_dep, nnstreamer_dep, tensorrt_deps]
+  nnstreamer_filter_tensorrt_deps = [glib_dep, gst_dep, nnstreamer_dep, tensorrt_support_deps]
 
   shared_library('nnstreamer_filter_tensorrt',
     nnstreamer_filter_tensorrt_sources,

--- a/meson.build
+++ b/meson.build
@@ -194,6 +194,10 @@ if not get_option('snpe-support').disabled()
 endif
 
 # tensorrt
+nvinfer_dep = dependency('', required: false)
+nvparsers_dep = dependency('', required: false)
+cuda_dep = dependency('', required: false)
+cudart_dep = dependency('', required: false)
 if not get_option('tensorrt-support').disabled()
   # check available cuda versions (11.0 and 10.2 are recommended)
   cuda_vers = [
@@ -222,11 +226,12 @@ if not get_option('tensorrt-support').disabled()
 
   nvparsers_lib = cxx.find_library('nvparsers', required: false)
   nvparsers_dep = declare_dependency(dependencies: nvparsers_lib)
-
-  tensorrt_deps = [ nvinfer_dep, nvparsers_dep, cuda_dep, cudart_dep ]
 endif
 
 # gRPC
+grpc_dep = dependency('', required: false)
+gpr_dep = dependency('', required: false)
+grpcpp_dep = dependency('', required: false)
 if not get_option('grpc-support').disabled()
   grpc_dep = dependency('grpc', required: false)
   gpr_dep = dependency('gpr', required: false)
@@ -298,7 +303,7 @@ features = {
     'extra_deps': [ pb_comp, protobuf_dep ]
   },
   'tensorrt-support': {
-    'extra_deps': tensorrt_deps
+    'extra_deps': [ nvinfer_dep, nvparsers_dep, cuda_dep, cudart_dep ]
   },
   'grpc-support': {
     'extra_deps': [ grpc_dep, gpr_dep, grpcpp_dep ]

--- a/nnstreamer_example/meson.build
+++ b/nnstreamer_example/meson.build
@@ -97,7 +97,7 @@ library('nnscustom_framecounter',
 if tensorrt_support_is_available
   library('nnstreamer_customfilter_tensorrt_reshape',
     join_paths('custom_example_tensorrt', 'nnstreamer_customfilter_example_tensorrt_reshape.cc'),
-    dependencies: [glib_dep, gst_dep, nnstreamer_dep, tensorrt_deps],
+    dependencies: [glib_dep, gst_dep, nnstreamer_dep, tensorrt_support_deps],
     install: get_option('install-test'),
     install_dir: customfilter_install_dir
   )


### PR DESCRIPTION
command: meson build -Dtensorrt-support=disabled
log: ERROR: Unknown variable "tensorrt_deps".

Without empty dependency declaration, features can not recognize
"tensorrt_deps"
Ditto grpc.


1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
