### PR TITLE
[Spec] Enable nnfw filter on x86 architecture

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -71,8 +71,8 @@
 %define		vivante_support 0
 %endif
 
-# Disable NNFW if it's not ARM/x64 (Since Tizen6, it supports x64)
-%ifnarch %arm aarch64 x86_64
+# Disable NNFW if it's not ARM/x64 and x86
+%ifnarch %arm aarch64 x86_64 i586 i686 %ix86
 %define		nnfw_support 0
 %endif
 


### PR DESCRIPTION
Since nnfw works on on x86 architecture for the Tizen emulator, This
patch enables the nnfw filter when building x86 architecture.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

#### Tizen NNFW Build status
* https://dashboard.tizen.org/index.code?sr=submit/tizen/20201214.093059
