### PR TITLE
[meson] supports alternative target name to find pkg dependency @open sesame 02/22 15:50

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -277,6 +277,7 @@ features = {
   },
   'armnn-support': {
     'target': 'armnn',
+    'target_alt': 'Armnn',
     'project_args': { 'ENABLE_ARMNN': 1 }
   },
   'orcc-support': {
@@ -319,7 +320,14 @@ foreach feature_name, data : features
   _deps = data.get('extra_deps', [])
 
   if target != ''
-    _deps += dependency(target, required: get_option(feature_name))
+    target_dep = dependency(target, required: get_option(feature_name))
+    if not target_dep.found()
+      target_alt = data.get('target_alt', '')
+      if target_alt != ''
+        target_dep = dependency(target_alt, required: get_option(feature_name))
+      endif
+    endif
+    _deps += target_dep
   endif
 
   foreach dep : _deps


### PR DESCRIPTION
This patch supports alternative target name to find pkg dependency.

For example, in case of armnn, the dependency name should be
`Armnn` not `armnn` to find its cmake config files.

Related issue: https://github.com/nnstreamer/nnstreamer/issues/3079

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

