### PR TITLE
[C-API] fix double free case

### DIFF
--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -133,7 +133,9 @@ int ml_single_close (ml_single_h single);
  * @param[in] input The input data to be inferred.
  * @param[out] output The allocated output buffer. The caller is responsible for freeing the output buffer with ml_tensors_data_destroy().
  * @return @c 0 on success. Otherwise a negative error value.
- * @note If the data for the output buffer is allocated by the neural network framework (ML_NNFW_TYPE_CUSTOM_FILTER supports this), then this data will be freed when closing the @a single automatically by the neural network framework, and will not available for use later. It is recommended to copy the data from @a output if it is required to use it after the @a single handle is closed.
+ * @note If the data for the output buffer is allocated by the neural network framework (ML_NNFW_TYPE_CUSTOM_FILTER supports this),
+ *       then this buffer will be freed when closing the @a single automatically by the neural network framework, and will not available for use later.
+ *       It is recommended to copy the output buffer from @a output if it is required to use it after the @a single handle is closed.
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -181,15 +181,6 @@ __destroy_notify (gpointer data_h, gpointer single_data)
 }
 
 /**
- * @brief Wrapper for ml_tensors_data_destroy with signature of GDestroyNotify
- */
-static void
-ml_tensors_data_destroy_gwrapper (gpointer data)
-{
-  ml_tensors_data_destroy (data);
-}
-
-/**
  * @brief Wrapper function for __destroy_notify
  */
 int
@@ -855,8 +846,7 @@ ml_single_close (ml_single_h single)
   /** locking ensures correctness with parallel calls on close */
   if (single_h->filter) {
     g_list_foreach (single_h->destroy_data_list, __destroy_notify, single_h);
-    g_list_free_full (single_h->destroy_data_list,
-        ml_tensors_data_destroy_gwrapper);
+    g_list_free (single_h->destroy_data_list);
 
     if (single_h->klass)
       single_h->klass->stop (single_h->filter);


### PR DESCRIPTION
If filter sub-plugin allocates output tensor, single-shot notifies releasing output buffer when closing the single handle.
In this case, we dont need to free the output handle itself. Calling single-close and destroy-outdata functions will make an error.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
