### PR TITLE
[Packaging] Add test-devel to rpm/dpkg

### DIFF
--- a/Documentation/writing-subplugin-tensor-filter.md
+++ b/Documentation/writing-subplugin-tensor-filter.md
@@ -63,12 +63,49 @@ As you can see in packaging/*.spec and meson.build of the template, ```nnstreame
 
 In order to provide callbacks required by ```tensor_filter```, you need to include ```nnstreamer_plugin_api_filter.h```, which is supplied with ```nnstreamer-dev``` package (in Tizen or Ubuntu).
 
+### Testing
+
+There is a templated test suite provided inside `nnstreamer-test-dev` package for dpkg, `nnstreamer-test-devel` for tizen distro.
+You may install or _BuildRequire_ this package to utilize predefined test templates.
+After installing the package, you can locate the package.
+
+
+```sh
+$ TEMPLATE_DIR=$(pkg-config nnstreamer --variable=test_templatedir)
+$ echo $TEMPLATE_DIR # result varies depending on the platform
+/usr/lib/nnstreamer/bin/unittest-nnstreamer
+$ ls $TEMPLATE_DIR
+nnstreamer-test.ini.in  subplugin_unittest_template.cc.in
+```
+
+There are two test template provided. One is conf file for the test enviornment, and the other is for the basic unittests (requires gtest).
+
+List of variables that needs to be provided are provided below...
+| File                              | Variables                                                                                                                            |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| nnstreamer-test.ini.in            | SUBPLUGIN_INSTALL_PREFIX, ENABLE_ENV_VAR, ENABLE_SYMBOLIC_LINK, TORCH_USE_GPU, TFLITE_SUBPLUGIN_PRIORITY, ELEMENT_RESTRICTION_CONFIG |
+| subplugin_unittest_template.cc.in | EXT_NAME, EXT_ABBRV, MODEL_FILE,                                                                                                     |
+
+You can change the provided each variable on the go using a script, for example...
+```sh
+$ sed s/@EXT_ABBRV@/cutom_plugin/g subplugin_unittest_template.cc.in > subplugin_unittest.cc
+```
+
+but preferably, using meson through `configure_data` and `configure_file`
+
+and defining `NNSTREAMER_CONF_PATH` environment variable will locate the `nnstreamer-test.ini` to find your subplugin
+
+with generated `nnstreamer-test.ini`
+
+You can run the test as below:
+
+```sh
+NNSTREMAER_CONF_PATH=your/conf/file.ini ./subplugin_unittest
+```
 
 ### Install Path
 
 The default ```tensor_filter``` subplugin path is ```/usr/lib/nnstreamer/filters/```. It can be modified by configuring ```/etc/nnstreamer.ini```.
-
-
 ### Flexible/Dynamic Input/Output Tensor Dimension
 
 Although the given template code supports static input/output tensor dimension (a single neural network model is supposed to have a single set of input/output tensor/tensors dimensions), NNStreamer's ```tensor_filter``` itself supports dynamic input/output tensor/tensors dimensions; output dimensions may be determined by input dimensions, which is determined at run-time.

--- a/debian/control
+++ b/debian/control
@@ -19,9 +19,27 @@ Homepage: https://github.com/nnstreamer/nnstreamer
 Package: nnstreamer
 Architecture: any
 Multi-Arch: same
+Depends: nnstreamer-core, nnstreamer-configuration, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer plugins for Gstreamer
+ Gstreamer plugins, "NNStreamer", provides access to neural network frameworks for media streams.
+ This package is meta package of nnstreamer-core and nnstreamer-configuration.
+
+Package: nnstreamer-core
+Architecture: any
+Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer plugins for Gstreamer
  Gstreamer plugins, "NNStreamer", provides access to neural network frameworks for media streams.
+ This package is core package without configuration.
+
+Package: nnstreamer-configuration
+Architecture: any
+Multi-Arch: same
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer plugins for Gstreamer
+ Gstreamer plugins, "NNStreamer", provides access to neural network frameworks for media streams.
+ This package contains nnstreamer configuration.
+
 
 Package: nnstreamer-tensorflow
 Architecture: amd64

--- a/debian/control
+++ b/debian/control
@@ -124,6 +124,14 @@ Description: Development package to access internal functions of NNStreamer.
  This may be used by API packages.
  In most cases, custom-filter or subplugin authors do not need this internal devel package; however, if they want to access more internal functions, they may need this.
 
+Package: nnstreamer-test-dev
+Architecture: any
+Multi-Arch: same
+Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer development package
+ Gstreamer plugins, "NNStreamer", provides access to neural network frameworks for media streams.
+ This is development package for nnstreamer.
+
 Package: nnstreamer-util
 Architecture: any
 Multi-Arch: same

--- a/debian/control
+++ b/debian/control
@@ -127,10 +127,10 @@ Description: Development package to access internal functions of NNStreamer.
 Package: nnstreamer-test-dev
 Architecture: any
 Multi-Arch: same
-Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
-Description: NNStreamer development package
- Gstreamer plugins, "NNStreamer", provides access to neural network frameworks for media streams.
- This is development package for nnstreamer.
+Depends: nnstreamer-dev, ${shlibs:Depends}, ${misc:Depends}
+Description: Development package to provide testable environment of a subplugin (tensor_filter/custom).
+ This package enables testable environment of NNStreamer sub-plugin by making nnstreamer to recognize NNSTREAMER_CONF_PATH to steer a sub-plugin path to a custom path.
+ Also This package provides test templates to be used with.
 
 Package: nnstreamer-util
 Architecture: any

--- a/debian/nnstreamer-configuration.install
+++ b/debian/nnstreamer-configuration.install
@@ -1,0 +1,1 @@
+/etc/nnstreamer.ini

--- a/debian/nnstreamer-core.install
+++ b/debian/nnstreamer-core.install
@@ -5,4 +5,3 @@
 /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_direct_video.so
 /usr/lib/nnstreamer/filters/libnnstreamer_filter_cpp.so
 /usr/lib/*/gstreamer-1.0/libnnstreamer.so
-/etc/nnstreamer.ini

--- a/debian/nnstreamer-test-dev.install
+++ b/debian/nnstreamer-test-dev.install
@@ -1,0 +1,2 @@
+/usr/lib/nnstreamer/bin/unittest-nnstreamer/nnstreamer-test.ini.in
+/usr/lib/nnstreamer/bin/unittest-nnstreamer/subplugin_unittest_template.cc.in

--- a/debian/rules
+++ b/debian/rules
@@ -36,7 +36,7 @@ override_dh_auto_configure:
 	mkdir -p ${BUILDDIR}
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
 	-Denable-edgetpu=true -Denable-openvino=true \
-	-Denable-tizen=false ${BUILDDIR}
+	-Denable-tizen=false -Denable-test=true -Dinstall-test=true ${BUILDDIR}
 
 override_dh_auto_build:
 	ninja -C ${BUILDDIR}

--- a/meson.build
+++ b/meson.build
@@ -446,6 +446,7 @@ restricted_elements=''' + get_option('restricted-elements')
 endif
 
 nnstreamer_install_conf.set('ELEMENT_RESTRICTION_CONFIG', restriction_config)
+nnstreamer_install_conf.set('TEST_TEMPLATE_DIR', unittest_base_dir) # TEST_TEMPLATE_DIR will be empty if `install-test` is false
 
 # Install .ini
 configure_file(input: 'nnstreamer.ini.in', output: 'nnstreamer.ini',
@@ -472,6 +473,13 @@ subdir('tools/development')
 if get_option('enable-test')
   # Build nnstreamer examples
   subdir('nnstreamer_example')
+
+  # ini file generator template for the plugins from other repository
+  configure_file(input: 'nnstreamer.ini.in', output: 'nnstreamer-test.ini.in',
+    install: get_option('install-test'),
+    install_dir: unittest_base_dir,
+    copy: true,
+  )
 
   # temporary ini file for test, enable env variables.
   nnstreamer_test_conf = configuration_data()

--- a/nnstreamer.pc.in
+++ b/nnstreamer.pc.in
@@ -4,6 +4,7 @@ prefix=@PREFIX@
 exec_prefix=@EXEC_PREFIX@
 libdir=@LIB_INSTALL_DIR@
 includedir=@INCLUDE_INSTALL_DIR@
+test_templatedir=@TEST_TEMPLATE_DIR@ # test template dir to be used
 
 Name: nnstreamer
 Description: Dev Kit of Neural Network Suite (NNStreamer) for GStreamer

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -391,6 +391,14 @@ Requires:   nnstreamer-devel = %{version}-%{release}
 %description devel-static
 Static library package of nnstreamer-devel.
 
+%package test-devel
+Summary: Development package to provide testable environment of a subplugin (tensor_filter/custom)
+Requires: nnstreamer-devel = %{version}-%{release}
+%description test-devel
+Development package to provide testable environment of NNStreamer sub-plugin.
+This package enables testable environment of NNStreamer sub-plugin by making nnstreamer to recognize NNSTREAMER_CONF_PATH to steer a sub-plugin path to a custom path.
+Also This package provides test templates to be used with.
+
 %if 0%{?testcoverage}
 %package unittest-coverage
 Summary:	NNStreamer UnitTest Coverage Analysis Result
@@ -736,6 +744,12 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 
 %postun -p /sbin/ldconfig
 
+%post test-devel
+mv /etc/nnstreamer.ini /etc/nnstreamer.ini.bak
+
+%postun test-devel
+mv /etc/nnstreamer.ini.bak /etc/nnstreamer.ini
+
 %files
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
@@ -932,6 +946,12 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 
 %files misc
 %{gstlibdir}/libgstjoin.so
+
+%if 0%{?release_test}
+%files test-devel
+%{_prefix}/%{nnstbindir}/unittest-nnstreamer/subplugin_unittest_template.cc.in
+%{_prefix}/%{nnstbindir}/unittest-nnstreamer/nnstreamer-test.ini.in
+%endif
 
 %changelog
 * Fri Nov 20 2020 MyungJoo Ham <myungjoo.ham@samsung.com>

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -124,8 +124,11 @@ Source0:	nnstreamer-%{version}.tar.gz
 Source1:	generate-tarball.sh
 Source1001:	nnstreamer.manifest
 
+## Define requirements ##
+Requires: nnstreamer-core = %{version}-%{release}
+Requires: nnstreamer-configuration = %{version}-%{release}
+
 ## Define build requirements ##
-Requires:	gstreamer >= 1.8.0
 BuildRequires:	gstreamer-devel
 BuildRequires:	gst-plugins-base-devel
 BuildRequires:	gst-plugins-bad-devel
@@ -262,7 +265,20 @@ BuildRequires:	pkgconfig(orc-0.4)
 ## Define Packages ##
 %description
 NNStreamer is a set of gstreamer plugins to support general neural networks
-and their plugins in a gstreamer stream.
+and their plugins in a gstreamer stream. NNStreamer is a meta package of
+nnstreamer-core and nnstreamer-configuration
+
+%package core
+Requires: gstreamer >= 1.8.0
+Summary: NNStreamer core package
+%description core
+NNStreamer is a set of gstreamer plugins to support general neural networks
+and their plugins in a gstreamer stream, this package is core package without configuration
+
+%package configuration
+Summary: NNStreamer global configuration
+%description configuration
+NNStreamer's configuration setup for the end user.
 
 # for tensorflow
 %if 0%{?tensorflow_support}
@@ -370,7 +386,7 @@ NNStreamer's tensor_fliter subplugin of caffe2
 
 %package devel
 Summary:	Development package for custom tensor operator developers (tensor_filter/custom)
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-core = %{version}-%{release}
 Requires:	glib2-devel
 Requires:	gstreamer-devel
 %description devel
@@ -394,6 +410,7 @@ Static library package of nnstreamer-devel.
 %package test-devel
 Summary: Development package to provide testable environment of a subplugin (tensor_filter/custom)
 Requires: nnstreamer-devel = %{version}-%{release}
+Conflicts: nnstreamer-configuration
 %description test-devel
 Development package to provide testable environment of NNStreamer sub-plugin.
 This package enables testable environment of NNStreamer sub-plugin by making nnstreamer to recognize NNSTREAMER_CONF_PATH to steer a sub-plugin path to a custom path.
@@ -744,13 +761,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 
 %postun -p /sbin/ldconfig
 
-%post test-devel
-mv /etc/nnstreamer.ini /etc/nnstreamer.ini.bak
-
-%postun test-devel
-mv /etc/nnstreamer.ini.bak /etc/nnstreamer.ini
-
-%files
+%files core
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
 %license LICENSE
@@ -762,6 +773,8 @@ mv /etc/nnstreamer.ini.bak /etc/nnstreamer.ini
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_cpp.so
 %{gstlibdir}/libnnstreamer.so
 %{_libdir}/libnnstreamer.so
+
+%files configuration
 %{_sysconfdir}/nnstreamer.ini
 
 # for tensorflow

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -43,7 +43,16 @@ endif
 
 sed_command = find_program('sed', required: true)
 ext_test_template_prefix = 'unittest_tizen_'
-ext_test_template = files (ext_test_template_prefix + 'template.cc.in')
+ext_test_template_str = ext_test_template_prefix + 'template.cc.in'
+ext_test_template = files (ext_test_template_str)
+
+configure_file(
+  input: ext_test_template_str,
+  output: 'subplugin_unittest_template.cc.in',
+  install: get_option('install-test'),
+  install_dir: unittest_base_dir,
+  copy: true
+)
 
 foreach ext : extensions
   ext_test_path_each = ext_test_template_prefix + ext[4] + '.cc'


### PR DESCRIPTION
- [Packaging] Add test-devel to rpm/dpkg
```
Add test-devel to rpm/dpkg

This patch...
1. offers `nnstreamer-template.ini.in` from test-devel package
1. offers `subplugin_unittest_template.cc.in` from test-devel package
1. for rpm test-devel, it renames /etc/nnstreamer.ini until test-devel
is unintalled
1. add pkg-config variable to locate test related templates

Resolves #3124

Tested using gbs and pdebuild

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
- [Doc] Add documentation of using test-devel
```
Add documentation of how to utilize test-devel package in the
perspective of subplugin developer

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
- **v2** [Package] Seperate nnstreamer into core and conf
```
This patch separates nnstreamer into nnstreamer-core and nnstreamer-configuration.
From this patch, nnstreamer becomes a meta package that requires
nnstreamer-core and nnstreamer-configuration.

Evaluation Method
gbs and pdebuild

Self evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped
Signed-off-by: Jihoon Lee jhoon.it.lee@samsung.com
```

resolves #3124 