### PR TITLE
[BUILD/TF-Lite] Add nnapi delegate option

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -194,6 +194,10 @@ if tflite2_support_is_available
     tflite2_compile_args += '-DTFLITE_GPU_DELEGATE_SUPPORTED'
   endif
 
+  if get_option('tflite2-nnapi-delegate-support')
+    tflite2_compile_args += '-DTFLITE_NNAPI_DELEGATE_SUPPORTED'
+  endif
+
   tflite2_extra_dep = declare_dependency(
     compile_args : tflite2_compile_args
   )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -23,6 +23,7 @@ option('enable-test', type: 'boolean', value: true)
 option('install-test', type: 'boolean', value: false)
 option('enable-pytorch-use-gpu', type: 'boolean', value: false) # default value, can be specified at run time
 option('tflite2-gpu-delegate-support', type: 'boolean', value: 'false')
+option('tflite2-nnapi-delegate-support', type: 'boolean', value: 'false')
 option('enable-mediapipe', type: 'boolean', value: false)
 option('enable-env-var', type: 'boolean', value: true)
 option('enable-symbolic-link', type: 'boolean', value: true)


### PR DESCRIPTION
Some NPU vendors such as Verisilicon integrate their neural network
stack within TF-LITE through NNAPI for Linux OS.

https://github.com/VeriSilicon/tensorflow/commit/07a2d86919d2c27dc350a065ab01c815a3f4aa15

Thus, this option enables NNAPI support on tf-lite tensor filter plugin
for non android build such as NPU delegates could use NNAPI on non
Android OS.

Signed-off-by: Xavier Roumegue <xavier.roumegue@nxp.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```

