### PR TITLE
[Tests/Rate] Fix -Werror=sign-compare errors @open sesame 01/08 11:45

### DIFF
--- a/tests/nnstreamer_rate/unittest_rate.cc
+++ b/tests/nnstreamer_rate/unittest_rate.cc
@@ -374,8 +374,8 @@ TEST (nnstreamer_rate, passthrough)
 
   EXPECT_EQ (in, option.source_num_buffers);
   EXPECT_EQ (out, option.source_num_buffers);
-  EXPECT_EQ (dup, 0);
-  EXPECT_EQ (drop, 0);
+  EXPECT_EQ (dup, 0U);
+  EXPECT_EQ (drop, 0U);
 
   EXPECT_EQ (setPipelineStateSync (test_data.pipeline, GST_STATE_NULL,
         UNITTEST_STATECHANGE_TIMEOUT), 0);
@@ -413,7 +413,7 @@ TEST (nnstreamer_rate, no_throttling)
   g_object_get (rate, "drop", &drop, NULL);
 
   EXPECT_EQ (in, option.source_num_buffers);
-  EXPECT_EQ (dup, 0);
+  EXPECT_EQ (dup, 0U);
 
   /** we don't expect the exact values */
   EXPECT_GE (out, (guint64) ((option.source_num_buffers / 2) * 0.95));


### PR DESCRIPTION
This is a trivial patch to fix the following -Werror=sign-compare errors in unittest_rate.

```bash
...omission...
[167/223] Compiling C++ object 'tests/59830eb@@unittest_rate@exe/nnstreamer_rate_unittest_rate.cc.o'.
FAILED: tests/59830eb@@unittest_rate@exe/nnstreamer_rate_unittest_rate.cc.o 
...omission...
../tests/nnstreamer_rate/unittest_rate.cc:377:3:   required from here
/usr/src/gtest/include/gtest/gtest.h:1392:11: error: comparison of integer expressions of different signedness: ‘const long unsigned int’ and ‘const int’ [-Werror=sign-compare]
   if (lhs == rhs) {

[165/223] Compiling C++ object 'tests/59830eb@@unittest_rate@exe/nnstreamer_rate_unittest_rate.cc.o'.
FAILED: tests/59830eb@@unittest_rate@exe/nnstreamer_rate_unittest_rate.cc.o 
...omission...
../tests/nnstreamer_rate/unittest_rate.cc:416:3:   required from here
/usr/src/gtest/include/gtest/gtest.h:1392:11: error: comparison of integer expressions of different signedness: ‘const long unsigned int’ and ‘const int’ [-Werror=sign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
cc1plus: all warnings being treated as errors
[174/223] Compiling C++ object 'tests/59830eb@@unittest_rate@exe/gtest-all.cc.o'.
...omission...
```

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>

