### PR TITLE
[Tizen/gRPC] add extra dependencies for gRPC 1.35.0

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -220,7 +220,9 @@ BuildRequires:  pkgconfig(amlogic-vsi-npu-sdk)
 %endif
 
 %if 0%{?grpc_support}
-BuildRequires:  grpc-devel
+BuildRequires:	pkgconfig(re2)
+BuildRequires:	pkgconfig(libcares)
+BuildRequires:	grpc-devel
 %endif
 
 %if %{with tizen}


### PR DESCRIPTION
This patch adds extra dependencies for gRPC 1.35.0

CC: @leemgs 

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
