### PR TITLE
[gRPC/Fix] Decoupling gRPC IDL dependencies @open sesame 12/17 10:05

### DIFF
--- a/debian/nnstreamer-grpc.install
+++ b/debian/nnstreamer-grpc.install
@@ -1,3 +1,2 @@
 /usr/lib/*/gstreamer-1.0/libnnstreamer-grpc.so
-/usr/lib/*/libnnstreamer_grpc_protobuf.so
-/usr/lib/*/libnnstreamer_grpc_flatbuf.so
+/usr/lib/*/libnnstreamer_grpc_*.so

--- a/ext/nnstreamer/extra/meson.build
+++ b/ext/nnstreamer/extra/meson.build
@@ -28,54 +28,61 @@ if protobuf_support_is_available
 endif
 
 if grpc_support_is_available
-  if not protobuf_support_is_available
-    error('failed to resolve dependency: gRPC requires libprotobuf.')
-  endif
+  grpc_common_src = ['nnstreamer_grpc_common.cc']
+  grpc_util_sources = []
 
-  if not flatbuf_support_is_available
-    error('failed to resolve dependency: gRPC requires libflatbuf.')
-  endif
-
-  # Don't generate proto files twice
-  nns_protobuf_grpc_lib = shared_library ('nnstreamer_grpc_protobuf',
-    sources : grpc_pb_gen_src,
-    dependencies : [grpc_support_deps, nns_protobuf_dep],
-    install: true,
-    install_dir: nnstreamer_libdir
-  )
-  nns_protobuf_grpc_dep = declare_dependency(
-    link_with: nns_protobuf_grpc_lib,
-    dependencies : [grpc_support_deps, nns_protobuf_dep],
-    include_directories: nns_protobuf_grpc_lib.private_dir_include()
-  )
-
-  nns_flatbuf_grpc_lib = shared_library ('nnstreamer_grpc_flatbuf',
-    sources : grpc_fb_gen_src,
-    dependencies : [grpc_support_deps, flatbuf_dep],
-    install: true,
-    install_dir: nnstreamer_libdir
-  )
-  nns_flatbuf_grpc_dep = declare_dependency(
-    link_with: nns_flatbuf_grpc_lib,
-    dependencies : [grpc_support_deps, flatbuf_dep],
-    include_directories: nns_flatbuf_grpc_lib.private_dir_include()
-  )
-
-  grpc_util_sources = [
-    'nnstreamer_grpc_common.cc',
-    'nnstreamer_grpc_protobuf.cc',
-    'nnstreamer_grpc_flatbuf.cc'
-  ]
-  grpc_util_deps = [nns_protobuf_grpc_dep, nns_flatbuf_grpc_dep]
-
-  nns_grpc_util_sources = []
-  foreach s : grpc_util_sources
-    nns_grpc_util_sources += join_paths(meson.current_source_dir(), s)
+  foreach s : grpc_common_src
+    grpc_util_sources += join_paths(meson.current_source_dir(), s)
   endforeach
 
   grpc_util_dep = declare_dependency(
-    sources: nns_grpc_util_sources,
-    dependencies: [nnstreamer_dep, glib_dep, gst_dep, grpc_util_deps],
+    sources: grpc_util_sources,
+    dependencies: [nnstreamer_dep, glib_dep, gst_dep, libdl_dep, grpc_support_deps],
     include_directories: include_directories('.')
   )
