### PR TITLE
[Android/Build] remove unnecessary so

### DIFF
--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -306,10 +306,9 @@ if [[ $enable_nnfw == "yes" ]]; then
         tar -zxf external/onert-ext-$nnfw_ver-android-aarch64.tar.gz -C external/nnfw
     fi
 
-    # Remove duplicated file c++shared.so
-    if [[ -e external/nnfw/lib/libc++_shared.so ]]; then
-        rm external/nnfw/lib/libc++_shared.so
-    fi
+    # Remove duplicated, unnecessary files (c++shared and tensorflowlite_jni)
+    rm -f external/nnfw/lib/libc++_shared.so
+    rm -f external/nnfw/lib/libtensorflowlite_jni.so
 
     mkdir -p api/src/main/jni/nnfw/include api/src/main/jni/nnfw/lib
     mkdir -p api/src/main/jni/nnfw/ext/arm64-v8a


### PR DESCRIPTION
When building Android lib, remove unnecessary file (tf-lite lib) in ONE package.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
