### PR TITLE
[Android/Build] remove unnecessary lib for nnapi

### DIFF
--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -376,9 +376,10 @@ if [[ $enable_nnfw == "yes" ]]; then
         tar -zxf external/onert-ext-$nnfw_ver-android-aarch64.tar.gz -C external/nnfw
     fi
 
-    # Remove duplicated, unnecessary files (c++shared and tensorflowlite_jni)
+    # Remove duplicated, unnecessary files (c++shared and tensorflow-lite)
     rm -f external/nnfw/lib/libc++_shared.so
     rm -f external/nnfw/lib/libtensorflowlite_jni.so
+    rm -f external/nnfw/lib/libneuralnetworks.so
 
     mkdir -p api/src/main/jni/nnfw/include api/src/main/jni/nnfw/lib
     mkdir -p api/src/main/jni/nnfw/ext/arm64-v8a


### PR DESCRIPTION
NNFW internally uses nnapi library, this can break tf-lite nnapi option on android-11.
Remove this when building with NNFW.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
