### PR TITLE
[Converter/Sub] sub-plugin name prefix

### DIFF
--- a/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
@@ -145,13 +145,15 @@ done:
   return out_buf;
 }
 
-static const gchar converter_subplugin_flatbuf[] = "libnnstreamer_converter_flatbuf";
+static const gchar converter_subplugin_flatbuf[] = "flatbuf";
 
 /** @brief flatbuffer tensor converter sub-plugin NNStreamerExternalConverter instance */
-static NNStreamerExternalConverter flatBuf = {.name = converter_subplugin_flatbuf,
+static NNStreamerExternalConverter flatBuf = {
+  .name = converter_subplugin_flatbuf,
   .convert = fbc_convert,
   .get_out_config = fbc_get_out_config,
-  .query_caps = fbc_query_caps };
+  .query_caps = fbc_query_caps
+};
 
 /** @brief Initialize this object for tensor converter sub-plugin */
 void

--- a/ext/nnstreamer/tensor_converter/tensor_converter_protobuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_protobuf.cc
@@ -84,13 +84,15 @@ pbc_convert (GstBuffer *in_buf, gsize *frame_size, guint *frames_in, GstTensorsC
   return gst_tensor_converter_protobuf (in_buf, frame_size, frames_in, config);
 }
 
-static gchar converter_subplugin_protobuf[] = "libnnstreamer_converter_protobuf";
+static gchar converter_subplugin_protobuf[] = "protobuf";
 
 /** @brief protobuf tensor converter sub-plugin NNStreamerExternalConverter instance */
-static NNStreamerExternalConverter protobuf = {.name = converter_subplugin_protobuf,
+static NNStreamerExternalConverter protobuf = {
+  .name = converter_subplugin_protobuf,
   .convert = pbc_convert,
   .get_out_config = pbc_get_out_config,
-  .query_caps = pbc_query_caps };
+  .query_caps = pbc_query_caps
+};
 
 /** @brief Initialize this object for tensor converter sub-plugin */
 void

--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -38,7 +38,7 @@
 #define NNSTREAMER_PREFIX_DECODER	"libnnstreamer_decoder_"
 #define NNSTREAMER_PREFIX_FILTER	"libnnstreamer_filter_"
 #define NNSTREAMER_PREFIX_CUSTOMFILTERS	""
-#define NNSTREAMER_PREFIX_CONVERTER	""
+#define NNSTREAMER_PREFIX_CONVERTER	"libnnstreamer_converter_"
 /* Custom filter does not have prefix */
 
 /* Env-var names */


### PR DESCRIPTION
define name prefix of tensor-converter sub-plugins.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
