### PR TITLE
[Dist/Debian] Revise 'Build-Depends' to support protobuf (>=3.12) @open sesame 12/30 11:49

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,8 +10,9 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  python, python3, python3-dev, python3-numpy,
  tensorflow-lite-dev, pytorch, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
  openvino-dev, openvino-cpu-mkldnn [amd64], libflatbuffers-dev, flatbuffers-compiler,
- protobuf-compiler17, tensorflow-dev [amd64], python2.7-dev, libprotobuf-dev [amd64 arm64 armhf],
- protobuf-compiler-grpc [amd64], libgrpc-dev [amd64], libgrpc++-dev [amd64]
+ protobuf-compiler (>=3.12), libprotobuf-dev [amd64 arm64 armhf],
+ protobuf-compiler-grpc [amd64], libgrpc-dev [amd64], libgrpc++-dev [amd64],
+ tensorflow-dev [amd64], python2.7-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer
 


### PR DESCRIPTION
This patch revises the 'Build-Depends' field to use the protobuf v3.12.3, which is provided by nnstreamer/ppa. This also fixes build failure for Focal (and the laters) on the launchpad because of unmet dependencies related to protobuf-compiler17.

Signed-off-by: Wook Song <wook16.song@samsung.com>

See also: #2881 

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped