### PR TITLE
Decoder pose

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -206,8 +206,7 @@ pose_getOutCaps (void **pdata, const GstTensorsConfig * config)
     g_return_val_if_fail (dim1[i] == 1, NULL);
 
   str = g_strdup_printf ("video/x-raw, format = RGBA, " /* Use alpha channel to make the background transparent */
-      "width = %u, height = %u"
-      , data->width, data->height);
+      "width = %u, height = %u", data->width, data->height);
   caps = gst_caps_from_string (str);
   setFramerateFromConfig (caps, config);
   g_free (str);

--- a/ext/nnstreamer/tensor_decoder/tensordecutil.c
+++ b/ext/nnstreamer/tensor_decoder/tensordecutil.c
@@ -38,6 +38,10 @@ loadImageLabels (const char *label_path, imglabel_t * l)
     g_clear_error (&err);
     return;
   }
+  len = strlen (contents);
+
+  if (contents[len - 1] == '\n')
+    contents[len - 1] = '\0';
 
   _labels = g_strsplit (contents, "\n", -1);
   l->total_labels = g_strv_length (_labels);

--- a/ext/nnstreamer/tensor_decoder/tensordecutil.c
+++ b/ext/nnstreamer/tensor_decoder/tensordecutil.c
@@ -125,7 +125,7 @@ _free_labels (imglabel_t * data)
  * @param[in]   config to copy from
  */
 void
-setFramerateFromConfig  (GstCaps * caps, const GstTensorsConfig * config)
+setFramerateFromConfig (GstCaps * caps, const GstTensorsConfig * config)
 {
   gint fn, fd;
 

--- a/tests/nnstreamer_decoder_pose/runTest.sh
+++ b/tests/nnstreamer_decoder_pose/runTest.sh
@@ -31,6 +31,6 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc ! videoconvert ! video
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 1 0 0 $PERFORMANCE
 
 # TEST WITH MORE BUFFERS
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=20 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:128,div:255 ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 option3=notused ! fakesink" 2 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=20 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:128,div:255 ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 2 0 0 $PERFORMANCE
 
 report


### PR DESCRIPTION
Hi nnstreamer folks,

This PR adds support for using pose decoder with latest posenet neural network model which are using 17 different key points.

https://www.tensorflow.org/lite/examples/pose_estimation/overview#model_description

A sub plugin pose decoder option(3) has been added to specify the body joint labels.
If the option is not set or the specified file is not present, the default (14) pose labels are used as fallback.

Signed-off-by: Xavier Roumegue <xavier.roumegue@nxp.com>

Self evaluation:
Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped
