### PR TITLE
[Tools/Parser] Other All Remaining Rules

### DIFF
--- a/tools/development/parser/types.c
+++ b/tools/development/parser/types.c
@@ -28,17 +28,39 @@ gst2pbtxt_parse_error_quark (void)
   return quark;
 }
 
+/** @brief Internal function to construct _Element */
+static void
+_nnstparser_config_element (_Element * e, const gchar * element,
+    const gchar * name)
+{
+  e->specialType = eST_normal;
+  e->element = g_strdup (element);
+  e->name = g_strdup (name);
+  e->refcount = 1;
+  e->id = oTI_Element;
+}
+
 /**
  * @brief Replacement of gst_parse_element_make
  */
 _Element *
 nnstparser_element_make (const gchar * element, const gchar * name)
 {
-  _Element ret = g_new0 (_Element, 1);
-  ret->specialType = eST_normal;
-  ret->element = g_strdup (element);
-  ret->name = g_strdup (name);
-  ret->refcount = 1;
+  _Element *ret = g_new0 (_Element, 1);
+  _nnstparser_config_element (ret, element, name);
+  return ret;
+}
+
+/**
+ * @brief Replacement of gst_parse_element_make
+ */
+_Element *
+nnstparser_gstbin_make (const gchar * element, const gchar * name)
+{
+  _Element *ret = g_new0 (_Element, 1);
+  _nnstparser_config_element (ret, element, name);
+  ret->id = oTI_GstBin;
+  ret->elements = NULL;
   return ret;
 }
 

--- a/tools/development/parser/types.c
+++ b/tools/development/parser/types.c
@@ -38,8 +38,46 @@ nnstparser_element_make (const gchar * element, const gchar * name)
   ret->specialType = eST_normal;
   ret->element = g_strdup (element);
   ret->name = g_strdup (name);
-
+  ret->refcount = 1;
   return ret;
+}
+
+/**
+ * @brief Unref an element
+ */
+_Element *
+nnstparser_element_unref (_Element * element)
+{
+  g_assert (element);
+
+  if (element->refcount <= 0) {
+    g_printerr ("ERROR! Refcounter is broken: %s.", __func__);
+  }
+  g_assert (element->refcount > 0);
+
+  element->refcount--;
+  if (element->refcount <= 0) {
+    g_free (element);
+    return NULL;
+  }
+
+  return element;
+}
+
+/**
+ * @brief Ref an element
+ */
+void
+nnstparser_element_ref (_Element * element)
+{
+  g_assert (element);
+
+  if (element->refcount <= 0) {
+    g_printerr ("ERROR! Refcounter is broken: %s.", __func__);
+  }
+  g_assert (element->refcount > 0);
+
+  element->refcount++;
 }
 
 /**
@@ -56,6 +94,6 @@ nnstparser_element_from_uri (_URIType type, const gchar * uri,
   ret->specialType = (type == GST_URI_SINK) ? eST_URI_SINK : eST_URI_SRC;
   ret->element = g_strdup (url);
   ret->name = g_strdup (elementname);
-
+  ret->refcount = 1;
   return ret;
 }

--- a/tools/development/parser/types.h
+++ b/tools/development/parser/types.h
@@ -20,13 +20,26 @@ typedef enum {
   eST_URI_SRC,
 } elementSpecialType;
 
+typedef enum {
+  oTI_Element = 0,
+  oTI_GstBin,
+} objectTypeId;
+
+typedef struct _chain_t chain_t;
+
 /** @brief Simplified GST-Element */
 typedef struct {
+  objectTypeId id;
+  elementSpecialType specialType;
+
   gchar *element;
   gchar *name;
-  elementSpecialType specialType;
   GSList *properties; /**< List of key-value pairs (_Property), added for gst-pbtxt, except for name=.... */
   int refcount;
+
+  union {
+    GSList *elements; /**< _GstBin type uses this */
+  };
 } _Element;
 
 extern _Element *
@@ -54,11 +67,15 @@ typedef struct {
 } link_t;
 
 /** @brief Chain of elements */
-typedef struct {
+struct _chain_t {
   GSList *elements; /**< Originally its data is "GstElement". It's now _Element */
   reference_t first;
   reference_t last;
-} chain_t;
+};
+
+extern _Element *
+nnstparser_gstbin_make (const gchar * element, const gchar * name);
+
 
 /**
  * @brief A dummy created for gst2pbtxt

--- a/tools/development/parser/types.h
+++ b/tools/development/parser/types.h
@@ -26,6 +26,7 @@ typedef struct {
   gchar *name;
   elementSpecialType specialType;
   GSList *properties; /**< List of key-value pairs (_Property), added for gst-pbtxt, except for name=.... */
+  int refcount;
 } _Element;
 
 extern _Element *
@@ -93,6 +94,13 @@ extern _Element *
 nnstparser_element_from_uri (const _URIType type, const gchar *uri,
     const gchar * elementname, void **error);
 
+/** @brief gst_object_unref for psuedo element */
+extern _Element *
+nnstparser_element_unref (_Element * element);
+
+/** @brief gst_object_ref for psuedo element */
+extern void
+nnstparser_element_ref (_Element * element);
 
 typedef struct _graph_t graph_t;
 /** @brief The pipeline graph */


### PR DESCRIPTION
All remaining parsing rules for "gstreamer-string --> pbtxt" are written.
The next steps include aux parts of the parser (reference resolving) and integration with the pbtxt converter.



commit 4acbe348fe2bf8224990d1278bcb80b98965fbac
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Fri Dec 11 15:36:14 2020 +0900

    [Tools/Parser] Rule Implementation Done
    
    Redefine "GstBin" and "GstElement" for nns-parser.
    As we do not create actual pipelines from strings,
    we only need symbolic data.
    
    All the parsing rule implementations are fixed for nns-parser.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 14ef5e806db8b118ea1446863543db54f02a2f76
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Mon Nov 30 16:04:04 2020 +0900

    [Tools/Parser] Remove GSTPARSE functions
    
    GSTPARSE has defined its own functions,
    which are replaced with general functions
    by this commit.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 342406330f6ce7897345d6c74d20241e3beefcac
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Tue Dec 1 17:04:29 2020 +0900

    [Tools/Parser] Do ref counting with pseudo elements
    
    With linked list, psuedo elements are required to be ref-counted.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

