### PR TITLE
[Spec] Disable some components in tizen-6.0 profile @open sesame 12/15 17:00

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -60,6 +60,12 @@
 %define		edgetpu_support 0
 %endif
 
+# tizen 6.0 (or less) backward-compatibility check
+%if ( 0%{?tizen_version_major} == 6 && 0%{?tizen_version_minor} < 5 ) || 0%{?tizen_version_major} < 6
+%define		grpc_support 0
+%define		tensorflow2_lite_support 0
+%endif
+
 # Disable e-TPU if it's not 64bit system
 %ifnarch aarch64 x86_64
 %define		edgetpu_support 0

--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -18,7 +18,23 @@ fi
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)
 testInit $1
 
+# NNStreamer and plugins path for test
 PATH_TO_PLUGIN="../../build"
+
+if [[ -d $PATH_TO_PLUGIN ]]; then
+    ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer"
+    if [[ -d ${ini_path} ]]; then
+        check=$(ls ${ini_path} | grep nnstreamer-grpc.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find nnstreamer-grpc shared lib"
+            report
+            exit
+        fi
+    else
+        echo "Cannot find ${ini_path}"
+    fi
+fi
+
 NUM_BUFFERS=10
 
 # Dump original frames, passthrough, other/tensor


### PR DESCRIPTION
This patch disables some components in tizen-6.0 profile.

The below does not work in tizen-6.0
- tensorflow-lite2
- grpc/flatbuffers
---> This needs some revision on grpc because grpc/protobuf works well. 

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*] Passed [ ]Failed []Skipped