### PR TITLE
[pkg-config] Update require section of capi-nnstreamer @open sesame 01/25 22:25

### DIFF
--- a/api/capi/capi-nnstreamer.pc.in
+++ b/api/capi/capi-nnstreamer.pc.in
@@ -9,6 +9,6 @@ includedir=@INCLUDE_INSTALL_DIR@
 Name: tizen-api-nnstreamer
 Description: NNStreamer API for Tizen
 Version: @VERSION@
-Requires:
+Requires: capi-ml-common
 Libs: -L${libdir} -lcapi-nnstreamer
 Cflags: -I${includedir}/nnstreamer


### PR DESCRIPTION
- ~**#3011** Add pc file for capi-ml-common-devel~
- ~**#3013** [debian] Add nnstreamer-api-common-dev package~
- ~**#3014** [Chores] Merge platform/tizen_error into ml_error~
- [pkg-config] Update require to capi-nnstreamer
```
As users of capi-nnstreamer.pc need `capi-ml-common.pc`, it should be
added to the require although currently, capi-ml-common.pc has the
exactly same include path so nothing really changes.

This is more of a future proof that one day capi-ml-common.pc might
point to a different include header.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
