### PR TITLE
[Coverage/Fix] Exclude auto-generated files from coverage analysis

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -738,8 +738,8 @@ find . -name "CMakeCXXCompilerId*.gcda" -delete
 #find . -path "/build/*.j
 # Generate report
 lcov -t 'NNStreamer Unit Test Coverage' -o unittest.info -c -d . -b $(pwd) --no-external
-# Exclude generated files (Orc) and device-dependent filters.
-lcov -r unittest.info "*/*-orc.*" "*/tests/*" "*/meson*/*" "*/*@sha/*" "*/*_openvino*" "*/*_edgetpu*" "*/*_movidius_ncsdk2*" -o unittest-filtered.info
+# Exclude generated files (e.g., Orc, Protobuf) and device-dependent filters.
+lcov -r unittest.info "*/*-orc.*" "*/tests/*" "*/meson*/*" "*/*@sha/*" "*/*_openvino*" "*/*_edgetpu*" "*/*_movidius_ncsdk2*" "*/*.so.p/*" -o unittest-filtered.info
 # Visualize the report
 genhtml -o result unittest-filtered.info -t "nnstreamer %{version}-%{release} ${VCS}" --ignore-errors source -p ${RPM_BUILD_DIR}
 


### PR DESCRIPTION
This patch excludes auto-generated files from coverage analysis.
It's mostly related to protobuf/flatbuf build process.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

