### PR TITLE
[Android/Build] fix invalid path

### DIFF
--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -544,7 +544,7 @@ popd
 rm -rf $build_dir
 
 popd
-cd ${NNSTREAMER_ROOT} && find -name nnstreamer_version.h -delete
+cd ${nnstreamer_dir} && find -name nnstreamer_version.h -delete
 
 # exit with success/failure status
 exit $android_lib_build_res


### PR DESCRIPTION
Fix invalid path to nnstreamer src directory.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
