### PR TITLE
[unittest] Fix signed-unsigned compare and command line option

### DIFF
--- a/tests/nnstreamer_grpc/unittest_grpc.cc
+++ b/tests/nnstreamer_grpc/unittest_grpc.cc
@@ -266,7 +266,7 @@ TEST (nnstreamer_grpc, src_set_property)
 
   g_object_set (src, "port", 1000, NULL);
   g_object_get (src, "port", &port, NULL);
-  EXPECT_EQ (port, 1000);
+  EXPECT_EQ (port, 1000U);
 
   gst_object_unref (src);
   gst_object_unref (test_data.pipeline);
@@ -306,7 +306,7 @@ TEST (nnstreamer_grpc, sink_set_property)
 
   g_object_set (sink, "port", 1000, NULL);
   g_object_get (sink, "port", &port, NULL);
-  EXPECT_EQ (port, 1000);
+  EXPECT_EQ (port, 1000U);
 
   gst_object_unref (sink);
   gst_object_unref (test_data.pipeline);

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -5515,6 +5515,8 @@ main (int argc, char **argv)
     g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
   }
 
+  gst_init (&argc, &argv);
+
   optionctx = g_option_context_new (NULL);
   g_option_context_add_main_entries (optionctx, main_entries, NULL);
 
@@ -5534,7 +5536,6 @@ main (int argc, char **argv)
     }
   }
 
-  gst_init (&argc, &argv);
 
   try {
     ret = RUN_ALL_TESTS ();


### PR DESCRIPTION
- Fix signed vs unsigned comapre in unittest_grpc
- Make unittest_sink properly get command line option like `--gst-plugin-path=`

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

