### PR TITLE
[lts][android/test] Remove unnecessary permission @open sesame 12/14 18:33

### DIFF
--- a/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestCommon.java
+++ b/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestCommon.java
@@ -47,8 +47,7 @@ public class APITestCommon {
      * Grants required runtime permissions.
      */
     public static GrantPermissionRule grantPermissions() {
-        return GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        return GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE);
     }
 
     /**

--- a/api/android/api/src/main/AndroidManifest.xml
+++ b/api/android/api/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <uses-feature android:glEsVersion="0x00020000"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:extractNativeLibs="true"


### PR DESCRIPTION
Merging for lts/1.6.y

- WRITE_EXTERNAL_STORAGE permission is not necessary for test
- Remove the permission

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

