### PR TITLE
TAOS-CI: Use .TAOS-CI/.gbs.conf by default @open sesame 02/05 11:07

### DIFF
--- a/.TAOS-CI/.gbs.conf
+++ b/.TAOS-CI/.gbs.conf
@@ -1,0 +1,37 @@
+# TAOS-CI: About a default location of the ".gbs.conf" file
+# If TAOS-CI could not import the (1) ./.TAOS-CI/.gbs.conf or
+# 2) ./packaging/.gbs.conf file, it imports the (3) ~/.gbs.conf file of www-data account.
+# Please keep the ./packaging/.gbs.conf file ASAP for customized GitHub repository.
+
+[general]
+# Current profile name which should match a profile section name
+profile = profile.tizen
+tmpdir = /var/tmp
+editor = vim
+packaging_branch = tizen
+workdir = .
+
+[profile.tizen]
+# Common authentication info for whole profile
+# user = <WRITE_YOUR_TIZEN_ID>
+# passwd = <WRITE_YOUR_TIZEN_PASSSWORD>
+# obs = obs.tizen
+
+# https://docs.tizen.org/platform/reference/gbs/gbs.conf/
+# Note that a buildconf file of the last repo (e.g., /var/tmp/{USER}-gbs/tizen.of) is used by default.
+repos = repo.base, repo.unified, repo.extra
+buildroot = ~/GBS-ROOT-Snapshot/
+
+[obs.tizen]
+# OBS API URL pointing to a remote OBS.
+url = https://api.tizen.org
+
+[repo.base]
+url = http://download.tizen.org/snapshots/tizen/base/latest/repos/standard/packages/
+
+[repo.unified]
+url = http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/
+
+[repo.extra]
+url = http://download.tizen.org/live/devel:/Tizen:/6.0:/AI/Tizen_Unified_standard/
+

--- a/Documentation/getting-started-tizen.md
+++ b/Documentation/getting-started-tizen.md
@@ -16,26 +16,26 @@ title: Tizen GBS
 ### Build without options
 
 ```bash
-$ gbs build
+$ gbs -c .TAOS-CI/.gbs.conf build
 ```
 
 ### Build with options
 
 ***Enable full unit testing***
 ```bash
-$ gbs build --define "unit_test 1"
+$ gbs -c .TAOS-CI/.gbs.conf build --define "unit_test 1"
 ```
 
 ***Get unit-test coverage report with the unit test for aarch64***
 ```bash
-$ gbs build -A aarch64 --define "unit_test 1" --define "testcoverage 1"
+$ gbs -c .TAOS-CI/.gbs.conf build -A aarch64 --define "unit_test 1" --define "testcoverage 1"
 ```
 
 ***Update Tizen-build options and build it without git commit***
 ```bash
 $ vi packaging/nnstreamer.spec
 # Modify the default options described in the top lines
-$ gbs build --include-all
+$ gbs -c .TAOS-CI/.gbs.conf build --include-all
 # Build with changes not committed.
 ```
 

--- a/ext/nnstreamer/tensor_filter/vivante/README.md
+++ b/ext/nnstreamer/tensor_filter/vivante/README.md
@@ -52,7 +52,7 @@ Build and run the NNStreamer tensor filter on Tizen (aarch64).
 
 ```bash
 $ vi ~/.gbs.conf
-$ gbs build -A aarch64 --clean --include-all
+$ gbs -c .TAOS-CI/.gbs.conf build -A aarch64 --clean --include-all
 ```
 
 ## How to run

--- a/ext/nnstreamer/tensor_filter/vivante/tensor_filter_subplugin.c
+++ b/ext/nnstreamer/tensor_filter/vivante/tensor_filter_subplugin.c
@@ -45,7 +45,7 @@
  * 2. Packaging, Build & run test, and Custom property
  * 2.1. Distribution: Tizen packaging
  * ubuntu$ git clone https://github.sec.samsung.net/AIP/vivante-nnstreamer-filter.git
- * ubuntu$ time gbs build -A armv7l --clean --include-all
+ * ubuntu$ time gbs -c .TAOS-CI/.gbs.conf build -A armv7l --clean --include-all
  *
  * 2.2. Development: Build and run source code on real target
  * You may run the below script to build and run on the real target boards manually.

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -2,13 +2,13 @@
 #
 #              Options for gbs/rpmbuild users
 #
-# gbs build --define "unit_test 1"
+# gbs -c .TAOS-CI/.gbs.conf build --define "unit_test 1"
 #       Execute all unit test cases
 #
-# gbs build --define "testcoverage 1"
+# gbs -c .TAOS-CI/.gbs.conf build --define "testcoverage 1"
 # 	Generate unittest coverage statistics
 #       Use with "unit_test 1" to do it with as many cases as possible:
-#       $ gbs build --define "unit_test 1" --define "testcoverage 1"
+#       $ gbs -c .TAOS-CI/.gbs.conf build --define "unit_test 1" --define "testcoverage 1"
 #
 
 %define		gstpostfix	gstreamer-1.0
@@ -269,7 +269,7 @@ BuildRequires:	ssat >= 1.1.0
 BuildRequires:	pkgconfig(orc-0.4)
 
 # Note that debug packages generate an additional build and storage cost.
-# If you do not need debug packages, run '$ gbs build ... --define "_skip_debug_rpm 1"'.
+# If you do not need debug packages, run '$ gbs -c .TAOS-CI/.gbs.conf build ... --define "_skip_debug_rpm 1"'.
 
 %if "%{?_skip_debug_rpm}" == "1"
 %global debug_package %{nil}


### PR DESCRIPTION
This commit is to use a (1) ./.TAOS-CI/.gbs.conf or (2) ./packaging/.gbs.conf file
by default to support customized GBS repositories for each GitHub repository
because the (3) ~/.gbs.conf file of user account (e.g., www-data) can be used among
lots of repositories.

**Changelog**
 * Added ./.TAOS-CI/.gbs.conf
 * Added ./packaging/.gbs.conf
 * Replaced https with http to avoid ssl issue due to firewall

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>