### PR TITLE
[Tools/Parser] GST Object Emulators

### DIFF
--- a/tools/development/parser/grammar.y
+++ b/tools/development/parser/grammar.y
@@ -168,14 +168,14 @@ typedef struct {
   gulong signal_id;
 } DelayedSet;
 
-static int  gst_resolve_reference(reference_t *rr, GstElement *pipeline){
-  GstBin *bin;
+static int  gst_resolve_reference(reference_t *rr, _Element *pipeline){
+  _Element *bin;
 
   if(rr->element) return  0;  /* already resolved! */
   if(!rr->name)   return -2;  /* no chance! */
 
-  if (GST_IS_BIN (pipeline)){
-    bin = GST_BIN (pipeline);
+  if (__GST_IS_BIN (pipeline)){
+    bin = __GST_BIN (pipeline);
     rr->element = gst_bin_get_by_name_recurse_up (bin, rr->name);
   } else {
     rr->element = strcmp (GST_ELEMENT_NAME (pipeline), rr->name) == 0 ?
@@ -209,15 +209,15 @@ static void gst_parse_add_delayed_set (GstElement *element, gchar *name, gchar *
       gst_parse_free_delayed_set, (GConnectFlags) 0);
 
   /* FIXME: we would need to listen on all intermediate bins too */
-  if (GST_IS_BIN (element)) {
+  if (__GST_IS_BIN (element)) {
     gchar **names, **current;
     GstElement *parent, *child;
 
     current = names = g_strsplit (name, "::", -1);
-    parent = gst_bin_get_by_name (GST_BIN_CAST (element), current[0]);
+    parent = gst_bin_get_by_name (__GST_BIN_CAST (element), current[0]);
     current++;
     while (parent && current[0]) {
-      child = gst_bin_get_by_name (GST_BIN (parent), current[0]);
+      child = gst_bin_get_by_name (__GST_BIN (parent), current[0]);
       if (!child && current[1]) {
         char *sub_name = g_strjoinv ("::", &current[0]);
 
@@ -1078,9 +1078,9 @@ priv_gst_parse_launch (const gchar *str, GError **error, GstParseContext *ctx,
   /* put all elements in our bin if necessary */
   if(g.chain->elements->next){
     if (flags & GST_PARSE_FLAG_PLACE_IN_BIN)
-      bin = GST_BIN (gst_element_factory_make ("bin", NULL));
+      bin = __GST_BIN (gst_element_factory_make ("bin", NULL));
     else
-      bin = GST_BIN (gst_element_factory_make ("pipeline", NULL));
+      bin = __GST_BIN (gst_element_factory_make ("pipeline", NULL));
     g_assert (bin);
 
     for (walk = g.chain->elements; walk; walk = walk->next) {
@@ -1094,8 +1094,8 @@ priv_gst_parse_launch (const gchar *str, GError **error, GstParseContext *ctx,
   ret = (GstElement *) g.chain->elements->data;
   g_slist_free (g.chain->elements);
   g.chain->elements=NULL;
-  if (GST_IS_BIN (ret))
-    bin = GST_BIN (ret);
+  if (__GST_IS_BIN (ret))
+    bin = __GST_BIN (ret);
   gst_parse_free_chain (g.chain);
   g.chain = NULL;
 

--- a/tools/development/parser/types.c
+++ b/tools/development/parser/types.c
@@ -119,3 +119,29 @@ nnstparser_element_from_uri (_URIType type, const gchar * uri,
   ret->refcount = 1;
   return ret;
 }
+
+/**
+ * @brief Substitutes GST's gst_bin_get_by_name ()
+ */
+_Element *
+nnstparser_bin_get_by_name (_Bin * bin, const gchar * name)
+{
+}
+
+/**
+ * @brief Substitutes GST's gst_bin_get_by_name_recurse_up ()
+ */
+_Element *
+nnstparser_bin_get_by_name_recurse_up (_Bin * bin, const gchar * name)
+{
+  _Element *result;
+
+  g_return_val_if_fail (__GST_IS_BIN (bin), NULL);
+  g_return_val_if_fail (name != NULL, NULL);
+
+  result = gst_bin_get_by_name (bin, name);
+
+  if (!result) {
+    ///////////////// WORKING HERE. May need to analyze gst object parent structure
+  }
+}

--- a/tools/development/parser/types.h
+++ b/tools/development/parser/types.h
@@ -14,6 +14,12 @@
 
 #include <glib-object.h>
 
+/** Define GST macro's substitutions */
+#define __GST_BIN(e) (((e)->id == oTI_GstBin && (e)->specialType == 0) ? \
+  (e) : NULL)
+#define __GST_IS_BIN(e) ((e)->id == oTI_GstBin)
+#define __GST_BIN_CAST(e) (e)
+
 typedef enum {
   eST_normal = 0,
   eST_URI_SINK,
@@ -129,43 +135,6 @@ struct _graph_t {
   _ParseFlags flags;
 };
 
-
-/**
- * Memory checking. Should probably be done with gsttrace stuff, but that
- * doesn't really work.
- * This is not safe from reentrance issues, but that doesn't matter as long as
- * we lock a mutex before parsing anyway.
- *
- * FIXME: Disable this for now for the above reasons
- */
-#if 0
-#ifdef GST_DEBUG_ENABLED
-#  define __GST_PARSE_TRACE
-#endif
-#endif
-
-#ifdef __GST_PARSE_TRACE
-G_GNUC_INTERNAL  gchar  *__gst_parse_strdup (gchar *org);
-G_GNUC_INTERNAL  void	__gst_parse_strfree (gchar *str);
-G_GNUC_INTERNAL  link_t *__gst_parse_link_new (void);
-G_GNUC_INTERNAL  void	__gst_parse_link_free (link_t *data);
-G_GNUC_INTERNAL  chain_t *__gst_parse_chain_new (void);
-G_GNUC_INTERNAL  void	__gst_parse_chain_free (chain_t *data);
-#  define gst_parse_strdup __gst_parse_strdup
-#  define gst_parse_strfree __gst_parse_strfree
-#  define gst_parse_link_new __gst_parse_link_new
-#  define gst_parse_link_free __gst_parse_link_free
-#  define gst_parse_chain_new __gst_parse_chain_new
-#  define gst_parse_chain_free __gst_parse_chain_free
-#else /* __GST_PARSE_TRACE */
-#  define gst_parse_strdup g_strdup
-#  define gst_parse_strfree g_free
-#  define gst_parse_link_new() g_slice_new0 (link_t)
-#  define gst_parse_link_free(l) g_slice_free (link_t, l)
-#  define gst_parse_chain_new() g_slice_new0 (chain_t)
-#  define gst_parse_chain_free(c) g_slice_free (chain_t, c)
-#endif /* __GST_PARSE_TRACE */
-
 /** @brief GST Parser's internal function imported */
 static inline void
 gst_parse_unescape (gchar *str)
@@ -219,5 +188,13 @@ G_GNUC_INTERNAL _Element *priv_gst_parse_launch (const gchar      * str,
                                                    GError          ** err,
                                                    _ParseContext  * ctx,
                                                    _ParseFlags      flags);
+
+/** @brief Substitutes GST's gst_bin_get_by_name () */
+_Element *
+nnstparser_bin_get_by_name (_Bin * bin, const gchar * name);
+
+/** @brief Substitutes GST's gst_bin_get_by_name_recurse_up () */
+_Element *
+nnstparser_bin_get_by_name_recurse_up (_Bin * bin, const gchar * name);
 
 #endif /* __GST_PARSE_TYPES_H__ */


### PR DESCRIPTION
These aux routines emulate GST Objects so that
parsers wouldn't rely on actual GStreamer libraries
and pipeline instances.
    
This commit is WIP and will be continued by DJ.
    
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
