### PR TITLE
[OSX] Build error fix

### DIFF
--- a/gst/nnstreamer/hw_accel.c
+++ b/gst/nnstreamer/hw_accel.c
@@ -24,7 +24,16 @@
 #endif /* __TIZEN__ */
 #endif /* __arch64__ || __arm__ */
 
+#if !defined(__APPLE__)
 #include <sys/auxv.h>
+#else
+#define HWCAP_ASIMD 0x1
+#if defined(__aarch64__)
+#define getauxval(x) (HWCAP_ASIMD)
+#else
+#define getauxval(x) (0x0)
+#endif /* __aarch64__ */
+#endif /* __APPLE__ */
 
 /**
  * @brief Check if neon is supported


### PR DESCRIPTION
OSX does not have sys/auxv.h
Add a macro assuming that SIMD is always available for
OSX-AARCH64 (e.g., M1) devices.

Tested at MacBook-Air M1

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
