### PR TITLE
[Pytorch] Add pytorch & caffe2 filter package and require options @open sesame 01/06 13:51

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -186,11 +186,22 @@ TorchCore::loadModel ()
   gint64 start_time = g_get_real_time ();
 #endif
 
+  try {
 #ifdef PYTORCH_VER_ATLEAST_1_2_0
   model = std::make_shared<torch::jit::script::Module> (torch::jit::load (model_path));
 #else
   model = torch::jit::load (model_path);
 #endif
+  } catch (const std::invalid_argument &ia) {
+    ml_loge ("Invalid argument while loading the model: %s", ia.what ());
+    return -1;
+  } catch (const std::exception &ex) {
+    ml_loge ("Exception while loading the model: %s", ex.what ());
+    return -1;
+  } catch (...) {
+    ml_loge ("Unknown exception while loading the pytorch model");
+    return -1;
+  }
 
   if (model == nullptr) {
     ml_loge ("Failed to read graph.");

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -253,6 +253,15 @@ BuildConflicts: libarmcl-release
 BuildRequires:  json-glib-devel
 %endif
 
+%if 0%{?pytorch_support}
+BuildRequires:	pytorch-devel
+%endif
+
+# Caffe2 is merged to pytorch
+%if 0%{?caffe2_support}
+BuildRequires:	pytorch-devel
+%endif
+
 # Unit Testing Uses SSAT (hhtps://github.com/myungjoo/SSAT.git)
 %if 0%{?unit_test}
 BuildRequires:	ssat >= 1.1.0
@@ -356,6 +365,26 @@ Requires:	nnstreamer = %{version}-%{release}
 Requires:	flatbuffers
 %description flatbuf
 NNStreamer's tensor_converter and decoder subplugin of flatbuf.
+%endif
+
+# for pytorch
+%if 0%{?pytorch_support}
+%package pytorch
+Summary:	NNStreamer PyTorch Support
+Requires:	nnstreamer = %{version}-%{release}
+Requires:	pytorch
+%description pytorch
+NNStreamer's tensor_fliter subplugin of pytorch
+%endif
+
+# for caffe2
+%if 0%{?caffe2_support}
+%package caffe2
+Summary:	NNStreamer caffe2 Support
+Requires:	nnstreamer = %{version}-%{release}
+Requires:	pytorch
+%description caffe2
+NNStreamer's tensor_fliter subplugin of caffe2
 %endif
 
 %package devel
@@ -824,6 +853,22 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %defattr(-,root,root,-)
 %{_prefix}/lib/nnstreamer/decoders/libnnstreamer_decoder_flatbuf.so
 %{_prefix}/lib/nnstreamer/converters/libnnstreamer_converter_flatbuf.so
+%endif
+
+# for pytorch
+%if 0%{?pytorch_support}
+%files pytorch
+%manifest nnstreamer.manifest
+%defattr(-,root,root,-)
+%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_pytorch.so
+%endif
+
+# for caffe2
+%if 0%{?caffe2_support}
+%files caffe2
+%manifest nnstreamer.manifest
+%defattr(-,root,root,-)
+%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_caffe2.so
 %endif
 
 %files devel


### PR DESCRIPTION
Even though `pytorch_support` is enabled, the pytorch filter is not
built since the necessary option is omitted. This patch newly adds the
pytorch filter package and the requires option.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed []Skipped
2. Run test: [ ]Passed [X]Failed []Skipped

### Submit history
#### Submit v2
* Fix the loadModel bug in pytorch filter
* Add caffe2 filter package

#### Submit v1
* First draft


