### PR TITLE
[C-Api] fix res leak in timeout mode

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -133,6 +133,15 @@ typedef struct {
 } ml_tensors_info_s;
 
 /**
+ * @brief The function to be called to release the allocated buffer.
+ * @since_tizen 6.5
+ * @param[in] data The handle of the tensors data.
+ * @param[in,out] user_data The user data to pass to the callback function.
+ * @return @c 0 on success. Otherwise a negative error value.
+ */
+typedef int (*ml_tensors_data_destroy_cb) (ml_tensors_data_h data, void *user_data);
+
+/**
  * @brief An instance of a single input or output frame.
  * @since_tizen 5.5
  */
@@ -148,7 +157,10 @@ typedef struct {
 typedef struct {
   unsigned int num_tensors; /**< The number of tensors. */
   ml_tensor_data_s tensors[ML_TENSOR_SIZE_LIMIT]; /**< The list of tensor data. NULL for unused tensors. */
-  void *handle; /**< The handle which owns this buffer and will be used to de-alloc the data */
+
+  /* private */
+  void *user_data; /**< The user data to pass to the callback function */
+  ml_tensors_data_destroy_cb destroy; /**< The function to be called to release the allocated buffer */
 } ml_tensors_data_s;
 
 /**
@@ -409,8 +421,6 @@ ml_nnfw_type_e ml_get_nnfw_type_by_subplugin_name (const char *name);
  * @return The reference of pipeline itself. Null if the pipeline is not constructed or closed.
  */
 GstElement* ml_pipeline_get_gst_element (ml_pipeline_h pipe);
-
-int ml_single_destroy_notify (ml_single_h single, ml_tensors_data_s *data);
 
 #if defined (__TIZEN__)
 /**

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -570,8 +570,8 @@ ml_tensors_data_destroy (ml_tensors_data_h data)
 
   _data = (ml_tensors_data_s *) data;
 
-  if (_data->handle != NULL) {
-    status = ml_single_destroy_notify (_data->handle, _data);
+  if (_data->destroy) {
+    status = _data->destroy (_data, _data->user_data);
   } else {
     for (i = 0; i < ML_TENSOR_SIZE_LIMIT; i++) {
       if (_data->tensors[i].tensor) {
@@ -611,7 +611,6 @@ ml_tensors_data_create_no_alloc (const ml_tensors_info_h info,
     return ML_ERROR_OUT_OF_MEMORY;
   }
 
-  _data->handle = NULL;
   _info = (ml_tensors_info_s *) info;
   if (_info != NULL) {
     _data->num_tensors = _info->num_tensors;
@@ -649,7 +648,6 @@ ml_tensors_data_clone_no_alloc (const ml_tensors_data_s * data_src,
     return ML_ERROR_OUT_OF_MEMORY;
   }
 
-  _data->handle = NULL;
   _data->num_tensors = data_src->num_tensors;
   memcpy (_data->tensors, data_src->tensors,
       sizeof (ml_tensor_data_s) * data_src->num_tensors);


### PR DESCRIPTION
In single-shot timeout case, the flag to release output handle may reset when setting short timeout value.
To prevent this case, add output handle to del-list and change params to set input/output handle in invoke thread.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
