### PR TITLE
[Meson/TensorRT] Fix bugs in resolving dependencies on nvlibs @open sesame 01/08 11:45

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -222,10 +222,14 @@ if not get_option('tensorrt-support').disabled()
   endforeach
 
   nvinfer_lib = cxx.find_library('nvinfer', required: false)
-  nvinfer_dep = declare_dependency(dependencies: nvinfer_lib)
+  if nvinfer_lib.found() and cxx.check_header('NvInfer.h')
+    nvinfer_dep = declare_dependency(dependencies: nvinfer_lib)
+  endif
 
   nvparsers_lib = cxx.find_library('nvparsers', required: false)
-  nvparsers_dep = declare_dependency(dependencies: nvparsers_lib)
+  if nvparsers_lib.found() and cxx.check_header('NvUffParser.h')
+    nvparsers_dep = declare_dependency(dependencies: nvparsers_lib)
+  endif
 endif
 
 # gRPC


### PR DESCRIPTION
The existing logic to resolve dependencies on nvinfer and nvparsers have bugs as follows:
1) Even though it is failed to find_library(), the declare_dependency()
   creates a valid dependency object that returns True for .found(). For
   this reason, the feature is enabled with some missing libraries.
2) Checking for required header files, NvUffParser.h and NvInfer.h, has
   been omitted.

This patch fixes the above bugs.

Signed-off-by: Wook Song <wook16.song@samsung.com>


FYI, I attached meson and ninja logs on my machine.
```bash
$ rm -rf build/ && meson build
The Meson build system
Version: 0.50.1
Source dir: /home/wook/Work/NNS/nnstreamer
Build dir: /home/wook/Work/NNS/nnstreamer/build
Build type: native build
Project name: nnstreamer
Project version: 1.7.1
Native C compiler: cc (gcc 8.4.0 "cc (Ubuntu 8.4.0-1ubuntu1~18.04) 8.4.0")
Native C++ compiler: c++ (gcc 8.4.0 "c++ (Ubuntu 8.4.0-1ubuntu1~18.04) 8.4.0")
Build machine cpu family: x86_64
Build machine cpu: x86_64
Compiler for C supports arguments -Wwrite-strings: YES
Compiler for C++ supports arguments -Wwrite-strings: YES
Compiler for C supports arguments -Wformat: YES
Compiler for C++ supports arguments -Wformat: YES
Compiler for C supports arguments -Wformat-nonliteral: YES
Compiler for C++ supports arguments -Wformat-nonliteral: YES
Compiler for C supports arguments -Wformat-security: YES
Compiler for C++ supports arguments -Wformat-security: YES
Compiler for C supports arguments -Winit-self: YES
Compiler for C++ supports arguments -Winit-self: YES
Compiler for C supports arguments -Waddress: YES
Compiler for C++ supports arguments -Waddress: YES
Compiler for C supports arguments -Wno-multichar -Wmultichar: YES
Compiler for C++ supports arguments -Wno-multichar -Wmultichar: YES
Compiler for C supports arguments -Wvla: YES
Compiler for C++ supports arguments -Wvla: YES
Compiler for C supports arguments -Wpointer-arith: YES
Compiler for C++ supports arguments -Wpointer-arith: YES
Compiler for C supports arguments -Wmissing-declarations: YES
Compiler for C supports arguments -Wmissing-include-dirs: YES
Compiler for C supports arguments -Wmissing-prototypes: YES
Compiler for C supports arguments -Wnested-externs: YES
Compiler for C supports arguments -Waggregate-return: YES
Compiler for C supports arguments -Wold-style-definition: YES
Compiler for C supports arguments -Wdeclaration-after-statement: YES
Found pkg-config: /usr/bin/pkg-config (0.29.1)
Dependency glib-2.0 found: YES 2.56.4
Dependency gobject-2.0 found: YES 2.56.4
Dependency gmodule-2.0 found: YES 2.56.4
Dependency gstreamer-1.0 found: YES 1.14.5
Dependency gstreamer-base-1.0 found: YES 1.14.5
Dependency gstreamer-controller-1.0 found: YES 1.14.5
Dependency gstreamer-video-1.0 found: YES 1.14.5
Dependency gstreamer-audio-1.0 found: YES 1.14.5
Dependency gstreamer-app-1.0 found: YES 1.14.5
Dependency gstreamer-check-1.0 found: YES 1.14.5
Library m found: YES
Library dl found: YES
Dependency threads found: YES 
Dependency protobuf found: YES 3.12.3
Program flatc found: YES (/usr/bin/flatc)
Dependency flatbuffers found: YES 1.12.0
Program protoc found: YES (/usr/bin/protoc)
Program orcc found: YES (/usr/bin/orcc)
Dependency orc-0.4 found: YES 0.4.28
Library mvnc found: NO
Check usable header "mvnc2/mvnc.h" : NO
Found CMake: /usr/bin/cmake (3.10.2)
Dependency nnfw found: NO (tried pkgconfig and cmake)
Library nnfw-dev found: NO
Dependency cuda-11.0 found: NO (tried pkgconfig and cmake)
Dependency cudart-11.0 found: NO (tried pkgconfig and cmake)
Dependency cuda-10.2 found: YES 10.2
Dependency cudart-10.2 found: YES 10.2
Library nvinfer found: YES
Library nvparsers found: NO
Dependency grpc found: NO (tried pkgconfig and cmake)
Dependency gpr found: NO (tried pkgconfig and cmake)
Dependency grpc++ found: NO (tried pkgconfig and cmake)
Dependency tensorflow found: YES 1.13.1
Dependency tensorflow-lite found: YES 1.13.1
Dependency tensorflow2-lite found: NO (tried pkgconfig and cmake)
Message: tflite2-support is off because it is either not available or disabled
Dependency pytorch found: NO (tried pkgconfig and cmake)
Message: pytorch-support is off because it is either not available or disabled
Dependency caffe2 found: NO (tried pkgconfig and cmake)
Message: caffe2-support is off because it is either not available or disabled
Message: mvncsdk2-support is off because it is either not available or disabled
Message: nnfw-runtime-support is off because it is either not available or disabled
Dependency armnn found: NO (tried pkgconfig and cmake)
Message: armnn-support is off because it is either not available or disabled
Message: snpe-support is off because it is either not available or disabled
Message: grpc-support is off because it is either not available or disabled
Message: Following project_args are going to be included
Message: {'ENABLE_TENSORFLOW' : 1, 'ENABLE_TENSORFLOW_LITE' : 1, 'HAVE_ORC' : 1, 'ENABLE_FLATBUF' : 1}
Compiler for C supports arguments -Wredundant-decls: YES
Compiler for C++ supports arguments -Wredundant-decls: YES
Dependency python3 found: YES 3.6
Program pkg-config found: YES (/usr/bin/pkg-config)
Compiler for C++ supports arguments -I/usr/include/python3.6m: YES
Check usable header "numpy/arrayobject.h" with dependency python3: YES
Configuring nnstreamer.ini using configuration
Configuring nnstreamer.pc using configuration
Dependency gstreamer-1.0 found: YES (cached)
Configuring nnstreamer_version.h using configuration
Checking for type "kTfLiteInt8" : YES
Checking for type "kTfLiteInt16" : YES
Checking for type "kTfLiteFloat16" : NO
Checking for type "kTfLiteComplex64" : YES
Configuring nnstreamer-cpp.pc using configuration
Configuring capi-nnstreamer.pc using configuration
Dependency opencv found: NO (tried pkgconfig and cmake)
Configuring nnstreamer-test.ini using configuration
Program cp found: YES (/bin/cp)
Dependency libpng found: YES 1.6.34
Dependency GTest found: YES (building self)
Dependency gstreamer-1.0 found: YES (cached)
Program sed found: YES (/bin/sed)
Build targets in project: 74
Found ninja-1.8.2 at /usr/bin/ninja
```

