### PR TITLE
[Build] internal header for APIs

### DIFF
--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -26,8 +26,7 @@
 #include "nnstreamer-capi-private.h"
 #include "nnstreamer_plugin_api.h"
 #include "nnstreamer_plugin_api_filter.h"
-#include "nnstreamer_conf.h"
-#include <tensor_filter_common.h>
+#include "nnstreamer_internal.h"
 
 /**
  * @brief The name of sub-plugin for defined neural net frameworks.

--- a/debian/control
+++ b/debian/control
@@ -138,6 +138,14 @@ Description: NNStreamer development package
  Gstreamer plugins, "NNStreamer", provides access to neural network frameworks for media streams.
  This is development package for nnstreamer.
 
+Package: nnstreamer-dev-internal
+Architecture: any
+Multi-Arch: same
+Depends: nnstreamer-dev, ${shlibs:Depends}, ${misc:Depends}
+Description: Development package to access internal functions of NNStreamer.
+ This may be used by API packages.
+ In most cases, custom-filter or subplugin authors do not need this internal devel package; however, if they want to access more internal functions, they may need this.
+
 Package: nnstreamer-util
 Architecture: any
 Multi-Arch: same

--- a/debian/nnstreamer-dev-internal.install
+++ b/debian/nnstreamer-dev-internal.install
@@ -1,0 +1,3 @@
+/usr/include/nnstreamer/nnstreamer_internal.h
+/usr/include/nnstreamer/nnstreamer_log.h
+/usr/include/nnstreamer/tensor_filter_single.h

--- a/debian/nnstreamer-dev.install
+++ b/debian/nnstreamer-dev.install
@@ -6,7 +6,6 @@
 /usr/include/nnstreamer/tensor_if.h
 /usr/include/nnstreamer/tensor_filter_custom.h
 /usr/include/nnstreamer/tensor_filter_custom_easy.h
-/usr/include/nnstreamer/tensor_filter_single.h
 /usr/include/nnstreamer/tensor_typedef.h
 /usr/include/nnstreamer/tensor_filter_cpp.hh
 /usr/include/nnstreamer/nnstreamer_cppplugin_api_filter.hh

--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -64,6 +64,10 @@ endforeach
 
 subdir('include')
 
+# Private header for sub-plugins and native APIs
+nnstreamer_headers += join_paths(meson.current_source_dir(), 'nnstreamer_internal.h')
+nnstreamer_headers += join_paths(meson.current_source_dir(), 'nnstreamer_log.h')
+
 # Build libraries ("both_libraries" are supported from 0.46.)
 nnstreamer_shared = shared_library('nnstreamer',
   nnstreamer_sources,

--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -500,7 +500,11 @@ nnsconf_get_subplugin_info (nnsconf_type_path type, subplugin_info_s * info)
  */
 static GHashTable *custom_table = NULL;
 
-/** @brief Public function defined in the header */
+/**
+ * @brief Public function defined in the header.
+ * @note This function is included in nnstreamer internal header for native APIs.
+ *       When changing the declaration, you should update the internal header (nnstreamer_internal.h).
+ */
 gchar *
 nnsconf_get_custom_value_string (const gchar * group, const gchar * key)
 {
@@ -548,7 +552,11 @@ nnsconf_get_custom_value_string (const gchar * group, const gchar * key)
   return g_strdup (value);
 }
 
-/** @brief Public function defined in the header */
+/**
+ * @brief Public function defined in the header.
+ * @note This function is included in nnstreamer internal header for native APIs.
+ *       When changing the declaration, you should update the internal header (nnstreamer_internal.h).
+ */
 gboolean
 nnsconf_get_custom_value_bool (const gchar * group, const gchar * key,
     gboolean def)

