### PR TITLE
[Decoder/BoundingBox/TF-SSD] Add output tensors mapping configuration option, plus minor fixes & enhancements

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -943,7 +943,7 @@ draw (GstMapInfo * out_info, bounding_boxes * bdata, GArray * results)
 
 
     if ((bdata->flag_use_label) &&
-        ((a->class_id <= 0 || a->class_id >= bdata->labeldata.total_labels))) {
+        ((a->class_id < 0 || a->class_id >= bdata->labeldata.total_labels))) {
       /** @todo make it "logw_once" after we get logw_once API. */
       ml_logw ("Invalid class found with tensordec-boundingbox.c.\n");
       continue;

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -61,8 +61,8 @@
 #include <nnstreamer_log.h>
 #include "tensordecutil.h"
 
-void init_bb (void) __attribute__ ((constructor));
-void fini_bb (void) __attribute__ ((destructor));
+void init_bb (void) __attribute__((constructor));
+void fini_bb (void) __attribute__((destructor));
 
 /* font.c */
 extern uint8_t rasters[][13];
@@ -76,7 +76,7 @@ extern uint8_t rasters[][13];
 #define OV_PERSON_DETECTION_MAX_TENSORS         (1U)
 #define OV_PERSON_DETECTION_SIZE_DETECTION_DESC (7)
 #define OV_PERSON_DETECTION_CONF_THRESHOLD      (0.8)
-#define PIXEL_VALUE                             (0xFF0000FF) /* RED 100% in RGBA */
+#define PIXEL_VALUE                             (0xFF0000FF)    /* RED 100% in RGBA */
 
 /**
  * @todo Fill in the value at build time or hardcode this. It's const value
@@ -427,7 +427,7 @@ _check_tensors (const GstTensorsConfig * config, const int limit)
  * @brief check the label relevant properties are valid
 */
 static gboolean
-_check_label_props(bounding_boxes * data)
+_check_label_props (bounding_boxes * data)
 {
   if ((!data->label_path) || (!data->labeldata.labels) ||
       (data->labeldata.total_labels <= 0))
@@ -546,7 +546,7 @@ bb_getOutCaps (void **pdata, const GstTensorsConfig * config)
       return NULL;
     }
   } else if ((data->mode == OV_PERSON_DETECTION_BOUNDING_BOX) ||
-      (data->mode == OV_FACE_DETECTION_BOUNDING_BOX)){
+      (data->mode == OV_FACE_DETECTION_BOUNDING_BOX)) {
     const guint *dim;
 
     if (!_check_tensors (config, OV_PERSON_DETECTION_MAX_TENSORS))
@@ -565,8 +565,7 @@ bb_getOutCaps (void **pdata, const GstTensorsConfig * config)
   }
 
   str = g_strdup_printf ("video/x-raw, format = RGBA, " /* Use alpha channel to make the background transparent */
-      "width = %u, height = %u"
-      , data->width, data->height);
+      "width = %u, height = %u", data->width, data->height);
   caps = gst_caps_from_string (str);
   setFramerateFromConfig (caps, config);
   g_free (str);
@@ -904,7 +903,7 @@ draw (GstMapInfo * out_info, bounding_boxes * bdata, GArray * results)
       for (j = 0; j < label_len; j++) {
         unsigned int char_index = label[j];
         if ((x1 + 8) > bdata->width)
-          break;                  /* Stop drawing if it may overfill */
+          break;                /* Stop drawing if it may overfill */
         pos2 = pos1;
         for (y2 = 0; y2 < 13; y2++) {
           /* 13 : character height */
@@ -915,7 +914,7 @@ draw (GstMapInfo * out_info, bounding_boxes * bdata, GArray * results)
           pos2 += bdata->width;
         }
         x1 += 9;
-        pos1 += 9;                /* charater width + 1px */
+        pos1 += 9;              /* charater width + 1px */
       }
     }
   }
@@ -935,7 +934,7 @@ bb_decode (void **pdata, const GstTensorsConfig * config,
 
   g_assert (outbuf);
 
-  if (_check_label_props(bdata))
+  if (_check_label_props (bdata))
     bdata->flag_use_label = TRUE;
   else
     bdata->flag_use_label = FALSE;
@@ -1017,7 +1016,7 @@ bb_decode (void **pdata, const GstTensorsConfig * config,
         g_assert (0);
     }
   } else if ((bdata->mode == OV_PERSON_DETECTION_BOUNDING_BOX) ||
-      (bdata->mode == OV_FACE_DETECTION_BOUNDING_BOX))  {
+      (bdata->mode == OV_FACE_DETECTION_BOUNDING_BOX)) {
     results = g_array_sized_new (FALSE, TRUE, sizeof (detectedObject),
         OV_PERSON_DETECTION_MAX);
 
@@ -1025,16 +1024,16 @@ bb_decode (void **pdata, const GstTensorsConfig * config,
     g_assert (num_tensors >= OV_PERSON_DETECTION_MAX_TENSORS);
 
     switch (config->info.info[0].type) {
-      _get_persons_ov(bdata, uint8_t, input[0].data, _NNS_UINT8, results);
-      _get_persons_ov(bdata, int8_t, input[0].data, _NNS_INT8, results);
-      _get_persons_ov(bdata, uint16_t, input[0].data, _NNS_UINT16, results);
-      _get_persons_ov(bdata, int16_t, input[0].data, _NNS_INT16, results);
-      _get_persons_ov(bdata, uint32_t, input[0].data, _NNS_UINT32, results);
-      _get_persons_ov(bdata, int32_t, input[0].data, _NNS_INT32, results);
-      _get_persons_ov(bdata, uint64_t, input[0].data, _NNS_UINT64, results);
-      _get_persons_ov(bdata, int64_t, input[0].data, _NNS_INT64, results);
-      _get_persons_ov(bdata, float, input[0].data, _NNS_FLOAT32, results);
-      _get_persons_ov(bdata, double, input[0].data, _NNS_FLOAT64, results);
+        _get_persons_ov (bdata, uint8_t, input[0].data, _NNS_UINT8, results);
+        _get_persons_ov (bdata, int8_t, input[0].data, _NNS_INT8, results);
+        _get_persons_ov (bdata, uint16_t, input[0].data, _NNS_UINT16, results);
+        _get_persons_ov (bdata, int16_t, input[0].data, _NNS_INT16, results);
+        _get_persons_ov (bdata, uint32_t, input[0].data, _NNS_UINT32, results);
+        _get_persons_ov (bdata, int32_t, input[0].data, _NNS_INT32, results);
+        _get_persons_ov (bdata, uint64_t, input[0].data, _NNS_UINT64, results);
+        _get_persons_ov (bdata, int64_t, input[0].data, _NNS_INT64, results);
+        _get_persons_ov (bdata, float, input[0].data, _NNS_FLOAT32, results);
+        _get_persons_ov (bdata, double, input[0].data, _NNS_FLOAT64, results);
       default:
         g_assert (0);
     }

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -851,13 +851,18 @@ nms (GArray * results)
     results = g_array_sized_new (FALSE, TRUE, sizeof (detectedObject), num); \
     boxbpi = config->info.info[locations_idx].dimension[0]; \
     for (d = 0; d < num; d++) { \
+      _type x1, x2, y1, y2; \
       detectedObject object; \
       object.valid = TRUE; \
       object.class_id = (int) classes_[d]; \
-      object.x = (int) (boxes_[d * boxbpi + 1] * bb->i_width); \
-      object.y = (int) (boxes_[d * boxbpi] * bb->i_height); \
-      object.width = (int) ((boxes_[d * boxbpi + 3] - boxes_[d * boxbpi + 1]) * bb->i_width); \
-      object.height = (int) ((boxes_[d * boxbpi + 2] - boxes_[d * boxbpi]) * bb->i_height); \
+      x1 = MIN(MAX(boxes_[d * boxbpi + 1], 0), 1); \
+      y1 = MIN(MAX(boxes_[d * boxbpi], 0), 1); \
+      x2 = MIN(MAX(boxes_[d * boxbpi + 3], 0), 1); \
+      y2 = MIN(MAX(boxes_[d * boxbpi + 2], 0), 1); \
+      object.x = (int) (x1 * bb->i_width); \
+      object.y = (int) (y1 * bb->i_height); \
+      object.width = (int) ((x2 - x1) * bb->i_width); \
+      object.height = (int) ((y2 - y1) * bb->i_height); \
       object.prob = scores_[d]; \
       g_array_append_val (results, object); \
     } \


### PR DESCRIPTION
Hello nnstreamer community,

Please find the few patches I had to develop to get [mobilenet_ssd_v2_coco](https://coral.googlesource.com/edgetpu/+/refs/heads/release-chef/test_data/mobilenet_ssd_v2_coco_quant_postprocess.tflite) neural network model imported from Google corail database running on iMX8MP NXP SoC.

The main enhancement is related to the default output tensor mapping within tensor decoder bounding boxes in TF-SSD mode, which is incompatible with [default object detection NN output tensors mapping delivered by tensor flow lite community](https://www.tensorflow.org/lite/models/object_detection/overview#output_signature) used nowadays.

Even though neural network output mapping could be reorganized offline to fit default tensor decoder bounding boxes mapping, this might be preferable to let the user specify optionally the output tensor mapping.
The option-3 is used to specify the mapping as the following:
option3=Bounding boxes locations tensor index **:** classes tensor index **:** score tensor index **:** number of detected object index

For instance, option3=0:1:2:3 follows [tflite object detection default mapping](https://www.tensorflow.org/lite/models/object_detection/overview#output_signature) convention.

Backward compatibility (similar as option3=3:1:2:0) is preserved if the option is not provided.

Additionally, clamping the bounding boxes location tensor values before processing was required to avoid segfault exception while drawing as this model might output some coordinates as negative value (-0.f), obviously incorrectly interpreted with a simple int cast.

To avoid too many incorrect object detection draw, a score detection threshold is applied as well on TF-SSD, which is configurable thanks to options3, adding ",threshold" to it.

Lastly, an off-by-one error while applying a sanity check on the detected class is fixed, such [label class "0"](https://raw.githubusercontent.com/google-coral/test_data/master/coco_labels.txt)  is assessed as valid.

1. Coding style: [*]Passed [ ]Failed [ ]Skipped
2. Build test: [*]Passed [ ]Failed [ ]Skipped
3. Run test: [*]Passed [ ]Failed [ ]Skipped
4. Tensor decoder bounding box unittest: [*]Passed [ ]Failed [ ]Skipped

Regards,
 Xavier
