### PR TITLE
[debian] Add nnstreamer-api-common-dev package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -65,13 +65,6 @@ Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer CPP Filter Subplugin Support
  This package allows nnstreamer to support custom filters of C++ classes
 
-Package: nnstreamer-cpp-dev
-Architecture: any
-Multi-Arch: same
-Depends: nnstreamer-cpp, ${shlibs:Depends}, ${misc:Depends}
-Description: NNStreamer CPP Filter Subplugin Development Support
- This package allows developers to write custom filters of C++ classes
-
 Package: nnstreamer-edgetpu
 Architecture: any
 Multi-Arch: same
@@ -122,14 +115,29 @@ Depends: nnstreamer, nnstreamer-grpc, nnstreamer-flatbuf, ${shlibs:Depends}, ${m
 Description: NNStreamer gRPC IDL support for flatbuf
  This package allows nnstreamer-grpc to use flatbuf as its IDL
 
+Package: nnstreamer-api-common-dev
+Architecture: any
+Multi-Arch: same
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer api common
+ Provides headers commonly used across api, such as error definitions.
+ This is a development package for nnstreamer.
+
 Package: nnstreamer-dev
 Architecture: any
 Multi-Arch: same
-Depends: nnstreamer
+Depends: nnstreamer, nnstreamer-api-common-dev, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer development package
  Gstreamer plugins, "NNStreamer", provides access to neural network frameworks for media streams.
  This is development package for nnstreamer.
  If you want to develop Android applications with nnstreamer+gstreamer, you need the libnnstreamer.a from this package.
+
+Package: nnstreamer-cpp-dev
+Architecture: any
+Multi-Arch: same
+Depends: nnstreamer-cpp, nnstreamer-dev, nnstreamer-api-common-dev, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer CPP Filter Subplugin Development Support
+ This package allows developers to write custom filters of C++ classes
 
 Package: nnstreamer-util
 Architecture: any

--- a/debian/nnstreamer-api-common-dev.install
+++ b/debian/nnstreamer-api-common-dev.install
@@ -1,0 +1,3 @@
+/usr/include/nnstreamer/ml-api-common.h
+/usr/include/nnstreamer/tizen_error.h
+/usr/lib/*/pkgconfig/capi-ml-common.pc

--- a/debian/nnstreamer-dev.install
+++ b/debian/nnstreamer-dev.install
@@ -9,10 +9,10 @@
 /usr/include/nnstreamer/tensor_typedef.h
 /usr/include/nnstreamer/tensor_filter_cpp.hh
 /usr/include/nnstreamer/nnstreamer_cppplugin_api_filter.hh
-/usr/include/nnstreamer/ml-api-common.h
-/usr/include/nnstreamer/tizen_error.h
 /usr/include/nnstreamer/nnstreamer.h
 /usr/include/nnstreamer/nnstreamer-single.h
-/usr/lib/*/pkgconfig/*.pc
+/usr/lib/*/pkgconfig/capi-nnstreamer.pc
+/usr/lib/*/pkgconfig/nnstreamer.pc
+/usr/lib/*/pkgconfig/nnstreamer-cpp.pc
 /usr/lib/*/*.a
 /usr/lib/*/libcapi-*.so


### PR DESCRIPTION
Currently, `capi-ml-common-devel` was added to rpm package but
corresponding package was not available in debian.

This patch adds `nnstreamer-api-common-dev` to the debian which
corresponds with `capi-ml-common-devel` in rpm.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
