### PR TITLE
Remove underscore in test names

### DIFF
--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -25,7 +25,7 @@
 /**
  * @brief Test for int32 type string.
  */
-TEST (common_get_tensor_type, failure_n)
+TEST (commonGetTensorType, failure_n)
 {
   EXPECT_EQ (gst_tensor_get_type (""), _NNS_END);
   EXPECT_EQ (gst_tensor_get_type (NULL), _NNS_END);
@@ -34,7 +34,7 @@ TEST (common_get_tensor_type, failure_n)
 /**
  * @brief Test for int32 type string.
  */
-TEST (common_get_tensor_type, int32)
+TEST (commonGetTensorType, int32)
 {
   EXPECT_EQ (gst_tensor_get_type ("int32"), _NNS_INT32);
   EXPECT_EQ (gst_tensor_get_type ("INT32"), _NNS_INT32);
@@ -45,7 +45,7 @@ TEST (common_get_tensor_type, int32)
 /**
  * @brief Test for int32 type string.
  */
-TEST (common_get_tensor_type, int32_n)
+TEST (commonGetTensorType, int32_n)
 {
   EXPECT_EQ (gst_tensor_get_type ("InT322"), _NNS_END);
   EXPECT_EQ (gst_tensor_get_type ("int3"), _NNS_END);
@@ -54,7 +54,7 @@ TEST (common_get_tensor_type, int32_n)
 /**
  * @brief Test for int16 type string.
  */
-TEST (common_get_tensor_type, int16)
+TEST (commonGetTensorType, int16)
 {
   EXPECT_EQ (gst_tensor_get_type ("int16"), _NNS_INT16);
   EXPECT_EQ (gst_tensor_get_type ("INT16"), _NNS_INT16);
@@ -65,7 +65,7 @@ TEST (common_get_tensor_type, int16)
 /**
  * @brief Test for int16 type string.
  */
-TEST (common_get_tensor_type, int16_n)
+TEST (commonGetTensorType, int16_n)
 {
   EXPECT_EQ (gst_tensor_get_type ("InT162"), _NNS_END);
   EXPECT_EQ (gst_tensor_get_type ("int1"), _NNS_END);
@@ -74,7 +74,7 @@ TEST (common_get_tensor_type, int16_n)
 /**
  * @brief Test for int8 type string.
  */
-TEST (common_get_tensor_type, int8)
+TEST (commonGetTensorType, int8)
 {
   EXPECT_EQ (gst_tensor_get_type ("int8"), _NNS_INT8);
   EXPECT_EQ (gst_tensor_get_type ("INT8"), _NNS_INT8);
@@ -85,7 +85,7 @@ TEST (common_get_tensor_type, int8)
 /**
  * @brief Test for int8 type string.
  */
-TEST (common_get_tensor_type, int8_n)
+TEST (commonGetTensorType, int8_n)
 {
   EXPECT_EQ (gst_tensor_get_type ("InT82"), _NNS_END);
   EXPECT_EQ (gst_tensor_get_type ("int3"), _NNS_END);
@@ -94,7 +94,7 @@ TEST (common_get_tensor_type, int8_n)
 /**
  * @brief Test for uint32 type string.
  */
-TEST (common_get_tensor_type, uint32)
+TEST (commonGetTensorType, uint32)
 {
   EXPECT_EQ (gst_tensor_get_type ("uint32"), _NNS_UINT32);
   EXPECT_EQ (gst_tensor_get_type ("UINT32"), _NNS_UINT32);
@@ -105,7 +105,7 @@ TEST (common_get_tensor_type, uint32)
 /**
  * @brief Test for uint32 type string.
  */
-TEST (common_get_tensor_type, uint32_n)
+TEST (commonGetTensorType, uint32_n)
 {
   EXPECT_EQ (gst_tensor_get_type ("UInT322"), _NNS_END);
   EXPECT_EQ (gst_tensor_get_type ("uint3"), _NNS_END);
@@ -114,7 +114,7 @@ TEST (common_get_tensor_type, uint32_n)
 /**
  * @brief Test for uint16 type string.
  */
-TEST (common_get_tensor_type, uint16)
+TEST (commonGetTensorType, uint16)
 {
   EXPECT_EQ (gst_tensor_get_type ("uint16"), _NNS_UINT16);
   EXPECT_EQ (gst_tensor_get_type ("UINT16"), _NNS_UINT16);
@@ -125,7 +125,7 @@ TEST (common_get_tensor_type, uint16)
 /**
  * @brief Test for uint16 type string.
  */
-TEST (common_get_tensor_type, uint16_n)
+TEST (commonGetTensorType, uint16_n)
 {
   EXPECT_EQ (gst_tensor_get_type ("UInT162"), _NNS_END);
   EXPECT_EQ (gst_tensor_get_type ("uint1"), _NNS_END);
@@ -134,7 +134,7 @@ TEST (common_get_tensor_type, uint16_n)
 /**
  * @brief Test for uint8 type string.
  */
-TEST (common_get_tensor_type, uint8)
+TEST (commonGetTensorType, uint8)
 {
   EXPECT_EQ (gst_tensor_get_type ("uint8"), _NNS_UINT8);
   EXPECT_EQ (gst_tensor_get_type ("UINT8"), _NNS_UINT8);
@@ -145,7 +145,7 @@ TEST (common_get_tensor_type, uint8)
 /**
  * @brief Test for uint8 type string.
  */
-TEST (common_get_tensor_type, uint8_n)
+TEST (commonGetTensorType, uint8_n)
 {
   EXPECT_EQ (gst_tensor_get_type ("UInT82"), _NNS_END);
   EXPECT_EQ (gst_tensor_get_type ("uint3"), _NNS_END);
@@ -154,7 +154,7 @@ TEST (common_get_tensor_type, uint8_n)
 /**
  * @brief Test for float32 type string.
  */
-TEST (common_get_tensor_type, float32)
+TEST (commonGetTensorType, float32)
 {
   EXPECT_EQ (gst_tensor_get_type ("float32"), _NNS_FLOAT32);
   EXPECT_EQ (gst_tensor_get_type ("FLOAT32"), _NNS_FLOAT32);
@@ -165,7 +165,7 @@ TEST (common_get_tensor_type, float32)
 /**
  * @brief Test for float32 type string.
  */
-TEST (common_get_tensor_type, float32_n)
+TEST (commonGetTensorType, float32_n)
 {
   EXPECT_EQ (gst_tensor_get_type ("FloaT322"), _NNS_END);
   EXPECT_EQ (gst_tensor_get_type ("float3"), _NNS_END);
@@ -174,7 +174,7 @@ TEST (common_get_tensor_type, float32_n)
 /**
  * @brief Test for float64 type string.
  */
-TEST (common_get_tensor_type, float64)
+TEST (commonGetTensorType, float64)
 {
   EXPECT_EQ (gst_tensor_get_type ("float64"), _NNS_FLOAT64);
   EXPECT_EQ (gst_tensor_get_type ("FLOAT64"), _NNS_FLOAT64);
@@ -185,7 +185,7 @@ TEST (common_get_tensor_type, float64)
 /**
  * @brief Test for float64 type string.
  */
-TEST (common_get_tensor_type, float64_n)
+TEST (commonGetTensorType, float64_n)
 {
   EXPECT_EQ (gst_tensor_get_type ("FloaT642"), _NNS_END);
   EXPECT_EQ (gst_tensor_get_type ("float6"), _NNS_END);
@@ -194,7 +194,7 @@ TEST (common_get_tensor_type, float64_n)
 /**
  * @brief Test for int64 type string.
  */
-TEST (common_get_tensor_type, int64)
+TEST (commonGetTensorType, int64)
 {
   EXPECT_EQ (gst_tensor_get_type ("int64"), _NNS_INT64);
   EXPECT_EQ (gst_tensor_get_type ("INT64"), _NNS_INT64);
@@ -205,7 +205,7 @@ TEST (common_get_tensor_type, int64)
 /**
  * @brief Test for int64 type string.
  */
-TEST (common_get_tensor_type, int64_n)
+TEST (commonGetTensorType, int64_n)
 {
   EXPECT_EQ (gst_tensor_get_type ("InT642"), _NNS_END);
   EXPECT_EQ (gst_tensor_get_type ("int6"), _NNS_END);
@@ -214,7 +214,7 @@ TEST (common_get_tensor_type, int64_n)
 /**
  * @brief Test for uint64 type string.
  */
-TEST (common_get_tensor_type, uint64)
+TEST (commonGetTensorType, uint64)
 {
   EXPECT_EQ (gst_tensor_get_type ("uint64"), _NNS_UINT64);
   EXPECT_EQ (gst_tensor_get_type ("UINT64"), _NNS_UINT64);
@@ -225,7 +225,7 @@ TEST (common_get_tensor_type, uint64)
 /**
  * @brief Test for uint64 type string.
  */
-TEST (common_get_tensor_type, uint64_n)
+TEST (commonGetTensorType, uint64_n)
 {
   EXPECT_EQ (gst_tensor_get_type ("UInT642"), _NNS_END);
   EXPECT_EQ (gst_tensor_get_type ("uint6"), _NNS_END);
@@ -234,7 +234,7 @@ TEST (common_get_tensor_type, uint64_n)
 /**
  * @brief Test to find index of the key.
  */
-TEST (common_find_key_strv, key_index)
+TEST (commonFindKeyStrv, keyIndex)
 {
   const gchar *teststrv[] = { "abcde", "ABCDEF", "1234", "abcabc", "tester", NULL };
 
@@ -249,7 +249,7 @@ TEST (common_find_key_strv, key_index)
 /**
  * @brief Test for tensor dimension.
  */
-TEST (common_get_tensor_dimension, case1)
+TEST (commonGetTensorDimension, case1)
 {
   tensor_dim dim;
   gchar *dim_str;
@@ -270,7 +270,7 @@ TEST (common_get_tensor_dimension, case1)
 /**
  * @brief Test for tensor dimension.
  */
-TEST (common_get_tensor_dimension, case2)
+TEST (commonGetTensorDimension, case2)
 {
   tensor_dim dim;
   gchar *dim_str;
@@ -291,7 +291,7 @@ TEST (common_get_tensor_dimension, case2)
 /**
  * @brief Test for tensor dimension.
  */
-TEST (common_get_tensor_dimension, case3)
+TEST (commonGetTensorDimension, case3)
 {
   tensor_dim dim;
   gchar *dim_str;
@@ -312,7 +312,7 @@ TEST (common_get_tensor_dimension, case3)
 /**
  * @brief Test for tensor dimension.
  */
-TEST (common_get_tensor_dimension, case4)
+TEST (commonGetTensorDimension, case4)
 {
   tensor_dim dim;
   gchar *dim_str;
@@ -333,7 +333,7 @@ TEST (common_get_tensor_dimension, case4)
 /**
  * @brief Test to copy tensor info.
  */
-TEST (common_tensor_info, copy_tensor)
+TEST (commonTensorInfo, copyTensor)
 {
   GstTensorInfo src, dest;
   gchar *test_name = g_strdup ("test-tensor");
@@ -370,7 +370,7 @@ TEST (common_tensor_info, copy_tensor)
 /**
  * @brief Test to copy tensor info.
  */
-TEST (common_tensor_info, copy_tensors)
+TEST (commonTensorInfo, copyTensors)
 {
   GstTensorsInfo src, dest;
   gchar *test_name = g_strdup ("test-tensors");
@@ -447,7 +447,7 @@ fill_tensors_config_for_test (GstTensorsConfig *conf1, GstTensorsConfig *conf2)
 /**
  * @brief Test for data size.
  */
-TEST (common_tensor_info, size_01_p)
+TEST (commonTensorInfo, size01_p)
 {
   GstTensorsInfo info1, info2;
   gsize size1, size2;
@@ -473,7 +473,7 @@ TEST (common_tensor_info, size_01_p)
 /**
  * @brief Test for data size.
  */
-TEST (common_tensor_info, size_02_n)
+TEST (commonTensorInfo, size02_n)
 {
   GstTensorsInfo info1, info2;
   gsize size1;
@@ -491,7 +491,7 @@ TEST (common_tensor_info, size_02_n)
 /**
  * @brief Test for data size.
  */
-TEST (common_tensor_info, size_03_n)
+TEST (commonTensorInfo, size03_n)
 {
   GstTensorsInfo info1, info2;
   gsize size1;
@@ -509,7 +509,7 @@ TEST (common_tensor_info, size_03_n)
 /**
  * @brief Test for same tensors info.
  */
-TEST (common_tensor_info, equal_01_p)
+TEST (commonTensorInfo, equal01_p)
 {
   GstTensorsInfo info1, info2;
 
@@ -521,7 +521,7 @@ TEST (common_tensor_info, equal_01_p)
 /**
  * @brief Test for same tensors info.
  */
-TEST (common_tensor_info, equal_02_n)
+TEST (commonTensorInfo, equal02_n)
 {
   GstTensorsInfo info1, info2;
 
@@ -535,7 +535,7 @@ TEST (common_tensor_info, equal_02_n)
 /**
  * @brief Test for same tensors info.
  */
-TEST (common_tensor_info, equal_03_n)
+TEST (commonTensorInfo, equal03_n)
 {
   GstTensorsInfo info1, info2;
 
@@ -550,7 +550,7 @@ TEST (common_tensor_info, equal_03_n)
 /**
  * @brief Test for same tensors info.
  */
-TEST (common_tensor_info, equal_04_n)
+TEST (commonTensorInfo, equal04_n)
 {
   GstTensorsInfo info1, info2;
 
@@ -565,7 +565,7 @@ TEST (common_tensor_info, equal_04_n)
 /**
  * @brief Test for same tensors info.
  */
-TEST (common_tensor_info, equal_05_n)
+TEST (commonTensorInfo, equal05_n)
 {
   GstTensorsInfo info1, info2;
 
@@ -580,7 +580,7 @@ TEST (common_tensor_info, equal_05_n)
 /**
  * @brief Test for same tensors config.
  */
-TEST (common_tensors_config, equal_01_p)
+TEST (commonTensorsConfig, equal01_p)
 {
   GstTensorsConfig conf1, conf2;
 
@@ -592,7 +592,7 @@ TEST (common_tensors_config, equal_01_p)
 /**
  * @brief Test for same tensors config.
  */
-TEST (common_tensors_config, equal_02_p)
+TEST (commonTensorsConfig, equal02_p)
 {
   GstTensorsConfig conf1, conf2;
 
@@ -606,7 +606,7 @@ TEST (common_tensors_config, equal_02_p)
 /**
  * @brief Test for same tensors config.
  */
-TEST (common_tensors_config, equal_03_p)
+TEST (commonTensorsConfig, equal03_p)
 {
   GstTensorsConfig conf1, conf2;
 
@@ -620,7 +620,7 @@ TEST (common_tensors_config, equal_03_p)
 /**
  * @brief Test for same tensors config.
  */
-TEST (common_tensors_config, equal_04_n)
+TEST (commonTensorsConfig, equal04_n)
 {
   GstTensorsConfig conf1, conf2;
 
@@ -633,7 +633,7 @@ TEST (common_tensors_config, equal_04_n)
 /**
  * @brief Test for same tensors config.
  */
-TEST (common_tensors_config, equal_05_n)
+TEST (commonTensorsConfig, equal05_n)
 {
   GstTensorsConfig conf1, conf2;
 
@@ -647,7 +647,7 @@ TEST (common_tensors_config, equal_05_n)
 /**
  * @brief Test for same tensors config.
  */
-TEST (common_tensors_config, equal_06_n)
+TEST (commonTensorsConfig, equal06_n)
 {
   GstTensorsConfig conf1, conf2;
 
@@ -660,7 +660,7 @@ TEST (common_tensors_config, equal_06_n)
 /**
  * @brief Test for dimensions string in tensors info.
  */
-TEST (common_tensors_info_string, dimensions)
+TEST (commonTensorsInfoString, dimensions)
 {
   GstTensorsInfo info;
   guint num_dims;
@@ -697,7 +697,7 @@ TEST (common_tensors_info_string, dimensions)
 /**
  * @brief Test for types string in tensors info.
  */
-TEST (common_tensors_info_string, types)
+TEST (commonTensorsInfoString, types)
 {
   GstTensorsInfo info;
   guint num_types;
@@ -735,7 +735,7 @@ TEST (common_tensors_info_string, types)
 /**
  * @brief Test for names string in tensors info.
  */
-TEST (common_tensors_info_string, names)
+TEST (commonTensorsInfoString, names)
 {
   GstTensorsInfo info;
   guint i, num_names;
@@ -790,7 +790,7 @@ TEST (common_tensors_info_string, names)
 /**
  * @brief Test to replace string.
  */
-TEST (common_string_util, replace_str_01)
+TEST (commonStringUtil, replaceStr01)
 {
   gchar *result;
   guint changed;
@@ -819,7 +819,7 @@ TEST (common_string_util, replace_str_01)
 /**
  * @brief Test to replace string.
  */
-TEST (common_string_util, replace_str_02)
+TEST (commonStringUtil, replaceStr02)
 {
   gchar *result;
   guint changed;
@@ -879,7 +879,7 @@ check_custom_conf (const gchar *group, const gchar *key, const gchar *expected)
 /**
  * @brief Test custom configurations
  */
-TEST (conf_custom, env_str_01)
+TEST (confCustom, envStr01)
 {
   gchar *fullpath = g_build_path ("/", g_get_tmp_dir (), "nns-tizen-XXXXXX", NULL);
   gchar *dir = g_mkdtemp (fullpath);
@@ -1019,7 +1019,7 @@ TEST (conf_custom, env_str_01)
 /**
  * @brief Test version control (positive)
  */
-TEST (version_control, get_ver_01)
+TEST (versionControl, getVer01)
 {
   gchar *verstr = nnstreamer_version_string ();
   guint major, minor, micro;
@@ -1045,7 +1045,7 @@ TEST (version_control, get_ver_01)
 /**
  * @brief Test pad has tensor cap
  */
-TEST (common_pad_cap, tensor_0)
+TEST (commonPadCap, tensor0)
 {
   gchar *pipeline;
   GstElement *gstpipe;
@@ -1083,7 +1083,7 @@ TEST (common_pad_cap, tensor_0)
 /**
  * @brief Test pad has tensor cap
  */
-TEST (common_pad_cap, tensors_0)
+TEST (commonPadCap, tensors0)
 {
   gchar *pipeline;
   GstElement *gstpipe;

--- a/tests/cpp_methods/unittest_cpp_methods.cc
+++ b/tests/cpp_methods/unittest_cpp_methods.cc
@@ -16,7 +16,7 @@
 static char *path_to_lib = NULL;
 
 /** @brief Positive case for the simpliest execution path */
-TEST (cpp_filter_on_demand, basic_01)
+TEST (cppFilterOnDemand, basic01)
 {
   filter_basic basic ("basic_01");
   EXPECT_EQ (basic._register (), 0);
@@ -24,7 +24,7 @@ TEST (cpp_filter_on_demand, basic_01)
 }
 
 /** @brief Negative case for the simpliest execution path */
-TEST (cpp_filter_on_demand, basic_02_n)
+TEST (cppFilterOnDemand, basic02_n)
 {
   filter_basic basic ("basic_02");
   EXPECT_NE (basic._unregister (), 0);
@@ -35,7 +35,7 @@ TEST (cpp_filter_on_demand, basic_02_n)
 }
 
 /** @brief Negative case for the simpliest execution path w/ static calls */
-TEST (cpp_filter_on_demand, basic_03_n)
+TEST (cppFilterOnDemand, basic03_n)
 {
   filter_basic basic ("basic_03");
   EXPECT_NE (filter_basic::__unregister ("basic_03"), 0);
@@ -46,7 +46,7 @@ TEST (cpp_filter_on_demand, basic_03_n)
 }
 
 /** @brief Negative case for the simpliest execution path w/ static calls */
-TEST (cpp_filter_on_demand, basic_04_n)
+TEST (cppFilterOnDemand, basic04_n)
 {
   filter_basic basic ("basic_04");
   EXPECT_NE (filter_basic::__unregister ("basic_xx"), 0);
@@ -63,7 +63,7 @@ TEST (cpp_filter_on_demand, basic_04_n)
 }
 
 /** @brief Actual GST Pipeline with cpp on demand */
-TEST (cpp_filter_on_demand, pipeline_01)
+TEST (cppFilterOnDemand, pipelne01)
 {
   filter_basic basic ("pl01");
   char *tmp1 = getTempFilename ();
@@ -112,7 +112,7 @@ TEST (cpp_filter_on_demand, pipeline_01)
 }
 
 /** @brief Negative case for the simpliest execution path */
-TEST (cpp_filter_on_demand, unregistered_01_n)
+TEST (cppFilterOnDemand, unregstered01_n)
 {
   filter_basic basic ("basic_01");
   gchar *str_pipeline = g_strdup_printf (
@@ -146,7 +146,7 @@ TEST (cpp_filter_on_demand, unregistered_01_n)
 }
 
 /** @brief gtest method */
-TEST (cpp_filter_obj, base_01_n)
+TEST (cppFilterObj, base01_n)
 {
   char *tmp1 = getTempFilename ();
   char *tmp2 = getTempFilename ();
@@ -189,7 +189,7 @@ TEST (cpp_filter_obj, base_01_n)
 }
 
 /** @brief gtest method */
-TEST (cpp_filter_obj, base_02_n)
+TEST (cppFilterObj, base02_n)
 {
   char *tmp1 = getTempFilename ();
   char *tmp2 = getTempFilename ();
@@ -232,7 +232,7 @@ TEST (cpp_filter_obj, base_02_n)
 }
 
 /** @brief gtest method */
-TEST (cpp_filter_obj, base_03)
+TEST (cppFilterObj, base03)
 {
   char *tmp1 = getTempFilename ();
   char *tmp2 = getTempFilename ();

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -59,7 +59,7 @@ new_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
 /**
  * @brief Test join element with appsrc
  */
-TEST (join, normal_0)
+TEST (join, normal0)
 {
   gint idx, n_pads;
   GstBuffer *buf_0, *buf_1, *buf_3, *buf_4;
@@ -148,7 +148,7 @@ TEST (join, normal_0)
 /**
  * @brief Test get property with invalid parameter
  */
-TEST (join, prop_0_n)
+TEST (join, prop0_n)
 {
   GstElement *join_handle;
   gchar *str_val = NULL;
@@ -176,7 +176,7 @@ TEST (join, prop_0_n)
 /**
  * @brief Test get property with NULL parameter
  */
-TEST (join, prop_1_n)
+TEST (join, prop1_n)
 {
   GstElement *join_handle;
   gchar *str_val = NULL;

--- a/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
+++ b/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
@@ -19,7 +19,7 @@
 /**
  * @brief Test armnn subplugin existence.
  */
-TEST (nnstreamer_filter_armnn, check_existence)
+TEST (nnstreamerFilterArmnn, checkExistence)
 {
   const GstTensorFilterFramework *sp = nnstreamer_filter_find ("armnn");
   EXPECT_NE (sp, (void *)NULL);
@@ -28,7 +28,7 @@ TEST (nnstreamer_filter_armnn, check_existence)
 /**
  * @brief Test armnn subplugin with failing open/close (no model file)
  */
-TEST (nnstreamer_filter_armnn, open_close_00_n)
+TEST (nnstreamerFilterArmnn, openClose00_n)
 {
   int ret;
   const gchar *model_files[] = {
@@ -49,7 +49,7 @@ TEST (nnstreamer_filter_armnn, open_close_00_n)
 /**
  * @brief Test armnn subplugin with successful open/close
  */
-TEST (nnstreamer_filter_armnn, open_close_01_n)
+TEST (nnstreamerFilterArmnn, openClose01_n)
 {
   int ret;
   void *data = NULL;
@@ -87,7 +87,7 @@ TEST (nnstreamer_filter_armnn, open_close_01_n)
 /**
  * @brief Get input/output dimensions with armnn subplugin
  */
-TEST (nnstreamer_filter_armnn, get_dimension)
+TEST (nnstreamerFilterArmnn, getDimension)
 {
   int ret;
   void *data = NULL;
@@ -159,7 +159,7 @@ TEST (nnstreamer_filter_armnn, get_dimension)
 /**
  * @brief Test armnn subplugin with successful invoke for tflite
  */
-TEST (nnstreamer_filter_armnn, invoke_00)
+TEST (nnstreamerFilterArmnn, invoke00)
 {
   int ret;
   void *data = NULL;
@@ -241,7 +241,7 @@ get_argmax (T *array, size_t size)
 /**
  * @brief Test armnn subplugin with successful invoke for tflite advanced model
  */
-TEST (nnstreamer_filter_armnn, invoke_advanced)
+TEST (nnstreamerFilterArmnn, invokeAdvanced)
 {
   int ret, fd;
   void *data = NULL;
@@ -350,7 +350,7 @@ TEST (nnstreamer_filter_armnn, invoke_advanced)
 /**
  * @brief Test armnn subplugin with successful invoke for caffe
  */
-TEST (nnstreamer_filter_armnn, invoke_01)
+TEST (nnstreamerFilterArmnn, invoke01)
 {
   int ret;
   void *data = NULL;

--- a/tests/nnstreamer_filter_edgetpu/unittest_edgetpu.cc
+++ b/tests/nnstreamer_filter_edgetpu/unittest_edgetpu.cc
@@ -16,7 +16,7 @@
 /**
  * @brief Standard positive case with a small tensorflow-lite model
  */
-TEST (edgetpu_tflite_direct, run_01)
+TEST (edgetpuTfliteDirect, run01)
 {
   gchar *pipeline;
   GstElement *gstpipe;
@@ -53,7 +53,7 @@ TEST (edgetpu_tflite_direct, run_01)
 /**
  * @brief Negative case with incorrect path
  */
-TEST (edgetpu_tflite_direct, error_01_n)
+TEST (edgetpuTfliteDirect, error01_n)
 {
   gchar *pipeline;
   GstElement *gstpipe;
@@ -93,7 +93,7 @@ TEST (edgetpu_tflite_direct, error_01_n)
 /**
  * @brief Negative case with incorrect tensor meta
  */
-TEST (edgetpu_tflite_direct, error_02_n)
+TEST (edgetpuTfliteDirect, error02_n)
 {
   gchar *pipeline;
   GstElement *gstpipe;

--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
@@ -17,7 +17,7 @@
 /**
  * @brief Test @EXT_ABBRV@ subplugin existence.
  */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, check_existence)
+TEST (nnstreamer@EXT_ABBRV@BasicFunctions, checkExistence)
 {
   const GstTensorFilterFramework *sp = nnstreamer_filter_find ("@EXT_NAME@");
   EXPECT_NE (sp, (void *) NULL);
@@ -26,7 +26,7 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, check_existence)
 /**
  * @brief Test @EXT_ABBRV@ subplugin with failing open/close (no model file)
  */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, open_close_00_n)
+TEST (nnstreamer@EXT_ABBRV@BasicFunctions, openClose00_n)
 {
   int ret;
   const gchar *model_files[] = {
@@ -106,7 +106,7 @@ ret:
 /**
  * @brief Test @EXT_ABBRV@ subplugin with successful open/close
  */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, open_close_01_n)
+TEST (nnstreamer@EXT_ABBRV@BasicFunctions, openClose01_n)
 {
   int ret;
   void *data = NULL;
@@ -141,7 +141,7 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, open_close_01_n)
 /**
  * @brief Get input/output dimensions with @EXT_ABBRV@ subplugin
  */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, get_dimension_fail_n)
+TEST (nnstreamer@EXT_ABBRV@BasicFunctions, getDimensionFail_n)
 {
   int ret;
   void *data = NULL;
@@ -187,7 +187,7 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, get_dimension_fail_n)
 /**
  * @brief Get input/output dimensions with @EXT_ABBRV@ subplugin
  */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, get_dimension)
+TEST (nnstreamer@EXT_ABBRV@BasicFunctions, getDimension)
 {
   int ret;
   void *data = NULL;
@@ -231,7 +231,7 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, get_dimension)
 /**
  * @brief Set input dimensions with @EXT_ABBRV@ subplugin
  */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, set_dimension_fail_n)
+TEST (nnstreamer@EXT_ABBRV@BasicFunctions, setDimensionFail_n)
 {
   int ret;
   void *data = NULL;
@@ -280,7 +280,7 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, set_dimension_fail_n)
 /**
  * @brief Set input dimensions with @EXT_ABBRV@ subplugin
  */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, set_dimension)
+TEST (nnstreamer@EXT_ABBRV@BasicFunctions, setDimension)
 {
   int ret;
   void *data = NULL;
@@ -366,7 +366,7 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, set_dimension)
 /**
  * @brief Test @EXT_ABBRV@ subplugin with unsuccessful invoke
  */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, invoke_fail_n)
+TEST (nnstreamer@EXT_ABBRV@BasicFunctions, invokeFail_n)
 {
   int ret;
   void *data = NULL;
@@ -416,7 +416,7 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, invoke_fail_n)
 /**
  * @brief Test @EXT_ABBRV@ subplugin with successful invoke
  */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, invoke)
+TEST (nnstreamer@EXT_ABBRV@BasicFunctions, invoke)
 {
   int ret;
   int ret_get_in, ret_get_out, ret_set_in;
@@ -523,7 +523,7 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, invoke)
 /**
  * @brief Reload model with @EXT_ABBRV@ subplugin
  */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, reload_model)
+TEST (nnstreamer@EXT_ABBRV@BasicFunctions, reloadModel)
 {
   int ret;
   void *data = NULL;
@@ -588,7 +588,7 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, reload_model)
 /**
  * @brief Validate destroy notify with @EXT_ABBRV@ subplugin
  */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, destroyNotify_n)
+TEST (nnstreamer@EXT_ABBRV@BasicFunctions, destroyNotify_n)
 {
   int ret;
   void *data = NULL;
@@ -626,7 +626,7 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, destroyNotify_n)
 /**
  * @brief Check allocate in invoke with @EXT_ABBRV@ subplugin
  */
-TEST (nnstreamer_@EXT_ABBRV@_basic_functions, allocateInInvoke_n)
+TEST (nnstreamer@EXT_ABBRV@BasicFunctions, allocateInInvoke_n)
 {
   int ret;
   void *data = NULL;

--- a/tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2.cc
+++ b/tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2.cc
@@ -22,7 +22,7 @@
 /**
  * @brief Testing valid pipeline launching and its state changing
  */
-TEST (pipeline_mvncsdk2_filter, launch_normal)
+TEST (pipelineMvncsdk2Filter, launchNormal)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *pipeline;
@@ -111,7 +111,7 @@ TEST (pipeline_mvncsdk2_filter, launch_normal)
 }
 
 #define TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(idx, fail_stage)                                                  \
-  TEST (pipeline_mvncsdk2_filter, launch_normal_##idx##_n)                                                    \
+  TEST (pipelineMvncsdk2Filter, launchNormal##idx##_n)                                                        \
   {                                                                                                           \
     const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");                                        \
     gchar *pipeline;                                                                                          \

--- a/tests/nnstreamer_filter_openvino/unittest_openvino.cc
+++ b/tests/nnstreamer_filter_openvino/unittest_openvino.cc
@@ -93,7 +93,7 @@ TensorFilterOpenvinoTest::setOutputsDataMap (InferenceEngine::OutputsDataMap &ma
 /**
  * @brief Test cases for open and close callbacks varying the model files
  */
-TEST (tensor_filter_openvino, open_and_close_0)
+TEST (tensorFilterOpenvino, openAndClose0)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
@@ -227,7 +227,7 @@ TEST (tensor_filter_openvino, open_and_close_0)
 /**
  * @brief A test case for open and close callbacks with the private_data, which has the models already loaded
  */
-TEST (tensor_filter_openvino, open_and_close_1)
+TEST (tensorFilterOpenvino, openAndClose1)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
@@ -301,7 +301,7 @@ TEST (tensor_filter_openvino, open_and_close_1)
 /**
  * @brief A test case for open and close callbacks with the private_data, which has the models are not loaded
  */
-TEST (tensor_filter_openvino, open_and_close_2)
+TEST (tensorFilterOpenvino, openAndClose2)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
@@ -368,7 +368,7 @@ TEST (tensor_filter_openvino, open_and_close_2)
 /**
  * @brief Negative test cases for open and close callbacks with wrong model files
  */
-TEST (tensor_filter_openvino, open_and_close_0_n)
+TEST (tensorFilterOpenvino, openAndClose0_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
@@ -470,7 +470,7 @@ TEST (tensor_filter_openvino, open_and_close_0_n)
  * @brief Negative test cases for open and close callbacks with accelerator
  *        property values, which are not supported
  */
-TEST (tensor_filter_openvino, open_and_close_1_n)
+TEST (tensorFilterOpenvino, openAndClose1_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
@@ -539,7 +539,7 @@ TEST (tensor_filter_openvino, open_and_close_1_n)
  * @brief Negative test cases for open and close callbacks with accelerator
  *        property values, which are wrong
  */
-TEST (tensor_filter_openvino, open_and_close_2_n)
+TEST (tensorFilterOpenvino, openAndClose2_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
@@ -595,7 +595,7 @@ TEST (tensor_filter_openvino, open_and_close_2_n)
 /**
  * @brief Test cases for getInputTensorDim and getOutputTensorDim callbacks
  */
-TEST (tensor_filter_openvino, getTensorDim_0)
+TEST (tensorFilterOpenvino, getTensorDim0)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
@@ -670,7 +670,7 @@ TEST (tensor_filter_openvino, getTensorDim_0)
 /**
  * @brief A negative test case for getInputTensorDim callbacks (The number of tensors is exceeded NNS_TENSOR_SIZE_LIMIT)
  */
-TEST (tensor_filter_openvino, getTensorDim_0_n)
+TEST (tensorFilterOpenvino, getTensorDim0_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
@@ -748,7 +748,7 @@ TEST (tensor_filter_openvino, getTensorDim_0_n)
 /**
  * @brief A negative test case for the getInputTensorDim callback (A wrong rank)
  */
-TEST (tensor_filter_openvino, getTensorDim_1_n)
+TEST (tensorFilterOpenvino, getTensorDim1_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
@@ -824,7 +824,7 @@ TEST (tensor_filter_openvino, getTensorDim_1_n)
 /**
  * @brief A negative test case for getOutputTensorDim callbacks (The number of tensors is exceeded NNS_TENSOR_SIZE_LIMIT)
  */
-TEST (tensor_filter_openvino, getTensorDim_2_n)
+TEST (tensorFilterOpenvino, getTensorDim2_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
@@ -899,7 +899,7 @@ TEST (tensor_filter_openvino, getTensorDim_2_n)
 /**
  * @brief A negative test case for getOutputTensorDim callbacks (The number of tensors is exceeded NNS_TENSOR_SIZE_LIMIT)
  */
-TEST (tensor_filter_openvino, getTensorDim_3_n)
+TEST (tensorFilterOpenvino, getTensorDim3_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const gchar fw_name[] = "openvino";
@@ -972,7 +972,7 @@ TEST (tensor_filter_openvino, getTensorDim_3_n)
 /**
  * @brief A test case for the helper function, convertFromIETypeStr ()
  */
-TEST (tensor_filter_openvino, convertFromIETypeStr_0)
+TEST (tensorFilterOpenvino, convertFromIETypeStr0)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const std::vector<std::string> ie_suport_type_strs = {
@@ -1018,7 +1018,7 @@ TEST (tensor_filter_openvino, convertFromIETypeStr_0)
 /**
  * @brief A negative test case for the helper function, convertFromIETypeStr ()
  */
-TEST (tensor_filter_openvino, convertFromIETypeStr_0_n)
+TEST (tensorFilterOpenvino, convertFromIETypeStr0_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const std::vector<std::string> ie_not_suport_type_strs = {
@@ -1063,7 +1063,7 @@ TEST (tensor_filter_openvino, convertFromIETypeStr_0_n)
 /**
  * @brief A negative test case for the helper function, convertFromIETypeStr ()
  */
-TEST (tensor_filter_openvino, convertFromIETypeStr_1_n)
+TEST (tensorFilterOpenvino, convertFromIETypeStr1_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const std::string ie_suport_type_str ("Q78");
@@ -1126,7 +1126,7 @@ TEST (tensor_filter_openvino, convertFromIETypeStr_1_n)
 /**
  * @brief A test case for the helper function, convertFromIETypeStr ()
  */
-TEST (tensor_filter_openvino, convertGstTensorMemoryToBlobPtr_0)
+TEST (tensorFilterOpenvino, convertGstTensorMemoryToBlobPtr0)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   std::string str_test_model;

--- a/tests/nnstreamer_grpc/unittest_grpc.cc
+++ b/tests/nnstreamer_grpc/unittest_grpc.cc
@@ -20,7 +20,7 @@
 /**
  * @brief Test gRPC tensor_src/sink existence.
  */
-TEST (nnstreamer_grpc, check_existence)
+TEST (nnstreamerGrpc, checkExistence)
 {
   GstPlugin *plugin;
   GstElementFactory *factory;
@@ -42,7 +42,7 @@ TEST (nnstreamer_grpc, check_existence)
 /**
  * @brief Test gRPC tensor_src/sink existence (negative).
  */
-TEST (nnstreamer_grpc, check_existence_n)
+TEST (nnstreamerGrpc, checkExistence_n)
 {
   GstPlugin *plugin;
   GstElementFactory *factory;
@@ -157,7 +157,7 @@ _set_default_option (TestOption &option)
 /**
  * @brief Test gRPC tensor_src get default property
  */
-TEST (nnstreamer_grpc, src_get_property_default)
+TEST (nnstreamerGrpc, srcGetPropertyDefault)
 {
   TestOption option;
   GstElement *src;
@@ -196,7 +196,7 @@ TEST (nnstreamer_grpc, src_get_property_default)
 /**
  * @brief Test gRPC tensor_sink get default property
  */
-TEST (nnstreamer_grpc, sink_get_property_default)
+TEST (nnstreamerGrpc, sinkGetPropertyDefault)
 {
   TestOption option;
   GstElement *sink;
@@ -235,7 +235,7 @@ TEST (nnstreamer_grpc, sink_get_property_default)
 /**
  * @brief Test gRPC tensor_src set property
  */
-TEST (nnstreamer_grpc, src_set_property)
+TEST (nnstreamerGrpc, srcSetProperty)
 {
   TestOption option;
   GstElement *src;
@@ -275,7 +275,7 @@ TEST (nnstreamer_grpc, src_set_property)
 /**
  * @brief Test gRPC tensor_sink set property
  */
-TEST (nnstreamer_grpc, sink_set_property)
+TEST (nnstreamerGrpc, sinkSetProperty)
 {
   TestOption option;
   GstElement *sink;
@@ -315,7 +315,7 @@ TEST (nnstreamer_grpc, sink_set_property)
 /**
  * @brief Test gRPC tensor_src invalid host
  */
-TEST (nnstreamer_grpc, src_invalid_host_n)
+TEST (nnstreamerGrpc, srcInvalidHost_n)
 {
   TestOption option;
   GstElement *src;
@@ -341,7 +341,7 @@ TEST (nnstreamer_grpc, src_invalid_host_n)
 /**
  * @brief Test gRPC tensor_sink invalid host
  */
-TEST (nnstreamer_grpc, sink_invalid_host_n)
+TEST (nnstreamerGrpc, sinkInvalidHost_n)
 {
   TestOption option;
   GstElement *sink;
@@ -367,7 +367,7 @@ TEST (nnstreamer_grpc, sink_invalid_host_n)
 /**
  * @brief Test gRPC tensor_src invalid port
  */
-TEST (nnstreamer_grpc, src_invalid_port_n)
+TEST (nnstreamerGrpc, srcInvalidPort_n)
 {
   TestOption option;
   GstElement *src;
@@ -396,7 +396,7 @@ TEST (nnstreamer_grpc, src_invalid_port_n)
 /**
  * @brief Test gRPC tensor_sink invalid port
  */
-TEST (nnstreamer_grpc, sink_invalid_port_n)
+TEST (nnstreamerGrpc, sinkInvalidPort_n)
 {
   TestOption option;
   GstElement *sink;

--- a/tests/nnstreamer_if/unittest_if.cc
+++ b/tests/nnstreamer_if/unittest_if.cc
@@ -94,7 +94,7 @@ class tensor_if_run : public ::testing::Test
 /**
  * @brief Test for tensor_if get and set properties
  */
-TEST (tensor_if_prop, properties_0)
+TEST (tensorIfProp, properties0)
 {
   gchar *pipeline;
   GstElement *gstpipe;
@@ -195,7 +195,7 @@ TEST (tensor_if_prop, properties_0)
 /**
  * @brief Test for invalid properties of tensor_if
  */
-TEST (tensor_if_prop, properties_1_n)
+TEST (tensorIfProp, properties1_n)
 {
   gchar *pipeline;
   GstElement *gstpipe;
@@ -229,7 +229,7 @@ TEST (tensor_if_prop, properties_1_n)
 /**
  * @brief Test for invalid tensor index of tensor_if compared value option
  */
-TEST (tensor_if_prop, properties_2_n)
+TEST (tensorIfProp, properties2_n)
 {
   gchar *str_pipeline = g_strdup_printf (
       "videotestsrc num-buffers=1 pattern=13 ! videoconvert ! videoscale ! "
@@ -251,7 +251,7 @@ TEST (tensor_if_prop, properties_2_n)
 /**
  * @brief Test for invalid tensor index of tensor_if compared value option
  */
-TEST (tensor_if_prop, properties_3_n)
+TEST (tensorIfProp, properties3_n)
 {
   gchar *str_pipeline = g_strdup_printf (
       "videotestsrc num-buffers=1 pattern=13 ! videoconvert ! videoscale ! "
@@ -273,7 +273,7 @@ TEST (tensor_if_prop, properties_3_n)
 /**
  * @brief Test for invalid value of tensor_if compared value option
  */
-TEST (tensor_if_prop, properties_4_n)
+TEST (tensorIfProp, properties4_n)
 {
   gchar *str_pipeline = g_strdup_printf (
       "videotestsrc num-buffers=1 pattern=13 ! videoconvert ! videoscale ! "
@@ -295,7 +295,7 @@ TEST (tensor_if_prop, properties_4_n)
 /**
  * @brief Test for invalid value of tensor_if compared value option
  */
-TEST (tensor_if_prop, properties_5_n)
+TEST (tensorIfProp, properties5_n)
 {
   gchar *str_pipeline = g_strdup_printf (
       "videotestsrc num-buffers=2 pattern=13 ! videoconvert ! videoscale ! "
@@ -544,7 +544,7 @@ new_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
 /**
  * @brief Test behavior: PASSTHROUGH, SKIP with tensor stream using appsrc
  */
-TEST (tensor_if_appsrc, action_0)
+TEST (tensorIfAppsrc, action0)
 {
   GstBuffer *buf_0, *buf_1;
   GstMemory *mem;
@@ -631,7 +631,7 @@ TEST (tensor_if_appsrc, action_0)
 /**
  * @brief Test behavior: TENSORPICK with tensors stream using appsrc
  */
-TEST (tensor_if_appsrc, action_1)
+TEST (tensorIfAppsrc, action1)
 {
   GstBuffer *buf_0, *buf_1;
   GstMemory *mem;
@@ -733,7 +733,7 @@ tensor_if_custom_cb (const GstTensorsInfo *info, const GstTensorMemory *input,
 /**
  * @brief Test behavior: custom callback
  */
-TEST (tensor_if_custom, normal_0)
+TEST (tensorIfCustom, normal0)
 {
   GstBuffer *buf_0, *buf_1;
   GstMemory *mem;
@@ -814,7 +814,7 @@ TEST (tensor_if_custom, normal_0)
 /**
  * @brief Test behavior: custom callback, change the order of compared value option.
  */
-TEST (tensor_if_custom, normal_1)
+TEST (tensorIfCustom, normal1)
 {
   GstElement *tif_handle;
   gchar *str_val;
@@ -848,7 +848,7 @@ TEST (tensor_if_custom, normal_1)
 /**
  * @brief Register custom callback with NULL parameter
  */
-TEST (tensor_if_custom, invalid_param_0_n)
+TEST (tensorIfCustom, invalidParam0_n)
 {
   EXPECT_NE (0, nnstreamer_if_custom_register (NULL, tensor_if_custom_cb, NULL));
   EXPECT_NE (0, nnstreamer_if_custom_register ("tifx", NULL, NULL));
@@ -857,7 +857,7 @@ TEST (tensor_if_custom, invalid_param_0_n)
 /**
  * @brief Register custom callback twice with same name
  */
-TEST (tensor_if_custom, invalid_param_1_n)
+TEST (tensorIfCustom, invalidParam1_n)
 {
   EXPECT_EQ (0, nnstreamer_if_custom_register ("tifx", tensor_if_custom_cb, NULL));
   EXPECT_NE (0, nnstreamer_if_custom_register ("tifx", tensor_if_custom_cb, NULL));
@@ -867,7 +867,7 @@ TEST (tensor_if_custom, invalid_param_1_n)
 /**
  * @brief Unregister custom callback with NULL parameter
  */
-TEST (tensor_if_custom, invalid_param_2_n)
+TEST (tensorIfCustom, invalidParam2_n)
 {
   EXPECT_NE (0, nnstreamer_if_custom_unregister (NULL));
 }
@@ -875,7 +875,7 @@ TEST (tensor_if_custom, invalid_param_2_n)
 /**
  * @brief Unregister custom callback which is not registered
  */
-TEST (tensor_if_custom, invalid_param_3_n)
+TEST (tensorIfCustom, invalidParam3_n)
 {
   EXPECT_NE (0, nnstreamer_if_custom_unregister ("tifx"));
 }

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -54,7 +54,7 @@
 #define str(s) #s
 #define TEST_TRANSFORM_TYPECAST(                                               \
     name, num_bufs, size, from_t, from_nns_t, to_t, str_to_t, to_nns_t, accel) \
-  TEST (test_tensor_transform, name)                                           \
+  TEST (testTensorTransform, name)                                             \
   {                                                                            \
     const guint num_buffers = num_bufs;                                        \
     const guint array_size = size;                                             \
@@ -195,7 +195,7 @@
 /**
  * @brief Test for setting/getting properties of tensor_transform
  */
-TEST (test_tensor_transform, properties_01)
+TEST (testTensorTransform, properties01)
 {
   const gboolean default_silent = TRUE;
   const gboolean default_accl = DEFAULT_VAL_PROP_ACCELERATION;
@@ -257,7 +257,7 @@ TEST (test_tensor_transform, properties_01)
 /**
  * @brief Test for invalid properties of tensor_transform
  */
-TEST (test_tensor_transform, properties_02_n)
+TEST (testTensorTransform, properties02_n)
 {
   GstHarness *h;
   gchar *str = NULL;
@@ -276,7 +276,7 @@ TEST (test_tensor_transform, properties_02_n)
 /**
  * @brief Test for invalid properties of tensor_transform
  */
-TEST (test_tensor_transform, properties_03_n)
+TEST (testTensorTransform, properties03_n)
 {
   GstHarness *h;
   gchar *str = NULL;
@@ -299,7 +299,7 @@ TEST (test_tensor_transform, properties_03_n)
 /**
  * @brief Test for invalid properties of tensor_transform
  */
-TEST (test_tensor_transform, properties_04_n)
+TEST (testTensorTransform, properties04_n)
 {
   GstHarness *h;
   gchar *str = NULL;
@@ -318,7 +318,7 @@ TEST (test_tensor_transform, properties_04_n)
 /**
  * @brief Test for invalid properties of tensor_transform
  */
-TEST (test_tensor_transform, properties_05_n)
+TEST (testTensorTransform, properties05_n)
 {
   GstHarness *h;
   gchar *str = NULL;
@@ -505,7 +505,7 @@ TEST_TRANSFORM_TYPECAST (typecast_14_accel, 3U, 5U, double, _NNS_FLOAT64,
 /**
  * @brief Test for tensor_transform arithmetic (float32, add .5)
  */
-TEST (test_tensor_transform, arithmetic_1)
+TEST (testTensorTransform, arithmetic1)
 {
   const guint num_buffers = 3;
   const guint array_size = 5;
@@ -575,7 +575,7 @@ TEST (test_tensor_transform, arithmetic_1)
 /**
  * @brief Test for tensor_transform arithmetic (acceleration, float32, add .5)
  */
-TEST (test_tensor_transform, arithmetic_1_accel)
+TEST (testTensorTransform, arithmetic1Accel)
 {
   const guint num_buffers = 3;
   const guint array_size = 5;
@@ -645,7 +645,7 @@ TEST (test_tensor_transform, arithmetic_1_accel)
 /**
  * @brief Test for tensor_transform arithmetic (float64, mul .5)
  */
-TEST (test_tensor_transform, arithmetic_2)
+TEST (testTensorTransform, arithmetic2)
 {
   const guint num_buffers = 3;
   const guint array_size = 5;
@@ -715,7 +715,7 @@ TEST (test_tensor_transform, arithmetic_2)
 /**
  * @brief Test for tensor_transform arithmetic (acceleration, float64, mul .5)
  */
-TEST (test_tensor_transform, arithmetic_2_accel)
+TEST (testTensorTransform, arithmetic2Accel)
 {
   const guint num_buffers = 3;
   const guint array_size = 5;
@@ -785,7 +785,7 @@ TEST (test_tensor_transform, arithmetic_2_accel)
 /**
  * @brief Test for tensor_transform arithmetic (typecast uint8 > float32, add .5, mul .2)
  */
-TEST (test_tensor_transform, arithmetic_3)
+TEST (testTensorTransform, arithmetic3)
 {
   const guint num_buffers = 3;
   const guint array_size = 5;
@@ -859,7 +859,7 @@ TEST (test_tensor_transform, arithmetic_3)
 /**
  * @brief Test for tensor_transform arithmetic (acceleration, typecast uint8 > float32, add .5, mul .2)
  */
-TEST (test_tensor_transform, arithmetic_3_accel)
+TEST (testTensorTransform, arithmetic3Accel)
 {
   const guint num_buffers = 3;
   const guint array_size = 5;
@@ -933,7 +933,7 @@ TEST (test_tensor_transform, arithmetic_3_accel)
 /**
  * @brief Test for tensor_transform arithmetic (typecast uint8 > float64, add .2, add .1, final typecast uint16 will be ignored)
  */
-TEST (test_tensor_transform, arithmetic_4)
+TEST (testTensorTransform, arithmetic4)
 {
   const guint num_buffers = 3;
   const guint array_size = 5;
@@ -1007,7 +1007,7 @@ TEST (test_tensor_transform, arithmetic_4)
 /**
  * @brief Test for tensor_transform arithmetic (acceleration, typecast uint8 > float64, add .2, add .1, final typecast uint16 will be ignored)
  */
-TEST (test_tensor_transform, arithmetic_4_accel)
+TEST (testTensorTransform, arithmetic4Accel)
 {
   const guint num_buffers = 3;
   const guint array_size = 5;
@@ -1081,7 +1081,7 @@ TEST (test_tensor_transform, arithmetic_4_accel)
 /**
  * @brief Test for tensor_transform arithmetic (typecast uint8 > int32, mul 2, div 2, add -1)
  */
-TEST (test_tensor_transform, arithmetic_5)
+TEST (testTensorTransform, arithmetic5)
 {
   const guint num_buffers = 3;
   const guint array_size = 5;
@@ -1155,7 +1155,7 @@ TEST (test_tensor_transform, arithmetic_5)
 /**
  * @brief Test for tensor_transform arithmetic (acceleration, typecast uint8 > int32, mul 2, div 2, add -1)
  */
-TEST (test_tensor_transform, arithmetic_5_accel)
+TEST (testTensorTransform, arithmetic5Accel)
 {
   const guint num_buffers = 3;
   const guint array_size = 5;
@@ -1229,7 +1229,7 @@ TEST (test_tensor_transform, arithmetic_5_accel)
 /**
  * @brief Test for tensor_transform arithmetic (changing option string dynamically)
  */
-TEST (test_tensor_transform, arithmetic_change_option_string)
+TEST (testTensorTransform, arithmeticChangeOptionString)
 {
   const guint array_size = 5;
   GstHarness *h;
@@ -1339,7 +1339,7 @@ const gint aggr_test_frames[2][48]
 /**
  * @brief Test for tensor aggregator properties
  */
-TEST (test_tensor_aggregator, properties)
+TEST (testTensorAggregator, properties)
 {
   GstHarness *h;
   guint fr_val, res_fr_val;
@@ -1406,7 +1406,7 @@ TEST (test_tensor_aggregator, properties)
 /**
  * @brief Test for tensor_aggregator (concatenate 2 frames with frames-dim 3, out-dimension 3:4:2:4)
  */
-TEST (test_tensor_aggregator, aggregate_1)
+TEST (testTensorAggregator, aggregate1)
 {
   GstHarness *h;
   GstBuffer *in_buf, *out_buf;
@@ -1480,7 +1480,7 @@ TEST (test_tensor_aggregator, aggregate_1)
 /**
  * @brief Test for tensor_aggregator (concatenate 2 frames with frames-dim 2, out-dimension 3:4:4:2)
  */
-TEST (test_tensor_aggregator, aggregate_2)
+TEST (testTensorAggregator, aggregate2)
 {
   GstHarness *h;
   GstBuffer *in_buf, *out_buf;
@@ -1554,7 +1554,7 @@ TEST (test_tensor_aggregator, aggregate_2)
 /**
  * @brief Test for tensor_aggregator (concatenate 2 frames with frames-dim 1, out-dimension 3:8:2:2)
  */
-TEST (test_tensor_aggregator, aggregate_3)
+TEST (testTensorAggregator, aggregate3)
 {
   GstHarness *h;
   GstBuffer *in_buf, *out_buf;
@@ -1628,7 +1628,7 @@ TEST (test_tensor_aggregator, aggregate_3)
 /**
  * @brief Test for tensor_aggregator (concatenate 2 frames with frames-dim 0, out-dimension 6:4:2:2)
  */
-TEST (test_tensor_aggregator, aggregate_4)
+TEST (testTensorAggregator, aggregate4)
 {
   GstHarness *h;
   GstBuffer *in_buf, *out_buf;
@@ -1702,7 +1702,7 @@ TEST (test_tensor_aggregator, aggregate_4)
 /**
  * @brief Test for tensor_aggregator (no-concat, same in-out frames)
  */
-TEST (test_tensor_aggregator, aggregate_5)
+TEST (testTensorAggregator, aggregate5)
 {
   GstHarness *h;
   GstBuffer *in_buf, *out_buf;
@@ -1764,7 +1764,7 @@ TEST (test_tensor_aggregator, aggregate_5)
 /**
  * @brief Test for tensor_converter (bytes to multi tensors)
  */
-TEST (test_tensor_converter, bytes_to_multi_1)
+TEST (testTensorConverter, bytesToMulti1)
 {
   GstHarness *h;
   GstBuffer *in_buf, *out_buf;
@@ -1838,7 +1838,7 @@ TEST (test_tensor_converter, bytes_to_multi_1)
 /**
  * @brief Test for tensor_converter (bytes to multi tensors)
  */
-TEST (test_tensor_converter, bytes_to_multi_2)
+TEST (testTensorConverter, bytesToMulti2)
 {
   GstHarness *h;
   GstBuffer *in_buf, *out_buf;
@@ -1930,7 +1930,7 @@ TEST (test_tensor_converter, bytes_to_multi_2)
 /**
  * @brief Test for tensor_converter (bytes to multi tensors)
  */
-TEST (test_tensor_converter, bytes_to_multi_invalid_dim_01_n)
+TEST (testTensorConverter, bytesToMultiInvalidDim01_n)
 {
   GstHarness *h;
   GstBuffer *in_buf;
@@ -1969,7 +1969,7 @@ TEST (test_tensor_converter, bytes_to_multi_invalid_dim_01_n)
 /**
  * @brief Test for tensor_converter (bytes to multi tensors)
  */
-TEST (test_tensor_converter, bytes_to_multi_invalid_dim_02_n)
+TEST (testTensorConverter, bytesToMultiInvalidDim02_n)
 {
   GstHarness *h;
   GstBuffer *in_buf;
@@ -2009,7 +2009,7 @@ TEST (test_tensor_converter, bytes_to_multi_invalid_dim_02_n)
 /**
  * @brief Test for tensor_converter (bytes to multi tensors)
  */
-TEST (test_tensor_converter, bytes_to_multi_invalid_type_01_n)
+TEST (testTensorConverter, bytesToMultiInvalidType01_n)
 {
   GstHarness *h;
   GstBuffer *in_buf;
@@ -2048,7 +2048,7 @@ TEST (test_tensor_converter, bytes_to_multi_invalid_type_01_n)
 /**
  * @brief Test for tensor_converter (bytes to multi tensors)
  */
-TEST (test_tensor_converter, bytes_to_multi_invalid_type_02_n)
+TEST (testTensorConverter, bytesToMultiInvalidType02_n)
 {
   GstHarness *h;
   GstBuffer *in_buf;
@@ -2088,7 +2088,7 @@ TEST (test_tensor_converter, bytes_to_multi_invalid_type_02_n)
 /**
  * @brief Test for tensor_converter (bytes to multi tensors)
  */
-TEST (test_tensor_converter, bytes_to_multi_invalid_type_03_n)
+TEST (testTensorConverter, bytesToMultiInvalidType03_n)
 {
   GstHarness *h;
   GstBuffer *in_buf;
@@ -2130,7 +2130,7 @@ TEST (test_tensor_converter, bytes_to_multi_invalid_type_03_n)
 /**
  * @brief Test for tensor_converter (bytes to multi tensors)
  */
-TEST (test_tensor_converter, bytes_to_multi_invalid_size_n)
+TEST (testTensorConverter, bytesToMultiInvalidSize_n)
 {
   GstHarness *h;
   GstBuffer *in_buf;
@@ -2170,7 +2170,7 @@ TEST (test_tensor_converter, bytes_to_multi_invalid_size_n)
 /**
  * @brief Test for tensor_converter (bytes to multi tensors)
  */
-TEST (test_tensor_converter, bytes_to_multi_invalid_frames_n)
+TEST (testTensorConverter, bytesToMultiInvalidFrames_n)
 {
   GstHarness *h;
   GstBuffer *in_buf;
@@ -2213,7 +2213,7 @@ TEST (test_tensor_converter, bytes_to_multi_invalid_frames_n)
 /**
  * @brief Test for tensor_transform orc functions (add constant value)
  */
-TEST (test_tensor_transform, orc_add)
+TEST (testTensorTransform, orcAdd)
 {
   const guint array_size = 10;
   guint i;
@@ -2392,7 +2392,7 @@ TEST (test_tensor_transform, orc_add)
 /**
  * @brief Test for tensor_transform orc functions (mul constant value)
  */
-TEST (test_tensor_transform, orc_mul)
+TEST (testTensorTransform, orcMul)
 {
   const guint array_size = 10;
   guint i;
@@ -2571,7 +2571,7 @@ TEST (test_tensor_transform, orc_mul)
 /**
  * @brief Test for tensor_transform orc functions (div constant value)
  */
-TEST (test_tensor_transform, orc_div)
+TEST (testTensorTransform, orcDiv)
 {
   const guint array_size = 10;
   guint i;
@@ -2630,7 +2630,7 @@ TEST (test_tensor_transform, orc_div)
 /**
  * @brief Test for tensor_transform orc functions (convert s8 to other type)
  */
-TEST (test_tensor_transform, orc_conv_s8)
+TEST (testTensorTransform, orcConvS8)
 {
   const guint array_size = 10;
   guint i;
@@ -2735,7 +2735,7 @@ TEST (test_tensor_transform, orc_conv_s8)
 /**
  * @brief Test for tensor_transform orc functions (convert u8 to other type)
  */
-TEST (test_tensor_transform, orc_conv_u8)
+TEST (testTensorTransform, orcConvU8)
 {
   const guint array_size = 10;
   guint i;
@@ -2840,7 +2840,7 @@ TEST (test_tensor_transform, orc_conv_u8)
 /**
  * @brief Test for tensor_transform orc functions (convert s16 to other type)
  */
-TEST (test_tensor_transform, orc_conv_s16)
+TEST (testTensorTransform, orcConvS16)
 {
   const guint array_size = 10;
   guint i;
@@ -2945,7 +2945,7 @@ TEST (test_tensor_transform, orc_conv_s16)
 /**
  * @brief Test for tensor_transform orc functions (convert u16 to other type)
  */
-TEST (test_tensor_transform, orc_conv_u16)
+TEST (testTensorTransform, orcConvU16)
 {
   const guint array_size = 10;
   guint i;
@@ -3050,7 +3050,7 @@ TEST (test_tensor_transform, orc_conv_u16)
 /**
  * @brief Test for tensor_transform orc functions (convert s32 to other type)
  */
-TEST (test_tensor_transform, orc_conv_s32)
+TEST (testTensorTransform, orcConvS32)
 {
   const guint array_size = 10;
   guint i;
@@ -3155,7 +3155,7 @@ TEST (test_tensor_transform, orc_conv_s32)
 /**
  * @brief Test for tensor_transform orc functions (convert u32 to other type)
  */
-TEST (test_tensor_transform, orc_conv_u32)
+TEST (testTensorTransform, orcConvU32)
 {
   const guint array_size = 10;
   guint i;
@@ -3260,7 +3260,7 @@ TEST (test_tensor_transform, orc_conv_u32)
 /**
  * @brief Test for tensor_transform orc functions (convert f32 to other type)
  */
-TEST (test_tensor_transform, orc_conv_f32)
+TEST (testTensorTransform, orcConvF32)
 {
   const guint array_size = 10;
   guint i;
@@ -3368,7 +3368,7 @@ TEST (test_tensor_transform, orc_conv_f32)
 /**
  * @brief Test for tensor_transform orc functions (convert f64 to other type)
  */
-TEST (test_tensor_transform, orc_conv_f64)
+TEST (testTensorTransform, orcConvF64)
 {
   const guint array_size = 10;
   guint i;
@@ -3476,7 +3476,7 @@ TEST (test_tensor_transform, orc_conv_f64)
 /**
  * @brief Test for tensor_transform orc functions (performance)
  */
-TEST (test_tensor_transform, orc_performance)
+TEST (testTensorTransform, orcPerformance)
 {
   const guint array_size = 80000;
   guint i;
@@ -4465,7 +4465,7 @@ TEST_REQUIRE_TFLITE (test_tensor_filter, framework_auto_wo_opt_no_permission_n)
  * @brief Test framework auto detecion option in tensor-filter.
  * @details Check if nnfw (second priority) is detected automatically
  */
-TEST (test_tensor_filter, framework_auto_ext_tflite_nnfw_04)
+TEST (testTensorFilter, frameworkAutoExtTfliteNnfw04)
 {
   gchar *test_model, *str_launch_line;
   GstElement *gstpipe;
@@ -4487,7 +4487,7 @@ TEST (test_tensor_filter, framework_auto_ext_tflite_nnfw_04)
  * @brief Test framework auto detecion without specifying the option in tensor-filter.
  * @details Check if nnfw (second priority) is detected automatically
  */
-TEST (test_tensor_filter, framework_auto_wo_opt_ext_tflite_nnfw)
+TEST (testTensorFilter, frameworkAutoWoOptExtTfliteNnfw)
 {
   gchar *test_model, *str_launch_line;
   GstElement *gstpipe;
@@ -4512,7 +4512,7 @@ TEST (test_tensor_filter, framework_auto_wo_opt_ext_tflite_nnfw)
  * @brief Test framework auto detecion option in tensor-filter.
  * @details Check if tensoflow is detected automatically
  */
-TEST (test_tensor_filter, framework_auto_ext_pb_01)
+TEST (testTensorFilter, frameworkAutoExtPb01)
 {
   gchar *test_model, *str_launch_line, *data_path;
   GstElement *gstpipe;
@@ -4544,7 +4544,7 @@ TEST (test_tensor_filter, framework_auto_ext_pb_01)
  * @brief Test framework auto detecion without specifying the option in tensor-filter.
  * @details Check if tensoflow is detected automatically
  */
-TEST (test_tensor_filter, framework_auto_wo_opt_ext_pb)
+TEST (testTensorFilter, frameworkAutoWoOptExtPb)
 {
   gchar *test_model, *str_launch_line, *data_path;
   GstElement *gstpipe;
@@ -4576,7 +4576,7 @@ TEST (test_tensor_filter, framework_auto_wo_opt_ext_pb)
  * @brief Test framework auto detecion option in tensor-filter.
  * @details Negative case whtn tensorflow is not enabled
  */
-TEST (test_tensor_filter, framework_auto_ext_pb_tf_disabled_n)
+TEST (testTensorFilter, frameworkAutoExtPbTfDisabled_n)
 {
   gchar *test_model, *str_launch_line, *data_path;
   const gchar *fw_name = NULL;
@@ -4609,7 +4609,7 @@ TEST (test_tensor_filter, framework_auto_ext_pb_tf_disabled_n)
  * @brief Test framework auto detecion without specifying the option in tensor-filter.
  * @details Negative case whtn tensorflow is not enabled
  */
-TEST (test_tensor_filter, framework_auto_wo_opt_ext_pb_tf_disabled_n)
+TEST (testTensorFilter, frameworkAutoWoOptExtPbTfDisabled_n)
 {
   gchar *test_model, *str_launch_line, *data_path;
   const gchar *fw_name = NULL;
@@ -4644,7 +4644,7 @@ TEST (test_tensor_filter, framework_auto_wo_opt_ext_pb_tf_disabled_n)
  * @brief Test framework auto detecion option in tensor-filter.
  * @details Check if caffe2 is detected automatically
  */
-TEST (test_tensor_filter, framework_auto_ext_pb_03)
+TEST (testTensorFilter, frameworkAutoExtPb03)
 {
   gchar *test_model, *str_launch_line, *test_model_2, *data_path;
   GstElement *gstpipe;
@@ -4681,7 +4681,7 @@ TEST (test_tensor_filter, framework_auto_ext_pb_03)
  * @brief Test framework auto detecion option in tensor-filter.
  * @details Check if caffe2 is not enabled
  */
-TEST (test_tensor_filter, framework_auto_ext_pb_caffe2_disabled_n)
+TEST (testTensorFilter, frameworkAutoExtPbCaffe2Disabled_n)
 {
   gchar *test_model, *str_launch_line, *test_model_2, *data_path;
   const gchar *fw_name = NULL;
@@ -4720,7 +4720,7 @@ TEST (test_tensor_filter, framework_auto_ext_pb_caffe2_disabled_n)
  * @brief Test framework auto detecion option in tensor-filter.
  * @details Check if pytorch is detected automatically
  */
-TEST (test_tensor_filter, framework_auto_ext_pt_01)
+TEST (testTensorFilter, frameworkAutoExtPt01)
 {
   gchar *test_model, *str_launch_line, *image_path;
   GstElement *gstpipe;
@@ -4752,7 +4752,7 @@ TEST (test_tensor_filter, framework_auto_ext_pt_01)
  * @brief Test framework auto detecion without specifying the option in tensor-filter.
  * @details Check if pytorch is detected automatically
  */
-TEST (test_tensor_filter, framework_auto_wo_opt_ext_pt_01)
+TEST (testTensorFilter, frameworkAutoWoOptExtPt01)
 {
   gchar *test_model, *str_launch_line, *image_path;
   GstElement *gstpipe;
@@ -4786,7 +4786,7 @@ TEST (test_tensor_filter, framework_auto_wo_opt_ext_pt_01)
  * @brief Test framework auto detecion option in tensor-filter.
  * @details Check if pytorch is not enabled
  */
-TEST (test_tensor_filter, framework_auto_ext_pt_pytorch_disabled_n)
+TEST (testTensorFilter, frameworkAutoExtPtPytorchDisabled_n)
 {
   gchar *test_model, *str_launch_line;
   const gchar *fw_name = NULL;
@@ -4820,7 +4820,7 @@ TEST (test_tensor_filter, framework_auto_ext_pt_pytorch_disabled_n)
  * @brief Test framework auto detecion without specifying the option in tensor-filter.
  * @details Check if pytorch is not enabled
  */
-TEST (test_tensor_filter, framework_auto_wo_opt_ext_pt_pytorch_disabled_n)
+TEST (testTensorFilter, frameworkAutoWoOptExtPtPytorchDisabled_n)
 {
   gchar *test_model, *str_launch_line;
   const gchar *fw_name = NULL;

--- a/tests/nnstreamer_rate/unittest_rate.cc
+++ b/tests/nnstreamer_rate/unittest_rate.cc
@@ -20,7 +20,7 @@
 /**
  * @brief Test tensor_rate existence.
  */
-TEST (nnstreamer_rate, check_existence)
+TEST (nnstreamerRate, checkExistence)
 {
   GstElementFactory *factory;
 
@@ -32,7 +32,7 @@ TEST (nnstreamer_rate, check_existence)
 /**
  * @brief Test tensor_rate existence (negative).
  */
-TEST (nnstreamer_rate, check_existence_n)
+TEST (nnstreamerRate, checkExistence_n)
 {
   GstElementFactory *factory;
   gchar *name;
@@ -161,7 +161,7 @@ _set_default_option (TestOption &option)
 /**
  * @brief Test tensor_rate get default property
  */
-TEST (nnstreamer_rate, get_property_default)
+TEST (nnstreamerRate, getPropertyDefault)
 {
   TestOption option;
   GstElement *rate;
@@ -206,7 +206,7 @@ TEST (nnstreamer_rate, get_property_default)
 /**
  * @brief Test tensor_rate set property
  */
-TEST (nnstreamer_rate, set_property)
+TEST (nnstreamerRate, setProperty)
 {
   TestOption option;
   GstElement *rate;
@@ -241,7 +241,7 @@ TEST (nnstreamer_rate, set_property)
 /**
  * @brief Test tensor_rate set property stats (negative)
  */
-TEST (nnstreamer_rate, set_propery_stats_n)
+TEST (nnstreamerRate, setProperyStats_n)
 {
   TestOption option;
   GstElement *rate;
@@ -278,7 +278,7 @@ TEST (nnstreamer_rate, set_propery_stats_n)
 /**
  * @brief Test tensor_rate set invalide framerate (negative)
  */
-TEST (nnstreamer_rate, set_propery_invalid_framerate_n)
+TEST (nnstreamerRate, setProperyInvalidFramerate_n)
 {
   TestOption option;
   GstElement *rate;
@@ -348,7 +348,7 @@ static gboolean wait_pipeline_eos (GstElement *pipeline)
 /**
  * @brief Test tensor_rate with passthrough mode
  */
-TEST (nnstreamer_rate, passthrough)
+TEST (nnstreamerRate, passthrough)
 {
   TestOption option;
   GstElement *rate;
@@ -387,7 +387,7 @@ TEST (nnstreamer_rate, passthrough)
 /**
  * @brief Test tensor_rate with no-throttling mode
  */
-TEST (nnstreamer_rate, no_throttling)
+TEST (nnstreamerRate, noThrottling)
 {
   TestOption option;
   GstElement *rate;
@@ -434,7 +434,7 @@ TEST (nnstreamer_rate, no_throttling)
 /**
  * @brief Test tensor_rate with throttling mode
  */
-TEST (nnstreamer_rate, throttling)
+TEST (nnstreamerRate, throttling)
 {
   TestOption option;
   GstElement *rate;

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -1059,7 +1059,7 @@ error:
 /**
  * @brief Test for tensor sink properties.
  */
-TEST (tensor_sink_test, properties)
+TEST (tensorSinkTest, properties)
 {
   guint rate, res_rate;
   gint64 lateness, res_lateness;
@@ -1128,7 +1128,7 @@ TEST (tensor_sink_test, properties)
 /**
  * @brief Test for tensor sink signals.
  */
-TEST (tensor_sink_test, signals)
+TEST (tensorSinkTest, signals)
 {
   const guint num_buffers = 5;
   gulong handle_id;
@@ -1187,7 +1187,7 @@ TEST (tensor_sink_test, signals)
 /**
  * @brief Test for tensor sink emit-signal (case for no signal).
  */
-TEST (tensor_sink_test, emit_signal)
+TEST (tensorSinkTest, emitSignal)
 {
   const guint num_buffers = 5;
   gulong handle_id;
@@ -1232,7 +1232,7 @@ TEST (tensor_sink_test, emit_signal)
 /**
  * @brief Test for tensor sink signal-rate.
  */
-TEST (tensor_sink_test, signal_rate)
+TEST (tensorSinkTest, signalRate)
 {
   const guint num_buffers = 6;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB };
@@ -1282,7 +1282,7 @@ TEST (tensor_sink_test, signal_rate)
 /**
  * @brief Test for caps negotiation failed.
  */
-TEST (tensor_sink_test, caps_error_n)
+TEST (tensorSinkTest, capsError_n)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_NEGO_FAILED };
@@ -1326,7 +1326,7 @@ TEST (tensor_sink_test, caps_error_n)
 /**
  * @brief Test for other/tensors caps negotiation.
  */
-TEST (tensor_sink_test, caps_tensors)
+TEST (tensorSinkTest, capsTensors)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_TENSORS };
@@ -1392,7 +1392,7 @@ TEST (tensor_sink_test, caps_tensors)
 /**
  * @brief Test for video format RGB.
  */
-TEST (tensor_stream_test, video_rgb)
+TEST (tensorStreamTest, videoRgb)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB };
@@ -1436,7 +1436,7 @@ TEST (tensor_stream_test, video_rgb)
 /**
  * @brief Test for video format BGR.
  */
-TEST (tensor_stream_test, video_bgr)
+TEST (tensorStreamTest, videoBgr)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_BGR };
@@ -1480,7 +1480,7 @@ TEST (tensor_stream_test, video_bgr)
 /**
  * @brief Test for video format RGB, remove padding.
  */
-TEST (tensor_stream_test, video_rgb_padding)
+TEST (tensorStreamTest, videoRgbPadding)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB_PADDING };
@@ -1524,7 +1524,7 @@ TEST (tensor_stream_test, video_rgb_padding)
 /**
  * @brief Test for video format BGR, remove padding.
  */
-TEST (tensor_stream_test, video_bgr_padding)
+TEST (tensorStreamTest, videoBgrPadding)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_BGR_PADDING };
@@ -1568,7 +1568,7 @@ TEST (tensor_stream_test, video_bgr_padding)
 /**
  * @brief Test for video format RGB, 3 frames from tensor_converter.
  */
-TEST (tensor_stream_test, video_rgb_3f)
+TEST (tensorStreamTest, videoRgb3f)
 {
   const guint num_buffers = 7;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB_3F };
@@ -1612,7 +1612,7 @@ TEST (tensor_stream_test, video_rgb_3f)
 /**
  * @brief Test for video format RGBA.
  */
-TEST (tensor_stream_test, video_rgba)
+TEST (tensorStreamTest, videoRgba)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGBA };
@@ -1656,7 +1656,7 @@ TEST (tensor_stream_test, video_rgba)
 /**
  * @brief Test for video format BGRA.
  */
-TEST (tensor_stream_test, video_bgra)
+TEST (tensorStreamTest, videoBgra)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_BGRA };
@@ -1700,7 +1700,7 @@ TEST (tensor_stream_test, video_bgra)
 /**
  * @brief Test for video format ARGB.
  */
-TEST (tensor_stream_test, video_argb)
+TEST (tensorStreamTest, videoArgb)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_ARGB };
@@ -1744,7 +1744,7 @@ TEST (tensor_stream_test, video_argb)
 /**
  * @brief Test for video format ABGR.
  */
-TEST (tensor_stream_test, video_abgr)
+TEST (tensorStreamTest, videoAbgr)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_ABGR };
@@ -1788,7 +1788,7 @@ TEST (tensor_stream_test, video_abgr)
 /**
  * @brief Test for video format RGBx.
  */
-TEST (tensor_stream_test, video_rgbx)
+TEST (tensorStreamTest, videoRgbx)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGBx };
@@ -1832,7 +1832,7 @@ TEST (tensor_stream_test, video_rgbx)
 /**
  * @brief Test for video format xRGB.
  */
-TEST (tensor_stream_test, video_xrgb)
+TEST (tensorStreamTest, videoXrgb)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_xRGB };
@@ -1876,7 +1876,7 @@ TEST (tensor_stream_test, video_xrgb)
 /**
  * @brief Test for video format xBGR.
  */
-TEST (tensor_stream_test, video_xbgr)
+TEST (tensorStreamTest, videoXbgr)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_xBGR };
@@ -1920,7 +1920,7 @@ TEST (tensor_stream_test, video_xbgr)
 /**
  * @brief Test for video format BGRx.
  */
-TEST (tensor_stream_test, video_bgrx)
+TEST (tensorStreamTest, videoBgrx)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_BGRx };
@@ -1964,7 +1964,7 @@ TEST (tensor_stream_test, video_bgrx)
 /**
  * @brief Test for video format BGRx, 2 frames from tensor_converter.
  */
-TEST (tensor_stream_test, video_bgrx_2f)
+TEST (tensorStreamTest, videoBgrx2f)
 {
   const guint num_buffers = 6;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_BGRx_2F };
@@ -2008,7 +2008,7 @@ TEST (tensor_stream_test, video_bgrx_2f)
 /**
  * @brief Test for video format GRAY8.
  */
-TEST (tensor_stream_test, video_gray8)
+TEST (tensorStreamTest, videoGray8)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_GRAY8 };
@@ -2052,7 +2052,7 @@ TEST (tensor_stream_test, video_gray8)
 /**
  * @brief Test for video format GRAY8, remove padding.
  */
-TEST (tensor_stream_test, video_gray8_padding)
+TEST (tensorStreamTest, videoGray8Padding)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_GRAY8_PADDING };
@@ -2096,7 +2096,7 @@ TEST (tensor_stream_test, video_gray8_padding)
 /**
  * @brief Test for video format GRAY8, 3 frames from tensor_converter, remove padding.
  */
-TEST (tensor_stream_test, video_gray8_3f_padding)
+TEST (tensorStreamTest, videoGray83fPadding)
 {
   const guint num_buffers = 6;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_GRAY8_3F_PADDING };
@@ -2140,7 +2140,7 @@ TEST (tensor_stream_test, video_gray8_3f_padding)
 /**
  * @brief Test for audio format S8.
  */
-TEST (tensor_stream_test, audio_s8)
+TEST (tensorStreamTest, audioS8)
 {
   const guint num_buffers = 5; /** 5 * 500 frames */
   TestOption option = { num_buffers, TEST_TYPE_AUDIO_S8 };
@@ -2184,7 +2184,7 @@ TEST (tensor_stream_test, audio_s8)
 /**
  * @brief Test for audio format U8, 100 frames from tensor_converter.
  */
-TEST (tensor_stream_test, audio_u8_100f)
+TEST (tensorStreamTest, audioU8100f)
 {
   const guint num_buffers = 5; /** 5 * 500 frames */
   TestOption option = { num_buffers, TEST_TYPE_AUDIO_U8_100F };
@@ -2228,7 +2228,7 @@ TEST (tensor_stream_test, audio_u8_100f)
 /**
  * @brief Test for audio format S16.
  */
-TEST (tensor_stream_test, audio_s16)
+TEST (tensorStreamTest, audioS16)
 {
   const guint num_buffers = 5; /** 5 * 500 frames */
   TestOption option = { num_buffers, TEST_TYPE_AUDIO_S16 };
@@ -2272,7 +2272,7 @@ TEST (tensor_stream_test, audio_s16)
 /**
  * @brief Test for audio format U16, 1000 frames from tensor_converter.
  */
-TEST (tensor_stream_test, audio_u16_1000f)
+TEST (tensorStreamTest, audioU161000f)
 {
   const guint num_buffers = 5; /** 5 * 500 frames */
   TestOption option = { num_buffers, TEST_TYPE_AUDIO_U16_1000F };
@@ -2316,7 +2316,7 @@ TEST (tensor_stream_test, audio_u16_1000f)
 /**
  * @brief Test for audio format S32.
  */
-TEST (tensor_stream_test, audio_s32)
+TEST (tensorStreamTest, audioS32)
 {
   const guint num_buffers = 5; /** 5 * 500 frames */
   TestOption option = { num_buffers, TEST_TYPE_AUDIO_S32 };
@@ -2360,7 +2360,7 @@ TEST (tensor_stream_test, audio_s32)
 /**
  * @brief Test for audio format U32.
  */
-TEST (tensor_stream_test, audio_u32)
+TEST (tensorStreamTest, audioU32)
 {
   const guint num_buffers = 5; /** 5 * 500 frames */
   TestOption option = { num_buffers, TEST_TYPE_AUDIO_U32 };
@@ -2404,7 +2404,7 @@ TEST (tensor_stream_test, audio_u32)
 /**
  * @brief Test for audio format F32.
  */
-TEST (tensor_stream_test, audio_f32)
+TEST (tensorStreamTest, audioF32)
 {
   const guint num_buffers = 5; /** 5 * 500 frames */
   TestOption option = { num_buffers, TEST_TYPE_AUDIO_F32 };
@@ -2448,7 +2448,7 @@ TEST (tensor_stream_test, audio_f32)
 /**
  * @brief Test for audio format F64.
  */
-TEST (tensor_stream_test, audio_f64)
+TEST (tensorStreamTest, audioF64)
 {
   const guint num_buffers = 5; /** 5 * 500 frames */
   TestOption option = { num_buffers, TEST_TYPE_AUDIO_F64 };
@@ -2492,7 +2492,7 @@ TEST (tensor_stream_test, audio_f64)
 /**
  * @brief Test for text format utf8.
  */
-TEST (tensor_stream_test, text_utf8)
+TEST (tensorStreamTest, textUtf8)
 {
   const guint num_buffers = 10;
   TestOption option = { num_buffers, TEST_TYPE_TEXT };
@@ -2542,7 +2542,7 @@ TEST (tensor_stream_test, text_utf8)
 /**
  * @brief Test for text format utf8, 3 frames from tensor_converter.
  */
-TEST (tensor_stream_test, text_utf8_3f)
+TEST (tensorStreamTest, textUtf83f)
 {
   const guint num_buffers = 10;
   TestOption option = { num_buffers, TEST_TYPE_TEXT_3F };
@@ -2619,7 +2619,7 @@ TEST (tensor_stream_test, text_utf8_3f)
 /**
  * @brief Test for octet stream.
  */
-TEST (tensor_stream_test, octet_current_ts)
+TEST (tensorStreamTest, octetCurrentTs)
 {
   const guint num_buffers = 10;
   TestOption option = { num_buffers, TEST_TYPE_OCTET_CUR_TS };
@@ -2669,7 +2669,7 @@ TEST (tensor_stream_test, octet_current_ts)
 /**
  * @brief Test for octet stream.
  */
-TEST (tensor_stream_test, octet_framerate_ts)
+TEST (tensorStreamTest, octetFramerateTs)
 {
   const guint num_buffers = 10;
   TestOption option = { num_buffers, TEST_TYPE_OCTET_RATE_TS };
@@ -2719,7 +2719,7 @@ TEST (tensor_stream_test, octet_framerate_ts)
 /**
  * @brief Test for octet stream.
  */
-TEST (tensor_stream_test, octet_valid_ts)
+TEST (tensorStreamTest, octetValidTs)
 {
   const guint num_buffers = 10;
   TestOption option = { num_buffers, TEST_TYPE_OCTET_VALID_TS };
@@ -2796,7 +2796,7 @@ TEST (tensor_stream_test, octet_valid_ts)
 /**
  * @brief Test for octet stream.
  */
-TEST (tensor_stream_test, octet_invalid_ts)
+TEST (tensorStreamTest, octetInvalidTs)
 {
   const guint num_buffers = 10;
   TestOption option = { num_buffers, TEST_TYPE_OCTET_INVALID_TS };
@@ -2873,7 +2873,7 @@ TEST (tensor_stream_test, octet_invalid_ts)
 /**
  * @brief Test for octet stream.
  */
-TEST (tensor_stream_test, octet_2f)
+TEST (tensorStreamTest, octet2f)
 {
   const guint num_buffers = 10;
   TestOption option = { num_buffers, TEST_TYPE_OCTET_2F };
@@ -2950,7 +2950,7 @@ TEST (tensor_stream_test, octet_2f)
 /**
  * @brief Test for octet stream.
  */
-TEST (tensor_stream_test, octet_multi_tensors)
+TEST (tensorStreamTest, octetMultiTensors)
 {
   const guint num_buffers = 10;
   TestOption option = { num_buffers, TEST_TYPE_OCTET_MULTI_TENSORS };
@@ -3029,7 +3029,7 @@ TEST (tensor_stream_test, octet_multi_tensors)
 /**
  * @brief Test for other/tensor, passthrough custom filter.
  */
-TEST (tensor_stream_test, custom_filter_tensor)
+TEST (tensorStreamTest, customFilterTensor)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_CUSTOM_TENSOR };
@@ -3089,7 +3089,7 @@ TEST (tensor_stream_test, custom_filter_tensor)
 /**
  * @brief Test for other/tensors, passthrough custom filter.
  */
-TEST (tensor_stream_test, custom_filter_tensors)
+TEST (tensorStreamTest, customFilterTensors)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_CUSTOM_TENSORS_1 };
@@ -3165,7 +3165,7 @@ TEST (tensor_stream_test, custom_filter_tensors)
 /**
  * @brief Test for multiple custom filters.
  */
-TEST (tensor_stream_test, custom_filter_multi)
+TEST (tensorStreamTest, customFilterMulti)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_CUSTOM_MULTI };
@@ -3225,7 +3225,7 @@ TEST (tensor_stream_test, custom_filter_multi)
 /**
  * @brief Test for tensor filter properties.
  */
-TEST (tensor_stream_test, filter_properties_1)
+TEST (tensorStreamTest, filterProperties1)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_CUSTOM_TENSOR };
@@ -3367,7 +3367,7 @@ TEST (tensor_stream_test, filter_properties_1)
 /**
  * @brief Test for tensor filter properties.
  */
-TEST (tensor_stream_test, filter_properties_2)
+TEST (tensorStreamTest, filterProperties2)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_CUSTOM_TENSORS_1 };
@@ -3476,7 +3476,7 @@ TEST (tensor_stream_test, filter_properties_2)
 /**
  * @brief Test for tensor filter properties.
  */
-TEST (tensor_stream_test, filter_properties_3)
+TEST (tensorStreamTest, filterProperties3)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_CUSTOM_TENSORS_2 };
@@ -3611,7 +3611,7 @@ TEST (tensor_stream_test, filter_properties_3)
 /**
  * @brief Test for tensor filter properties.
  */
-TEST (tensor_stream_test, filter_properties_4_n)
+TEST (tensorStreamTest, filterProperties4_n)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_CUSTOM_TENSOR };
@@ -3638,7 +3638,7 @@ TEST (tensor_stream_test, filter_properties_4_n)
 /**
  * @brief Test to drop incoming buffer in tensor_filter using custom filter.
  */
-TEST (tensor_stream_test, custom_filter_drop_buffer)
+TEST (tensorStreamTest, customFilterDropBuffer)
 {
   const guint num_buffers = 22;
   TestOption option = { num_buffers, TEST_TYPE_CUSTOM_BUF_DROP };
@@ -3841,7 +3841,7 @@ test_custom_run_pipeline (void)
 /**
  * @brief Test for plugin registration with invalid param.
  */
-TEST (tensor_stream_test, subplugin_invalid_ver_n)
+TEST (tensorStreamTest, subpluginInvalidVer_n)
 {
   GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
 
@@ -3860,7 +3860,7 @@ TEST (tensor_stream_test, subplugin_invalid_ver_n)
 /**
  * @brief Test for passthrough custom filter without model.
  */
-TEST (tensor_stream_test, subplugin_v0_run)
+TEST (tensorStreamTest, subpluginV0Run)
 {
   GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
 
@@ -3884,7 +3884,7 @@ TEST (tensor_stream_test, subplugin_v0_run)
 /**
  * @brief Test for preserved sub-plugin name.
  */
-TEST (tensor_stream_test, subplugin_v0_preserved_name_n)
+TEST (tensorStreamTest, subpluginV0PreservedName_n)
 {
   GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
 
@@ -3908,7 +3908,7 @@ TEST (tensor_stream_test, subplugin_v0_preserved_name_n)
 /**
  * @brief Test for plugin registration with invalid param.
  */
-TEST (tensor_stream_test, subplugin_v0_null_name_n)
+TEST (tensorStreamTest, subpluginV0NullName_n)
 {
   GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
 
@@ -3927,7 +3927,7 @@ TEST (tensor_stream_test, subplugin_v0_null_name_n)
 /**
  * @brief Test for plugin registration with invalid param.
  */
-TEST (tensor_stream_test, subplugin_v0_null_cb_n)
+TEST (tensorStreamTest, subpluginV0NullCb_n)
 {
   GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
 
@@ -3951,7 +3951,7 @@ TEST (tensor_stream_test, subplugin_v0_null_cb_n)
 /**
  * @brief Test for passthrough custom filter without model (v1).
  */
-TEST (tensor_stream_test, subplugin_v1_run)
+TEST (tensorStreamTest, subpluginV1Run)
 {
   GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
 
@@ -3975,7 +3975,7 @@ TEST (tensor_stream_test, subplugin_v1_run)
 /**
  * @brief Test for plugin registration with invalid param (v1).
  */
-TEST (tensor_stream_test, subplugin_v1_null_name_n)
+TEST (tensorStreamTest, subpluginV1NullName_n)
 {
   GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
 
@@ -3994,7 +3994,7 @@ TEST (tensor_stream_test, subplugin_v1_null_name_n)
 /**
  * @brief Test for plugin registration with invalid param (v1).
  */
-TEST (tensor_stream_test, subplugin_v1_invalid_cb_n)
+TEST (tensorStreamTest, subpluginV1InvalidCb_n)
 {
   GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
 
@@ -4013,7 +4013,7 @@ TEST (tensor_stream_test, subplugin_v1_invalid_cb_n)
 /**
  * @brief Test for plugin registration with invalid param (v1).
  */
-TEST (tensor_stream_test, subplugin_v1_null_cb_n)
+TEST (tensorStreamTest, subpluginV1NullCb_n)
 {
   GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
 
@@ -4036,7 +4036,7 @@ TEST (tensor_stream_test, subplugin_v1_null_cb_n)
 /**
  * @brief Test for tensors (mixed, video and audio).
  */
-TEST (tensor_stream_test, tensors_mix)
+TEST (tensorStreamTest, tensorsMix)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_TENSORS_MIX_1 };
@@ -4097,7 +4097,7 @@ TEST (tensor_stream_test, tensors_mix)
 /**
  * @brief Test for tensor demux properties.
  */
-TEST (tensor_stream_test, demux_properties_1)
+TEST (tensorStreamTest, demuxProperties1)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_TENSORS_MIX_2 };
@@ -4163,7 +4163,7 @@ TEST (tensor_stream_test, demux_properties_1)
 /**
  * @brief Test for tensor demux properties.
  */
-TEST (tensor_stream_test, demux_properties_2)
+TEST (tensorStreamTest, demuxProperties2)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_TENSORS_MIX_3 };
@@ -4229,7 +4229,7 @@ TEST (tensor_stream_test, demux_properties_2)
 /**
  * @brief Test for tensor demux properties.
  */
-TEST (tensor_stream_test, demux_properties_3_n)
+TEST (tensorStreamTest, demuxProperties3_n)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_TENSORS_MIX_3 };
@@ -4306,7 +4306,7 @@ _test_transform_typecast (TestType test, tensor_type type, guint buffers)
 /**
  * @brief Test for typecast to int32 using tensor_transform.
  */
-TEST (tensor_stream_test, typecast_int32)
+TEST (tensorStreamTest, typecastInt32)
 {
   _test_transform_typecast (TEST_TYPE_TYPECAST, _NNS_INT32, 2);
 }
@@ -4314,7 +4314,7 @@ TEST (tensor_stream_test, typecast_int32)
 /**
  * @brief Test for typecast to uint32 using tensor_transform.
  */
-TEST (tensor_stream_test, typecast_uint32)
+TEST (tensorStreamTest, typecastUint32)
 {
   _test_transform_typecast (TEST_TYPE_TYPECAST, _NNS_UINT32, 2);
 }
@@ -4322,7 +4322,7 @@ TEST (tensor_stream_test, typecast_uint32)
 /**
  * @brief Test for typecast to int16 using tensor_transform.
  */
-TEST (tensor_stream_test, typecast_int16)
+TEST (tensorStreamTest, typecastInt16)
 {
   _test_transform_typecast (TEST_TYPE_TYPECAST, _NNS_INT16, 2);
 }
@@ -4330,7 +4330,7 @@ TEST (tensor_stream_test, typecast_int16)
 /**
  * @brief Test for typecast to uint16 using tensor_transform.
  */
-TEST (tensor_stream_test, typecast_uint16)
+TEST (tensorStreamTest, typecastUint16)
 {
   _test_transform_typecast (TEST_TYPE_TYPECAST, _NNS_UINT16, 2);
 }
@@ -4338,7 +4338,7 @@ TEST (tensor_stream_test, typecast_uint16)
 /**
  * @brief Test for typecast to float64 using tensor_transform.
  */
-TEST (tensor_stream_test, typecast_float64)
+TEST (tensorStreamTest, typecastFloat64)
 {
   _test_transform_typecast (TEST_TYPE_TYPECAST, _NNS_FLOAT64, 2);
 }
@@ -4346,7 +4346,7 @@ TEST (tensor_stream_test, typecast_float64)
 /**
  * @brief Test for typecast to float32 using tensor_transform.
  */
-TEST (tensor_stream_test, typecast_float32)
+TEST (tensorStreamTest, typecastFloat32)
 {
   _test_transform_typecast (TEST_TYPE_TYPECAST, _NNS_FLOAT32, 2);
 }
@@ -4354,7 +4354,7 @@ TEST (tensor_stream_test, typecast_float32)
 /**
  * @brief Test for typecast to int64 using tensor_transform.
  */
-TEST (tensor_stream_test, typecast_int64)
+TEST (tensorStreamTest, typecastInt64)
 {
   _test_transform_typecast (TEST_TYPE_TYPECAST, _NNS_INT64, 2);
 }
@@ -4362,7 +4362,7 @@ TEST (tensor_stream_test, typecast_int64)
 /**
  * @brief Test for typecast to uint64 using tensor_transform.
  */
-TEST (tensor_stream_test, typecast_uint64)
+TEST (tensorStreamTest, typecastUint64)
 {
   _test_transform_typecast (TEST_TYPE_TYPECAST, _NNS_UINT64, 2);
 }
@@ -4370,7 +4370,7 @@ TEST (tensor_stream_test, typecast_uint64)
 /**
  * @brief Test for caps negotiation in tensor_transform.
  */
-TEST (tensor_stream_test, transform_caps_nego_typecast_float32)
+TEST (tensorStreamTest, transformCapsNegoTypecastFloat32)
 {
   _test_transform_typecast (TEST_TYPE_TRANSFORM_CAPS_NEGO_1, _NNS_FLOAT32, 2);
 }
@@ -4378,7 +4378,7 @@ TEST (tensor_stream_test, transform_caps_nego_typecast_float32)
 /**
  * @brief Test for caps negotiation in tensor_transform.
  */
-TEST (tensor_stream_test, transform_caps_nego_arithmetic_float32)
+TEST (tensorStreamTest, transformCapsNegoArithmeticFloat32)
 {
   _test_transform_typecast (TEST_TYPE_TRANSFORM_CAPS_NEGO_2, _NNS_FLOAT32, 2);
 }
@@ -4386,7 +4386,7 @@ TEST (tensor_stream_test, transform_caps_nego_arithmetic_float32)
 /**
  * @brief Test for caps negotiation in tensor_transform.
  */
-TEST (tensor_stream_test, transform_caps_nego_typecast_uint32)
+TEST (tensorStreamTest, transformCapsNegoTypecastUint32)
 {
   _test_transform_typecast (TEST_TYPE_TRANSFORM_CAPS_NEGO_1, _NNS_UINT32, 2);
 }
@@ -4394,7 +4394,7 @@ TEST (tensor_stream_test, transform_caps_nego_typecast_uint32)
 /**
  * @brief Test for caps negotiation in tensor_transform.
  */
-TEST (tensor_stream_test, transform_caps_nego_arithmetic_uint32)
+TEST (tensorStreamTest, transformCapsNegoArithmeticUint32)
 {
   _test_transform_typecast (TEST_TYPE_TRANSFORM_CAPS_NEGO_2, _NNS_UINT32, 2);
 }
@@ -4402,7 +4402,7 @@ TEST (tensor_stream_test, transform_caps_nego_arithmetic_uint32)
 /**
  * @brief Test for video stream with tensor_split.
  */
-TEST (tensor_stream_test, video_split)
+TEST (tensorStreamTest, videoSplit)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB_SPLIT };
@@ -4466,7 +4466,7 @@ TEST (tensor_stream_test, video_split)
 /**
  * @brief Test for tensor_split properties.
  */
-TEST (tensor_stream_test, split_properties_1_n)
+TEST (tensorStreamTest, splitProperties1_n)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB_SPLIT };
@@ -4495,7 +4495,7 @@ TEST (tensor_stream_test, split_properties_1_n)
 /**
  * @brief Test for video stream with tensor_aggregator.
  */
-TEST (tensor_stream_test, video_aggregate_1)
+TEST (tensorStreamTest, videoAggregate1)
 {
   const guint num_buffers = 35;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB_AGGR_1 };
@@ -4539,7 +4539,7 @@ TEST (tensor_stream_test, video_aggregate_1)
 /**
  * @brief Test for video stream with tensor_aggregator.
  */
-TEST (tensor_stream_test, video_aggregate_2)
+TEST (tensorStreamTest, videoAggregate2)
 {
   const guint num_buffers = 35;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB_AGGR_2 };
@@ -4583,7 +4583,7 @@ TEST (tensor_stream_test, video_aggregate_2)
 /**
  * @brief Test for video stream with tensor_aggregator.
  */
-TEST (tensor_stream_test, video_aggregate_3)
+TEST (tensorStreamTest, videoAggregate3)
 {
   const guint num_buffers = 40;
   TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB_AGGR_3 };
@@ -4627,7 +4627,7 @@ TEST (tensor_stream_test, video_aggregate_3)
 /**
  * @brief Test for audio stream with tensor_aggregator.
  */
-TEST (tensor_stream_test, audio_aggregate_s16)
+TEST (tensorStreamTest, audioAggregateS16)
 {
   const guint num_buffers = 21;
   TestOption option = { num_buffers, TEST_TYPE_AUDIO_S16_AGGR };
@@ -4671,7 +4671,7 @@ TEST (tensor_stream_test, audio_aggregate_s16)
 /**
  * @brief Test for audio stream with tensor_aggregator.
  */
-TEST (tensor_stream_test, audio_aggregate_u16)
+TEST (tensorStreamTest, audioAggregateU16)
 {
   const guint num_buffers = 10;
   TestOption option = { num_buffers, TEST_TYPE_AUDIO_U16_AGGR };
@@ -4715,7 +4715,7 @@ TEST (tensor_stream_test, audio_aggregate_u16)
 /**
  * @brief Test multi-stream sync & frame-dropping of Issue #739, 1st subissue
  */
-TEST (tensor_stream_test, issue739_mux_parallel_1)
+TEST (tensorStreamTest, issue739MuxParallel1)
 {
   const guint num_buffers = 2;
   TestOption option = { num_buffers, TEST_TYPE_ISSUE739_MUX_PARALLEL_1 };
@@ -4776,7 +4776,7 @@ TEST (tensor_stream_test, issue739_mux_parallel_1)
 /**
  * @brief Test multi-stream sync & frame-dropping of Issue #739, 1st subissue
  */
-TEST (tensor_stream_test, issue739_mux_parallel_2)
+TEST (tensorStreamTest, issue739MuxParallel2)
 {
   const guint num_buffers = 2;
   TestOption option = { num_buffers, TEST_TYPE_ISSUE739_MUX_PARALLEL_2 };
@@ -4837,7 +4837,7 @@ TEST (tensor_stream_test, issue739_mux_parallel_2)
 /**
  * @brief Test multi-stream sync & frame-dropping of Issue #739, 1st subissue
  */
-TEST (tensor_stream_test, issue739_mux_parallel_3)
+TEST (tensorStreamTest, issue739MuxParallel3)
 {
   const guint num_buffers = 2;
   TestOption option = { num_buffers, TEST_TYPE_ISSUE739_MUX_PARALLEL_3 };
@@ -4908,7 +4908,7 @@ TEST (tensor_stream_test, issue739_mux_parallel_3)
 /**
  * @brief Test multi-stream sync & frame-dropping of Issue #739, 1st subissue
  */
-TEST (tensor_stream_test, issue739_mux_parallel_4)
+TEST (tensorStreamTest, issue739MuxParallel4)
 {
   /** @todo Write this after the tensor-mux/merge sync-option "basepad" is updated */
   EXPECT_EQ (1, 1);
@@ -4917,7 +4917,7 @@ TEST (tensor_stream_test, issue739_mux_parallel_4)
 /**
  * @brief Test multi-stream sync & frame-dropping of Issue #739, 1st subissue
  */
-TEST (tensor_stream_test, issue739_merge_parallel_1)
+TEST (tensorStreamTest, issue739MergeParallel1)
 {
   const guint num_buffers = 2;
   TestOption option = { num_buffers, TEST_TYPE_ISSUE739_MERGE_PARALLEL_1 };
@@ -4978,7 +4978,7 @@ TEST (tensor_stream_test, issue739_merge_parallel_1)
 /**
  * @brief Test multi-stream sync & frame-dropping of Issue #739, 1st subissue
  */
-TEST (tensor_stream_test, issue739_merge_parallel_2)
+TEST (tensorStreamTest, issue739MergeParallel2)
 {
   const guint num_buffers = 2;
   TestOption option = { num_buffers, TEST_TYPE_ISSUE739_MERGE_PARALLEL_2 };
@@ -5039,7 +5039,7 @@ TEST (tensor_stream_test, issue739_merge_parallel_2)
 /**
  * @brief Test multi-stream sync & frame-dropping of Issue #739, 1st subissue
  */
-TEST (tensor_stream_test, issue739_merge_parallel_3)
+TEST (tensorStreamTest, issue739MergeParallel3)
 {
   const guint num_buffers = 2;
   TestOption option = { num_buffers, TEST_TYPE_ISSUE739_MERGE_PARALLEL_3 };
@@ -5110,7 +5110,7 @@ TEST (tensor_stream_test, issue739_merge_parallel_3)
 /**
  * @brief Test for tensor_mux properties.
  */
-TEST (tensor_stream_test, mux_properties_1)
+TEST (tensorStreamTest, muxProperties1)
 {
   const guint num_buffers = 2;
   TestOption option = { num_buffers, TEST_TYPE_ISSUE739_MUX_PARALLEL_2 };
@@ -5154,7 +5154,7 @@ TEST (tensor_stream_test, mux_properties_1)
 /**
  * @brief Test for tensor_mux properties.
  */
-TEST (tensor_stream_test, mux_properties_2_n)
+TEST (tensorStreamTest, muxProperties2_n)
 {
   const guint num_buffers = 2;
   TestOption option = { num_buffers, TEST_TYPE_ISSUE739_MUX_PARALLEL_2 };
@@ -5186,7 +5186,7 @@ TEST (tensor_stream_test, mux_properties_2_n)
 /**
  * @brief Test for tensor_merge properties.
  */
-TEST (tensor_stream_test, merge_properties_1)
+TEST (tensorStreamTest, mergeProperties1)
 {
   const guint num_buffers = 2;
   TestOption option = { num_buffers, TEST_TYPE_ISSUE739_MERGE_PARALLEL_2 };
@@ -5240,7 +5240,7 @@ TEST (tensor_stream_test, merge_properties_1)
 /**
  * @brief Test for tensor_merge properties.
  */
-TEST (tensor_stream_test, merge_properties_2_n)
+TEST (tensorStreamTest, mergeProperties2_n)
 {
   const guint num_buffers = 2;
   TestOption option = { num_buffers, TEST_TYPE_ISSUE739_MERGE_PARALLEL_2 };
@@ -5272,7 +5272,7 @@ TEST (tensor_stream_test, merge_properties_2_n)
 /**
  * @brief Test get/set property of tensor_decoder
  */
-TEST (tensor_stream_test, tensor_decoder_property_1)
+TEST (tensorStreamTest, tensorDecoderProperty1)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_DECODER_PROPERTY };
@@ -5358,7 +5358,7 @@ TEST (tensor_stream_test, tensor_decoder_property_1)
 /**
  * @brief Test get/set property of tensor_decoder
  */
-TEST (tensor_stream_test, tensor_decoder_property_2_n)
+TEST (tensorStreamTest, tensorDecoderProperty2_n)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_DECODER_PROPERTY };
@@ -5387,7 +5387,7 @@ TEST (tensor_stream_test, tensor_decoder_property_2_n)
 /**
  * @brief Test tensor out
  */
-TEST (tensor_stream_test, tensor_cap_0)
+TEST (tensorStreamTest, tensorCap0)
 {
    const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_TENSOR_CAP_1 };
@@ -5451,7 +5451,7 @@ TEST (tensor_stream_test, tensor_cap_0)
 /**
  * @brief Test tensor out
  */
-TEST (tensor_stream_test, tensor_cap_1)
+TEST (tensorStreamTest, tensorCap1)
 {
    const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_TENSOR_CAP_2 };
@@ -5515,7 +5515,7 @@ TEST (tensor_stream_test, tensor_cap_1)
 /**
  * @brief Test tensors out when the number of the tensors is 1.
  */
-TEST (tensor_stream_test, tensors_cap_0)
+TEST (tensorStreamTest, tensorsCap0)
 {
    const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_TENSORS_CAP_1 };
@@ -5580,7 +5580,7 @@ TEST (tensor_stream_test, tensors_cap_0)
 /**
  * @brief Test for other/tensors, passthrough custom filter.
  */
-TEST (tensor_stream_test, tensors_cap_1)
+TEST (tensorStreamTest, tensorsCap1)
 {
   const guint num_buffers = 5;
   TestOption option = { num_buffers, TEST_TYPE_TENSORS_CAP_2 };
@@ -5676,7 +5676,7 @@ cef_func_safe_memcpy (void *data, const GstTensorFilterProperties *prop,
 /**
  * @brief Test custom-easy filter with an in-code function.
  */
-TEST (tensor_filter_custom_easy, in_code_func_01)
+TEST (tensorFilterCustomEasy, inCodeFunc01)
 {
   int ret;
   const guint num_buffers = 10;
@@ -5743,7 +5743,7 @@ TEST (tensor_filter_custom_easy, in_code_func_01)
 /**
  * @brief Test unregister custom_easy filter
  */
-TEST (tensor_filter_custom_easy, unregister_1_p)
+TEST (tensorFilterCustomEasy, unregister1_p)
 {
   int ret;
   const GstTensorsInfo info_in = {
@@ -5767,7 +5767,7 @@ TEST (tensor_filter_custom_easy, unregister_1_p)
 /**
  * @brief Test non-registered custom_easy filter
  */
-TEST (tensor_filter_custom_easy, unregister_1_n)
+TEST (tensorFilterCustomEasy, unregister1_n)
 {
   int ret;
 

--- a/tests/nnstreamer_source/unittest_src_iio.cc
+++ b/tests/nnstreamer_source/unittest_src_iio.cc
@@ -759,7 +759,7 @@ destroy_dev_dir (const iio_dev_dir_struct *iio_dev)
 /**
  * @brief tests properties of tensor source IIO
  */
-TEST (test_tensor_src_iio, properties)
+TEST (testTensorSrcIio, properties)
 {
   const gchar default_name[] = "tensorsrciio0";
 
@@ -945,7 +945,7 @@ make_full_device (const guint64 data_value, const gint data_bits,
 /**
  * @brief tests state change of tensor source IIO
  */
-TEST (test_tensor_src_iio, start_stop)
+TEST (testTensorSrcIio, startStop)
 {
   iio_dev_dir_struct *dev0;
   GstHarness *hrnss = NULL;
@@ -1024,7 +1024,7 @@ TEST (test_tensor_src_iio, start_stop)
   /**                                                                                            \
    * @brief tests tensor source IIO data without trigger                                         \
    */                                                                                            \
-  TEST (test_tensor_src_iio, data_verify_no_trigger_bits##DATA_BITS##_alternate##SKIP)           \
+  TEST (testTensorSrcIio, dataVerifyNoTriggerBits##DATA_BITS##alternate##SKIP)                   \
   {                                                                                              \
     static const int MAX_NUM_TRY = 100;                                                          \
     int num_try;                                                                                 \
@@ -1233,7 +1233,7 @@ test_tensor_src_iio_data_verify_util (
  * @note verifies that no frames have been lost as well
  * @note verifies caps for the src pad as well
  */
-TEST (test_tensor_src_iio, data_verify_trigger)
+TEST (testTensorSrcIio, dataVerifyTrigger)
 {
   iio_dev_dir_struct *dev0;
   GstElement *src_iio_pipeline;
@@ -1317,7 +1317,7 @@ TEST (test_tensor_src_iio, data_verify_trigger)
  * @brief tests tensor source IIO caps with custom channels
  * @note data verification with/without all channels is verified in another test
  */
-TEST (test_tensor_src_iio, data_verify_custom_channels)
+TEST (testTensorSrcIio, dataVerifyCustomChannels)
 {
   iio_dev_dir_struct *dev0;
   GstElement *src_iio_pipeline;
@@ -1401,7 +1401,7 @@ TEST (test_tensor_src_iio, data_verify_custom_channels)
  * @note verifies enabling of channels automatically
  * @note verifies using generic type information for channels
  */
-TEST (test_tensor_src_iio, data_verify_freq_generic_type)
+TEST (testTensorSrcIio, dataVerifyFreqGenericType)
 {
   iio_dev_dir_struct *dev0;
   GstElement *src_iio_pipeline;
@@ -1529,12 +1529,12 @@ TEST (test_tensor_src_iio, data_verify_freq_generic_type)
 /**
  * @brief test the unusual/exceptional cases.
  */
-TEST (test_tensor_src_iio, unusual_cases)
+TEST (testTensorSrcIio, unusualCases)
 #else
 /**
  * @brief test the unusual/exceptional cases.
  */
-TEST (test_tensor_src_iio, DISABLED_unusual_cases)
+TEST (testTensorSrcIio, DISABLED_unusualCases)
 #endif
 {
   iio_dev_dir_struct *dev0;
@@ -1631,7 +1631,7 @@ TEST (test_tensor_src_iio, DISABLED_unusual_cases)
 /**
  * @brief test the logic with invalid frequency value
  */
-TEST (test_tensor_src_iio, set_frequency_n)
+TEST (testTensorSrcIio, setFrequency_n)
 {
   iio_dev_dir_struct *dev0;
   GstElement *src_iio_pipeline;
@@ -1679,7 +1679,7 @@ TEST (test_tensor_src_iio, set_frequency_n)
 /**
  * @brief test the logic with invalid base dir
  */
-TEST (test_tensor_src_iio, set_base_dir_n)
+TEST (testTensorSrcIio, setBaseDir_n)
 {
   iio_dev_dir_struct *dev0;
   GstHarness *hrnss = NULL;

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -54,7 +54,7 @@ get_model_file ()
 /**
  * @brief Get input/output dimensions with nnfw subplugin
  */
-TEST (nnstreamer_nnfw_runtime_raw_functions, get_dimension)
+TEST (nnstreamerNnfwRuntimeRawFunctions, getDimension)
 {
   int ret;
   void *data = NULL;
@@ -111,7 +111,7 @@ TEST (nnstreamer_nnfw_runtime_raw_functions, get_dimension)
 /**
  * @brief Set input dimensions with nnfw subplugin
  */
-TEST (nnstreamer_nnfw_runtime_raw_functions, set_dimension)
+TEST (nnstreamerNnfwRuntimeRawFunctions, setDimension)
 {
   int ret;
   void *data = NULL;
@@ -209,7 +209,7 @@ TEST (nnstreamer_nnfw_runtime_raw_functions, set_dimension)
 /**
  * @brief Test nnfw subplugin with successful invoke
  */
-TEST (nnstreamer_nnfw_runtime_raw_functions, invoke)
+TEST (nnstreamerNnfwRuntimeRawFunctions, invoke)
 {
   int ret;
   void *data = NULL;
@@ -272,7 +272,7 @@ get_argmax (guint8 *array, size_t size)
 /**
  * @brief Test nnfw subplugin with successful invoke for tflite advanced model
  */
-TEST (nnstreamer_nnfw_runtime_raw_functions, invoke_advanced)
+TEST (nnstreamerNnfwRuntimeRawFunctions, invokeAdvanced)
 {
   int ret;
   void *data = NULL;

--- a/tests/tizen_sensor/unittest_tizen_sensor.cc
+++ b/tests/tizen_sensor/unittest_tizen_sensor.cc
@@ -40,7 +40,7 @@ static const unsigned int TEST_TIME_OUT_TIZEN_SENSOR_MS
 /**
  * @brief Test pipeline creation of it
  */
-TEST (tizensensor_as_source, virtual_sensor_create_01)
+TEST (tizensensorAsSource, virtualSensorCreate01)
 {
   gchar *pipeline;
   sensor_event_s value;
@@ -77,7 +77,7 @@ TEST (tizensensor_as_source, virtual_sensor_create_01)
 /**
  * @brief Test pipeline creation.
  */
-TEST (tizensensor_as_source, virtual_sensor_create_02)
+TEST (tizensensorAsSource, virtualSensorCreate02)
 {
   gchar *pipeline;
   sensor_event_s value;
@@ -167,7 +167,7 @@ callback_nns (GstElement *element, GstBuffer *buffer, gpointer user_data)
 /**
  * @brief Test pipeline creation and sink
  */
-TEST (tizensensor_as_source, virtual_sensor_flow_03)
+TEST (tizensensorAsSource, virtualSensorFlow03)
 {
   GError *err = NULL;
   GstElement *pipe, *sink;
@@ -225,7 +225,7 @@ TEST (tizensensor_as_source, virtual_sensor_flow_03)
 /**
  * @brief Test pipeline creation and sink
  */
-TEST (tizensensor_as_source, virtual_sensor_flow_04)
+TEST (tizensensorAsSource, virtualSensorFlow04)
 {
   GError *err = NULL;
   GstElement *pipe, *sink;
@@ -286,7 +286,7 @@ TEST (tizensensor_as_source, virtual_sensor_flow_04)
 /**
  * @brief Test pipeline creation and sink (negative)
  */
-TEST (tizensensor_as_source, virtual_sensor_flow_05_n)
+TEST (tizensensorAsSource, virtualSensorFlow05_n)
 {
   GError *err = NULL;
   GstElement *pipe, *sink;
@@ -355,7 +355,7 @@ TEST (tizensensor_as_source, virtual_sensor_flow_05_n)
 /**
  * @brief Test pipeline creation with not supported sensor (negative)
  */
-TEST (tizensensor_as_source, virtual_sensor_create_06_n)
+TEST (tizensensorAsSource, virtualSensorCreate06_n)
 {
   GError *err = NULL;
   GstElement *pipe;
@@ -383,7 +383,7 @@ TEST (tizensensor_as_source, virtual_sensor_create_06_n)
 /**
  * @brief Test pipeline creation with invalid sensor (negative)
  */
-TEST (tizensensor_as_source, virtual_sensor_create_07_n)
+TEST (tizensensorAsSource, virtualSensorCreate07_n)
 {
   GError *err = NULL;
   GstElement *pipe;
@@ -411,7 +411,7 @@ TEST (tizensensor_as_source, virtual_sensor_create_07_n)
 /**
  * @brief Test for tizen sensor get property
  */
-TEST (tizensensor_as_source, get_property_1)
+TEST (tizensensorAsSource, getProperty1)
 {
   gchar *pipeline;
   GstElement *gstpipe;
@@ -466,7 +466,7 @@ TEST (tizensensor_as_source, get_property_1)
 /**
  * @brief Test for tizen sensor get property
  */
-TEST (tizensensor_as_source, get_property_2_n)
+TEST (tizensensorAsSource, getProperty2_n)
 {
   gchar *pipeline;
   GstElement *gstpipe;
@@ -503,7 +503,7 @@ TEST (tizensensor_as_source, get_property_2_n)
 /**
  * @brief Test for tizen sensor set and get property
  */
-TEST (tizensensor_as_source, get_property_3_n)
+TEST (tizensensorAsSource, getProperty3_n)
 {
   gchar *pipeline;
   GstElement *gstpipe;


### PR DESCRIPTION
Resolves #2541
Update test suit names and test names not to contain underscore.
This follows gtest recommendations.
https://github.com/google/googletest/blob/master/docs/faq.md#why-should-test-suite-names-and-test-names-not-contain-underscore

Signed-off-by: Juyeong Lee <2jy22@naver.com>