--- a/gst/nnstreamer/nnstreamer_internal.h
+++ b/gst/nnstreamer/nnstreamer_internal.h
@@ -1,0 +1,78 @@
+/**
+ * SPDX-License-Identifier: LGPL-2.1-only
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file	nnstreamer_internal.h
+ * @date	28 Jan 2021
+ * @brief	Internal header for NNStreamer plugins and native APIs.
+ * @see		http://github.com/nnstreamer/nnstreamer
+ * @author	Jaeyun Jung <jy1210.jung@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#ifndef __NNSTREAMER_INTERNAL_H__
+#define __NNSTREAMER_INTERNAL_H__
+
+#include <glib.h>
+#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_filter.h>
+
+/**
+ * @brief Get the custom configuration value from .ini and envvar.
+ * @detail For predefined configurations defined in this header,
+ *         use the given enum for faster configuration processing.
+ *         For custom configurations not defined in this header,
+ *         you may use this API to access your own custom configurations.
+ *         Configuration values may be loaded only once during runtime,
+ *         thus, if the values are changed in run-time, the changes are
+ *         not guaranteed to be reflected.
+ *         The ENVVAR is supposed to be NNSTREAMER_${group}_${key}, which
+ *         has higher priority than the .ini configuration.
+ *         Be careful not to use special characters in group name ([, ], _).
+ * @param[in] group The group name, [group], in .ini file.
+ * @param[in] key The key name, key = value, in .ini file.
+ * @return The newly allocated string. A caller must free it. NULL if it's not available.
+ */
+extern gchar *
+nnsconf_get_custom_value_string (const gchar * group, const gchar * key);
+
+/**
+ * @brief Get the custom configuration value from .ini and envvar.
+ * @detail For predefined configurations defined in this header,
+ *         use the given enum for faster configuration processing.
+ *         For custom configurations not defined in this header,
+ *         you may use this API to access your own custom configurations.
+ *         Configuration values may be loaded only once during runtime,
+ *         thus, if the values are changed in run-time, the changes are
+ *         not guaranteed to be reflected.
+ *         The ENVVAR is supposed to be NNSTREAMER_${group}_${key}, which
+ *         has higher priority than the .ini configuration.
+ *         Be careful not to use special characters in group name ([, ], _).
+ * @param[in] group The group name, [group], in .ini file.
+ * @param[in] key The key name, key = value, in .ini file.
+ * @param[in] def The default return value in case there is no value available.
+ * @return The value interpreted as TRUE/FALSE.
+ */
+extern gboolean
+nnsconf_get_custom_value_bool (const gchar * group, const gchar * key, gboolean def);
+
+/**
+ * @brief Get neural network framework name from given model file. This does not guarantee the framework is available on the target device.
+ * @param[in] model_files the prediction model paths
+ * @param[in] num_models the number of model files
+ * @param[in] load_conf flag to load configuration for the priority of framework
+ * @return Possible framework name (NULL if it fails to detect automatically). Caller should free returned value using g_free().
+ */
+extern gchar *
+gst_tensor_filter_detect_framework (const gchar * const *model_files, const guint num_models, const gboolean load_conf);
+
+/**
+ * @brief Check if the given hw is supported by the framework.
+ * @param[in] name The name of filter sub-plugin.
+ * @param[in] hw Backend accelerator hardware.
+ * @return TRUE if given hw is available.
+ */
+extern gboolean
+gst_tensor_filter_check_hw_availability (const gchar * name, const accl_hw hw);
+
+#endif /* __NNSTREAMER_INTERNAL_H__ */

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -1144,6 +1144,8 @@ _detect_framework_from_config (const gchar * extension)
  * @param[in] num_models the number of model files
  * @param[in] load_conf flag to load configuration for the priority of framework
  * @return Possible framework name (NULL if it fails to detect automatically). Caller should free returned value using g_free().
+ * @note This function is included in nnstreamer internal header for native APIs.
+ *       When changing the declaration, you should update the internal header (nnstreamer_internal.h).
  */
 gchar *
 gst_tensor_filter_detect_framework (const gchar * const *model_files,
@@ -2588,7 +2590,9 @@ accl_hw_get_type (void)
 }
 
 /**
- * @brief check if the given hw is supported by the framework
+ * @brief Check if the given hw is supported by the framework.
+ * @note This function is included in nnstreamer internal header for native APIs.
+ *       When changing the declaration, you should update the internal header (nnstreamer_internal.h).
  */
 gboolean
 gst_tensor_filter_check_hw_availability (const gchar * name, const accl_hw hw)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -394,6 +394,14 @@ Requires:	gstreamer-devel
 Development package for custom tensor operator developers (tensor_filter/custom).
 This contains corresponding header files and .pc pkgconfig file.
 
+%package devel-internal
+Summary:    Development package to access internal functions of NNStreamer
+Requires:   devel = %{version}-%{release}
+%description devel-internal
+Development package to access internal functions of NNStreamer.
+This may be used by API packages.
+In most cases, custom-filter or subplugin authors do not need this internal devel package; however, if they want to access more internal functions, they may need this.
+
 %package devel-static
 Summary:    Static library for nnstreamer-devel package
 Requires:   devel = %{version}-%{release}
@@ -897,7 +905,6 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{_includedir}/nnstreamer/tensor_typedef.h
 %{_includedir}/nnstreamer/tensor_filter_custom.h
 %{_includedir}/nnstreamer/tensor_filter_custom_easy.h
-%{_includedir}/nnstreamer/tensor_filter_single.h
 %{_includedir}/nnstreamer/nnstreamer_plugin_api_filter.h
 %{_includedir}/nnstreamer/nnstreamer_plugin_api_decoder.h
 %{_includedir}/nnstreamer/nnstreamer_plugin_api_converter.h
@@ -907,6 +914,11 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{_includedir}/nnstreamer/nnstreamer_cppplugin_api_filter.hh
 %{_libdir}/pkgconfig/nnstreamer.pc
 %{_libdir}/pkgconfig/nnstreamer-cpp.pc
+
+%files devel-internal
+%{_includedir}/nnstreamer/nnstreamer_internal.h
+%{_includedir}/nnstreamer/nnstreamer_log.h
+%{_includedir}/nnstreamer/tensor_filter_single.h
 
 %files devel-static
 %{_libdir}/*.a


### PR DESCRIPTION
Add internal header for sub-plugins and native APIs.
After separating API repo, native API build will include this header.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
