### PR TITLE
[CAPI] Wait until the pipeline state is changed

### DIFF
--- a/api/capi/src/nnstreamer-capi-pipeline.c
+++ b/api/capi/src/nnstreamer-capi-pipeline.c
@@ -630,6 +630,17 @@ construct_pipeline_internal (const char *pipeline_description,
   /* finally set pipeline state to PAUSED */
   if (status == ML_ERROR_NONE) {
     status = ml_pipeline_stop ((ml_pipeline_h) pipe_h);
+
+    if (status == ML_ERROR_NONE) {
+      /**
+       * Let's wait until the pipeline state is changed to paused.
+       * Otherwise, the following APIs like 'set_property' may incur
+       * unintended behaviors. But, don't need to return any error
+       * even if this state change is not finished within the timeout,
+       * just replying on the caller.
+       */
+      gst_element_get_state (pipeline, NULL, NULL, 10 * GST_MSECOND);
+    }
   }
 
 failed:


### PR DESCRIPTION
This patch fixes a potential danger after `ml_pipeline_construct()` is called.

Currently, as `ml_pipeline_construct()` does not wait the pipeline state change,
the following APIs such as `set_property` may affect the initial pipeline processing
with dummy data (even if the pipe line is not started).

For example, the below sequence may incurs some problems because the property
is changed while processing the demux's `chain()`.
```
status = ml_pipeline_construct (pipeline, nullptr, nullptr, &handle);
EXPECT_EQ (status, ML_ERROR_NONE);

status = ml_pipeline_element_get_handle (handle, "demux", &demux_h);
EXPECT_EQ (status, ML_ERROR_NONE);

status = ml_pipeline_element_set_property_string (demux_h, "tensorpick", "1,2"); 
EXPECT_EQ (status, ML_ERROR_NONE);
```

It resolves https://github.com/nnstreamer/nnstreamer/issues/2956

Please check this PR: @jaeyun-jung @again4you 

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

