### PR TITLE
[Docs] Remove unnecessary HTML link for feature/privilege.

### DIFF
--- a/api/capi/doc/nnstreamer_doc.h
+++ b/api/capi/doc/nnstreamer_doc.h
@@ -48,8 +48,8 @@
  *
  * @section CAPI_ML_NNSTREAMER_PIPELINE_FEATURE Related Features
  * This function is related with the following features:\n
- *  - http://tizen.org/feature/machine_learning\n
- *  - http://tizen.org/feature/machine_learning.inference\n
+ *  - %http://tizen.org/feature/machine_learning\n
+ *  - %http://tizen.org/feature/machine_learning.inference\n
  *
  * It is recommended to probe features in your application for reliability.\n
  * You can check if a device supports the related features for this function by using
@@ -89,8 +89,8 @@
  *
  * @section CAPI_ML_NNSTREAMER_SINGLE_FEATURE Related Features
  * This function is related with the following features:\n
- *  - http://tizen.org/feature/machine_learning\n
- *  - http://tizen.org/feature/machine_learning.inference\n
+ *  - %http://tizen.org/feature/machine_learning\n
+ *  - %http://tizen.org/feature/machine_learning.inference\n
  *
  * It is recommended to probe features in your application for reliability.\n
  * You can check if a device supports the related features for this function by using


### PR DESCRIPTION
This patch removes the unnecessary HTML link for feature/privilege.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed []Skipped
2. Run test: [X]Passed [ ]Failed []Skipped

#### Related Issue
* https://code.sec.samsung.net/confluence/pages/viewpage.action?pageId=197150692



