### PR TITLE
[gRPC/debian] Disable gRPC in Debian and perform async tests in Tizen env.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  tensorflow-lite-dev, pytorch, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
  openvino-dev, openvino-cpu-mkldnn [amd64], libflatbuffers-dev, flatbuffers-compiler,
  protobuf-compiler (>=3.12), libprotobuf-dev [amd64 arm64 armhf],
- protobuf-compiler-grpc [amd64], libgrpc-dev [amd64], libgrpc++-dev [amd64],
  tensorflow-dev [amd64], python2.7-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer
@@ -103,28 +102,6 @@ Multi-Arch: same
 Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer Flatbuf converter/decoder support
  This package allows to pack/unpack tensor streams to/from flatbuf.
-
-Package: nnstreamer-grpc
-Architecture: amd64
-Multi-Arch: same
-Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
-Recommends: nnstreamer-grpc-protobuf, nnstreamer-grpc-flatbuf
-Description: NNStreamer gRPC tensor source/sink support
- This package allows nnstreamer to support gRPC tensor source/sink as a extra plugin
-
-Package: nnstreamer-grpc-protobuf
-Architecture: amd64
-Multi-Arch: same
-Depends: nnstreamer, nnstreamer-grpc, nnstreamer-protobuf, ${shlibs:Depends}, ${misc:Depends}
-Description: NNStreamer gRPC IDL support for protobuf
- This package allows nnstreamer-grpc to use protobuf as its IDL
-
-Package: nnstreamer-grpc-flatbuf
-Architecture: amd64
-Multi-Arch: same
-Depends: nnstreamer, nnstreamer-grpc, nnstreamer-flatbuf, ${shlibs:Depends}, ${misc:Depends}
-Description: NNStreamer gRPC IDL support for flatbuf
- This package allows nnstreamer-grpc to use flatbuf as its IDL
 
 Package: nnstreamer-dev
 Architecture: any

--- a/debian/nnstreamer-grpc-flatbuf.install
+++ b/debian/nnstreamer-grpc-flatbuf.install
@@ -1,1 +1,0 @@
-/usr/lib/*/libnnstreamer_grpc_flatbuf.so

--- a/debian/nnstreamer-grpc-protobuf.install
+++ b/debian/nnstreamer-grpc-protobuf.install
@@ -1,1 +1,0 @@
-/usr/lib/*/libnnstreamer_grpc_protobuf.so

--- a/debian/rules
+++ b/debian/rules
@@ -35,7 +35,7 @@ override_dh_auto_clean:
 override_dh_auto_configure:
 	mkdir -p ${BUILDDIR}
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
-	-Denable-edgetpu=true -Denable-openvino=true \
+	-Denable-edgetpu=true -Denable-openvino=true -Dgrpc-support=disabled  \
 	-Denable-tizen=false -Denable-test=true -Dinstall-test=true ${BUILDDIR}
 
 override_dh_auto_build:

--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -67,121 +67,87 @@ export LD_LIBRARY_PATH=${PATH_TO_PLUGIN_EXTRA}:${LD_LIBRARY_PATH}
 
 NUM_BUFFERS=10
 
-# Dump original frames, passthrough, other/tensor
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! multifilesink location=original1_%1d.log" 0 0 0 $PERFORMANCE
+## Initial pipelines to generate reference outputs
+# passthrough, other/tensor
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! multifilesink location=original1_%1d.log" Initial-1 0 0 $PERFORMANCE
+# passthrough, other/tensors
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! multifilesink location=original2_%1d.log" Initial-2 0 0 $PERFORMANCE
 
-# Dump original frames, passthrough, other/tensors
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! multifilesink location=original2_%1d.log" 1 0 0 $PERFORMANCE
-
+INDEX=1
+BLOCKING_LIST=("TRUE" "FALSE")
+IDL_LIST=()
 if [[ $TEST_PROTOBUF -eq 1 ]]; then
-  IDL="protobuf"
-  PORT=`python3 get_available_port.py`
-  # tensor_sink (client) --> tensor_src (server), other/tensor, protobuf
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 2 0 0 $PERFORMANCE &
-  sleep 1
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL}" 2 0 0 $PERFORMANCE
-
-  for i in `seq 0 $((NUM_BUFFERS-1))`
-  do
-    callCompareTest original1_${i}.log result_${i}.log 2-${i} "gRPC/Protobuf Compare 2-${i}" 0 0
-  done
-
-  rm result_*.log
-
-  PORT=`python3 get_available_port.py`
-  # tensor_sink (server) --> tensor_src (client), other/tensor, protobuf
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 3 0 0 $PERFORMANCE &
-  sleep 1
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} server=false idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 3 0 0 $PERFORMANCE
-
-  for i in `seq 0 $((NUM_BUFFERS-1))`
-  do
-    callCompareTest original1_${i}.log result_${i}.log 3-${i} "gRPC/Protobuf Compare 3-${i}" 0 0
-  done
-
-  rm result_*.log
-
-  PORT=`python3 get_available_port.py`
-  # tensor_sink (client) --> tensor_src (server), other/tensors, protobuf
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 4 0 0 $PERFORMANCE &
-  sleep 1
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} idl=${IDL}" 4 0 0 $PERFORMANCE
-
-  for i in `seq 0 $((NUM_BUFFERS/2-1))`
-  do
-    callCompareTest original2_${i}.log result_${i}.log 4-${i} "gRPC/Protobuf Compare 4-${i}" 0 0
-  done
-
-  rm result_*.log
-
-  PORT=`python3 get_available_port.py`
-  # tensor_sink (server) --> tensor_src (client), other/tensors, protobuf
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 5 0 0 $PERFORMANCE &
-  sleep 1
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) server=false idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 5 0 0 $PERFORMANCE
-
-  for i in `seq 0 $((NUM_BUFFERS/2-1))`
-  do
-    callCompareTest original2_${i}.log result_${i}.log 5-${i} "gRPC/Protobuf Compare 5-${i}" 0 0
-  done
-
-  rm result_*.log
+  IDL_LIST[${#IDL_LIST[@]}]="Protobuf"
 fi
-
 if [[ $TEST_FLATBUF -eq 1 ]]; then
-  IDL="flatbuf"
-  PORT=`python3 get_available_port.py`
-  # tensor_sink (client) --> tensor_src (server), other/tensor, flatbuf
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 6 0 0 $PERFORMANCE &
-  sleep 1
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL}" 6 0 0 $PERFORMANCE
-
-  for i in `seq 0 $((NUM_BUFFERS-1))`
-  do
-    callCompareTest original1_${i}.log result_${i}.log 6-${i} "gRPC/Flatbuf Compare 6-${i}" 0 0
-  done
-
-  rm result_*.log
-
-  PORT=`python3 get_available_port.py`
-  # tensor_sink (server) --> tensor_src (client), other/tensor, flatbuf
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 7 0 0 $PERFORMANCE &
-  sleep 1
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} server=false idl=${IDL} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 7 0 0 $PERFORMANCE
-
-  for i in `seq 0 $((NUM_BUFFERS-1))`
-  do
-    callCompareTest original1_${i}.log result_${i}.log 7-${i} "gRPC/Flatbuf Compare 7-${i}" 0 0
-  done
-
-  rm result_*.log
-
-  PORT=`python3 get_available_port.py`
-  # tensor_sink (client) --> tensor_src (server), other/tensors, flatbuf
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 8 0 0 $PERFORMANCE &
-  sleep 1
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} idl=${IDL}" 8 0 0 $PERFORMANCE
-
-  for i in `seq 0 $((NUM_BUFFERS/2-1))`
-  do
-    callCompareTest original2_${i}.log result_${i}.log 8-${i} "gRPC/Flatbuf Compare 8-${i}" 0 0
-  done
-
-  rm result_*.log
-
-  PORT=`python3 get_available_port.py`
-  # tensor_sink (server) --> tensor_src (client), other/tensors, flatbuf
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL}" 9 0 0 $PERFORMANCE &
-  sleep 1
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) server=false idl=${IDL} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" 9 0 0 $PERFORMANCE
-
-  for i in `seq 0 $((NUM_BUFFERS/2-1))`
-  do
-    callCompareTest original2_${i}.log result_${i}.log 9-${i} "gRPC/Flatbuf Compare 9-${i}" 0 0
-  done
-
-  rm result_*.log
+  IDL_LIST[${#IDL_LIST[@]}]="Flatbuf"
 fi
+
+## Test gRPC multi-pipelines with different IDL and blocking modes.
+for IDL in "${IDL_LIST[@]}"; do
+for BLOCKING in "${BLOCKING_LIST[@]}"; do
+  PORT=`python3 get_available_port.py`
+  BLOCKING_STR="Blocking"
+  if [[ $BLOCKING == "FALSE" ]]; then
+    BLOCKING_STR="Non-blocking"
+  fi
+
+  # tensor_sink (client) --> tensor_src (server), other/tensor
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} blocking=${BLOCKING} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" ${INDEX}-1 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL} blocking=${BLOCKING}" ${INDEX}-2 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS-1))`
+  do
+    callCompareTest original1_${i}.log result_${i}.log GoldenTest-${INDEX} "gRPC ${IDL}/${BLOCKING_STR} $((i+1))/${NUM_BUFFERS}" 0 0
+  done
+
+  INDEX=$((INDEX + 1))
+  rm result_*.log
+
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (server) --> tensor_src (client), other/tensor
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL} blocking=${BLOCKING}" ${INDEX}-1 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} server=false idl=${IDL} blocking=${BLOCKING} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" ${INDEX}-2 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS-1))`
+  do
+    callCompareTest original1_${i}.log result_${i}.log GoldenTest-${INDEX} "gRPC ${IDL}/${BLOCKING_STR} $((i+1))/${NUM_BUFFERS}" 0 0
+  done
+
+  INDEX=$((INDEX + 1))
+  rm result_*.log
+
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (client) --> tensor_src (server), other/tensors
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} blocking=${BLOCKING} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" ${INDEX}-1 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} idl=${IDL} blocking=${BLOCKING}" ${INDEX}-2 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS/2-1))`
+  do
+    callCompareTest original2_${i}.log result_${i}.log GoldenTest-${INDEX} "gRPC ${IDL}/${BLOCKING_STR} $((i+1))/$((NUM_BUFFERS/2))" 0 0
+  done
+
+  INDEX=$((INDEX + 1))
+  rm result_*.log
+
+  PORT=`python3 get_available_port.py`
+  # tensor_sink (server) --> tensor_src (client), other/tensors
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL} blocking=${BLOCKING}" ${INDEX}-1 0 0 $PERFORMANCE &
+  sleep 1
+  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) server=false idl=${IDL} blocking=${BLOCKING} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" ${INDEX}-2 0 0 $PERFORMANCE
+
+  for i in `seq 0 $((NUM_BUFFERS/2-1))`
+  do
+    callCompareTest original2_${i}.log result_${i}.log GoldenTest-${INDEX} "gRPC ${IDL}/${BLOCKING_STR} $((i+1))/$((NUM_BUFFERS/2))" 0 0
+  done
+
+  INDEX=$((INDEX + 1))
+  rm result_*.log
+done
+done
 
 rm original*.log
 


### PR DESCRIPTION
This PR includes old commits including
- disable gRPC in debian
- perform async tests in Tizen env.

Unfortunately, gRPC/Debian seems unstable, which often causes hanging or test failures.
I'm not sure why but it seems to be related gRPC debian packaging issue.

For now, gRPC is only supported in Tizen env.

See also: https://github.com/nnstreamer/nnstreamer/issues/3089

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>