### PR TITLE
[TEST/SSAT] Print progress log @open sesame 12/23 09:59

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -52,7 +52,7 @@ override_dh_auto_test:
 	./packaging/run_unittests_binaries.sh ./tests
 	# SKIP CAPI-UnitTest until we fix it. In Launchpad emulator, capi_src.dummy01 and single_invoke01/02 makes errors due to the slugghish issue.
 	# cd build && ./tests/tizen_capi/unittest_tizen_capi --gst-plugin-path=. && cd ..
-	cd tests && ssat -n && cd ..
+	cd tests && ssat -n -p=1 && cd ..
 
 override_dh_auto_install:
 	DESTDIR=$(CURDIR)/debian/tmp ninja -C ${BUILDDIR} install

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -684,7 +684,7 @@ export NNSTREAMER_CONVERTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor
     LD_LIBRARY_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/tests/nnstreamer_filter_edgetpu:. bash %{test_script} ./tests/nnstreamer_filter_edgetpu/unittest_edgetpu
 %endif #ifarch 64
     pushd tests
-    ssat -n --summary summary.txt -cn _n
+    ssat -n -p=1 --summary summary.txt -cn _n
     popd
 %endif #if unit_test
 


### PR DESCRIPTION
Because the SSAT result is printed after the tests are finished, the test results are not printed in deadlock status.
Change to print the test group name.

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped