### PR TITLE
[gRPC/Test] Skip SSAT tests on qemu/aarch64

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -743,6 +743,14 @@ export NNSTREAMER_CONVERTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor
     LD_LIBRARY_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/tests/nnstreamer_filter_edgetpu:. bash %{test_script} ./tests/nnstreamer_filter_edgetpu/unittest_edgetpu
 %endif #ifarch 64
     pushd tests
+
+    %ifarch aarch64
+    # A few testcases may use this var.
+    export SKIP_QEMU_ARM64_INCOMPATIBLE_TESTS=1
+    %else
+    export SKIP_QEMU_ARM64_INCOMPATIBLE_TESTS=0
+    %endif
+
     ssat -n -p=1 --summary summary.txt -cn _n
     popd
 %endif #if unit_test

--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -18,6 +18,13 @@ fi
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)
 testInit $1
 
+# Skip test on qemu env.
+if [[ "$SKIP_QEMU_ARM64_INCOMPATIBLE_TESTS" == "1" ]]; then
+  echo "Skip ssat tests on qemu/arm64 env."
+  report
+  exit
+fi
+
 # Check gRPC availability
 PATH_TO_PLUGIN=${NNSTREAMER_BUILD_ROOT_PATH}
 if [[ -d $PATH_TO_PLUGIN ]]; then


### PR DESCRIPTION
This patch makes gbs skip ssat tests on qemu/aarch64 env.

In gRPC 1.35.0, some behaviors are not supported on qemu/aarch64.

See the below error log
```
[  119s] qemu: Unsupported syscall: 168
[  119s] E0208 04:45:45.854670498   21089 cpu_linux.cc:41] Error determining current CPU: Function not implemented
[  119s]
[  119s] Unsupported setsockopt level=1 optname=15
[  119s] E0208 04:45:45.874942631   21089 socket_utils_common_posix.cc:222] check for SO_REUSEPORT: {"created":"@1612759545.874068306","description":"Protocol not available","errno":92,"file":"/home/abuild/rpmbuild/BUILD/grpc-1.35.0/src/core/lib/iomgr/socket_utils_common_posix.cc","file_line":198,"os_error":"Protocol not available","syscall":"setsockopt(SO_REUSEPORT)"}
[  119s] qemu: uncaught target signal 4 (Illegal instruction) - core dumped
```

CC: @gichan-jang 

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