+
+  if protobuf_support_is_available
+    nns_protobuf_grpc_src = ['nnstreamer_grpc_protobuf.cc']
+    nns_protobuf_grpc_sources = []
+    foreach s : nns_protobuf_grpc_src
+      nns_protobuf_grpc_sources += join_paths(meson.current_source_dir(), s)
+    endforeach
+
+    # Don't generate proto files twice
+    nns_protobuf_grpc_lib = shared_library ('nnstreamer_grpc_protobuf',
+      sources : [grpc_pb_gen_src, nns_protobuf_grpc_sources],
+      dependencies : [grpc_util_dep, nns_protobuf_dep],
+      install: true,
+      install_dir: nnstreamer_libdir
+    )
+    nns_protobuf_grpc_dep = declare_dependency(
+      link_with: nns_protobuf_grpc_lib,
+      dependencies : [grpc_util_dep, nns_protobuf_dep],
+      include_directories: nns_protobuf_grpc_lib.private_dir_include()
+    )
+  else
+    warning('gRPC/Protobuf is not supported')
+  endif
+
+  if flatbuf_support_is_available
+    nns_flatbuf_grpc_src = ['nnstreamer_grpc_flatbuf.cc']
+    nns_flatbuf_grpc_sources = []
+    foreach s : nns_flatbuf_grpc_src
+      nns_flatbuf_grpc_sources += join_paths(meson.current_source_dir(), s)
+    endforeach
+
+    nns_flatbuf_grpc_lib = shared_library ('nnstreamer_grpc_flatbuf',
+      sources : [grpc_fb_gen_src, nns_flatbuf_grpc_sources],
+      dependencies : [grpc_util_dep, flatbuf_dep],
+      install: true,
+      install_dir: nnstreamer_libdir
+    )
+    nns_flatbuf_grpc_dep = declare_dependency(
+      link_with: nns_flatbuf_grpc_lib,
+      dependencies : [grpc_util_dep, flatbuf_dep],
+      include_directories: nns_flatbuf_grpc_lib.private_dir_include()
+    )
+  else
+    warning('gRPC/Flatbuf is not supported')
+  endif
 endif

--- a/ext/nnstreamer/extra/nnstreamer_grpc_common.h
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_common.h
@@ -65,6 +65,17 @@ class NNStreamerRPC {
         return -EINVAL;
     }
 
+    /** @brief set library module handle */
+    void setModuleHandle (void * handle) {
+      if (handle_ == NULL)
+        handle_ = handle;
+    }
+
+    /** @brief get library module handle */
+    void *getModuleHandle () {
+      return handle_;
+    }
+
   protected:
     gboolean is_server_;
     const gchar *host_;
@@ -80,6 +91,8 @@ class NNStreamerRPC {
 
     GstDataQueue *queue_;
     GstTensorsConfig config_;
+
+    void * handle_;
 
   private:
     /** @brief start gRPC server */

--- a/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.cc
@@ -127,6 +127,7 @@ ServiceImplFlatbuf::_client_thread ()
      *
      * writer->Finish ();
      */
+    g_usleep (G_USEC_PER_SEC / 100);
   } else if (direction_ == GRPC_DIRECTION_BUFFER_TO_TENSORS) {
     MessageBuilder builder;
 
@@ -251,4 +252,11 @@ ServiceImplFlatbuf::_get_tensors_from_buffer (GstBuffer *buffer,
   msg = builder.ReleaseMessage<Tensors>();
 
   gst_buffer_unmap (buffer, &map);
+}
+
+/** @brief create gRPC/Flatbuf instance */
+extern "C" NNStreamerRPC *
+create_instance (gboolean server, const gchar *host, const gint port)
+{
+  return new ServiceImplFlatbuf (server, host, port);
 }

--- a/ext/nnstreamer/meson.build
+++ b/ext/nnstreamer/meson.build
@@ -18,38 +18,34 @@ if protobuf_support_is_available
 endif
 
 if grpc_support_is_available
-  if not protobuf_support_is_available
-    error('failed to resolve dependency: gRPC requires libprotobuf.')
+  if protobuf_support_is_available
+    # gRPC/Protobuf
+    prog_which = find_program('which')
+    grpc_cpp_plugin_path = run_command(prog_which, 'grpc_cpp_plugin').stdout().strip()
+    if grpc_cpp_plugin_path == ''
+      error('cannot find the path of grpc_cpp_plugin.')
+    endif
+
+    grpc_pb_gen = generator(pb_comp,
+        output: ['@BASENAME@.grpc.pb.h', '@BASENAME@.grpc.pb.cc'],
+        arguments : [
+          '--proto_path=@CURRENT_SOURCE_DIR@/include',
+          '--plugin=protoc-gen-grpc=' + grpc_cpp_plugin_path,
+          '--grpc_out=@BUILD_DIR@',
+          '@INPUT@'
+        ]
+      )
+    grpc_pb_gen_src = grpc_pb_gen.process('./include/nnstreamer.proto')
   endif
 
-  if not flatbuf_support_is_available
-    error('failed to resolve dependency: gRPC requires libflatbuf.')
+  if flatbuf_support_is_available
+    # gRPC/Flatbuf
+    grpc_fb_gen = generator(flatc,
+        output : ['@BASENAME@_generated.h', '@BASENAME@.grpc.fb.h', '@BASENAME@.grpc.fb.cc'],
+        arguments : ['--cpp', '--grpc', '-o', '@BUILD_DIR@', '@INPUT@']
+      )
+    grpc_fb_gen_src = grpc_fb_gen.process('./include/nnstreamer.fbs')
   endif
-
-  # gRPC/Protobuf
-  prog_which = find_program('which')
-  grpc_cpp_plugin_path = run_command(prog_which, 'grpc_cpp_plugin').stdout().strip()
-  if grpc_cpp_plugin_path == ''
-    error('cannot find the path of grpc_cpp_plugin.')
-  endif
-
-  grpc_pb_gen = generator(pb_comp,
-      output: ['@BASENAME@.grpc.pb.h', '@BASENAME@.grpc.pb.cc'],
-      arguments : [
-        '--proto_path=@CURRENT_SOURCE_DIR@/include',
-        '--plugin=protoc-gen-grpc=' + grpc_cpp_plugin_path,
-        '--grpc_out=@BUILD_DIR@',
-        '@INPUT@'
-      ]
-    )
-  grpc_pb_gen_src = grpc_pb_gen.process('./include/nnstreamer.proto')
-
-  # gRPC/Flatbuf
-  grpc_fb_gen = generator(flatc,
-      output : ['@BASENAME@_generated.h', '@BASENAME@.grpc.fb.h', '@BASENAME@.grpc.fb.cc'],
-      arguments : ['--cpp', '--grpc', '-o', '@BUILD_DIR@', '@INPUT@']
-    )
-  grpc_fb_gen_src = grpc_fb_gen.process('./include/nnstreamer.fbs')
 endif
 
 subdir('extra')

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -908,8 +908,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %defattr(-,root,root,-)
 %manifest nnstreamer.manifest
 %license LICENSE
-%{_libdir}/libnnstreamer_grpc_protobuf.so
-%{_libdir}/libnnstreamer_grpc_flatbuf.so
+%{_libdir}/libnnstreamer_grpc_*.so
 %{gstlibdir}/libnnstreamer-grpc.so
 %endif  # grpc_support
 

--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -18,9 +18,8 @@ fi
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)
 testInit $1
 
-# NNStreamer and plugins path for test
-PATH_TO_PLUGIN="../../build"
-
+# Check gRPC availability
+PATH_TO_PLUGIN=${NNSTREAMER_BUILD_ROOT_PATH}
 if [[ -d $PATH_TO_PLUGIN ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer"
     if [[ -d ${ini_path} ]]; then
@@ -35,118 +34,148 @@ if [[ -d $PATH_TO_PLUGIN ]]; then
     fi
 fi
 
+# Check IDL availability
+PATH_TO_PLUGIN_EXTRA=${PATH_TO_PLUGIN}/ext/nnstreamer/extra
+TEST_PROTOBUF=1
+TEST_FLATBUF=1
+if [[ -d $PATH_TO_PLUGIN_EXTRA ]]; then
+  ini_path="${PATH_TO_PLUGIN_EXTRA}"
+  if [[ -d ${ini_path} ]]; then
+    check=$(ls ${ini_path} | grep nnstreamer_grpc_protobuf.so)
+    if [[ ! $check ]]; then
+      echo "Cannot find nnstreamer_grpc_protobuf shared lib"
+      TEST_PROTOBUF=0
+    fi
+    check=$(ls ${ini_path} | grep nnstreamer_grpc_flatbuf.so)
+    if [[ ! $check ]]; then
+      echo "Cannot find nnstreamer_grpc_flatbuf shared lib"
+      TEST_FLATBUF=0
+    fi
+  else
+    echo "Cannot find ${ini_path}"
+  fi
+fi
+
+export LD_LIBRARY_PATH=${PATH_TO_PLUGIN_EXTRA}:${LD_LIBRARY_PATH}
+
 NUM_BUFFERS=10
 
 # Dump original frames, passthrough, other/tensor
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! multifilesink location=original_%1d.log" 0 0 0 $PERFORMANCE
-
-IDL="protobuf"
-PORT=`python3 get_available_port.py`
-# tensor_sink (client) --> tensor_src (server), other/tensor, protobuf
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 1 0 0 $PERFORMANCE &
-sleep 1
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL}" 1 0 0 $PERFORMANCE
-
-for i in `seq 0 $((NUM_BUFFERS-1))`
-do
-  callCompareTest original_${i}.log result_${i}.log 1-${i} "Compare 1-${i}" 0 0
-done
-
-rm result_*.log
-
-PORT=`python3 get_available_port.py`
-# tensor_sink (server) --> tensor_src (client), other/tensor, protobuf
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 2 0 0 $PERFORMANCE &
-sleep 1
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} server=false idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 2 0 0 $PERFORMANCE
-
-for i in `seq 0 $((NUM_BUFFERS-1))`
-do
-  callCompareTest original_${i}.log result_${i}.log 2-${i} "Compare 2-${i}" 0 0
-done
-
-IDL="flatbuf"
-PORT=`python3 get_available_port.py`
-# tensor_sink (client) --> tensor_src (server), other/tensor, flatbuf
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 3 0 0 $PERFORMANCE &
-sleep 1
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL}" 3 0 0 $PERFORMANCE
-
-for i in `seq 0 $((NUM_BUFFERS-1))`
-do
-  callCompareTest original_${i}.log result_${i}.log 3-${i} "Compare 3-${i}" 0 0
-done
-
-rm result_*.log
-
-PORT=`python3 get_available_port.py`
-# tensor_sink (server) --> tensor_src (client), other/tensor, flatbuf
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 4 0 0 $PERFORMANCE &
-sleep 1
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} server=false idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 4 0 0 $PERFORMANCE
-
-for i in `seq 0 $((NUM_BUFFERS-1))`
-do
-  callCompareTest original_${i}.log result_${i}.log 4-${i} "Compare 4-${i}" 0 0
-done
-
-rm result_*.log
-rm original_*.log
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! multifilesink location=original1_%1d.log" 0 0 0 $PERFORMANCE
 
 # Dump original frames, passthrough, other/tensors
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! multifilesink location=original_%1d.log" 5 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! multifilesink location=original2_%1d.log" 1 0 0 $PERFORMANCE
 
-IDL="protobuf"
-PORT=`python3 get_available_port.py`
-# tensor_sink (client) --> tensor_src (server), other/tensors, protobuf
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 6 0 0 $PERFORMANCE &
-sleep 1
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} idl=${IDL}" 6 0 0 $PERFORMANCE
+if [[ $TEST_PROTOBUF -eq 1 ]]; then
+  IDL="protobuf"
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (client) --> tensor_src (server), other/tensor, protobuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 2 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL}" 2 0 0 $PERFORMANCE
 
-for i in `seq 0 $((NUM_BUFFERS/2-1))`
-do
-  callCompareTest original_${i}.log result_${i}.log 6-${i} "Compare 6-${i}" 0 0
-done
+  for i in `seq 0 $((NUM_BUFFERS-1))`
+  do
+    callCompareTest original1_${i}.log result_${i}.log 2-${i} "gRPC/Protobuf Compare 2-${i}" 0 0
+  done
 
-rm result_*.log
+  rm result_*.log
 
-PORT=`python3 get_available_port.py`
-# tensor_sink (server) --> tensor_src (client), other/tensors, protobuf
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 7 0 0 $PERFORMANCE &
-sleep 1
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) server=false idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 7 0 0 $PERFORMANCE
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (server) --> tensor_src (client), other/tensor, protobuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 3 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} server=false idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 3 0 0 $PERFORMANCE
 
-for i in `seq 0 $((NUM_BUFFERS/2-1))`
-do
-  callCompareTest original_${i}.log result_${i}.log 7-${i} "Compare 7-${i}" 0 0
-done
+  for i in `seq 0 $((NUM_BUFFERS-1))`
+  do
+    callCompareTest original1_${i}.log result_${i}.log 3-${i} "gRPC/Protobuf Compare 3-${i}" 0 0
+  done
 
-IDL="flatbuf"
-PORT=`python3 get_available_port.py`
-# tensor_sink (client) --> tensor_src (server), other/tensors, flatbuf
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 8 0 0 $PERFORMANCE &
-sleep 1
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} idl=${IDL}" 8 0 0 $PERFORMANCE
+  rm result_*.log
 
-for i in `seq 0 $((NUM_BUFFERS/2-1))`
-do
-  callCompareTest original_${i}.log result_${i}.log 8-${i} "Compare 8-${i}" 0 0
-done
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (client) --> tensor_src (server), other/tensors, protobuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 4 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} idl=${IDL}" 4 0 0 $PERFORMANCE
 
-rm result_*.log
+  for i in `seq 0 $((NUM_BUFFERS/2-1))`
+  do
+    callCompareTest original2_${i}.log result_${i}.log 4-${i} "gRPC/Protobuf Compare 4-${i}" 0 0
+  done
 
-PORT=`python3 get_available_port.py`
-# tensor_sink (server) --> tensor_src (client), other/tensors, flatbuf
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 9 0 0 $PERFORMANCE &
-sleep 1
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) server=false idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 9 0 0 $PERFORMANCE
+  rm result_*.log
 
-for i in `seq 0 $((NUM_BUFFERS/2-1))`
-do
-  callCompareTest original_${i}.log result_${i}.log 9-${i} "Compare 9-${i}" 0 0
-done
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (server) --> tensor_src (client), other/tensors, protobuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 5 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) server=false idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 5 0 0 $PERFORMANCE
 
-rm result_*.log
-rm original_*.log
+  for i in `seq 0 $((NUM_BUFFERS/2-1))`
+  do
+    callCompareTest original2_${i}.log result_${i}.log 5-${i} "gRPC/Protobuf Compare 5-${i}" 0 0
+  done
+
+  rm result_*.log
+fi
+
+if [[ $TEST_FLATBUF -eq 1 ]]; then
+  IDL="flatbuf"
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (client) --> tensor_src (server), other/tensor, flatbuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 6 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL}" 6 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS-1))`
+  do
+    callCompareTest original1_${i}.log result_${i}.log 6-${i} "gRPC/Flatbuf Compare 6-${i}" 0 0
+  done
+
+  rm result_*.log
+
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (server) --> tensor_src (client), other/tensor, flatbuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 7 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} server=false idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 7 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS-1))`
+  do
+    callCompareTest original1_${i}.log result_${i}.log 7-${i} "gRPC/Flatbuf Compare 7-${i}" 0 0
+  done
+
+  rm result_*.log
+
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (client) --> tensor_src (server), other/tensors, flatbuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 8 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} idl=${IDL}" 8 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS/2-1))`
+  do
+    callCompareTest original2_${i}.log result_${i}.log 8-${i} "gRPC/Flatbuf Compare 8-${i}" 0 0
+  done
+
+  rm result_*.log
+
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (server) --> tensor_src (client), other/tensors, flatbuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 9 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) server=false idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 9 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS/2-1))`
+  do
+    callCompareTest original2_${i}.log result_${i}.log 9-${i} "gRPC/Flatbuf Compare 9-${i}" 0 0
+  done
+
+  rm result_*.log
+fi
+
+rm original*.log
 
 report


### PR DESCRIPTION
This patch seperates gRPC IDL dependencies (protobuf/flatbuf) using dlopen().
From now on, gRPC plugin does not have mandatory dependencies for its IDLs.

It resolves https://github.com/nnstreamer/nnstreamer/issues/2931

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