```bash
$ ninja -C build
ninja: Entering directory `build'
[118/240] Compiling C++ object 'ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_tensorrt@sha/tensor_filter_tensorrt.cc.o'.
FAILED: ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_tensorrt@sha/tensor_filter_tensorrt.cc.o 
c++ -Iext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_tensorrt@sha -Iext/nnstreamer/tensor_filter -I../ext/nnstreamer/tensor_filter -Igst/nnstreamer -I../gst/nnstreamer -Igst/nnstreamer/./include/ -I../gst/nnstreamer/./include/ -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/gstreamer-1.0 -I/usr/include/orc-0.4 -I/usr/local/cuda-10.2/targets/x86_64-linux/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -Werror -std=c++14 -g '-DVERSION="1.7.1"' '-DVERSION_MAJOR="1"' '-DVERSION_MINOR="7"' '-DVERSION_MICRO="1"' -Wwrite-strings -Wformat -Wformat-nonliteral -Wformat-security -Winit-self -Waddress -Wno-multichar -Wvla -Wpointer-arith -DENABLE_TENSORFLOW=1 -DENABLE_TENSORFLOW_LITE=1 -DHAVE_ORC=1 -DENABLE_FLATBUF=1 -Wredundant-decls -fPIC -pthread -MD -MQ 'ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_tensorrt@sha/tensor_filter_tensorrt.cc.o' -MF 'ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_tensorrt@sha/tensor_filter_tensorrt.cc.o.d' -o 'ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_tensorrt@sha/tensor_filter_tensorrt.cc.o' -c /home/wook/Work/NNS/nnstreamer/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt.cc
/home/wook/Work/NNS/nnstreamer/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt.cc:27:10: fatal error: NvUffParser.h: No such file or directory
 #include <NvUffParser.h>
          ^~~~~~~~~~~~~~~
compilation terminated.
[119/240] Compiling C++ object 'ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_tensorrt@sta/tensor_filter_tensorrt.cc.o'.
FAILED: ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_tensorrt@sta/tensor_filter_tensorrt.cc.o 
c++ -Iext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_tensorrt@sta -Iext/nnstreamer/tensor_filter -I../ext/nnstreamer/tensor_filter -Igst/nnstreamer -I../gst/nnstreamer -Igst/nnstreamer/./include/ -I../gst/nnstreamer/./include/ -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/gstreamer-1.0 -I/usr/include/orc-0.4 -I/usr/local/cuda-10.2/targets/x86_64-linux/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -Werror -std=c++14 -g '-DVERSION="1.7.1"' '-DVERSION_MAJOR="1"' '-DVERSION_MINOR="7"' '-DVERSION_MICRO="1"' -Wwrite-strings -Wformat -Wformat-nonliteral -Wformat-security -Winit-self -Waddress -Wno-multichar -Wvla -Wpointer-arith -DENABLE_TENSORFLOW=1 -DENABLE_TENSORFLOW_LITE=1 -DHAVE_ORC=1 -DENABLE_FLATBUF=1 -Wredundant-decls -fPIC -pthread -MD -MQ 'ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_tensorrt@sta/tensor_filter_tensorrt.cc.o' -MF 'ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_tensorrt@sta/tensor_filter_tensorrt.cc.o.d' -o 'ext/nnstreamer/tensor_filter/584bea7@@nnstreamer_filter_tensorrt@sta/tensor_filter_tensorrt.cc.o' -c /home/wook/Work/NNS/nnstreamer/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt.cc
/home/wook/Work/NNS/nnstreamer/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt.cc:27:10: fatal error: NvUffParser.h: No such file or directory
 #include <NvUffParser.h>
          ^~~~~~~~~~~~~~~
compilation terminated.
[127/240] Compiling C++ object 'tests/nnstreamer_filter_extensions_common/b8951fb@@unittest_tizen_python3-set@exe/gtest-all.cc.o'.
ninja: build stopped: subcommand failed.
```