### PR TITLE
[NNFW] add a timer and DBG flag

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -735,7 +735,7 @@ nnfw_invoke_internal (const nnfw_pdata * pdata,
   nnfw_internal_stats.total_invoke_num += 1;
 
 #if (DBG)
-  g_message ("Invoke() is finished: %" G_GINT64_FORMAT ", model path: %s", stop_time - start_time, pdata->model_file);
+  g_message ("Invoke() is finished: %" G_GINT64_FORMAT "ms, model path: %s", (stop_time - start_time) / 1000, pdata->model_file);
   g_message ("%" G_GINT64_FORMAT " invoke average %" G_GINT64_FORMAT ", total overhead %" G_GINT64_FORMAT,
       nnfw_internal_stats.total_invoke_num,
       (nnfw_internal_stats.total_invoke_latency / nnfw_internal_stats.total_invoke_num),

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -39,6 +39,13 @@
 #include <nnfw.h>
 
 /**
+ * @brief Macro for debug mode.
+ */
+#ifndef DBG
+#define DBG FALSE
+#endif
+
+/**
  * @brief Internal structure for nnfw tensor info. The max size is NNS_TENSOR_SIZE_LIMIT.
  */
 typedef struct
@@ -726,6 +733,14 @@ nnfw_invoke_internal (const nnfw_pdata * pdata,
 
   nnfw_internal_stats.total_invoke_latency += stop_time - start_time;
   nnfw_internal_stats.total_invoke_num += 1;
+
+#if (DBG)
+  g_message ("Invoke() is finished: %" G_GINT64_FORMAT ", model path: %s", stop_time - start_time, pdata->model_file);
+  g_message ("%" G_GINT64_FORMAT " invoke average %" G_GINT64_FORMAT ", total overhead %" G_GINT64_FORMAT,
+      nnfw_internal_stats.total_invoke_num,
+      (nnfw_internal_stats.total_invoke_latency / nnfw_internal_stats.total_invoke_num),
+      nnfw_internal_stats.total_overhead_latency);
+#endif
 
   return err;
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -274,8 +274,8 @@ TFLiteInterpreter::invoke (const GstTensorMemory *input, GstTensorMemory *output
   tflite_internal_stats.total_invoke_num += 1;
 
 #if (DBG)
-  g_critical ("Invoke() is finished: %" G_GINT64_FORMAT ", model path: %s", (stop_time - start_time), getModelPath());
-  g_critical ("%" G_GINT64_FORMAT " invoke average %" G_GINT64_FORMAT ", total overhead %" G_GINT64_FORMAT,
+  g_message ("Invoke() is finished: %" G_GINT64_FORMAT "ms, model path: %s", (stop_time - start_time) / 1000, getModelPath());
+  g_message ("%" G_GINT64_FORMAT " invoke average %" G_GINT64_FORMAT ", total overhead %" G_GINT64_FORMAT,
       tflite_internal_stats.total_invoke_num,
       (tflite_internal_stats.total_invoke_latency / tflite_internal_stats.total_invoke_num),
       tflite_internal_stats.total_overhead_latency);


### PR DESCRIPTION
The `DBG` flag and log messages are added to check the time of `invoke()` function

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped