### PR TITLE
Enable detection for nntrainer singleshot

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -1198,6 +1198,8 @@ gst_tensor_filter_detect_framework (const gchar * const *model_files,
       detected_fw = g_strdup ("python");
     else if (g_str_equal (ext[0], ".graph"))
       detected_fw = g_strdup ("movidius-ncsdk2");
+    else if (g_str_equal (ext[0], ".ini"))
+      detected_fw = g_strdup ("nntrainer");
     else if (g_str_equal (ext[0], ".circle"))
       detected_fw = g_strdup ("nnfw");
     else if (g_str_equal (ext[0], NNSTREAMER_SO_FILE_EXTENSION))


### PR DESCRIPTION
This patch maps *.ini as nntrainer to utilize auto detection for
nntrainer.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
