### PR TITLE
[C-API] fix invalid parameter direction

### DIFF
--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -223,9 +223,9 @@ typedef enum {
  * @since_tizen 5.5
  * @remarks The @a data can be used only in the callback. To use outside, make a copy.
  * @remarks The @a info can be used only in the callback. To use outside, make a copy.
- * @param[out] data The handle of the tensor output (a single frame. tensor/tensors). Number of tensors is determined by ml_tensors_info_get_count() with the handle 'info'. Note that the maximum number of tensors is 16 (#ML_TENSOR_SIZE_LIMIT).
- * @param[out] info The handle of tensors information (cardinality, dimension, and type of given tensor/tensors).
- * @param[out] user_data User application's private data.
+ * @param[in] data The handle of the tensor output of the pipeline (a single frame. tensor/tensors). Number of tensors is determined by ml_tensors_info_get_count() with the handle 'info'. Note that the maximum number of tensors is 16 (#ML_TENSOR_SIZE_LIMIT).
+ * @param[in] info The handle of tensors information (cardinality, dimension, and type of given tensor/tensors).
+ * @param[in/out] user_data User application's private data.
  */
 typedef void (*ml_pipeline_sink_cb) (const ml_tensors_data_h data, const ml_tensors_info_h info, void *user_data);
 
@@ -233,7 +233,7 @@ typedef void (*ml_pipeline_sink_cb) (const ml_tensors_data_h data, const ml_tens
  * @brief Callback for the change of pipeline state.
  * @details If an application wants to get the change of pipeline state, use this callback. This callback can be registered when constructing the pipeline using ml_pipeline_construct(). Do not spend too much time in the callback.
  * @since_tizen 5.5
- * @param[out] state The new state of the pipeline.
+ * @param[in] state The new state of the pipeline.
  * @param[out] user_data User application's private data.
  */
 typedef void (*ml_pipeline_state_cb) (ml_pipeline_state_e state, void *user_data);
@@ -243,9 +243,9 @@ typedef void (*ml_pipeline_state_cb) (ml_pipeline_state_e state, void *user_data
  * @since_tizen 6.0
  * @remarks The @a in can be used only in the callback. To use outside, make a copy.
  * @remarks The @a out can be used only in the callback. To use outside, make a copy.
- * @param[out] in The handle of the tensor input (a single frame. tensor/tensors).
+ * @param[in] in The handle of the tensor input (a single frame. tensor/tensors).
  * @param[out] out The handle of the tensor output to be filled (a single frame. tensor/tensors).
- * @param[out] user_data User application's private data.
+ * @param[in/out] user_data User application's private data.
  * @return @c 0 on success. @c 1 to ignore the input data. Otherwise a negative error value.
  */
 typedef int (*ml_custom_easy_invoke_cb) (const ml_tensors_data_h in, ml_tensors_data_h out, void *user_data);


### PR DESCRIPTION
Fix invalid parameter direction of the C-API.

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped