### PR TITLE
[Fix/Meson] Find the dependency using alternative name

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -320,13 +320,18 @@ foreach feature_name, data : features
   _deps = []
 
   if target != ''
-    target_dep = dependency(target, required: get_option(feature_name))
+    target_dep = dependency(target, required: false)
     if not target_dep.found()
       target_alt = data.get('target_alt', '')
       if target_alt != ''
-        target_dep = dependency(target_alt, required: get_option(feature_name))
+        target_dep = dependency(target_alt, required: false)
       endif
     endif
+
+    if get_option(feature_name).enabled() and not target_dep.found()
+      error('@0@ is enabled but unable to find the target dependency'.format(feature_name))
+    endif
+
     _deps += target_dep
   endif
   _deps += data.get('extra_deps', [])


### PR DESCRIPTION
This patch checks the dependency using alternative name even with 'enabled' option.

resolves #3079 

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

