### PR TITLE
[Transform] tensor type in stand mode

### DIFF
--- a/gst/nnstreamer/tensor_transform/tensor_transform.h
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.h
@@ -133,6 +133,7 @@ typedef struct _tensor_transform_transpose {
  */
 typedef struct _tensor_transform_stand {
   tensor_transform_stand_mode mode;
+  tensor_type out_type;
 } tensor_transform_stand;
 
 /**


### PR DESCRIPTION
Currently only float32 can use stand mode in tensor-transform.

Add option to set output type and calc stand mode.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
