### PR TITLE
[lts][Java-API] Fix `StateChangeCallback` @open sesame 01/14 12:19

### DIFF
--- a/api/android/api/src/main/java/org/nnsuite/nnstreamer/Pipeline.java
+++ b/api/android/api/src/main/java/org/nnsuite/nnstreamer/Pipeline.java
@@ -145,12 +145,12 @@ public final class Pipeline implements AutoCloseable {
             throw new IllegalArgumentException("Given description is invalid");
         }
 
+        mStateCallback = callback;
+
         mHandle = nativeConstruct(description, (callback != null));
         if (mHandle == 0) {
             throw new IllegalStateException("Failed to construct the pipeline");
         }
-
-        mStateCallback = callback;
     }
 
     /**


### PR DESCRIPTION
- StateCallback occasionally fails to get initial state changes (null -> ready or ready -> pause)
- Assign `mStateCallback` before `ml_pipeline_construct`

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

