### PR TITLE
[TF 2.4] TF C-API breaking changes at 2.4

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -74,6 +74,7 @@ if tf_support_is_available
       '-DTF_VERSION_MICRO=' + tf_ver_micro,
     ],
   )
+  message('TensorFlow version: ' + tf_ver)
 
   filter_sub_tf_sources = ['tensor_filter_tensorflow.cc']
 
@@ -115,6 +116,7 @@ if tflite_support_is_available
       '-DTFLITE_VERSION_MICRO=' + tflite_ver_micro,
     ],
   )
+  message('TensorFlow-lite version: ' + tflite_ver)
 
   if not flatbuf_support_is_available
     flatbuf_dep = dependency('flatbuffers', required : true, \
@@ -187,6 +189,7 @@ if tflite2_support_is_available
       '-DTFLITE_VERSION_MICRO=' + tflite2_ver_micro,
     ],
   )
+  message('TensorFlow2-lite version: ' + tflite2_ver)
 
   filter_sub_tflite2_sources = ['tensor_filter_tensorflow_lite.cc']
 

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -59,7 +59,22 @@ if armnn_support_is_available
     dependencies: nnstreamer_filter_armnn_deps)
 endif
 
+tf_ver_dep = disabler()
 if tf_support_is_available
+  tf_ver = tf_support_deps[0].version()
+  tf_ver_major = tf_ver.split('.')[0]
+  tf_ver_minor = tf_ver.split('.')[1]
+  tf_ver_micro = tf_ver.split('.')[2]
+
+  tf_ver_dep = declare_dependency (
+    compile_args : [
+      '-DTF_VERSION=' + tf_ver,
+      '-DTF_VERSION_MAJOR=' + tf_ver_major,
+      '-DTF_VERSION_MINOR=' + tf_ver_minor,
+      '-DTF_VERSION_MICRO=' + tf_ver_micro,
+    ],
+  )
+
   filter_sub_tf_sources = ['tensor_filter_tensorflow.cc']
 
   nnstreamer_filter_tf_sources = []
@@ -68,6 +83,7 @@ if tf_support_is_available
   endforeach
 
   nnstreamer_filter_tf_deps = tf_support_deps + [glib_dep, gst_dep, nnstreamer_dep]
+  nnstreamer_filter_tf_deps += tf_ver_dep
 
   shared_library('nnstreamer_filter_tensorflow',
     nnstreamer_filter_tf_sources,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
@@ -491,6 +491,8 @@ TFCore::run (const GstTensorMemory *input, GstTensorMemory *output)
     input_ops.push_back (input_op);
 
     if (input_tensor_info[i].type == TF_STRING) {
+#if (TF_VERSION_MAJOR < 2) || (TF_VERSION_MAJOR == 2 && TF_VERSION_MINOR <= 3)
+      /* TF 2.3 or lower */
       size_t encoded_size = TF_StringEncodedSize (input[i].size);
       size_t total_size = 8 + encoded_size;
 
@@ -512,6 +514,10 @@ TFCore::run (const GstTensorMemory *input, GstTensorMemory *output)
       }
       in_tensor = TF_NewTensor (input_tensor_info[i].type, NULL, 0, input_encoded,
           total_size, DeallocateInputTensor, &input_tensor_info[i]);
+#else /* TF 2.4 or higher */
+      in_tensor = TF_NewTensor (input_tensor_info[i].type, NULL, 0, input[i].data,
+          input[i].size, DeallocateInputTensor, &input_tensor_info[i]);
+#endif /* TF <= 2.3 or >= 2.4 */
     } else {
       in_tensor = TF_NewTensor (input_tensor_info[i].type,
           input_tensor_info[i].dims.data (), input_tensor_info[i].rank, input[i].data,

--- a/meson.build
+++ b/meson.build
@@ -316,11 +316,13 @@ foreach feature_name, data : features
 
   target = data.get('target', '')
 
-  _deps = data.get('extra_deps', [])
+  _deps = []
 
   if target != ''
     _deps += dependency(target, required: get_option(feature_name))
   endif
+  _deps += data.get('extra_deps', [])
+
 
   foreach dep : _deps
     if not dep.found()


### PR DESCRIPTION
Because of breaking changes of TF 2.4
https://github.com/tensorflow/tensorflow/blob/e43be76009614be88454d2fdf2fe702acc5bab77/RELEASE.md#breaking-changes-1
, we need to use different C-API usages for TensorFlow.

The corresponding change is
> C-API functions TF_StringDecode, TF_StringEncode, and TF_StringEncodedSize are no longer relevant and have been removed; see core/platform/ctstring.h for string access/modification in C.

Fixing #3081
CC: @ggardet

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

