### PR TITLE
[Android/TF-lite] prevent conflict to nnfw @open sesame 12/16 17:53

### DIFF
--- a/api/android/api/src/main/jni/Android-tensorflow-lite.mk
+++ b/api/android/api/src/main/jni/Android-tensorflow-lite.mk
@@ -79,6 +79,7 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE := tensorflow-lite-lib
 LOCAL_SRC_FILES := $(TF_LITE_LIB_PATH)/libtensorflow-lite.a
+LOCAL_EXPORT_LDFLAGS := -Wl,--exclude-libs,libtensorflow-lite.a
 
 include $(PREBUILT_STATIC_LIBRARY)
 


### PR DESCRIPTION
Hide symbols in tensorflow-lite lib, to prevent conflict / exception case of tensorflow-lite and nnfw (ruy library).

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
