### PR TITLE
[Android/TFlite] Support an extra argument for the TFLite version to use

### DIFF
--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -67,6 +67,7 @@ decoder_flatbuf_ver="1.12.0"
 
 # Set tensorflow-lite version (available: 1.9.0 / 1.13.1 / 1.15.2 / 2.3.0)
 tf_lite_ver="1.13.1"
+tf_lite_vers_support="1.9.0 1.13.1 1.15.2 2.3.0"
 
 # Set NNFW version (https://github.com/Samsung/ONE/releases)
 nnfw_ver="1.12.0"
@@ -127,7 +128,25 @@ for arg in "$@"; do
             enable_snpe=${arg#*=}
             ;;
         --enable_tflite=*)
-            enable_tflite=${arg#*=}
+            IFS=':' read -ra enable_tflite_args <<< "${arg#*=}"
+            is_valid_tflite_version=0
+            enable_tflite=${enable_tflite_args[0]}
+            if [[ ${enable_tflite} == "yes" ]]; then
+                if [[ ${enable_tflite_args[1]} == "" ]]; then
+                    break
+                fi
+                for ver in ${tf_lite_vers_support}; do
+                    if [[ ${ver} == ${enable_tflite_args[1]} ]]; then
+                        is_valid_tflite_version=1
+                        tf_lite_ver=${ver}
+                        break
+                    fi
+                done
+                if [[ ${is_valid_tflite_version} == 0 ]]; then
+                    printf "'%s' is not a supported version of TensorFlow Lite." "${enable_tflite_args[1]}"
+                    printf "The default version, '%s', will be used.\n"  "${tf_lite_ver}"
+                fi
+            fi
             ;;
         --enable_decoder_flatbuf=*)
             enable_decoder_flatbuf=${arg#*=}


### PR DESCRIPTION
This patch updates the build script to support an extra argument for the TensorFlow Lite version to use. The version can be given using the '--enable-tflite' option as follows: --enable-tflite=yes:1.13.1. Note that 1.13.1 can be replaced with other valid versions, 1.9.0, 1.15.2, and 2.3.0.

Resolves: #2904
See also: #2948

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

#### Changes in this PR
V2: To address https://github.com/nnstreamer/nnstreamer/pull/2950#pullrequestreview-552220892, the following commit is appended; 
- [Android/Build] Add an option to display help messages 

```bash
$ bash ./build-android-lib.sh --help
Build script for Android NNStreamer API Library
 - Before running this script, below variables must be set.
 - ANDROID_SDK_ROOT: Android SDK
 - ANDROID_NDK_ROOT: Android NDK
 - GSTREAMER_ROOT_ANDROID: GStreamer prebuilt libraries for Android
 - NNSTREAMER_ROOT: The source root directory of NNStreamer

usage: build-android-lib.sh [OPTIONS]

basic options:
  --help
      display this help and exit
  --build-type=(all|lite|single|internal)
      'all'      : default
      'lite'     : build with GStreamer core plugins
      'single'   : no plugins, single-shot only
      'internal' : no plugins except for enable single-shot only, enable NNFW only
  --target_abi=(armeabi-v7a|arm64-v8a)
      'arm64-v8a' is the default Android ABI
  --run_test=(yes|no)
      'yes'      : run instrumentation test after build procedure is done
      'no'       : [default]
  --nnstreamer_dir=(the_source_root_of_nnstreamer)
      This option overrides the NNSTREAMER_ROOT variable

options for tensor filter sub-plugins:
  --enable_snap=(yes|no)
      'yes'      : build with sub-plugin for SNAP
                   This option requires 1n additional variable, 'SNAP_DIRECTORY',
                   which indicates the SNAP SDK interface's absolute path.
      'no'       : [default]
  --enable_nnfw=(yes|no)
      'yes'      : [default]
      'no'       : build without the sub-plugin for NNFW
  --enable_snpe=(yes|no)
      'yes'      : build with sub-plugin for SNPE
      'no'       : [default]
  --enable_tflite=(yes(:(1.9|1.13.1|1.15.2|2.3.0))?|no)
      'yes'      : [default] you can optionally specify the version of tensorflow-lite to use
                   by appending ':version' [1.13.1 is the default].
      'no'       : build without the sub-plugin for tensorflow-lite

options for tensor decoder sub-plugins:
  --enable_decoder_flatbuf=(yes|no)
      'yes'      : [default]
      'no'       : build without the sub-plugin for FlatBuffers

For example, to build library with core plugins for arm64-v8a
 ./build-android-lib.sh --api_option=lite --target_abi=arm64-v8a
```
