### PR TITLE
[Debian] Fix the broken symlink

### DIFF
--- a/debian/nnstreamer.links
+++ b/debian/nnstreamer.links
@@ -1,1 +1,0 @@
-usr/lib/$(DEB_HOST_MULTIARCH)/gstreamer-1.0/libnnstreamer.so  usr/lib/$(DEB_HOST_MULTIARCH)/libnnstreamer.so

--- a/debian/rules
+++ b/debian/rules
@@ -59,4 +59,5 @@ override_dh_auto_install:
 
 override_dh_install:
 	dh_install --sourcedir=debian/tmp --list-missing
+	dh_link usr/lib/$(DEB_HOST_MULTIARCH)/gstreamer-1.0/libnnstreamer.so  usr/lib/$(DEB_HOST_MULTIARCH)/libnnstreamer.so
 # Add --fail-missing option after adding *.install files for all subpackages.


### PR DESCRIPTION
This patch fixes the broken symlink for DEB_HOST_MULTIARCH environment
variable. This patch solves the build break issue of `nntrainer`

```bash
$ dpkg-query -L nnstreamer:amd64
...
/usr/lib/$(DEB_HOST_MULTIARCH)
/usr/lib/$(DEB_HOST_MULTIARCH)/libnnstreamer.so
```

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed []Skipped
2. Run test: [X]Passed [ ]Failed []Skipped