### PR TITLE
Revert "[gRPC/Async] Extend gRPC codes to support async/non-blocking APIs"

### DIFF
--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -67,87 +67,121 @@ export LD_LIBRARY_PATH=${PATH_TO_PLUGIN_EXTRA}:${LD_LIBRARY_PATH}
 
 NUM_BUFFERS=10
 
-## Initial pipelines to generate reference outputs
-# passthrough, other/tensor
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! multifilesink location=original1_%1d.log" Initial-1 0 0 $PERFORMANCE
-# passthrough, other/tensors
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! multifilesink location=original2_%1d.log" Initial-2 0 0 $PERFORMANCE
+# Dump original frames, passthrough, other/tensor
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! multifilesink location=original1_%1d.log" 0 0 0 $PERFORMANCE
 
-INDEX=1
-BLOCKING_LIST=("TRUE" "FALSE")
-IDL_LIST=()
+# Dump original frames, passthrough, other/tensors
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! multifilesink location=original2_%1d.log" 1 0 0 $PERFORMANCE
+
 if [[ $TEST_PROTOBUF -eq 1 ]]; then
-  IDL_LIST[${#IDL_LIST[@]}]="Protobuf"
+  IDL="protobuf"
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (client) --> tensor_src (server), other/tensor, protobuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 2 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL}" 2 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS-1))`
+  do
+    callCompareTest original1_${i}.log result_${i}.log 2-${i} "gRPC/Protobuf Compare 2-${i}" 0 0
+  done
+
+  rm result_*.log
+
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (server) --> tensor_src (client), other/tensor, protobuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 3 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} server=false idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 3 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS-1))`
+  do
+    callCompareTest original1_${i}.log result_${i}.log 3-${i} "gRPC/Protobuf Compare 3-${i}" 0 0
+  done
+
+  rm result_*.log
+
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (client) --> tensor_src (server), other/tensors, protobuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 4 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} idl=${IDL}" 4 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS/2-1))`
+  do
+    callCompareTest original2_${i}.log result_${i}.log 4-${i} "gRPC/Protobuf Compare 4-${i}" 0 0
+  done
+
+  rm result_*.log
+
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (server) --> tensor_src (client), other/tensors, protobuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 5 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) server=false idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 5 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS/2-1))`
+  do
+    callCompareTest original2_${i}.log result_${i}.log 5-${i} "gRPC/Protobuf Compare 5-${i}" 0 0
+  done
+
+  rm result_*.log
 fi
+
 if [[ $TEST_FLATBUF -eq 1 ]]; then
-  IDL_LIST[${#IDL_LIST[@]}]="Flatbuf"
+  IDL="flatbuf"
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (client) --> tensor_src (server), other/tensor, flatbuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 6 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL}" 6 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS-1))`
+  do
+    callCompareTest original1_${i}.log result_${i}.log 6-${i} "gRPC/Flatbuf Compare 6-${i}" 0 0
+  done
+
+  rm result_*.log
+
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (server) --> tensor_src (client), other/tensor, flatbuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 7 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} server=false idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 7 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS-1))`
+  do
+    callCompareTest original1_${i}.log result_${i}.log 7-${i} "gRPC/Flatbuf Compare 7-${i}" 0 0
+  done
+
+  rm result_*.log
+
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (client) --> tensor_src (server), other/tensors, flatbuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 8 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} idl=${IDL}" 8 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS/2-1))`
+  do
+    callCompareTest original2_${i}.log result_${i}.log 8-${i} "gRPC/Flatbuf Compare 8-${i}" 0 0
+  done
+
+  rm result_*.log
+
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (server) --> tensor_src (client), other/tensors, flatbuf
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 9 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) server=false idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 9 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS/2-1))`
+  do
+    callCompareTest original2_${i}.log result_${i}.log 9-${i} "gRPC/Flatbuf Compare 9-${i}" 0 0
+  done
+
+  rm result_*.log
 fi
-
-## Test gRPC multi-pipelines with different IDL and blocking modes.
-for IDL in "${IDL_LIST[@]}"; do
-for BLOCKING in "${BLOCKING_LIST[@]}"; do
-  PORT=`python3 get_available_port.py`
-  BLOCKING_STR="Blocking"
-  if [[ $BLOCKING == "FALSE" ]]; then
-    BLOCKING_STR="Non-blocking"
-  fi
-
-  # tensor_sink (client) --> tensor_src (server), other/tensor
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} blocking=${BLOCKING} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" ${INDEX}-1 0 0 $PERFORMANCE &
-  sleep 1
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL} blocking=${BLOCKING}" ${INDEX}-2 0 0 $PERFORMANCE
-
-  for i in `seq 0 $((NUM_BUFFERS-1))`
-  do
-    callCompareTest original1_${i}.log result_${i}.log GoldenTest-${INDEX} "gRPC ${IDL}/${BLOCKING_STR} $((i+1))/${NUM_BUFFERS}" 0 0
-  done
-
-  INDEX=$((INDEX + 1))
-  rm result_*.log
-
-  PORT=`python3 get_available_port.py`
-  # tensor_sink (server) --> tensor_src (client), other/tensor
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL} blocking=${BLOCKING}" ${INDEX}-1 0 0 $PERFORMANCE &
-  sleep 1
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} server=false idl=${IDL} blocking=${BLOCKING} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" ${INDEX}-2 0 0 $PERFORMANCE
-
-  for i in `seq 0 $((NUM_BUFFERS-1))`
-  do
-    callCompareTest original1_${i}.log result_${i}.log GoldenTest-${INDEX} "gRPC ${IDL}/${BLOCKING_STR} $((i+1))/${NUM_BUFFERS}" 0 0
-  done
-
-  INDEX=$((INDEX + 1))
-  rm result_*.log
-
-  PORT=`python3 get_available_port.py`
-  # tensor_sink (client) --> tensor_src (server), other/tensors
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} blocking=${BLOCKING} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" ${INDEX}-1 0 0 $PERFORMANCE &
-  sleep 1
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} idl=${IDL} blocking=${BLOCKING}" ${INDEX}-2 0 0 $PERFORMANCE
-
-  for i in `seq 0 $((NUM_BUFFERS/2-1))`
-  do
-    callCompareTest original2_${i}.log result_${i}.log GoldenTest-${INDEX} "gRPC ${IDL}/${BLOCKING_STR} $((i+1))/$((NUM_BUFFERS/2))" 0 0
-  done
-
-  INDEX=$((INDEX + 1))
-  rm result_*.log
-
-  PORT=`python3 get_available_port.py`
-  # tensor_sink (server) --> tensor_src (client), other/tensors
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL} blocking=${BLOCKING}" ${INDEX}-1 0 0 $PERFORMANCE &
-  sleep 1
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) server=false idl=${IDL} blocking=${BLOCKING} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" ${INDEX}-2 0 0 $PERFORMANCE
-
-  for i in `seq 0 $((NUM_BUFFERS/2-1))`
-  do
-    callCompareTest original2_${i}.log result_${i}.log GoldenTest-${INDEX} "gRPC ${IDL}/${BLOCKING_STR} $((i+1))/$((NUM_BUFFERS/2))" 0 0
-  done
-
-  INDEX=$((INDEX + 1))
-  rm result_*.log
-done
-done
 
 rm original*.log
 


### PR DESCRIPTION
Reverts nnstreamer/nnstreamer#2978

gRPC 1.35.0 & async mode often makes deadlock in the pbuilder.
Before finding the reason, let's revert this.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>
