### PR TITLE
Add pc file for capi-ml-common-devel

### DIFF
--- a/api/capi/capi-ml-common.pc.in
+++ b/api/capi/capi-ml-common.pc.in
@@ -1,0 +1,14 @@
+
+# Package Information for pkg-config
+
+prefix=@PREFIX@
+exec_prefix=@PREFIX@
+libdir=@LIB_INSTALL_DIR@
+includedir=@INCLUDE_INSTALL_DIR@
+
+Name: tizen-api-ml-common
+Description: ml-common API for Tizen
+Version: @VERSION@
+Requires:
+Libs: -L${libdir}
+Cflags: -I${includedir}/nnstreamer

--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -105,6 +105,11 @@ configure_file(input: 'capi-nnstreamer.pc.in', output: 'capi-nnstreamer.pc',
   configuration: nnstreamer_conf
 )
 
+configure_file(input: 'capi-ml-common.pc.in', output: 'capi-ml-common.pc',
+  install_dir: join_paths(nnstreamer_libdir, 'pkgconfig'),
+  configuration: nnstreamer_conf
+)
+
 install_headers(capi_devel_main,
   subdir: 'nnstreamer'
 )

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -931,6 +931,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 
 %files -n capi-ml-common-devel
 %{_includedir}/nnstreamer/ml-api-common.h
+%{_libdir}/pkgconfig/capi-ml-common.pc
 
 %files -n nnstreamer-tizen-internal-capi-devel
 %{_includedir}/nnstreamer/nnstreamer-tizen-internal.h


### PR DESCRIPTION
pc file was missing for capi-ml-common-devel package.
This patch adds pc file so that capi-ml-common can be included from
`pkg-config`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
