### PR TITLE
[Tests/Meson] Fix wrong option values for 'sed' in meson.build

### DIFF
--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -57,9 +57,9 @@ foreach ext : extensions
     input : ext_test_template,
     output : ext_test_path_each,
     command : [copy, '-f', '@INPUT@', '@OUTPUT@', \
-      '&&', 'sed', '-i\'.cc\'', sed_ext_name_option, '@OUTPUT@', \
-      '&&', 'sed', '-i\'.cc\'', sed_ext_abbrv_option, '@OUTPUT@', \
-      '&&', 'sed', '-i\'.cc\'', sed_ext_mf_option, '@OUTPUT@']
+      '&&', 'sed', '-i', sed_ext_name_option, '@OUTPUT@', \
+      '&&', 'sed', '-i', sed_ext_abbrv_option, '@OUTPUT@', \
+      '&&', 'sed', '-i', sed_ext_mf_option, '@OUTPUT@']
   )
 
   exec = executable(


### PR DESCRIPTION
This is a trivial patch to fix wrong option values following the '-i' option of 'sed' in the meson build script. Without this patch, some useless files such as "unittest_tizen_custom.cc'.cc'" are generated in the build directory.

Signed-off-by: Wook Song <wook16.song@samsung.com>

#### Before this PR
```bash
build/tests/nnstreamer_filter_extensions_common  (main) $ ls -1
...omission...
unittest_tizen_custom
unittest_tizen_custom.cc
"unittest_tizen_custom.cc'.cc'"
unittest_tizen_custom-set
unittest_tizen_custom-set.cc
"unittest_tizen_custom-set.cc'.cc'"
unittest_tizen_python3-get
unittest_tizen_python3-get.cc
"unittest_tizen_python3-get.cc'.cc'"
unittest_tizen_python3-set
unittest_tizen_python3-set.cc
"unittest_tizen_python3-set.cc'.cc'"
unittest_tizen_tensorflow
unittest_tizen_tensorflow.cc
"unittest_tizen_tensorflow.cc'.cc'"
unittest_tizen_tensorflow_lite
unittest_tizen_tensorflow_lite.cc
"unittest_tizen_tensorflow_lite.cc'.cc'"
unittest_tizen_tensorflow_lite-set
unittest_tizen_tensorflow_lite-set.cc
"unittest_tizen_tensorflow_lite-set.cc'.cc'"
```
#### After this PR
```bash
build/tests/nnstreamer_filter_extensions_common  (fix-trivial-things) $ ls -1
b8951fb@@unittest_tizen_custom@exe
b8951fb@@unittest_tizen_custom-set@exe
b8951fb@@unittest_tizen_python3-get@exe
b8951fb@@unittest_tizen_python3-set@exe
b8951fb@@unittest_tizen_tensorflow@exe
b8951fb@@unittest_tizen_tensorflow_lite@exe
b8951fb@@unittest_tizen_tensorflow_lite-set@exe
unittest_tizen_custom
unittest_tizen_custom.cc
unittest_tizen_custom-set
unittest_tizen_custom-set.cc
unittest_tizen_python3-get
unittest_tizen_python3-get.cc
unittest_tizen_python3-set
unittest_tizen_python3-set.cc
unittest_tizen_tensorflow
unittest_tizen_tensorflow.cc
unittest_tizen_tensorflow_lite
unittest_tizen_tensorflow_lite.cc
unittest_tizen_tensorflow_lite-set
unittest_tizen_tensorflow_lite-set.cc
```

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped