### PR TITLE
[Gst/MQTT] Introduce new GStreamer plugins, mqttsink and mqttsrc

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -35,7 +35,7 @@ override_dh_auto_clean:
 override_dh_auto_configure:
 	mkdir -p ${BUILDDIR}
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
-	-Denable-edgetpu=true -Denable-openvino=true -Dgrpc-support=disabled  \
+	-Denable-edgetpu=true -Denable-openvino=true -Dgrpc-support=disabled -Dmqtt-support=disabled \
 	-Denable-tizen=false -Denable-test=true -Dinstall-test=true ${BUILDDIR}
 
 override_dh_auto_build:

--- a/gst/meson.build
+++ b/gst/meson.build
@@ -1,2 +1,3 @@
-subdir('nnstreamer')
 subdir('join')
+subdir('mqtt')
+subdir('nnstreamer')

--- a/gst/meson.build
+++ b/gst/meson.build
@@ -1,3 +1,5 @@
 subdir('join')
-subdir('mqtt')
+if mqtt_support_is_available
+  subdir('mqtt')
+endif
 subdir('nnstreamer')

--- a/gst/mqtt/meson.build
+++ b/gst/mqtt/meson.build
@@ -1,0 +1,26 @@
+mqtt_plugin_srcs = [
+  join_paths(meson.current_source_dir(), 'mqttsink.c'),
+  join_paths(meson.current_source_dir(), 'mqttsrc.c'),
+  join_paths(meson.current_source_dir(), 'mqttelements.c'),
+]
+
+gstmqtt_shared = shared_library('gstmqtt',
+  mqtt_plugin_srcs,
+  dependencies: [glib_dep, gst_dep, gst_base_dep],
+  install: false,
+  install_dir: plugins_install_dir
+)
+
+gstmqtt_static = static_library('gstmqtt',
+  mqtt_plugin_srcs,
+  dependencies: [glib_dep, gst_dep, gst_base_dep],
+  install: false,
+  install_dir: nnstreamer_libdir
+)
+
+gstmqtt_lib = gstmqtt_shared
+if get_option('default_library') == 'static'
+  gstmqtt_lib = gstmqtt_static
+endif
+
+gstmqtt_dep = declare_dependency(link_with: gstmqtt_lib)

--- a/gst/mqtt/meson.build
+++ b/gst/mqtt/meson.build
@@ -6,14 +6,14 @@ mqtt_plugin_srcs = [
 
 gstmqtt_shared = shared_library('gstmqtt',
   mqtt_plugin_srcs,
-  dependencies: [glib_dep, gst_dep, gst_base_dep],
+  dependencies: [glib_dep, gst_dep, gst_base_dep, pahomqttc_dep],
   install: false,
   install_dir: plugins_install_dir
 )
 
 gstmqtt_static = static_library('gstmqtt',
   mqtt_plugin_srcs,
-  dependencies: [glib_dep, gst_dep, gst_base_dep],
+  dependencies: [glib_dep, gst_dep, gst_base_dep, pahomqttc_dep],
   install: false,
   install_dir: nnstreamer_libdir
 )

--- a/gst/mqtt/mqttcommon.h
+++ b/gst/mqtt/mqttcommon.h
@@ -28,6 +28,8 @@
  */
 #define GST_MQTT_MAX_NUM_MEMS   15
 
+#define GST_US_TO_NS_MULTIPLIER 1000
+
 /**
  * @brief Defined a custom data type, GstMQTTMessageHdr
  *
@@ -40,6 +42,11 @@ typedef struct _GstMQTTMessageHdr {
     struct {
       guint num_mems;
       gsize size_mems[GST_MQTT_MAX_NUM_MEMS];
+      gint64 base_time_epoch;
+      gint64 sent_time_epoch;
+      GstClockTime duration;
+      GstClockTime dts;
+      GstClockTime pts;
     };
     guint8 _reserved_hdr[GST_MQTT_LEN_MSG_HDR];
   };

--- a/gst/mqtt/mqttcommon.h
+++ b/gst/mqtt/mqttcommon.h
@@ -21,4 +21,28 @@
 #define GST_MQTT_ELEM_NAME_SINK "mqttsink"
 #define GST_MQTT_ELEM_NAME_SRC "mqttsrc"
 
+#define GST_MQTT_LEN_MSG_HDR    512
+/**
+ * @brief GST_BUFFER_MEM_MAX in gstreamer/gstbuffer.c is 16 so that 15 memory
+ * slots ramained in GstBuffer, which we are going to publish and subscribe.
+ */
+#define GST_MQTT_MAX_NUM_MEMS   15
+
+/**
+ * @brief Defined a custom data type, GstMQTTMessageHdr
+ *
+ * GstMQTTMessageHdr contains the information needed to parse the message data
+ * at the subscriber side and is prepended to the original message data at the
+ * publisher side.
+ */
+typedef struct _GstMQTTMessageHdr {
+  union {
+    struct {
+      guint num_mems;
+      gsize size_mems[GST_MQTT_MAX_NUM_MEMS];
+    };
+    guint8 _reserved_hdr[GST_MQTT_LEN_MSG_HDR];
+  };
+} GstMQTTMessageHdr;
+
 #endif /* !__GST_MQTT_COMMON_H__ */

--- a/gst/mqtt/mqttcommon.h
+++ b/gst/mqtt/mqttcommon.h
@@ -21,7 +21,8 @@
 #define GST_MQTT_ELEM_NAME_SINK "mqttsink"
 #define GST_MQTT_ELEM_NAME_SRC "mqttsrc"
 
-#define GST_MQTT_LEN_MSG_HDR    512
+#define GST_MQTT_LEN_MSG_HDR          1024
+#define GST_MQTT_MAX_LEN_GST_CPAS_STR 512
 /**
  * @brief GST_BUFFER_MEM_MAX in gstreamer/gstbuffer.c is 16 so that 15 memory
  * slots ramained in GstBuffer, which we are going to publish and subscribe.
@@ -47,6 +48,7 @@ typedef struct _GstMQTTMessageHdr {
       GstClockTime duration;
       GstClockTime dts;
       GstClockTime pts;
+      gchar gst_caps_str[GST_MQTT_MAX_LEN_GST_CPAS_STR];
     };
     guint8 _reserved_hdr[GST_MQTT_LEN_MSG_HDR];
   };

--- a/gst/mqtt/mqttcommon.h
+++ b/gst/mqtt/mqttcommon.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Wook Song <wook16.song@samsung.com>
+ */
+/**
+ * @file    mqttcommon.h
+ * @date    08 Mar 2021
+ * @brief   Common macros and utility functions for GStreamer MQTT plugins
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifndef __GST_MQTT_COMMON_H__
+#define __GST_MQTT_COMMON_H__
+
+#ifndef GST_MQTT_PACKAGE
+#define GST_MQTT_PACKAGE "GStreamer MQTT Plugins"
+#endif /* GST_MQTT_PACKAGE */
+
+#define GST_MQTT_ELEM_NAME_SINK "mqttsink"
+#define GST_MQTT_ELEM_NAME_SRC "mqttsrc"
+
+#endif /* !__GST_MQTT_COMMON_H__ */

--- a/gst/mqtt/mqttelements.c
+++ b/gst/mqtt/mqttelements.c
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Wook Song <wook16.song@samsung.com>
+ */
+/**
+ * @file    mqttsink.c
+ * @date    09 Mar 2021
+ * @brief   Register sub-plugins included in libgstmqtt
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#include <gst/gst.h>
+
+#include "mqttcommon.h"
+#include "mqttsink.h"
+#include "mqttsrc.h"
+
+/**
+ * @brief The entry point of the GStreamer MQTT plugin
+ */
+static gboolean
+plugin_init (GstPlugin * plugin)
+{
+  if (!gst_element_register (plugin, GST_MQTT_ELEM_NAME_SINK, GST_RANK_NONE,
+          GST_TYPE_MQTT_SINK)) {
+    return FALSE;
+  }
+
+  if (!gst_element_register (plugin, GST_MQTT_ELEM_NAME_SRC, GST_RANK_NONE,
+          GST_TYPE_MQTT_SRC)) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+#ifndef PACKAGE
+#define PACKAGE GST_MQTT_PACKAGE
+#endif
+
+GST_PLUGIN_DEFINE (GST_VERSION_MAJOR, GST_VERSION_MINOR, mqtt,
+    "A collection of GStreamer plugins to support MQTT",
+    plugin_init, VERSION, "LGPL", PACKAGE,
+    "https://github.com/nnstreamer/nnstreamer")

--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -19,6 +19,9 @@
 
 #include "mqttsink.h"
 
+static GstStaticPadTemplate sink_pad_template = GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
+
 #define gst_mqtt_sink_parent_class parent_class
 G_DEFINE_TYPE (GstMqttSink, gst_mqtt_sink, GST_TYPE_BASE_SINK);
 
@@ -29,7 +32,16 @@ enum
 {
   PROP_0,
 
+  PROP_NUM_BUFFERS,
+
   PROP_LAST
+};
+
+enum
+{
+  DEFAULT_NUM_BUFFERS = -1,
+  DEFAULT_QOS = TRUE,
+  DEFAULT_SYNC = FALSE,
 };
 
 /** Function prototype declarations */
@@ -52,6 +64,8 @@ gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * buffer);
 static GstFlowReturn
 gst_mqtt_sink_render_list (GstBaseSink * basesink, GstBufferList * list);
 static gboolean gst_mqtt_sink_event (GstBaseSink * basesink, GstEvent * event);
+static gint gst_mqtt_sink_get_num_buffers (GstMqttSink * self);
+static void gst_mqtt_sink_set_num_buffers (GstMqttSink * self, gint num);
 
 /**
  * @brief Initialize GstMqttSink object
@@ -59,7 +73,14 @@ static gboolean gst_mqtt_sink_event (GstBaseSink * basesink, GstEvent * event);
 static void
 gst_mqtt_sink_init (GstMqttSink * self)
 {
-  /** @todo */
+  GstBaseSink *basesink = GST_BASE_SINK (self);
+
+  /** init mqttsink properties */
+  self->num_buffers = DEFAULT_NUM_BUFFERS;
+
+  /** init basesink properties */
+  gst_base_sink_set_qos_enabled (basesink, DEFAULT_QOS);
+  gst_base_sink_set_sync (basesink, DEFAULT_SYNC);
 }
 
 /**
@@ -79,6 +100,12 @@ gst_mqtt_sink_class_init (GstMqttSinkClass * klass)
   gobject_class->get_property = gst_mqtt_sink_get_property;
   gobject_class->finalize = gst_mqtt_sink_class_finalize;
 
+  g_object_class_install_property (gobject_class, PROP_NUM_BUFFERS,
+      g_param_spec_int ("num-buffers", "num-buffers",
+          "Number of (remaining) buffers to accept until sending EOS event (-1 = no limit)",
+          -1, G_MAXINT, DEFAULT_NUM_BUFFERS,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
   gstelement_class->change_state = gst_mqtt_sink_change_state;
 
   gstbasesink_class->start = GST_DEBUG_FUNCPTR (gst_mqtt_sink_start);
@@ -93,6 +120,8 @@ gst_mqtt_sink_class_init (GstMqttSinkClass * klass)
       "MQTT sink", "Sink/MQTT",
       "Publish incoming data streams as a MQTT topic",
       "Wook Song <wook16.song@samsung.com>");
+  gst_element_class_add_static_pad_template (gstelement_class,
+      &sink_pad_template);
 }
 
 /**
@@ -102,7 +131,12 @@ static void
 gst_mqtt_sink_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
+  GstMqttSink *self = GST_MQTT_SINK (object);
+
   switch (prop_id) {
+    case PROP_NUM_BUFFERS:
+      gst_mqtt_sink_set_num_buffers (self, g_value_get_int (value));
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -116,7 +150,12 @@ static void
 gst_mqtt_sink_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec)
 {
+  GstMqttSink *self = GST_MQTT_SINK (object);
+
   switch (prop_id) {
+    case PROP_NUM_BUFFERS:
+      g_value_set_int (value, gst_mqtt_sink_get_num_buffers (self));
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -139,6 +178,36 @@ static GstStateChangeReturn
 gst_mqtt_sink_change_state (GstElement * element, GstStateChange transition)
 {
   GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+  GstMqttSink *mqttsink = GST_MQTT_SINK (element);
+
+  switch (transition) {
+    case GST_STATE_CHANGE_NULL_TO_READY:
+      GST_INFO_OBJECT (mqttsink, "GST_STATE_CHANGE_NULL_TO_READY");
+      break;
+    case GST_STATE_CHANGE_READY_TO_PAUSED:
+      GST_INFO_OBJECT (mqttsink, "GST_STATE_CHANGE_READY_TO_PAUSED");
+      break;
+    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
+      GST_INFO_OBJECT (mqttsink, "GST_STATE_CHANGE_PAUSED_TO_PLAYING");
+      break;
+    default:
+      break;
+  }
+
+  ret = GST_ELEMENT_CLASS (parent_class)->change_state (element, transition);
+
+  switch (transition) {
+    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
+      GST_INFO_OBJECT (mqttsink, "GST_STATE_CHANGE_PLAYING_TO_PAUSED");
+      break;
+    case GST_STATE_CHANGE_PAUSED_TO_READY:
+      GST_INFO_OBJECT (mqttsink, "GST_STATE_CHANGE_PAUSED_TO_READY");
+      break;
+    case GST_STATE_CHANGE_READY_TO_NULL:
+      GST_INFO_OBJECT (mqttsink, "GST_STATE_CHANGE_READY_TO_NULL");
+    default:
+      break;
+  }
 
   return ret;
 }
@@ -167,7 +236,25 @@ gst_mqtt_sink_stop (GstBaseSink * basesink)
 static gboolean
 gst_mqtt_sink_query (GstBaseSink * basesink, GstQuery * query)
 {
-  return TRUE;
+  gboolean ret = FALSE;
+
+  switch (GST_QUERY_TYPE (query)) {
+    case GST_QUERY_SEEKING:{
+      GstFormat fmt;
+
+      /* GST_QUERY_SEEKING is not supported */
+      gst_query_parse_seeking (query, &fmt, NULL, NULL, NULL);
+      gst_query_set_seeking (query, fmt, FALSE, 0, -1);
+      ret = TRUE;
+      break;
+    }
+    default:{
+      ret = GST_BASE_SINK_CLASS (parent_class)->query (basesink, query);
+      break;
+    }
+  }
+
+  return ret;
 }
 
 /**
@@ -176,7 +263,22 @@ gst_mqtt_sink_query (GstBaseSink * basesink, GstQuery * query)
 static GstFlowReturn
 gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * buffer)
 {
+  GstMqttSink *mqttsink = GST_MQTT_SINK (basesink);
+
+  GST_OBJECT_LOCK (mqttsink);
+  if (mqttsink->num_buffers == 0)
+    goto ret_eos;
+
+  if (mqttsink->num_buffers != -1)
+    mqttsink->num_buffers -= 1;
+  GST_OBJECT_UNLOCK (mqttsink);
+
   return GST_FLOW_OK;
+ret_eos:
+  {
+    GST_OBJECT_UNLOCK (mqttsink);
+    return GST_FLOW_EOS;
+  }
 }
 
 /**
@@ -186,7 +288,19 @@ gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * buffer)
 static GstFlowReturn
 gst_mqtt_sink_render_list (GstBaseSink * basesink, GstBufferList * list)
 {
-  return GST_FLOW_OK;
+  guint num_buffers = gst_buffer_list_length (list);
+  GstFlowReturn ret;
+  GstBuffer *buffer;
+  guint i;
+
+  for (i = 0; i < num_buffers; ++i) {
+    buffer = gst_buffer_list_get (list, i);
+    ret = gst_mqtt_sink_render (basesink, buffer);
+    if (ret != GST_FLOW_OK)
+      break;
+  }
+
+  return ret;
 }
 
 /**
@@ -195,5 +309,40 @@ gst_mqtt_sink_render_list (GstBaseSink * basesink, GstBufferList * list)
 static gboolean
 gst_mqtt_sink_event (GstBaseSink * basesink, GstEvent * event)
 {
-  return TRUE;
+  GstEventType type = GST_EVENT_TYPE (event);
+  gboolean ret = FALSE;
+
+  switch (type) {
+    default:
+      ret = GST_BASE_SINK_CLASS (parent_class)->event (basesink, event);
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief Getter for the 'num-buffers' property.
+ */
+static gint
+gst_mqtt_sink_get_num_buffers (GstMqttSink * self)
+{
+  gint num_buffers;
+
+  GST_OBJECT_LOCK (self);
+  num_buffers = self->num_buffers;
+  GST_OBJECT_UNLOCK (self);
+
+  return num_buffers;
+}
+
+/**
+ * @brief Setter for the 'num-buffers' property
+ */
+static void
+gst_mqtt_sink_set_num_buffers (GstMqttSink * self, gint num)
+{
+  GST_OBJECT_LOCK (self);
+  self->num_buffers = num;
+  GST_OBJECT_UNLOCK (self);
 }

--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -376,13 +376,17 @@ gst_mqtt_sink_class_finalize (GObject * object)
   self->mqtt_host_port = NULL;
   g_free (self->mqtt_client_handle);
   self->mqtt_client_handle = NULL;
+  g_free (self->mqtt_client_id);
+  self->mqtt_client_id = NULL;
   g_free (self->mqtt_msg_buf);
   self->mqtt_msg_buf = NULL;
+  g_free (self->mqtt_topic);
+  self->mqtt_topic = NULL;
+  gst_caps_replace (&self->in_caps, NULL);
+  g_free (self->mqtt_msg_buf);
 
   if (self->err)
     g_error_free (self->err);
-  if (self->in_caps)
-    gst_caps_unref (self->in_caps);
 
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
@@ -459,6 +463,7 @@ gst_mqtt_sink_start (GstBaseSink * basesink)
   int ret;
 
   if (!g_strcmp0 (DEFAULT_MQTT_CLIENT_ID, self->mqtt_client_id)) {
+    g_free (self->mqtt_client_id);
     self->mqtt_client_id = g_strdup_printf (DEFAULT_MQTT_CLIENT_ID_FORMAT,
         g_get_host_name (), getpid (), sink_client_id++);
   }

--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -657,11 +657,6 @@ gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * in_buf)
 
   /** Allocate a message buffer */
   if ((!self->mqtt_msg_buf) && (self->mqtt_msg_buf_size == 0)) {
-    if (!_mqtt_set_msg_buf_hdr (in_buf, &self->mqtt_msg_hdr)) {
-      ret = GST_FLOW_ERROR;
-      goto ret_with;
-    }
-
     if (self->max_msg_buf_size == 0) {
       self->mqtt_msg_buf_size = in_buf_size + GST_MQTT_LEN_MSG_HDR;
     } else {
@@ -682,13 +677,15 @@ gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * in_buf)
       ret = GST_FLOW_ERROR;
       goto ret_with;
     }
-
-    msg_pub = self->mqtt_msg_buf;
-    memcpy (msg_pub, &self->mqtt_msg_hdr, sizeof (self->mqtt_msg_hdr));
-  } else {
-    msg_pub = self->mqtt_msg_buf;
   }
 
+  msg_pub = self->mqtt_msg_buf;
+
+  if (!_mqtt_set_msg_buf_hdr (in_buf, &self->mqtt_msg_hdr)) {
+    ret = GST_FLOW_ERROR;
+    goto ret_with;
+  }
+  memcpy (msg_pub, &self->mqtt_msg_hdr, sizeof (self->mqtt_msg_hdr));
   _put_timestamp_to_msg_buf_hdr (self, in_buf, (GstMQTTMessageHdr *) msg_pub);
 
   in_buf_mem = gst_buffer_get_all_memory (in_buf);

--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -371,8 +371,14 @@ gst_mqtt_sink_class_finalize (GObject * object)
   GstMqttSink *self = GST_MQTT_SINK (object);
 
   g_free (self->mqtt_host_address);
+  self->mqtt_host_address = NULL;
   g_free (self->mqtt_host_port);
+  self->mqtt_host_port = NULL;
   g_free (self->mqtt_client_handle);
+  self->mqtt_client_handle = NULL;
+  g_free (self->mqtt_msg_buf);
+  self->mqtt_msg_buf = NULL;
+
   if (self->err)
     g_error_free (self->err);
   if (self->in_caps)

--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -94,6 +94,7 @@ gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * buffer);
 static GstFlowReturn
 gst_mqtt_sink_render_list (GstBaseSink * basesink, GstBufferList * list);
 static gboolean gst_mqtt_sink_event (GstBaseSink * basesink, GstEvent * event);
+static gboolean gst_mqtt_sink_set_caps (GstBaseSink * basesink, GstCaps * caps);
 static gchar *gst_mqtt_sink_get_client_id (GstMqttSink * self);
 static void gst_mqtt_sink_set_client_id (GstMqttSink * self, const gchar * id);
 static gchar *gst_mqtt_sink_get_host_address (GstMqttSink * self);
@@ -168,6 +169,7 @@ gst_mqtt_sink_init (GstMqttSink * self)
   self->mqtt_msg_buf_size = 0;
   memset (&self->mqtt_msg_hdr, 0x0, sizeof (self->mqtt_msg_hdr));
   self->base_time_epoch = GST_CLOCK_TIME_NONE;
+  self->in_caps = NULL;
 
   /** init mqttsink properties */
   self->num_buffers = DEFAULT_NUM_BUFFERS;
@@ -264,6 +266,7 @@ gst_mqtt_sink_class_init (GstMqttSinkClass * klass)
   gstbasesink_class->render_list =
       GST_DEBUG_FUNCPTR (gst_mqtt_sink_render_list);
   gstbasesink_class->event = GST_DEBUG_FUNCPTR (gst_mqtt_sink_event);
+  gstbasesink_class->set_caps = GST_DEBUG_FUNCPTR (gst_mqtt_sink_set_caps);
 
   gst_element_class_set_static_metadata (gstelement_class,
       "MQTT sink", "Sink/MQTT",
@@ -372,6 +375,8 @@ gst_mqtt_sink_class_finalize (GObject * object)
   g_free (self->mqtt_client_handle);
   if (self->err)
     g_error_free (self->err);
+  if (self->in_caps)
+    gst_caps_unref (self->in_caps);
 
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
@@ -760,6 +765,27 @@ gst_mqtt_sink_event (GstBaseSink * basesink, GstEvent * event)
   }
 
   ret = GST_BASE_SINK_CLASS (parent_class)->event (basesink, event);
+
+  return ret;
+}
+
+/**
+ * @brief An implementation of the set_caps vmethod in GstBaseSinkClass
+ */
+static gboolean
+gst_mqtt_sink_set_caps (GstBaseSink * basesink, GstCaps * caps)
+{
+  GstMqttSink *self = GST_MQTT_SINK (basesink);
+  gboolean ret;
+
+  ret = gst_caps_replace (&self->in_caps, caps);
+
+  if (ret && gst_caps_is_fixed (self->in_caps)) {
+    char *caps_str = gst_caps_to_string (caps);
+
+    strncpy (self->mqtt_msg_hdr.gst_caps_str, caps_str, strlen (caps_str));
+    g_free (caps_str);
+  }
 
   return ret;
 }

--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -1,0 +1,199 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Wook Song <wook16.song@samsung.com>
+ */
+/**
+ * @file    mqttsink.c
+ * @date    08 Mar 2021
+ * @brief   Publish incoming data streams as a MQTT topic
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <gst/base/gstbasesink.h>
+
+#include "mqttsink.h"
+
+#define gst_mqtt_sink_parent_class parent_class
+G_DEFINE_TYPE (GstMqttSink, gst_mqtt_sink, GST_TYPE_BASE_SINK);
+
+GST_DEBUG_CATEGORY_STATIC (gst_mqtt_sink_debug);
+#define GST_CAT_DEFAULT gst_mqtt_sink_debug
+
+enum
+{
+  PROP_0,
+
+  PROP_LAST
+};
+
+/** Function prototype declarations */
+static void
+gst_mqtt_sink_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec);
+static void
+gst_mqtt_sink_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec);
+static void gst_mqtt_sink_class_finalize (GObject * object);
+
+static GstStateChangeReturn
+gst_mqtt_sink_change_state (GstElement * element, GstStateChange transition);
+
+static gboolean gst_mqtt_sink_start (GstBaseSink * basesink);
+static gboolean gst_mqtt_sink_stop (GstBaseSink * basesink);
+static gboolean gst_mqtt_sink_query (GstBaseSink * basesink, GstQuery * query);
+static GstFlowReturn
+gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * buffer);
+static GstFlowReturn
+gst_mqtt_sink_render_list (GstBaseSink * basesink, GstBufferList * list);
+static gboolean gst_mqtt_sink_event (GstBaseSink * basesink, GstEvent * event);
+
+/**
+ * @brief Initialize GstMqttSink object
+ */
+static void
+gst_mqtt_sink_init (GstMqttSink * self)
+{
+  /** @todo */
+}
+
+/**
+ * @brief Initialize GstMqttSinkClass object
+ */
+static void
+gst_mqtt_sink_class_init (GstMqttSinkClass * klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
+  GstBaseSinkClass *gstbasesink_class = GST_BASE_SINK_CLASS (klass);
+
+  GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, GST_MQTT_ELEM_NAME_SINK, 0,
+      "MQTT sink");
+
+  gobject_class->set_property = gst_mqtt_sink_set_property;
+  gobject_class->get_property = gst_mqtt_sink_get_property;
+  gobject_class->finalize = gst_mqtt_sink_class_finalize;
+
+  gstelement_class->change_state = gst_mqtt_sink_change_state;
+
+  gstbasesink_class->start = GST_DEBUG_FUNCPTR (gst_mqtt_sink_start);
+  gstbasesink_class->stop = GST_DEBUG_FUNCPTR (gst_mqtt_sink_stop);
+  gstbasesink_class->query = GST_DEBUG_FUNCPTR (gst_mqtt_sink_query);
+  gstbasesink_class->render = GST_DEBUG_FUNCPTR (gst_mqtt_sink_render);
+  gstbasesink_class->render_list =
+      GST_DEBUG_FUNCPTR (gst_mqtt_sink_render_list);
+  gstbasesink_class->event = GST_DEBUG_FUNCPTR (gst_mqtt_sink_event);
+
+  gst_element_class_set_static_metadata (gstelement_class,
+      "MQTT sink", "Sink/MQTT",
+      "Publish incoming data streams as a MQTT topic",
+      "Wook Song <wook16.song@samsung.com>");
+}
+
+/**
+ * @brief The setter for the mqttsink's properties
+ */
+static void
+gst_mqtt_sink_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  switch (prop_id) {
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief The getter for the mqttsink's properties
+ */
+static void
+gst_mqtt_sink_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  switch (prop_id) {
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief Finalize GstMqttSinkClass object
+ */
+static void
+gst_mqtt_sink_class_finalize (GObject * object)
+{
+  G_OBJECT_CLASS (parent_class)->finalize (object);
+}
+
+/**
+ * @brief Handle mqttsink's state change
+ */
+static GstStateChangeReturn
+gst_mqtt_sink_change_state (GstElement * element, GstStateChange transition)
+{
+  GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+
+  return ret;
+}
+
+/**
+ * @brief Start mqttsink, called when state changed null to ready
+ */
+static gboolean
+gst_mqtt_sink_start (GstBaseSink * basesink)
+{
+  return TRUE;
+}
+
+/**
+ * @brief Stop mqttsink, called when state changed ready to null
+ */
+static gboolean
+gst_mqtt_sink_stop (GstBaseSink * basesink)
+{
+  return TRUE;
+}
+
+/**
+ * @brief Perform queries on the element
+ */
+static gboolean
+gst_mqtt_sink_query (GstBaseSink * basesink, GstQuery * query)
+{
+  return TRUE;
+}
+
+/**
+ * @brief The callback to process each buffer receiving on the sink pad
+ */
+static GstFlowReturn
+gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * buffer)
+{
+  return GST_FLOW_OK;
+}
+
+/**
+ * @brief The callback to process GstBufferList (instead of a single buffer)
+ *        on the sink pad
+ */
+static GstFlowReturn
+gst_mqtt_sink_render_list (GstBaseSink * basesink, GstBufferList * list)
+{
+  return GST_FLOW_OK;
+}
+
+/**
+ * @brief Handle events arriving on the sink pad
+ */
+static gboolean
+gst_mqtt_sink_event (GstBaseSink * basesink, GstEvent * event)
+{
+  return TRUE;
+}

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -43,6 +43,7 @@ typedef struct _GstMqttSinkClass GstMqttSinkClass;
  */
 struct _GstMqttSink {
   GstBaseSink parent;
+  guint num_buffers;
 };
 
 /**

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -60,6 +60,7 @@ typedef enum _mqtt_sink_state_t {
 struct _GstMqttSink {
   GstBaseSink parent;
   guint num_buffers;
+  gsize max_msg_buf_size;
   GQuark gquark_err_tag;
   GError *err;
   gint64 base_time_epoch;

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -15,6 +15,7 @@
 #define __GST_MQTT_SINK_H__
 #include <gst/base/gstbasesink.h>
 #include <gst/gst.h>
+#include <MQTTClient.h>
 
 #include "mqttcommon.h"
 
@@ -44,6 +45,17 @@ typedef struct _GstMqttSinkClass GstMqttSinkClass;
 struct _GstMqttSink {
   GstBaseSink parent;
   guint num_buffers;
+  GQuark gquark_err_tag;
+  GError *err;
+  MQTTClient *mqtt_client_handle;
+  MQTTClient_connectOptions *mqtt_conn_opts;
+  gchar *mqtt_client_id;
+  gchar *mqtt_host_address;
+  gchar *mqtt_host_port;
+  gchar *mqtt_topic;
+  gulong mqtt_pub_wait_timeout;
+  gboolean mqtt_msg_hdr_update_flag;
+  GstMQTTMessageHdr *mqtt_msg_hdr;
 };
 
 /**

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -59,6 +59,7 @@ typedef enum _mqtt_sink_state_t {
  */
 struct _GstMqttSink {
   GstBaseSink parent;
+  GstCaps *in_caps;
   guint num_buffers;
   gsize max_msg_buf_size;
   GQuark gquark_err_tag;

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Wook Song <wook16.song@samsung.com>
+ */
+/**
+ * @file    mqttsink.h
+ * @date    08 Mar 2021
+ * @brief   Publish incoming data streams as a MQTT topic
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifndef __GST_MQTT_SINK_H__
+#define __GST_MQTT_SINK_H__
+#include <gst/base/gstbasesink.h>
+#include <gst/gst.h>
+
+#include "mqttcommon.h"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_MQTT_SINK \
+    (gst_mqtt_sink_get_type())
+#define GST_MQTT_SINK(obj) \
+    (G_TYPE_CHECK_INSTANCE_CAST ((obj), GST_TYPE_MQTT_SINK, GstMqttSink))
+#define GST_IS_MQTT_SINK(obj) \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GST_TYPE_MQTT_SINK))
+#define GST_MQTT_SINK_CAST(obj) \
+    ((GstMqttSink *) obj)
+#define GST_MQTT_SINK_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_CAST ((klass), GST_TYPE_MQTT_SINK, GstMqttSinkClass))
+#define GST_IS_MQTT_SINK_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_TYPE ((klass), GST_TYPE_MQTT_SINK))
+
+typedef struct _GstMqttSink GstMqttSink;
+typedef struct _GstMqttSinkClass GstMqttSinkClass;
+
+/**
+ * @brief GstMqttSink data structure.
+ *
+ * GstMqttSink inherits GstBaseSink.
+ */
+struct _GstMqttSink {
+  GstBaseSink parent;
+};
+
+/**
+ * @brief GstMqttSinkClass data structure.
+ *
+ * GstMqttSinkClass inherits GstBaseSinkClass.
+ */
+struct _GstMqttSinkClass {
+  GstBaseSinkClass parent_class;
+};
+
+GType gst_mqtt_sink_get_type (void);
+
+G_END_DECLS
+#endif /* !__GST_MQTT_SINK_H__ */

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -62,6 +62,7 @@ struct _GstMqttSink {
   guint num_buffers;
   GQuark gquark_err_tag;
   GError *err;
+  gint64 base_time_epoch;
   gchar *mqtt_client_id;
   gchar *mqtt_host_address;
   gchar *mqtt_host_port;

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -15,9 +15,20 @@
 #include <config.h>
 #endif
 
+#ifdef G_OS_WIN32
+#include <process.h>
+#else
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
 #include <gst/base/gstbasesrc.h>
+#include <MQTTAsync.h>
 
 #include "mqttsrc.h"
+
+static GstStaticPadTemplate src_pad_template = GST_STATIC_PAD_TEMPLATE ("src",
+    GST_PAD_SRC, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
 
 #define gst_mqtt_src_parent_class parent_class
 G_DEFINE_TYPE (GstMqttSrc, gst_mqtt_src, GST_TYPE_BASE_SRC);
@@ -29,9 +40,30 @@ enum
 {
   PROP_0,
 
+  PROP_MQTT_CLIENT_ID,
+  PROP_MQTT_HOST_ADDRESS,
+  PROP_MQTT_HOST_PORT,
+  PROP_MQTT_SUB_TOPIC,
+  PROP_MQTT_SUB_TIMEOUT,
+  PROP_MQTT_OPT_CLEANSESSION,
+  PROP_MQTT_OPT_KEEP_ALIVE_INTERVAL,
+
   PROP_LAST
 };
 
+enum
+{
+  DEFAULT_MQTT_OPT_CLEANSESSION = TRUE,
+  DEFAULT_MQTT_OPT_KEEP_ALIVE_INTERVAL = 1000000,       /* 1 minute */
+  DEFAULT_MQTT_SUB_TIMEOUT = 10000000,  /* 10 seconds */
+  DEFAULT_MQTT_SUB_TIMEOUT_MIN = 1000000,       /* 1 seconds */
+};
+
+static const gchar DEFAULT_MQTT_HOST_ADDRESS[] = "tcp://localhost";
+static const gchar DEFAULT_MQTT_HOST_PORT[] = "1883";
+static const gchar TAG_ERR_MQTTSRC[] = "ERROR: MQTTSrc";
+const gchar *DEFAULT_MQTT_CLIENT_ID;
+const gchar *DEFAULT_MQTT_SUB_TOPIC;
 
 /** Function prototype declarations */
 static void
@@ -47,38 +79,110 @@ gst_mqtt_src_change_state (GstElement * element, GstStateChange transition);
 
 static gboolean gst_mqtt_src_start (GstBaseSrc * basesrc);
 static gboolean gst_mqtt_src_stop (GstBaseSrc * basesrc);
-static gboolean gst_mqtt_src_event (GstBaseSrc * basesrc, GstEvent * event);
-static gboolean gst_mqtt_src_set_caps (GstBaseSrc * basesrc, GstCaps * caps);
 static GstCaps *gst_mqtt_src_get_caps (GstBaseSrc * basesrc, GstCaps * filter);
-static GstCaps *gst_mqtt_src_fixate (GstBaseSrc * basesrc, GstCaps * caps);
+
 static void
 gst_mqtt_src_get_times (GstBaseSrc * basesrc, GstBuffer * buffer,
     GstClockTime * start, GstClockTime * end);
-static gboolean gst_mqtt_src_get_size (GstBaseSrc * basesrc, guint64 * size);
 static gboolean gst_mqtt_src_is_seekable (GstBaseSrc * basesrc);
 static GstFlowReturn
 gst_mqtt_src_create (GstBaseSrc * basesrc, guint64 offset, guint size,
     GstBuffer ** buf);
-static GstFlowReturn
-gst_mqtt_src_alloc (GstBaseSrc * basesrc, guint64 offset, guint size,
-    GstBuffer ** buf);
-static GstFlowReturn
-gst_mqtt_src_fill (GstBaseSrc * basesrc, guint64 offset, guint size,
-    GstBuffer * buf);
+
+static gchar *gst_mqtt_src_get_client_id (GstMqttSrc * self);
+static void gst_mqtt_src_set_client_id (GstMqttSrc * self, const gchar * id);
+static gchar *gst_mqtt_src_get_host_address (GstMqttSrc * self);
+static void gst_mqtt_src_set_host_address (GstMqttSrc * self,
+    const gchar * addr);
+static gchar *gst_mqtt_src_get_host_port (GstMqttSrc * self);
+static void gst_mqtt_src_set_host_port (GstMqttSrc * self, const gchar * port);
+static gint64 gst_mqtt_src_get_sub_timeout (GstMqttSrc * self);
+static void gst_mqtt_src_set_sub_timeout (GstMqttSrc * self, const gint64 t);
+static gchar *gst_mqtt_src_get_sub_topic (GstMqttSrc * self);
+static void gst_mqtt_src_set_sub_topic (GstMqttSrc * self, const gchar * topic);
+static gboolean gst_mqtt_src_get_opt_cleansession (GstMqttSrc * self);
+static void gst_mqtt_src_set_opt_cleansession (GstMqttSrc * self,
+    const gboolean val);
+static gint gst_mqtt_src_get_opt_keep_alive_interval (GstMqttSrc * self);
+static void gst_mqtt_src_set_opt_keep_alive_interval (GstMqttSrc * self,
+    const gint num);
+
+static void cb_mqtt_on_connection_lost (void *context, char *cause);
+static void cb_mqtt_on_delivery_complete (void *context, MQTTAsync_token token);
+static int cb_mqtt_on_message_arrived (void *context, char *topic_name,
+    int topic_len, MQTTAsync_message * message);
+static void cb_mqtt_on_connect (void *context,
+    MQTTAsync_successData * response);
+static void cb_mqtt_on_connect_failure (void *context,
+    MQTTAsync_failureData * response);
+static void cb_mqtt_on_subscribe (void *context,
+    MQTTAsync_successData * response);
+static void cb_mqtt_on_subscribe_failure (void *context,
+    MQTTAsync_failureData * response);
+
+static void cb_memory_wrapped_destroy (void *p);
+
+static GstMQTTMessageHdr *_extract_mqtt_msg_hdr_from (GstMemory * mem,
+    GstMemory ** hdr_mem, GstMapInfo * hdr_map_info);
+
 
 /** Function defintions */
+/**
+ * @brief Initialize GstMqttSrc object
+ */
 static void
 gst_mqtt_src_init (GstMqttSrc * self)
 {
-  /** @todo */
+  MQTTAsync_connectOptions conn_opts = MQTTAsync_connectOptions_initializer;
+
+  self->gquark_err_tag = g_quark_from_string (TAG_ERR_MQTTSRC);
+
+  self->mqtt_client_handle = g_malloc0 (sizeof (*self->mqtt_client_handle));
+  if (!self->mqtt_client_handle) {
+    self->err = g_error_new (self->gquark_err_tag, ENOMEM,
+        "%s: self->mqtt_client_handle: %s", __func__, g_strerror (ENOMEM));
+    return;
+  }
+  self->mqtt_conn_opts = g_malloc0 (sizeof (*self->mqtt_conn_opts));
+  if (!self->mqtt_conn_opts) {
+    self->err = g_error_new (self->gquark_err_tag, ENOMEM,
+        "%s: self->mqtt_conn_opts: %s", __func__, g_strerror (ENOMEM));
+    return;
+  }
+  self->mqtt_conn_opts = memcpy (self->mqtt_conn_opts, &conn_opts,
+      sizeof (conn_opts));
+  /** init mqttsrc properties */
+  self->mqtt_client_id = (gchar *) DEFAULT_MQTT_CLIENT_ID;
+  self->mqtt_host_address = g_strdup (DEFAULT_MQTT_HOST_ADDRESS);
+  self->mqtt_host_port = g_strdup (DEFAULT_MQTT_HOST_PORT);
+  self->mqtt_topic = (gchar *) DEFAULT_MQTT_SUB_TOPIC;
+  self->mqtt_sub_timeout = (gint64) DEFAULT_MQTT_SUB_TIMEOUT;
+  self->mqtt_conn_opts->cleansession = DEFAULT_MQTT_OPT_CLEANSESSION;
+  self->mqtt_conn_opts->keepAliveInterval =
+      DEFAULT_MQTT_OPT_KEEP_ALIVE_INTERVAL;
+  self->mqtt_conn_opts->onSuccess = cb_mqtt_on_connect;
+  self->mqtt_conn_opts->onFailure = cb_mqtt_on_connect_failure;
+
+  /** init private member variables */
+  self->aqueue = g_async_queue_new ();
+  self->is_connected = FALSE;
+  self->is_subscribed = FALSE;
+  g_cond_init (&self->gcond);
 }
 
+/**
+ * @brief Initialize GstMqttSrcClass object
+ */
 static void
 gst_mqtt_src_class_init (GstMqttSrcClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
   GstBaseSrcClass *gstbasesrc_class = GST_BASE_SRC_CLASS (klass);
+
+  DEFAULT_MQTT_CLIENT_ID = g_strdup_printf ("%s/%u/%u", g_get_host_name (),
+      getpid (), g_random_int_range (0, 0xFF));
+  DEFAULT_MQTT_SUB_TOPIC = g_strdup_printf ("%s/topic", DEFAULT_MQTT_CLIENT_ID);
 
   GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, GST_MQTT_ELEM_NAME_SRC, 0,
       "MQTT src");
@@ -87,105 +191,282 @@ gst_mqtt_src_class_init (GstMqttSrcClass * klass)
   gobject_class->get_property = gst_mqtt_src_get_property;
   gobject_class->finalize = gst_mqtt_src_class_finalize;
 
+  g_object_class_install_property (gobject_class, PROP_MQTT_CLIENT_ID,
+      g_param_spec_string ("client-id", "Client ID",
+          "The client identifier passed to the server (broker)",
+          DEFAULT_MQTT_CLIENT_ID, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_MQTT_HOST_ADDRESS,
+      g_param_spec_string ("host", "Host", "Host (broker) to connect to",
+          DEFAULT_MQTT_HOST_ADDRESS,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_MQTT_HOST_PORT,
+      g_param_spec_string ("port", "Port",
+          "Network port of host (broker) to connect to", DEFAULT_MQTT_HOST_PORT,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_MQTT_SUB_TIMEOUT,
+      g_param_spec_int64 ("sub-timeout", "Timeout for receiving a message",
+          "The timeout (in microseconds) for receiving a message from subscribed topic",
+          1000000, G_MAXINT64, DEFAULT_MQTT_SUB_TIMEOUT,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_MQTT_SUB_TOPIC,
+      g_param_spec_string ("sub-topic", "Topic to Subscribe",
+          "The topic's name to subscribe", DEFAULT_MQTT_SUB_TOPIC,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_MQTT_OPT_CLEANSESSION,
+      g_param_spec_boolean ("cleansession", "Cleansession",
+          "When it is TRUE, the state information is discarded at connect and disconnect.",
+          DEFAULT_MQTT_OPT_CLEANSESSION,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class,
+      PROP_MQTT_OPT_KEEP_ALIVE_INTERVAL,
+      g_param_spec_int ("keep-alive-interval", "Keep Alive Interval",
+          "The maximum time (in seconds) that should pass without communication between the client and the server (broker)",
+          1, G_MAXINT32, DEFAULT_MQTT_OPT_KEEP_ALIVE_INTERVAL,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
   gstelement_class->change_state =
       GST_DEBUG_FUNCPTR (gst_mqtt_src_change_state);
-  gst_element_class_set_static_metadata (gstelement_class,
-      "MQTT Source",
-      "Source/MQTT",
-      "Subscribe a MQTT topic and push incoming data to the GStreamer pipeline",
-      "Wook Song <wook16.song@samsung.com>");
 
   gstbasesrc_class->start = GST_DEBUG_FUNCPTR (gst_mqtt_src_start);
   gstbasesrc_class->stop = GST_DEBUG_FUNCPTR (gst_mqtt_src_stop);
-  gstbasesrc_class->event = GST_DEBUG_FUNCPTR (gst_mqtt_src_event);
-  gstbasesrc_class->set_caps = GST_DEBUG_FUNCPTR (gst_mqtt_src_set_caps);
   gstbasesrc_class->get_caps = GST_DEBUG_FUNCPTR (gst_mqtt_src_get_caps);
-  gstbasesrc_class->fixate = GST_DEBUG_FUNCPTR (gst_mqtt_src_fixate);
   gstbasesrc_class->get_times = GST_DEBUG_FUNCPTR (gst_mqtt_src_get_times);
-  gstbasesrc_class->get_size = GST_DEBUG_FUNCPTR (gst_mqtt_src_get_size);
   gstbasesrc_class->is_seekable = GST_DEBUG_FUNCPTR (gst_mqtt_src_is_seekable);
   gstbasesrc_class->create = GST_DEBUG_FUNCPTR (gst_mqtt_src_create);
-  gstbasesrc_class->alloc = GST_DEBUG_FUNCPTR (gst_mqtt_src_alloc);
-  gstbasesrc_class->fill = GST_DEBUG_FUNCPTR (gst_mqtt_src_fill);
+
+  gst_element_class_set_static_metadata (gstelement_class,
+      "MQTT Source", "Source/MQTT",
+      "Subscribe a MQTT topic and push incoming data to the GStreamer pipeline",
+      "Wook Song <wook16.song@samsung.com>");
+  gst_element_class_add_static_pad_template (gstelement_class,
+      &src_pad_template);
 }
 
+/**
+ * @brief The setter for the mqttsrc's properties
+ */
 static void
 gst_mqtt_src_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
+  GstMqttSrc *self = GST_MQTT_SRC (object);
+
   switch (prop_id) {
+    case PROP_MQTT_CLIENT_ID:
+      gst_mqtt_src_set_client_id (self, g_value_get_string (value));
+      break;
+    case PROP_MQTT_HOST_ADDRESS:
+      gst_mqtt_src_set_host_address (self, g_value_get_string (value));
+      break;
+    case PROP_MQTT_HOST_PORT:
+      gst_mqtt_src_set_host_port (self, g_value_get_string (value));
+      break;
+    case PROP_MQTT_SUB_TIMEOUT:
+      gst_mqtt_src_set_sub_timeout (self, g_value_get_int64 (value));
+      break;
+    case PROP_MQTT_SUB_TOPIC:
+      gst_mqtt_src_set_sub_topic (self, g_value_get_string (value));
+      break;
+    case PROP_MQTT_OPT_CLEANSESSION:
+      gst_mqtt_src_set_opt_cleansession (self, g_value_get_boolean (value));
+      break;
+    case PROP_MQTT_OPT_KEEP_ALIVE_INTERVAL:
+      gst_mqtt_src_set_opt_keep_alive_interval (self, g_value_get_int (value));
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
   }
 }
 
+/**
+ * @brief The getter for the mqttsrc's properties
+ */
 static void
 gst_mqtt_src_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec)
 {
+  GstMqttSrc *self = GST_MQTT_SRC (object);
+
   switch (prop_id) {
+    case PROP_MQTT_CLIENT_ID:
+      g_value_set_string (value, gst_mqtt_src_get_client_id (self));
+      break;
+    case PROP_MQTT_HOST_ADDRESS:
+      g_value_set_string (value, gst_mqtt_src_get_host_address (self));
+      break;
+    case PROP_MQTT_HOST_PORT:
+      g_value_set_string (value, gst_mqtt_src_get_host_port (self));
+      break;
+    case PROP_MQTT_SUB_TIMEOUT:
+      g_value_set_int64 (value, gst_mqtt_src_get_sub_timeout (self));
+      break;
+    case PROP_MQTT_SUB_TOPIC:
+      g_value_set_string (value, gst_mqtt_src_get_sub_topic (self));
+      break;
+    case PROP_MQTT_OPT_CLEANSESSION:
+      g_value_set_boolean (value, gst_mqtt_src_get_opt_cleansession (self));
+      break;
+    case PROP_MQTT_OPT_KEEP_ALIVE_INTERVAL:
+      g_value_set_int (value, gst_mqtt_src_get_opt_keep_alive_interval (self));
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
   }
 }
 
+/**
+ * @brief Finalize GstMqttSrcClass object
+ */
 static void
 gst_mqtt_src_class_finalize (GObject * object)
 {
+  GstMqttSrc *self = GST_MQTT_SRC (object);
+
+  g_free (self->mqtt_host_address);
+  g_free (self->mqtt_host_port);
+  g_free (self->mqtt_client_handle);
+  g_free (self->mqtt_conn_opts);
+  if (self->err)
+    g_error_free (self->err);
+
+  g_clear_pointer (&self->aqueue, g_async_queue_unref);
+
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 
+/**
+ * @brief Handle mqttsrc's state change
+ */
 static GstStateChangeReturn
 gst_mqtt_src_change_state (GstElement * element, GstStateChange transition)
 {
   GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+  GstMqttSrc *self = GST_MQTT_SRC (element);
+
+  switch (transition) {
+    case GST_STATE_CHANGE_NULL_TO_READY:
+      GST_INFO_OBJECT (self, "GST_STATE_CHANGE_NULL_TO_READY");
+      if (self->err) {
+        g_printerr ("%s: %s\n", g_quark_to_string (self->err->domain),
+            self->err->message);
+        return GST_STATE_CHANGE_FAILURE;
+      }
+      break;
+    case GST_STATE_CHANGE_READY_TO_PAUSED:
+      GST_INFO_OBJECT (self, "GST_STATE_CHANGE_READY_TO_PAUSED");
+      break;
+    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
+      GST_INFO_OBJECT (self, "GST_STATE_CHANGE_PAUSED_TO_PLAYING");
+      break;
+    default:
+      break;
+  }
+
+  ret = GST_ELEMENT_CLASS (parent_class)->change_state (element, transition);
+
+  switch (transition) {
+    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
+      GST_INFO_OBJECT (self, "GST_STATE_CHANGE_PLAYING_TO_PAUSED");
+      break;
+    case GST_STATE_CHANGE_PAUSED_TO_READY:
+      GST_INFO_OBJECT (self, "GST_STATE_CHANGE_PAUSED_TO_READY");
+      break;
+    case GST_STATE_CHANGE_READY_TO_NULL:
+      GST_INFO_OBJECT (self, "GST_STATE_CHANGE_READY_TO_NULL");
+    default:
+      break;
+  }
 
   return ret;
 }
 
+/**
+ * @brief Start mqttsrc, called when state changed null to ready
+ */
 static gboolean
 gst_mqtt_src_start (GstBaseSrc * basesrc)
 {
+  GstMqttSrc *self = GST_MQTT_SRC (basesrc);
+  gchar *haddr = g_strdup_printf ("%s:%s", self->mqtt_host_address,
+      self->mqtt_host_port);
+  int ret;
+
+  /**
+   * @todo Support other persistence mechanisms
+   *    MQTTCLIENT_PERSISTENCE_NONE: A memory-based persistence mechanism
+   *    MQTTCLIENT_PERSISTENCE_DEFAULT: The default file system-based
+   *                                    persistence mechanism
+   *    MQTTCLIENT_PERSISTENCE_USER: An application-specific persistence
+   *                                 mechanism
+   */
+  ret = MQTTAsync_create (self->mqtt_client_handle, haddr,
+      self->mqtt_client_id, MQTTCLIENT_PERSISTENCE_DEFAULT, NULL);
+  g_free (haddr);
+  if (ret != MQTTASYNC_SUCCESS)
+    return FALSE;
+
+  MQTTAsync_setCallbacks (*self->mqtt_client_handle, self,
+      cb_mqtt_on_connection_lost, cb_mqtt_on_message_arrived,
+      cb_mqtt_on_delivery_complete);
+
+  self->mqtt_conn_opts->context = self;
+  ret = MQTTAsync_connect (*self->mqtt_client_handle, self->mqtt_conn_opts);
+  if (ret != MQTTASYNC_SUCCESS)
+    return FALSE;
   return TRUE;
 }
 
+/**
+ * @brief Stop mqttsrc, called when state changed ready to null
+ */
 static gboolean
 gst_mqtt_src_stop (GstBaseSrc * basesrc)
 {
+  GstMqttSrc *self = GST_MQTT_SRC (basesrc);
+
+  /* todo */
+  MQTTAsync_disconnect (*self->mqtt_client_handle, NULL);
+  MQTTAsync_destroy (self->mqtt_client_handle);
+
   return TRUE;
 }
 
-static gboolean
-gst_mqtt_src_event (GstBaseSrc * basesrc, GstEvent * event)
-{
-  return TRUE;
-}
-
-static gboolean
-gst_mqtt_src_set_caps (GstBaseSrc * basesrc, GstCaps * caps)
-{
-  return TRUE;
-}
-
+/**
+ * @brief Get caps of subclass
+ */
 static GstCaps *
 gst_mqtt_src_get_caps (GstBaseSrc * basesrc, GstCaps * filter)
 {
-  GstCaps *caps = gst_caps_new_empty ();
+  GstMqttSrc *self = GST_MQTT_SRC (basesrc);
+  GstPad *pad = basesrc->srcpad;
+  GstCaps *cur_caps = gst_pad_get_current_caps (pad);
+  GstCaps *caps = gst_caps_new_any ();
+
+  GST_OBJECT_LOCK (self);
+  if (cur_caps) {
+    GstCaps *intersection =
+        gst_caps_intersect_full (cur_caps, caps, GST_CAPS_INTERSECT_FIRST);
+
+    gst_caps_unref (cur_caps);
+    gst_caps_unref (caps);
+    caps = intersection;
+  }
+  GST_OBJECT_UNLOCK (self);
 
   return caps;
 }
 
-static GstCaps *
-gst_mqtt_src_fixate (GstBaseSrc * basesrc, GstCaps * caps)
-{
-  caps = gst_caps_make_writable (caps);
-  caps = GST_BASE_SRC_CLASS (parent_class)->fixate (basesrc, caps);
-
-  return caps;
-}
-
+/**
+ * @brief Return the time information of the given buffer
+ */
 static void
 gst_mqtt_src_get_times (GstBaseSrc * basesrc, GstBuffer * buffer,
     GstClockTime * start, GstClockTime * end)
@@ -193,35 +474,400 @@ gst_mqtt_src_get_times (GstBaseSrc * basesrc, GstBuffer * buffer,
   return;
 }
 
-static gboolean
-gst_mqtt_src_get_size (GstBaseSrc * basesrc, guint64 * size)
-{
-  return TRUE;
-}
-
+/**
+ * @brief Check if source supports seeking
+ * @note Seeking is not supported since this element handles live subscription data.
+ */
 static gboolean
 gst_mqtt_src_is_seekable (GstBaseSrc * basesrc)
 {
-  return TRUE;
+  return FALSE;
 }
 
+/**
+ * @brief Create a buffer containing the subscribed data
+ */
 static GstFlowReturn
 gst_mqtt_src_create (GstBaseSrc * basesrc, guint64 offset, guint size,
     GstBuffer ** buf)
 {
+  GstMqttSrc *self = GST_MQTT_SRC (basesrc);
+  gint64 elapsed = self->mqtt_sub_timeout;
+
+  GST_OBJECT_LOCK (self);
+  while ((!self->is_connected) || (!self->is_subscribed)) {
+    g_cond_wait (&self->gcond, GST_OBJECT_GET_LOCK (self));
+    if (self->err) {
+      GST_OBJECT_UNLOCK (self);
+      goto ret_flow_err;
+    }
+  }
+  GST_OBJECT_UNLOCK (self);
+
+  while (elapsed > 0) {
+    *buf = g_async_queue_timeout_pop (self->aqueue,
+        DEFAULT_MQTT_SUB_TIMEOUT_MIN);
+    if (*buf || self->err)
+      break;
+    elapsed = elapsed - DEFAULT_MQTT_SUB_TIMEOUT_MIN;
+  }
+
+  if (*buf == NULL) {
+    /** @todo: Send EoS here */
+    if (!self->err)
+      self->err = g_error_new (self->gquark_err_tag, GST_FLOW_EOS,
+          "%s: Timeout for receiving a message has been expired. Regarding as an error",
+          __func__);
+    goto ret_flow_err;
+  }
+
   return GST_FLOW_OK;
+
+ret_flow_err:
+  if (self->err) {
+    g_printerr ("%s: %s\n", g_quark_to_string (self->err->domain),
+        self->err->message);
+  }
+  return GST_FLOW_ERROR;
 }
 
-static GstFlowReturn
-gst_mqtt_src_alloc (GstBaseSrc * basesrc, guint64 offset, guint size,
-    GstBuffer ** buf)
+/**
+ * @brief Getter for the 'client-id' property.
+ */
+static gchar *
+gst_mqtt_src_get_client_id (GstMqttSrc * self)
 {
-  return GST_FLOW_OK;
+  return self->mqtt_client_id;
 }
 
-static GstFlowReturn
-gst_mqtt_src_fill (GstBaseSrc * basesrc, guint64 offset, guint size,
-    GstBuffer * buf)
+/**
+ * @brief Setter for the 'client-id' property.
+ */
+static void
+gst_mqtt_src_set_client_id (GstMqttSrc * self, const gchar * id)
 {
-  return GST_FLOW_OK;
+  GST_OBJECT_LOCK (self);
+  self->mqtt_client_id = g_strdup (id);
+  GST_OBJECT_UNLOCK (self);
+  g_free ((void *) DEFAULT_MQTT_CLIENT_ID);
+}
+
+/**
+ * @brief Getter for the 'host' property.
+ */
+static gchar *
+gst_mqtt_src_get_host_address (GstMqttSrc * self)
+{
+  return self->mqtt_host_address;
+}
+
+/**
+ * @brief Setter for the 'host' property
+ */
+static void
+gst_mqtt_src_set_host_address (GstMqttSrc * self, const gchar * addr)
+{
+  /**
+   * @todo Handle the case where the addr is changed at runtime
+   */
+  GST_OBJECT_LOCK (self);
+  self->mqtt_host_address = g_strdup (addr);
+  GST_OBJECT_UNLOCK (self);
+}
+
+/**
+ * @brief Getter for the 'port' property.
+ */
+static gchar *
+gst_mqtt_src_get_host_port (GstMqttSrc * self)
+{
+  return self->mqtt_host_port;
+}
+
+/**
+ * @brief Setter for the 'port' property
+ */
+static void
+gst_mqtt_src_set_host_port (GstMqttSrc * self, const gchar * port)
+{
+  GST_OBJECT_LOCK (self);
+  self->mqtt_host_port = g_strdup (port);
+  GST_OBJECT_UNLOCK (self);
+}
+
+/**
+ * @brief Getter for the 'sub-timeout' property
+ */
+static gint64
+gst_mqtt_src_get_sub_timeout (GstMqttSrc * self)
+{
+  return self->mqtt_sub_timeout;
+}
+
+/**
+ * @brief Setter for the 'sub-timeout' property
+ */
+static void
+gst_mqtt_src_set_sub_timeout (GstMqttSrc * self, const gint64 t)
+{
+  GST_OBJECT_LOCK (self);
+  self->mqtt_sub_timeout = t;
+  GST_OBJECT_UNLOCK (self);
+}
+
+/**
+ * @brief Getter for the 'sub-topic' property
+ */
+static gchar *
+gst_mqtt_src_get_sub_topic (GstMqttSrc * self)
+{
+  return self->mqtt_topic;
+}
+
+/**
+ * @brief Setter for the 'sub-topic' property
+ */
+static void
+gst_mqtt_src_set_sub_topic (GstMqttSrc * self, const gchar * topic)
+{
+  GST_OBJECT_LOCK (self);
+  self->mqtt_topic = g_strdup (topic);
+  GST_OBJECT_UNLOCK (self);
+  g_free ((void *) DEFAULT_MQTT_SUB_TOPIC);
+}
+
+/**
+ * @brief Getter for the 'cleansession' property.
+ */
+static gboolean
+gst_mqtt_src_get_opt_cleansession (GstMqttSrc * self)
+{
+  return self->mqtt_conn_opts->cleansession;
+}
+
+/**
+ * @brief Setter for the 'cleansession' property.
+ */
+static void
+gst_mqtt_src_set_opt_cleansession (GstMqttSrc * self, const gboolean val)
+{
+  GST_OBJECT_LOCK (self);
+  self->mqtt_conn_opts->cleansession = val;
+  GST_OBJECT_UNLOCK (self);
+}
+
+/**
+ * @brief Getter for the 'keep-alive-interval' property
+ */
+static gint
+gst_mqtt_src_get_opt_keep_alive_interval (GstMqttSrc * self)
+{
+  return self->mqtt_conn_opts->keepAliveInterval;
+}
+
+/**
+ * @brief Setter for the 'keep-alive-interval' property
+ */
+static void
+gst_mqtt_src_set_opt_keep_alive_interval (GstMqttSrc * self, const gint num)
+{
+  GST_OBJECT_LOCK (self);
+  self->mqtt_conn_opts->keepAliveInterval = num;
+  GST_OBJECT_UNLOCK (self);
+}
+
+/**
+  * @brief A callback to handle the connection lost to the broker
+  */
+static void
+cb_mqtt_on_connection_lost (void *context, char *cause)
+{
+  GstMqttSrc *self = GST_MQTT_SRC_CAST (context);
+
+  GST_OBJECT_LOCK (self);
+  self->is_connected = FALSE;
+  self->is_subscribed = FALSE;
+  g_cond_broadcast (&self->gcond);
+  self->err = g_error_new (self->gquark_err_tag, EHOSTDOWN,
+      "Connection to the host (broker) has been lost: %s",
+      g_strerror (EHOSTDOWN));
+  GST_OBJECT_UNLOCK (self);
+}
+
+/**
+  * @brief A callback to handle the post-processing of the delivered message
+  * @todo Fill the function body
+  */
+static void
+cb_mqtt_on_delivery_complete (void *context, MQTTAsync_token token)
+{
+
+}
+
+/**
+  * @brief A callback to handle the arrived message
+  */
+static int
+cb_mqtt_on_message_arrived (void *context, char *topic_name, int topic_len,
+    MQTTAsync_message * message)
+{
+  const int size = message->payloadlen;
+  guint8 *data = message->payload;
+  GstMQTTMessageHdr *mqtt_msg_hdr;
+  GstMapInfo hdr_map_info;
+  GstMemory *recieved_mem;
+  GstMemory *hdr_mem;
+  GstBuffer *buffer;
+  GstMqttSrc *self;
+  gsize offset;
+  guint i;
+
+  self = GST_MQTT_SRC_CAST (context);
+  recieved_mem = gst_memory_new_wrapped (0, data, size, 0, size, message,
+      (GDestroyNotify) cb_memory_wrapped_destroy);
+  if (!recieved_mem) {
+    self->err = g_error_new (self->gquark_err_tag, ENODATA,
+        "%s: failed to wrap the raw data of recieved message in GstMemory: %s",
+        __func__, g_strerror (ENODATA));
+    return TRUE;
+  }
+
+  mqtt_msg_hdr = _extract_mqtt_msg_hdr_from (recieved_mem, &hdr_mem,
+      &hdr_map_info);
+  if (!mqtt_msg_hdr) {
+    self->err = g_error_new (self->gquark_err_tag, ENODATA,
+        "%s: failed to extract header information from recieved message: %s",
+        __func__, g_strerror (ENODATA));
+    goto ret_unref_recieved_mem;
+  }
+
+  buffer = gst_buffer_new ();
+  offset = GST_MQTT_LEN_MSG_HDR;
+  for (i = 0; i < mqtt_msg_hdr->num_mems; ++i) {
+    GstMemory *each_memory;
+    int each_size;
+
+    each_size = mqtt_msg_hdr->size_mems[i];
+    each_memory = gst_memory_share (recieved_mem, offset, each_size);
+    gst_buffer_append_memory (buffer, each_memory);
+    offset += each_size;
+  }
+
+  g_async_queue_push (self->aqueue, buffer);
+
+  gst_memory_unmap (hdr_mem, &hdr_map_info);
+  gst_memory_unref (hdr_mem);
+
+ret_unref_recieved_mem:
+  gst_memory_unref (recieved_mem);
+
+  return TRUE;
+}
+
+/**
+  * @brief A callback invoked when destroying the GstMemory which wrapped the arrived message
+  */
+static void
+cb_memory_wrapped_destroy (void *p)
+{
+  MQTTAsync_message *msg = p;
+
+  MQTTAsync_freeMessage (&msg);
+}
+
+/**
+  * @brief A callback invoked when the connection is established
+  */
+static void
+cb_mqtt_on_connect (void *context, MQTTAsync_successData * response)
+{
+  GstMqttSrc *self = GST_MQTT_SRC (context);
+  MQTTAsync_responseOptions opts = MQTTAsync_responseOptions_initializer;
+  int ret;
+
+  GST_OBJECT_LOCK (self);
+  self->is_connected = TRUE;
+  g_cond_signal (&self->gcond);
+  GST_OBJECT_UNLOCK (self);
+
+  opts.context = self;
+  opts.onSuccess = cb_mqtt_on_subscribe;
+  opts.onFailure = cb_mqtt_on_subscribe_failure;
+
+  /** @todo Support QoS option */
+  ret = MQTTAsync_subscribe (*self->mqtt_client_handle, self->mqtt_topic, 1,
+      &opts);
+  if (ret != MQTTASYNC_SUCCESS) {
+    g_printerr ("Failed to start subscribe, return code %d\n", ret);
+    return;
+  }
+
+  GST_OBJECT_LOCK (self);
+  self->is_subscribed = TRUE;
+  GST_OBJECT_UNLOCK (self);
+}
+
+/**
+  * @brief A callback invoked when it is failed to connect to the broker
+  */
+static void
+cb_mqtt_on_connect_failure (void *context, MQTTAsync_failureData * response)
+{
+  GstMqttSrc *self = GST_MQTT_SRC (context);
+
+  GST_OBJECT_LOCK (self);
+  self->is_connected = FALSE;
+  self->err = g_error_new (self->gquark_err_tag, response->code,
+      "%s: failed to connect to the broker: %s", __func__, response->message);
+  g_cond_signal (&self->gcond);
+  GST_OBJECT_UNLOCK (self);
+}
+
+/**
+ * @brief An implementation for the onSuccess callback of MQTTAsync_responseOptions
+ */
+static void
+cb_mqtt_on_subscribe (void *context, MQTTAsync_successData * response)
+{
+  GstMqttSrc *self = GST_MQTT_SRC (context);
+
+  GST_OBJECT_LOCK (self);
+  self->is_subscribed = TRUE;
+  g_cond_signal (&self->gcond);
+  GST_OBJECT_UNLOCK (self);
+}
+
+/**
+ * @brief An implementation for the onFailure callback of MQTTAsync_responseOptions
+ */
+static void
+cb_mqtt_on_subscribe_failure (void *context, MQTTAsync_failureData * response)
+{
+  GstMqttSrc *self = GST_MQTT_SRC (context);
+
+  GST_OBJECT_LOCK (self);
+  self->is_connected = FALSE;
+  self->err = g_error_new (self->gquark_err_tag, response->code,
+      "%s: failed to subscribe the given topic, %s: %s", __func__,
+      self->mqtt_topic, response->message);
+  g_cond_signal (&self->gcond);
+  GST_OBJECT_UNLOCK (self);
+}
+
+/**
+ * @brief A utility function to extract header information from a received message
+ */
+static GstMQTTMessageHdr *
+_extract_mqtt_msg_hdr_from (GstMemory * mem, GstMemory ** hdr_mem,
+    GstMapInfo * hdr_map_info)
+{
+  *hdr_mem = gst_memory_share (mem, 0, GST_MQTT_LEN_MSG_HDR);
+  g_return_val_if_fail (*hdr_mem != NULL, NULL);
+
+  if (!gst_memory_map (*hdr_mem, hdr_map_info, GST_MAP_READ)) {
+    gst_memory_unref (*hdr_mem);
+    return NULL;
+  }
+
+  return (GstMQTTMessageHdr *) hdr_map_info->data;
 }

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -570,6 +570,7 @@ gst_mqtt_src_set_host_address (GstMqttSrc * self, const gchar * addr)
   /**
    * @todo Handle the case where the addr is changed at runtime
    */
+  g_free (self->mqtt_host_address);
   GST_OBJECT_LOCK (self);
   self->mqtt_host_address = g_strdup (addr);
   GST_OBJECT_UNLOCK (self);
@@ -590,6 +591,7 @@ gst_mqtt_src_get_host_port (GstMqttSrc * self)
 static void
 gst_mqtt_src_set_host_port (GstMqttSrc * self, const gchar * port)
 {
+  g_free (self->mqtt_host_port);
   GST_OBJECT_LOCK (self);
   self->mqtt_host_port = g_strdup (port);
   GST_OBJECT_UNLOCK (self);

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -160,7 +160,8 @@ gst_mqtt_src_init (GstMqttSrc * self)
   self->aqueue = g_async_queue_new ();
   self->is_connected = FALSE;
   self->is_subscribed = FALSE;
-  g_cond_init (&self->gcond);
+  g_cond_init (&self->mqtt_src_gcond);
+  g_mutex_init (&self->mqtt_src_mutex);
 }
 
 /**
@@ -436,12 +437,10 @@ gst_mqtt_src_stop (GstBaseSrc * basesrc)
 static GstCaps *
 gst_mqtt_src_get_caps (GstBaseSrc * basesrc, GstCaps * filter)
 {
-  GstMqttSrc *self = GST_MQTT_SRC (basesrc);
   GstPad *pad = basesrc->srcpad;
   GstCaps *cur_caps = gst_pad_get_current_caps (pad);
   GstCaps *caps = gst_caps_new_any ();
 
-  GST_OBJECT_LOCK (self);
   if (cur_caps) {
     GstCaps *intersection =
         gst_caps_intersect_full (cur_caps, caps, GST_CAPS_INTERSECT_FIRST);
@@ -450,7 +449,6 @@ gst_mqtt_src_get_caps (GstBaseSrc * basesrc, GstCaps * filter)
     gst_caps_unref (caps);
     caps = intersection;
   }
-  GST_OBJECT_UNLOCK (self);
 
   return caps;
 }
@@ -485,15 +483,15 @@ gst_mqtt_src_create (GstBaseSrc * basesrc, guint64 offset, guint size,
   GstMqttSrc *self = GST_MQTT_SRC (basesrc);
   gint64 elapsed = self->mqtt_sub_timeout;
 
-  GST_OBJECT_LOCK (self);
+  g_mutex_lock (&self->mqtt_src_mutex);
   while ((!self->is_connected) || (!self->is_subscribed)) {
-    g_cond_wait (&self->gcond, GST_OBJECT_GET_LOCK (self));
+    g_cond_wait (&self->mqtt_src_gcond, &self->mqtt_src_mutex);
     if (self->err) {
-      GST_OBJECT_UNLOCK (self);
+      g_mutex_unlock (&self->mqtt_src_mutex);
       goto ret_flow_err;
     }
   }
-  GST_OBJECT_UNLOCK (self);
+  g_mutex_unlock (&self->mqtt_src_mutex);
 
   while (elapsed > 0) {
     *buf = g_async_queue_timeout_pop (self->aqueue,
@@ -537,9 +535,7 @@ gst_mqtt_src_get_client_id (GstMqttSrc * self)
 static void
 gst_mqtt_src_set_client_id (GstMqttSrc * self, const gchar * id)
 {
-  GST_OBJECT_LOCK (self);
   self->mqtt_client_id = g_strdup (id);
-  GST_OBJECT_UNLOCK (self);
   g_free ((void *) DEFAULT_MQTT_CLIENT_ID);
 }
 
@@ -562,9 +558,7 @@ gst_mqtt_src_set_host_address (GstMqttSrc * self, const gchar * addr)
    * @todo Handle the case where the addr is changed at runtime
    */
   g_free (self->mqtt_host_address);
-  GST_OBJECT_LOCK (self);
   self->mqtt_host_address = g_strdup (addr);
-  GST_OBJECT_UNLOCK (self);
 }
 
 /**
@@ -583,9 +577,7 @@ static void
 gst_mqtt_src_set_host_port (GstMqttSrc * self, const gchar * port)
 {
   g_free (self->mqtt_host_port);
-  GST_OBJECT_LOCK (self);
   self->mqtt_host_port = g_strdup (port);
-  GST_OBJECT_UNLOCK (self);
 }
 
 /**
@@ -603,9 +595,7 @@ gst_mqtt_src_get_sub_timeout (GstMqttSrc * self)
 static void
 gst_mqtt_src_set_sub_timeout (GstMqttSrc * self, const gint64 t)
 {
-  GST_OBJECT_LOCK (self);
   self->mqtt_sub_timeout = t;
-  GST_OBJECT_UNLOCK (self);
 }
 
 /**
@@ -623,10 +613,7 @@ gst_mqtt_src_get_sub_topic (GstMqttSrc * self)
 static void
 gst_mqtt_src_set_sub_topic (GstMqttSrc * self, const gchar * topic)
 {
-  GST_OBJECT_LOCK (self);
   self->mqtt_topic = g_strdup (topic);
-  GST_OBJECT_UNLOCK (self);
-  g_free ((void *) DEFAULT_MQTT_SUB_TOPIC);
 }
 
 /**
@@ -644,9 +631,7 @@ gst_mqtt_src_get_opt_cleansession (GstMqttSrc * self)
 static void
 gst_mqtt_src_set_opt_cleansession (GstMqttSrc * self, const gboolean val)
 {
-  GST_OBJECT_LOCK (self);
   self->mqtt_conn_opts.cleansession = val;
-  GST_OBJECT_UNLOCK (self);
 }
 
 /**
@@ -664,9 +649,7 @@ gst_mqtt_src_get_opt_keep_alive_interval (GstMqttSrc * self)
 static void
 gst_mqtt_src_set_opt_keep_alive_interval (GstMqttSrc * self, const gint num)
 {
-  GST_OBJECT_LOCK (self);
   self->mqtt_conn_opts.keepAliveInterval = num;
-  GST_OBJECT_UNLOCK (self);
 }
 
 /**
@@ -677,14 +660,14 @@ cb_mqtt_on_connection_lost (void *context, char *cause)
 {
   GstMqttSrc *self = GST_MQTT_SRC_CAST (context);
 
-  GST_OBJECT_LOCK (self);
+  g_mutex_lock (&self->mqtt_src_mutex);
   self->is_connected = FALSE;
   self->is_subscribed = FALSE;
-  g_cond_broadcast (&self->gcond);
+  g_cond_broadcast (&self->mqtt_src_gcond);
   self->err = g_error_new (self->gquark_err_tag, EHOSTDOWN,
       "Connection to the host (broker) has been lost: %s",
       g_strerror (EHOSTDOWN));
-  GST_OBJECT_UNLOCK (self);
+  g_mutex_unlock (&self->mqtt_src_mutex);
 }
 
 /**
@@ -777,10 +760,10 @@ cb_mqtt_on_connect (void *context, MQTTAsync_successData * response)
   GstMqttSrc *self = GST_MQTT_SRC (context);
   int ret;
 
-  GST_OBJECT_LOCK (self);
+  g_mutex_lock (&self->mqtt_src_mutex);
   self->is_connected = TRUE;
-  g_cond_signal (&self->gcond);
-  GST_OBJECT_UNLOCK (self);
+  g_cond_broadcast (&self->mqtt_src_gcond);
+  g_mutex_unlock (&self->mqtt_src_mutex);
 
   /** @todo Support QoS option */
   ret = MQTTAsync_subscribe (self->mqtt_client_handle, self->mqtt_topic, 1,
@@ -790,9 +773,9 @@ cb_mqtt_on_connect (void *context, MQTTAsync_successData * response)
     return;
   }
 
-  GST_OBJECT_LOCK (self);
+  g_mutex_lock (&self->mqtt_src_mutex);
   self->is_subscribed = TRUE;
-  GST_OBJECT_UNLOCK (self);
+  g_mutex_unlock (&self->mqtt_src_mutex);
 }
 
 /**
@@ -803,12 +786,12 @@ cb_mqtt_on_connect_failure (void *context, MQTTAsync_failureData * response)
 {
   GstMqttSrc *self = GST_MQTT_SRC (context);
 
-  GST_OBJECT_LOCK (self);
+  g_mutex_lock (&self->mqtt_src_mutex);
   self->is_connected = FALSE;
   self->err = g_error_new (self->gquark_err_tag, response->code,
       "%s: failed to connect to the broker: %s", __func__, response->message);
-  g_cond_signal (&self->gcond);
-  GST_OBJECT_UNLOCK (self);
+  g_cond_broadcast (&self->mqtt_src_gcond);
+  g_mutex_unlock (&self->mqtt_src_mutex);
 }
 
 /**
@@ -819,10 +802,10 @@ cb_mqtt_on_subscribe (void *context, MQTTAsync_successData * response)
 {
   GstMqttSrc *self = GST_MQTT_SRC (context);
 
-  GST_OBJECT_LOCK (self);
+  g_mutex_lock (&self->mqtt_src_mutex);
   self->is_subscribed = TRUE;
-  g_cond_signal (&self->gcond);
-  GST_OBJECT_UNLOCK (self);
+  g_cond_broadcast (&self->mqtt_src_gcond);
+  g_mutex_unlock (&self->mqtt_src_mutex);
 }
 
 /**
@@ -833,13 +816,13 @@ cb_mqtt_on_subscribe_failure (void *context, MQTTAsync_failureData * response)
 {
   GstMqttSrc *self = GST_MQTT_SRC (context);
 
-  GST_OBJECT_LOCK (self);
+  g_mutex_lock (&self->mqtt_src_mutex);
   self->is_connected = FALSE;
   self->err = g_error_new (self->gquark_err_tag, response->code,
       "%s: failed to subscribe the given topic, %s: %s", __func__,
       self->mqtt_topic, response->message);
-  g_cond_signal (&self->gcond);
-  GST_OBJECT_UNLOCK (self);
+  g_cond_broadcast (&self->mqtt_src_gcond);
+  g_mutex_unlock (&self->mqtt_src_mutex);
 }
 
 /**

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -59,11 +59,13 @@ enum
   DEFAULT_MQTT_SUB_TIMEOUT_MIN = 1000000,       /* 1 seconds */
 };
 
+static guint8 src_client_id = 0;
 static const gchar DEFAULT_MQTT_HOST_ADDRESS[] = "tcp://localhost";
 static const gchar DEFAULT_MQTT_HOST_PORT[] = "1883";
 static const gchar TAG_ERR_MQTTSRC[] = "ERROR: MQTTSrc";
-const gchar *DEFAULT_MQTT_CLIENT_ID;
-const gchar *DEFAULT_MQTT_SUB_TOPIC;
+static const gchar DEFAULT_MQTT_CLIENT_ID[] =
+    "$HOSTNAME_$PID_^[0-9][0-9]?$|^255$";
+static const gchar DEFAULT_MQTT_CLIENT_ID_FORMAT[] = "%s_%u_src%u";
 
 /** Function prototype declarations */
 static void
@@ -139,10 +141,10 @@ gst_mqtt_src_init (GstMqttSrc * self)
   self->gquark_err_tag = g_quark_from_string (TAG_ERR_MQTTSRC);
 
   /** init mqttsrc properties */
-  self->mqtt_client_id = (gchar *) DEFAULT_MQTT_CLIENT_ID;
+  self->mqtt_client_id = g_strdup (DEFAULT_MQTT_CLIENT_ID);
   self->mqtt_host_address = g_strdup (DEFAULT_MQTT_HOST_ADDRESS);
   self->mqtt_host_port = g_strdup (DEFAULT_MQTT_HOST_PORT);
-  self->mqtt_topic = (gchar *) DEFAULT_MQTT_SUB_TOPIC;
+  self->mqtt_topic = NULL;
   self->mqtt_sub_timeout = (gint64) DEFAULT_MQTT_SUB_TIMEOUT;
   self->mqtt_conn_opts.cleansession = DEFAULT_MQTT_OPT_CLEANSESSION;
   self->mqtt_conn_opts.keepAliveInterval = DEFAULT_MQTT_OPT_KEEP_ALIVE_INTERVAL;
@@ -174,10 +176,6 @@ gst_mqtt_src_class_init (GstMqttSrcClass * klass)
   GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
   GstBaseSrcClass *gstbasesrc_class = GST_BASE_SRC_CLASS (klass);
 
-  DEFAULT_MQTT_CLIENT_ID = g_strdup_printf ("%s/%u/%u", g_get_host_name (),
-      getpid (), g_random_int_range (0, 0xFF));
-  DEFAULT_MQTT_SUB_TOPIC = g_strdup_printf ("%s/topic", DEFAULT_MQTT_CLIENT_ID);
-
   GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, GST_MQTT_ELEM_NAME_SRC, 0,
       "MQTT src");
 
@@ -207,8 +205,8 @@ gst_mqtt_src_class_init (GstMqttSrcClass * klass)
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_MQTT_SUB_TOPIC,
-      g_param_spec_string ("sub-topic", "Topic to Subscribe",
-          "The topic's name to subscribe", DEFAULT_MQTT_SUB_TOPIC,
+      g_param_spec_string ("sub-topic", "Topic to Subscribe (mandatory)",
+          "The topic's name to subscribe", NULL,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_MQTT_OPT_CLEANSESSION,
@@ -392,6 +390,11 @@ gst_mqtt_src_start (GstBaseSrc * basesrc)
       self->mqtt_host_port);
   int ret;
 
+  if (!g_strcmp0 (DEFAULT_MQTT_CLIENT_ID, self->mqtt_client_id)) {
+    self->mqtt_client_id = g_strdup_printf (DEFAULT_MQTT_CLIENT_ID_FORMAT,
+        g_get_host_name (), getpid (), src_client_id++);
+  }
+
   /**
    * @todo Support other persistence mechanisms
    *    MQTTCLIENT_PERSISTENCE_NONE: A memory-based persistence mechanism
@@ -535,8 +538,8 @@ gst_mqtt_src_get_client_id (GstMqttSrc * self)
 static void
 gst_mqtt_src_set_client_id (GstMqttSrc * self, const gchar * id)
 {
+  g_free (self->mqtt_client_id);
   self->mqtt_client_id = g_strdup (id);
-  g_free ((void *) DEFAULT_MQTT_CLIENT_ID);
 }
 
 /**
@@ -613,6 +616,7 @@ gst_mqtt_src_get_sub_topic (GstMqttSrc * self)
 static void
 gst_mqtt_src_set_sub_topic (GstMqttSrc * self, const gchar * topic)
 {
+  g_free (self->mqtt_topic);
   self->mqtt_topic = g_strdup (topic);
 }
 

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -339,15 +339,21 @@ static void
 gst_mqtt_src_class_finalize (GObject * object)
 {
   GstMqttSrc *self = GST_MQTT_SRC (object);
+  GstBuffer *remained;
 
+  g_free (self->mqtt_client_handle);
+  g_free (self->mqtt_client_id);
   g_free (self->mqtt_host_address);
   g_free (self->mqtt_host_port);
-  g_free (self->mqtt_client_handle);
+  g_free (self->mqtt_topic);
+  gst_caps_replace (&self->caps, NULL);
+
   if (self->err)
     g_error_free (self->err);
-  if (self->caps)
-    gst_caps_unref (self->caps);
 
+  while ((remained = g_async_queue_try_pop (self->aqueue))) {
+    gst_buffer_unref (remained);
+  }
   g_clear_pointer (&self->aqueue, g_async_queue_unref);
 
   G_OBJECT_CLASS (parent_class)->finalize (object);
@@ -425,6 +431,7 @@ gst_mqtt_src_start (GstBaseSrc * basesrc)
   int ret;
 
   if (!g_strcmp0 (DEFAULT_MQTT_CLIENT_ID, self->mqtt_client_id)) {
+    g_free (self->mqtt_client_id);
     self->mqtt_client_id = g_strdup_printf (DEFAULT_MQTT_CLIENT_ID_FORMAT,
         g_get_host_name (), getpid (), src_client_id++);
   }
@@ -613,6 +620,7 @@ gst_mqtt_src_create (GstBaseSrc * basesrc, guint64 offset, guint size,
       /** This buffer is comming from the past. Drop it */
       if (!_is_gst_buffer_timestamp_valid (*buf)) {
         elapsed = self->mqtt_sub_timeout;
+        gst_buffer_unref (*buf);
         continue;
       }
       break;
@@ -816,12 +824,13 @@ cb_mqtt_on_message_arrived (void *context, char *topic_name, int topic_len,
   GstMemory *recieved_mem;
   GstMemory *hdr_mem;
   GstBuffer *buffer;
-  GstCaps *recv_caps;
+  GstBaseSrc *basesrc;
   GstMqttSrc *self;
   gsize offset;
   guint i;
 
   self = GST_MQTT_SRC_CAST (context);
+  basesrc = GST_BASE_SRC (self);
   recieved_mem = gst_memory_new_wrapped (0, data, size, 0, size, message,
       (GDestroyNotify) cb_memory_wrapped_destroy);
   if (!recieved_mem) {
@@ -840,16 +849,18 @@ cb_mqtt_on_message_arrived (void *context, char *topic_name, int topic_len,
     goto ret_unref_recieved_mem;
   }
 
-  recv_caps = gst_caps_from_string (mqtt_msg_hdr->gst_caps_str);
-  if (recv_caps) {
-    GstBaseSrc *basesrc = GST_BASE_SRC (self);
-
-    if (!self->caps) {
-      gst_caps_take (&self->caps, recv_caps);
-    } else if (!gst_caps_is_equal (self->caps, recv_caps)) {
-      gst_caps_replace (&self->caps, recv_caps);
-    }
+  if (!self->caps) {
+    self->caps = gst_caps_from_string (mqtt_msg_hdr->gst_caps_str);
     gst_mqtt_src_renegotiate (basesrc);
+  } else {
+    GstCaps *recv_caps = gst_caps_from_string (mqtt_msg_hdr->gst_caps_str);
+
+    if (recv_caps && !gst_caps_is_equal (self->caps, recv_caps)) {
+      gst_caps_replace (&self->caps, recv_caps);
+      gst_mqtt_src_renegotiate (basesrc);
+    } else {
+      gst_caps_replace (&recv_caps, NULL);
+    }
   }
 
   buffer = gst_buffer_new ();

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -1,0 +1,227 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Wook Song <wook16.song@samsung.com>
+ */
+/**
+ * @file    mqttsrc.c
+ * @date    08 Mar 2021
+ * @brief   Subscribe a MQTT topic and push incoming data to the GStreamer pipeline
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <gst/base/gstbasesrc.h>
+
+#include "mqttsrc.h"
+
+#define gst_mqtt_src_parent_class parent_class
+G_DEFINE_TYPE (GstMqttSrc, gst_mqtt_src, GST_TYPE_BASE_SRC);
+
+GST_DEBUG_CATEGORY_STATIC (gst_mqtt_src_debug);
+#define GST_CAT_DEFAULT gst_mqtt_src_debug
+
+enum
+{
+  PROP_0,
+
+  PROP_LAST
+};
+
+
+/** Function prototype declarations */
+static void
+gst_mqtt_src_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec);
+static void
+gst_mqtt_src_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec);
+static void gst_mqtt_src_class_finalize (GObject * object);
+
+static GstStateChangeReturn
+gst_mqtt_src_change_state (GstElement * element, GstStateChange transition);
+
+static gboolean gst_mqtt_src_start (GstBaseSrc * basesrc);
+static gboolean gst_mqtt_src_stop (GstBaseSrc * basesrc);
+static gboolean gst_mqtt_src_event (GstBaseSrc * basesrc, GstEvent * event);
+static gboolean gst_mqtt_src_set_caps (GstBaseSrc * basesrc, GstCaps * caps);
+static GstCaps *gst_mqtt_src_get_caps (GstBaseSrc * basesrc, GstCaps * filter);
+static GstCaps *gst_mqtt_src_fixate (GstBaseSrc * basesrc, GstCaps * caps);
+static void
+gst_mqtt_src_get_times (GstBaseSrc * basesrc, GstBuffer * buffer,
+    GstClockTime * start, GstClockTime * end);
+static gboolean gst_mqtt_src_get_size (GstBaseSrc * basesrc, guint64 * size);
+static gboolean gst_mqtt_src_is_seekable (GstBaseSrc * basesrc);
+static GstFlowReturn
+gst_mqtt_src_create (GstBaseSrc * basesrc, guint64 offset, guint size,
+    GstBuffer ** buf);
+static GstFlowReturn
+gst_mqtt_src_alloc (GstBaseSrc * basesrc, guint64 offset, guint size,
+    GstBuffer ** buf);
+static GstFlowReturn
+gst_mqtt_src_fill (GstBaseSrc * basesrc, guint64 offset, guint size,
+    GstBuffer * buf);
+
+/** Function defintions */
+static void
+gst_mqtt_src_init (GstMqttSrc * self)
+{
+  /** @todo */
+}
+
+static void
+gst_mqtt_src_class_init (GstMqttSrcClass * klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
+  GstBaseSrcClass *gstbasesrc_class = GST_BASE_SRC_CLASS (klass);
+
+  GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, GST_MQTT_ELEM_NAME_SRC, 0,
+      "MQTT src");
+
+  gobject_class->set_property = gst_mqtt_src_set_property;
+  gobject_class->get_property = gst_mqtt_src_get_property;
+  gobject_class->finalize = gst_mqtt_src_class_finalize;
+
+  gstelement_class->change_state =
+      GST_DEBUG_FUNCPTR (gst_mqtt_src_change_state);
+  gst_element_class_set_static_metadata (gstelement_class,
+      "MQTT Source",
+      "Source/MQTT",
+      "Subscribe a MQTT topic and push incoming data to the GStreamer pipeline",
+      "Wook Song <wook16.song@samsung.com>");
+
+  gstbasesrc_class->start = GST_DEBUG_FUNCPTR (gst_mqtt_src_start);
+  gstbasesrc_class->stop = GST_DEBUG_FUNCPTR (gst_mqtt_src_stop);
+  gstbasesrc_class->event = GST_DEBUG_FUNCPTR (gst_mqtt_src_event);
+  gstbasesrc_class->set_caps = GST_DEBUG_FUNCPTR (gst_mqtt_src_set_caps);
+  gstbasesrc_class->get_caps = GST_DEBUG_FUNCPTR (gst_mqtt_src_get_caps);
+  gstbasesrc_class->fixate = GST_DEBUG_FUNCPTR (gst_mqtt_src_fixate);
+  gstbasesrc_class->get_times = GST_DEBUG_FUNCPTR (gst_mqtt_src_get_times);
+  gstbasesrc_class->get_size = GST_DEBUG_FUNCPTR (gst_mqtt_src_get_size);
+  gstbasesrc_class->is_seekable = GST_DEBUG_FUNCPTR (gst_mqtt_src_is_seekable);
+  gstbasesrc_class->create = GST_DEBUG_FUNCPTR (gst_mqtt_src_create);
+  gstbasesrc_class->alloc = GST_DEBUG_FUNCPTR (gst_mqtt_src_alloc);
+  gstbasesrc_class->fill = GST_DEBUG_FUNCPTR (gst_mqtt_src_fill);
+}
+
+static void
+gst_mqtt_src_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  switch (prop_id) {
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+gst_mqtt_src_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  switch (prop_id) {
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+gst_mqtt_src_class_finalize (GObject * object)
+{
+  G_OBJECT_CLASS (parent_class)->finalize (object);
+}
+
+static GstStateChangeReturn
+gst_mqtt_src_change_state (GstElement * element, GstStateChange transition)
+{
+  GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+
+  return ret;
+}
+
+static gboolean
+gst_mqtt_src_start (GstBaseSrc * basesrc)
+{
+  return TRUE;
+}
+
+static gboolean
+gst_mqtt_src_stop (GstBaseSrc * basesrc)
+{
+  return TRUE;
+}
+
+static gboolean
+gst_mqtt_src_event (GstBaseSrc * basesrc, GstEvent * event)
+{
+  return TRUE;
+}
+
+static gboolean
+gst_mqtt_src_set_caps (GstBaseSrc * basesrc, GstCaps * caps)
+{
+  return TRUE;
+}
+
+static GstCaps *
+gst_mqtt_src_get_caps (GstBaseSrc * basesrc, GstCaps * filter)
+{
+  GstCaps *caps = gst_caps_new_empty ();
+
+  return caps;
+}
+
+static GstCaps *
+gst_mqtt_src_fixate (GstBaseSrc * basesrc, GstCaps * caps)
+{
+  caps = gst_caps_make_writable (caps);
+  caps = GST_BASE_SRC_CLASS (parent_class)->fixate (basesrc, caps);
+
+  return caps;
+}
+
+static void
+gst_mqtt_src_get_times (GstBaseSrc * basesrc, GstBuffer * buffer,
+    GstClockTime * start, GstClockTime * end)
+{
+  return;
+}
+
+static gboolean
+gst_mqtt_src_get_size (GstBaseSrc * basesrc, guint64 * size)
+{
+  return TRUE;
+}
+
+static gboolean
+gst_mqtt_src_is_seekable (GstBaseSrc * basesrc)
+{
+  return TRUE;
+}
+
+static GstFlowReturn
+gst_mqtt_src_create (GstBaseSrc * basesrc, guint64 offset, guint size,
+    GstBuffer ** buf)
+{
+  return GST_FLOW_OK;
+}
+
+static GstFlowReturn
+gst_mqtt_src_alloc (GstBaseSrc * basesrc, guint64 offset, guint size,
+    GstBuffer ** buf)
+{
+  return GST_FLOW_OK;
+}
+
+static GstFlowReturn
+gst_mqtt_src_fill (GstBaseSrc * basesrc, guint64 offset, guint size,
+    GstBuffer * buf)
+{
+  return GST_FLOW_OK;
+}

--- a/gst/mqtt/mqttsrc.h
+++ b/gst/mqtt/mqttsrc.h
@@ -47,6 +47,7 @@ struct _GstMqttSrc {
   GstBaseSrc parent;
   GQuark gquark_err_tag;
   GError *err;
+  gint64 base_time_epoch;
   gchar *mqtt_client_id;
   gchar *mqtt_host_address;
   gchar *mqtt_host_port;

--- a/gst/mqtt/mqttsrc.h
+++ b/gst/mqtt/mqttsrc.h
@@ -14,7 +14,9 @@
 #ifndef __GST_MQTT_SRC_H__
 #define __GST_MQTT_SRC_H__
 #include <gst/base/gstbasesrc.h>
+#include <gst/base/gstdataqueue.h>
 #include <gst/gst.h>
+#include <MQTTAsync.h>
 
 #include "mqttcommon.h"
 
@@ -36,10 +38,35 @@ G_BEGIN_DECLS
 typedef struct _GstMqttSrc GstMqttSrc;
 typedef struct _GstMqttSrcClass GstMqttSrcClass;
 
+/**
+ * @brief GstMqttSrc data structure.
+ *
+ * GstMqttSec inherits GstBaseSrc.
+ */
 struct _GstMqttSrc {
   GstBaseSrc parent;
+  GQuark gquark_err_tag;
+  GError *err;
+  MQTTAsync *mqtt_client_handle;
+  MQTTAsync_connectOptions *mqtt_conn_opts;
+  gchar *mqtt_client_id;
+  gchar *mqtt_host_address;
+  gchar *mqtt_host_port;
+  gchar *mqtt_topic;
+  gint64 mqtt_sub_timeout;
+
+  GAsyncQueue *aqueue;
+	GCond gcond;
+	gboolean is_connected;
+	gboolean is_subscribed;
+	GstStateChange transition;
 };
 
+/**
+ * @brief GstMqttSrcClass data structure.
+ *
+ * GstMqttSrcClass inherits GstBaseSrcClass.
+ */
 struct _GstMqttSrcClass {
   GstBaseSrcClass parent_class;
 };

--- a/gst/mqtt/mqttsrc.h
+++ b/gst/mqtt/mqttsrc.h
@@ -47,8 +47,6 @@ struct _GstMqttSrc {
   GstBaseSrc parent;
   GQuark gquark_err_tag;
   GError *err;
-  MQTTAsync *mqtt_client_handle;
-  MQTTAsync_connectOptions *mqtt_conn_opts;
   gchar *mqtt_client_id;
   gchar *mqtt_host_address;
   gchar *mqtt_host_port;
@@ -56,10 +54,13 @@ struct _GstMqttSrc {
   gint64 mqtt_sub_timeout;
 
   GAsyncQueue *aqueue;
-	GCond gcond;
-	gboolean is_connected;
-	gboolean is_subscribed;
-	GstStateChange transition;
+  GCond gcond;
+  gboolean is_connected;
+  gboolean is_subscribed;
+
+  MQTTAsync mqtt_client_handle;
+  MQTTAsync_connectOptions mqtt_conn_opts;
+  MQTTAsync_responseOptions mqtt_respn_opts;
 };
 
 /**

--- a/gst/mqtt/mqttsrc.h
+++ b/gst/mqtt/mqttsrc.h
@@ -54,7 +54,8 @@ struct _GstMqttSrc {
   gint64 mqtt_sub_timeout;
 
   GAsyncQueue *aqueue;
-  GCond gcond;
+  GMutex mqtt_src_mutex;
+  GCond mqtt_src_gcond;
   gboolean is_connected;
   gboolean is_subscribed;
 

--- a/gst/mqtt/mqttsrc.h
+++ b/gst/mqtt/mqttsrc.h
@@ -45,6 +45,7 @@ typedef struct _GstMqttSrcClass GstMqttSrcClass;
  */
 struct _GstMqttSrc {
   GstBaseSrc parent;
+  GstCaps *caps;
   GQuark gquark_err_tag;
   GError *err;
   gint64 base_time_epoch;

--- a/gst/mqtt/mqttsrc.h
+++ b/gst/mqtt/mqttsrc.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Wook Song <wook16.song@samsung.com>
+ */
+/**
+ * @file    mqttsrc.h
+ * @date    08 Mar 2021
+ * @brief   Subscribe a MQTT topic and push incoming data to the GStreamer pipeline
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifndef __GST_MQTT_SRC_H__
+#define __GST_MQTT_SRC_H__
+#include <gst/base/gstbasesrc.h>
+#include <gst/gst.h>
+
+#include "mqttcommon.h"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_MQTT_SRC \
+    (gst_mqtt_src_get_type())
+#define GST_MQTT_SRC(obj) \
+    (G_TYPE_CHECK_INSTANCE_CAST ((obj), GST_TYPE_MQTT_SRC, GstMqttSrc))
+#define GST_IS_MQTT_SRC(obj)  \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GST_TYPE_MQTT_SRC))
+#define GST_MQTT_SRC_CAST(obj) \
+    ((GstMqttSrc *) obj)
+#define GST_MQTT_SRC_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_CAST ((klass), GST_TYPE_MQTT_SRC, GstMqttSrcClass))
+#define GST_IS_MQTT_SRC_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_TYPE ((klass), GST_TYPE_MQTT_SRC))
+
+typedef struct _GstMqttSrc GstMqttSrc;
+typedef struct _GstMqttSrcClass GstMqttSrcClass;
+
+struct _GstMqttSrc {
+  GstBaseSrc parent;
+};
+
+struct _GstMqttSrcClass {
+  GstBaseSrcClass parent_class;
+};
+
+GType gst_mqtt_src_get_type (void);
+
+G_END_DECLS
+#endif /* !__GST_MQTT_SRC_H__ */

--- a/meson.build
+++ b/meson.build
@@ -222,6 +222,12 @@ if not get_option('grpc-support').disabled()
   grpcpp_dep = dependency('grpc++', required: false)
 endif
 
+# mqtt (paho.mqtt.c)
+pahomqttc_dep = dependency('', required: false)
+if not get_option('mqtt-support').disabled()
+  pahomqttc_dep = dependency('paho-mqtt-c', required: false)
+endif
+
 # features registration to be controlled
 #
 # register feature as follows
@@ -296,6 +302,9 @@ features = {
   'lua-support': {
     'target': 'lua',
     'project_args': { 'ENABLE_LUA' : 1}
+  },
+  'mqtt-support': {
+    'extra_deps': [ pahomqttc_dep ]
   }
 }
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,6 +18,7 @@ option('flatbuf-support', type: 'feature', value: 'auto')
 option('tensorrt-support', type: 'feature', value: 'auto')
 option('grpc-support', type: 'feature', value: 'auto')
 option('lua-support', type: 'feature', value: 'auto')
+option('mqtt-support', type: 'feature', value: 'auto')
 
 # booleans & other options
 option('enable-test', type: 'boolean', value: true)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -31,6 +31,7 @@
 %define		grpc_support 1
 %define		pytorch_support 0
 %define		caffe2_support 0
+%define		mqtt_support 0
 
 %define		check_test 1
 %define		release_test 1
@@ -635,6 +636,13 @@ Provides additional gstreamer plugins for nnstreamer pipelines
 %define enable_flatbuf -Dflatbuf-support=disabled
 %endif
 
+# Support mqtt
+%if 0%{?mqtt_support}
+%define enable_mqtt -Dmqtt-support=enabled
+%else
+%define enable_mqtt -Dmqtt-support=disabled
+%endif
+
 %prep
 rm -rf ./build
 %setup -q
@@ -663,7 +671,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir
 	%{enable_tizen} %{element_restriction} -Denable-env-var=false -Denable-symbolic-link=false \
 	%{enable_tf_lite} %{enable_tf2_lite} %{enable_tf} %{enable_pytorch} %{enable_caffe2} %{enable_python3} \
 	%{enable_nnfw_runtime} %{enable_mvncsdk2} %{enable_openvino} %{enable_armnn} %{enable_edgetpu}  %{enable_vivante} %{enable_flatbuf} \
-	%{enable_tizen_sensor} %{enable_test} %{enable_test_coverage} %{install_test} \
+	%{enable_tizen_sensor} %{enable_mqtt} %{enable_test} %{enable_test_coverage} %{install_test} \
 	build
 
 ninja -C build %{?_smp_mflags}


### PR DESCRIPTION
This PR introduces new GStreamer plugins, mqttsink and mqttsrc, which enable the GStreamer/NNStreamer pipelines to publish and subscribe MQTT topics. The mqttsink and mqttsrc were implemented based on [GstBaseSink](https://gstreamer.freedesktop.org/documentation/base/gstbasesink.html?gi-language=c) and [GstBaseSrc](https://gstreamer.freedesktop.org/documentation/base/gstbasesrc.html?gi-language=c) using [Paho Asynchronous MQTT C Client Library](https://www.eclipse.org/paho/files/mqttdoc/MQTTAsync/html/index.html). Therefore, libgstreamer1.0-dev and libpaho-mqtt-dev for Ubuntu (or equivalent development kits for the other platforms) are required to build and test this PR. In addition, the proposed MQTT plugins are clients from the perspective of the MQTT protocol. For this reason, an MQTT broker such as [Eclipse Mosquitto](https://mosquitto.org/) s needed and should run on any other network reachable place (including localhost).

Signed-off-by: Wook Song <wook16.song@samsung.com>