### PR TITLE
[lts-1.6.y][Build] fix package name

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -333,7 +333,7 @@ This contains corresponding header files and .pc pkgconfig file.
 
 %package devel-static
 Summary:    Static library for nnstreamer-devel package
-Requires:   devel = %{version}-%{release}
+Requires:   nnstreamer-devel = %{version}-%{release}
 %description devel-static
 Static library package of nnstreamer-devel.
 


### PR DESCRIPTION
fix package name required for devel packages.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
