### PR TITLE
[Edge-AI] Add flexbuffer converter and decoder @open sesame 03/16 10:58

### DIFF
--- a/debian/nnstreamer-flatbuf.install
+++ b/debian/nnstreamer-flatbuf.install
@@ -1,2 +1,3 @@
 /usr/lib/nnstreamer/converters/libnnstreamer_converter_flatbuf.so
 /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_flatbuf.so
+/usr/lib/nnstreamer/decoders/libnnstreamer_decoder_flexbuf.so

--- a/debian/nnstreamer-flatbuf.install
+++ b/debian/nnstreamer-flatbuf.install
@@ -1,3 +1,4 @@
 /usr/lib/nnstreamer/converters/libnnstreamer_converter_flatbuf.so
 /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_flatbuf.so
 /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_flexbuf.so
+/usr/lib/nnstreamer/converters/libnnstreamer_converter_flexbuf.so

--- a/ext/nnstreamer/tensor_converter/meson.build
+++ b/ext/nnstreamer/tensor_converter/meson.build
@@ -1,6 +1,5 @@
 # flatbuffer
 if flatbuf_support_is_available
-
   converter_sub_flatbuf_sources = [
     'tensor_converter_flatbuf.cc'
   ]
@@ -12,6 +11,22 @@ if flatbuf_support_is_available
 
   shared_library('nnstreamer_converter_flatbuf',
     nnstreamer_converter_flatbuf_sources,
+    dependencies: [nnstreamer_dep, glib_dep, gst_dep, flatbuf_dep],
+    install: true,
+    install_dir: converter_subplugin_install_dir
+  )
+
+  converter_sub_flexbuf_sources = [
+    'tensor_converter_flexbuf.cc'
+  ]
+
+  nnstreamer_converter_flexbuf_sources = []
+  foreach s : converter_sub_flexbuf_sources
+    nnstreamer_converter_flexbuf_sources += join_paths(meson.current_source_dir(), s)
+  endforeach
+
+  shared_library('nnstreamer_converter_flexbuf',
+    nnstreamer_converter_flexbuf_sources,
     dependencies: [nnstreamer_dep, glib_dep, gst_dep, flatbuf_dep],
     install: true,
     install_dir: converter_subplugin_install_dir

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
@@ -1,0 +1,181 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer / NNStreamer tensor_converter subplugin, "Flexbuffer"
+ * Copyright (C) 2021 Gichan Jang <gichan2.jang@samsung.com>
+ */
+/**
+ * @file        tensor_converter_flexbuf.cc
+ * @date        12 Mar 2021
+ * @brief       NNStreamer tensor-converter subplugin, "flexbuffer",
+ *              which converts flexbuffers byte stream to tensors.
+ * @see         https://github.com/nnstreamer/nnstreamer
+ * @author      Gichan Jang <gichan2.jang@samsung.com>
+ * @bug         No known bugs except for NYI items
+ *
+ */
+/**
+ * SECTION:tensor_converter::flexbuf
+ * @see https://google.github.io/flatbuffers/flexbuffers.html
+ *
+ * tensor_converter::flexbuf converts flexbuffers to tensors stream..
+ * The output is always in the format of other/tensor or other/tensors.
+ *
+ * Binary format of the flexbuffers for tensors (default in nnstreamer).
+ * Each data is represented in `KEY : TYPE | <VALUE>` form.
+ *
+ * Map {
+ *   "num_tensors" : UInt32 | <The number of tensors>
+ *   "rate_n" : Int32 | <Framerate numerator>
+ *   "rate_d" : Int32 | <Framerate denominator>
+ *   "tensor_#": Vector | { String | <tensor name>,
+ *                          Int32 | <data type>,
+ *                          Vector | <tensor dimension>,
+ *                          Blob | <tensor data>
+ *                         }
+ * }
+ */
+
+#include <glib.h>
+#include <nnstreamer_log.h>
+#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_converter.h>
+#include <flatbuffers/flexbuffers.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+void init_flxc (void) __attribute__ ((constructor));
+void fini_flxc (void) __attribute__ ((destructor));
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+/** @brief tensor converter plugin's NNStreamerExternalConverter callback */
+static GstCaps *
+flxc_query_caps (const GstTensorsConfig *config)
+{
+  return gst_caps_from_string (GST_FLEXBUF_CAP_DEFAULT);
+}
+
+/** @brief tensor converter plugin's NNStreamerExternalConverter callback */
+static gboolean
+flxc_get_out_config (const GstCaps *in_cap, GstTensorsConfig *config)
+{
+  GstStructure *structure;
+  g_return_val_if_fail (config != NULL, FALSE);
+  gst_tensors_config_init (config);
+  g_return_val_if_fail (in_cap != NULL, FALSE);
+
+  structure = gst_caps_get_structure (in_cap, 0);
+  g_return_val_if_fail (structure != NULL, FALSE);
+
+  /* All tensor info should be updated later in chain function. */
+  config->info.info[0].type = _NNS_UINT8;
+  config->info.num_tensors = 1;
+  if (gst_tensor_parse_dimension ("1:1:1:1", config->info.info[0].dimension) == 0) {
+    ml_loge ("Failed to set initial dimension for subplugin");
+    return FALSE;
+  }
+
+  if (gst_structure_has_field (structure, "framerate")) {
+    gst_structure_get_fraction (structure, "framerate", &config->rate_n, &config->rate_d);
+  } else {
+    /* cannot get the framerate */
+    config->rate_n = 0;
+    config->rate_d = 1;
+  }
+  return TRUE;
+}
+
+/** @brief tensor converter plugin's NNStreamerExternalConverter callback
+ */
+static GstBuffer *
+flxc_convert (GstBuffer *in_buf, gsize *frame_size, guint *frames_in, GstTensorsConfig *config)
+{
+  GstBuffer *out_buf = NULL;
+  GstMemory *in_mem, *out_mem;
+  GstMapInfo in_info;
+  guint mem_size;
+  gpointer mem_data;
+
+  in_mem = gst_buffer_peek_memory (in_buf, 0);
+  if (gst_memory_map (in_mem, &in_info, GST_MAP_READ) == FALSE) {
+    ml_loge ("Cannot map input memory / tensor_converter::flexbuf.\n");
+    return NULL;
+  }
+
+  flexbuffers::Map tensors = flexbuffers::GetRoot (in_info.data, in_info.size).AsMap ();
+  config->info.num_tensors = tensors["num_tensors"].AsUInt32 ();
+
+  if (config->info.num_tensors > NNS_TENSOR_SIZE_LIMIT) {
+    nns_loge ("The number of tensors is limited to %d", NNS_TENSOR_SIZE_LIMIT);
+    goto done;
+  }
+  config->rate_n = tensors["rate_n"].AsInt32 ();
+  config->rate_d = tensors["rate_d"].AsInt32 ();
+  out_buf = gst_buffer_new ();
+  *frame_size = 0;
+  *frames_in = 1;
+
+  for (guint i = 0; i < config->info.num_tensors; i++) {
+    gchar * tensor_key = g_strdup_printf ("tensor_%d", i);
+    flexbuffers::Vector tensor = tensors[tensor_key].AsVector ();
+    config->info.info[i].name = g_strdup (tensor[0].AsString ().c_str ());
+    config->info.info[i].type = (tensor_type) tensor[1].AsInt32 ();
+
+    flexbuffers::TypedVector dim = tensor[2].AsTypedVector ();
+    for (guint j = 0; j < NNS_TENSOR_RANK_LIMIT; j++) {
+      config->info.info[i].dimension[j] = dim[j].AsInt32 ();
+    }
+    flexbuffers::Blob tensor_data = tensor[3].AsBlob ();
+    mem_size = tensor_data.size ();
+    *frame_size += mem_size;
+
+    /** @todo Consider removing memory copies for better performance. */
+    mem_data = g_memdup (tensor_data.data (), mem_size);
+
+    out_mem = gst_memory_new_wrapped (GST_MEMORY_FLAG_READONLY, mem_data,
+        mem_size, 0, mem_size, mem_data, g_free);
+
+    gst_buffer_append_memory (out_buf, out_mem);
+    g_free (tensor_key);
+  }
+
+  /** copy timestamps */
+  gst_buffer_copy_into (
+      out_buf, in_buf, (GstBufferCopyFlags)GST_BUFFER_COPY_METADATA, 0, -1);
+done:
+  gst_memory_unmap (in_mem, &in_info);
+
+  return out_buf;
+}
+
+static const gchar converter_subplugin_flexbuf[] = "flexbuf";
+
+/** @brief flexbuffer tensor converter sub-plugin NNStreamerExternalConverter instance */
+static NNStreamerExternalConverter flexBuf = {
+  .name = converter_subplugin_flexbuf,
+  .convert = flxc_convert,
+  .get_out_config = flxc_get_out_config,
+  .query_caps = flxc_query_caps
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+/** @brief Initialize this object for tensor converter sub-plugin */
+void
+init_flxc (void)
+{
+  registerExternalConverter (&flexBuf);
+}
+
+/** @brief Destruct this object for tensor converter sub-plugin */
+void
+fini_flxc (void)
+{
+  unregisterExternalConverter (flexBuf.name);
+}
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */

--- a/ext/nnstreamer/tensor_decoder/meson.build
+++ b/ext/nnstreamer/tensor_decoder/meson.build
@@ -131,7 +131,7 @@ if protobuf_support_is_available
   foreach s : decoder_sub_protobuf_sources
     nnstreamer_decoder_protobuf_sources += join_paths(meson.current_source_dir(), s)
   endforeach
-  
+
   shared_library('nnstreamer_decoder_protobuf',
     nnstreamer_decoder_protobuf_sources,
     dependencies: [nnstreamer_dep, glib_dep, gst_dep, protobuf_util_dep],
@@ -150,10 +150,27 @@ if flatbuf_support_is_available
   nnstreamer_decoder_flatbuf_sources = [fb_gen_src]
   foreach s : decoder_sub_flatbuf_sources
     nnstreamer_decoder_flatbuf_sources += join_paths(meson.current_source_dir(), s)
-  endforeach  
+  endforeach
 
   shared_library('nnstreamer_decoder_flatbuf',
     nnstreamer_decoder_flatbuf_sources,
+    dependencies: [nnstreamer_dep, glib_dep, gst_dep, flatbuf_dep],
+    install: true,
+    install_dir: decoder_subplugin_install_dir,
+  )
+
+  decoder_sub_flexbuf_sources = [
+    'tensordec-flexbuf.cc',
+    'tensordecutil.c'
+  ]
+
+  nnstreamer_decoder_flexbuf_sources = []
+  foreach s : decoder_sub_flexbuf_sources
+    nnstreamer_decoder_flexbuf_sources += join_paths(meson.current_source_dir(), s)
+  endforeach
+
+  shared_library('nnstreamer_decoder_flexbuf',
+    nnstreamer_decoder_flexbuf_sources,
     dependencies: [nnstreamer_dep, glib_dep, gst_dep, flatbuf_dep],
     install: true,
     install_dir: decoder_subplugin_install_dir,

--- a/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
@@ -1,0 +1,185 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer / NNStreamer tensor_decoder subplugin, "Flexbuffer"
+ * Copyright (C) 2021 Gichan Jang <gichan2.jang@samsung.com>
+ */
+/**
+ * @file        tensordec-flexbuf.cc
+ * @date        12 Mar 2021
+ * @brief       NNStreamer tensor-decoder subplugin, "flexbuffer",
+ *              which converts tensor or tensors to flexbuffer byte stream.
+ *
+ * @see         https://github.com/nnstreamer/nnstreamer
+ * @author      Gichan Jang <gichan2.jang@samsung.com>
+ * @bug         No known bugs except for NYI items
+ *
+ */
+/**
+ * SECTION:tensor_decoder::flexbuf
+ * @see https://google.github.io/flatbuffers/flexbuffers.html
+ *
+ * tensor_decoder::flexbuf converts tensors stream to flexbuffers.
+ *
+ * Binary format of the flexbuffers for tensors (default in nnstreamer).
+ * Each data is represented in `KEY : TYPE | <VALUE>` form.
+ *
+ * Map {
+ *   "num_tensors" : UInt32 | <The number of tensors>
+ *   "rate_n" : Int32 | <Framerate numerator>
+ *   "rate_d" : Int32 | <Framerate denominator>
+ *   "tensor_#": Vector | { String | <tensor name>,
+ *                          Int32 | <data type>,
+ *                          Vector | <tensor dimension>,
+ *                          Blob | <tensor data>
+ *                         }
+ * }
+ */
+
+
+#include <glib.h>
+#include <nnstreamer_log.h>
+#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_decoder.h>
+#include "tensordecutil.h"
+#include <flatbuffers/flexbuffers.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+void init_flxb (void) __attribute__ ((constructor));
+void fini_flxb (void) __attribute__ ((destructor));
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
+static int
+flxb_init (void **pdata)
+{
+  *pdata = NULL;
+  return TRUE;
+}
+
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
+static void
+flxb_exit (void **pdata)
+{
+  return;
+}
+
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
+static int
+flxb_setOption (void **pdata, int opNum, const char *param)
+{
+  return TRUE;
+}
+
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
+static GstCaps *
+flxb_getOutCaps (void **pdata, const GstTensorsConfig *config)
+{
+  GstCaps *caps;
+  caps = gst_caps_from_string (GST_FLEXBUF_CAP_DEFAULT);
+  setFramerateFromConfig (caps, config);
+  return caps;
+}
+
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
+static GstFlowReturn
+flxb_decode (void **pdata, const GstTensorsConfig *config,
+    const GstTensorMemory *input, GstBuffer *outbuf)
+{
+  GstMapInfo out_info;
+  GstMemory *out_mem;
+  unsigned int i, num_tensors = config->info.num_tensors;
+  gboolean need_alloc;
+  size_t flex_size;
+  flexbuffers::Builder fbb;
+
+  fbb.Map ([&]() {
+    fbb.UInt ("num_tensors", num_tensors);
+    fbb.Int ("rate_n", config->rate_n);
+    fbb.Int ("rate_d", config->rate_d);
+    for (i = 0; i < num_tensors; i++) {
+      gchar * tensor_key = g_strdup_printf ("tensor_%d", i);
+      gchar * tensor_name = NULL;
+
+      if (config->info.info[i].name == NULL) {
+        tensor_name = g_strdup ("");
+      } else {
+        tensor_name = g_strdup (config->info.info[i].name);
+      }
+      tensor_type type = config->info.info[i].type;
+
+      fbb.Vector (tensor_key, [&]() {
+        fbb += tensor_name;
+        fbb += type;
+        fbb.Vector (config->info.info[i].dimension, NNS_TENSOR_RANK_LIMIT);
+        fbb.Blob (input[i].data, (size_t) input[i].size);
+      });
+      g_free (tensor_key);
+      g_free (tensor_name);
+    }
+  });
+  fbb.Finish ();
+  flex_size = fbb.GetSize ();
+
+  g_assert (outbuf);
+  need_alloc = (gst_buffer_get_size (outbuf) == 0);
+
+  if (need_alloc) {
+    out_mem = gst_allocator_alloc (NULL, flex_size, NULL);
+  } else {
+    if (gst_buffer_get_size (outbuf) < flex_size) {
+      gst_buffer_set_size (outbuf, flex_size);
+    }
+    out_mem = gst_buffer_get_all_memory (outbuf);
+  }
+
+  if (FALSE == gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+    if (need_alloc)
+      gst_allocator_free (NULL, out_mem);
+    nns_loge ("Cannot map gst memory (tensor decoder flexbuf)\n");
+    return GST_FLOW_ERROR;
+  }
+
+  memcpy (out_info.data, fbb.GetBuffer ().data (), flex_size);
+
+  gst_memory_unmap (out_mem, &out_info);
+
+  if (need_alloc)
+    gst_buffer_append_memory (outbuf, out_mem);
+
+  return GST_FLOW_OK;
+}
+
+static gchar decoder_subplugin_flexbuf[] = "flexbuf";
+
+/** @brief flexbuffer tensordec-plugin GstTensorDecoderDef instance */
+static GstTensorDecoderDef flexBuf = {.modename = decoder_subplugin_flexbuf,
+  .init = flxb_init,
+  .exit = flxb_exit,
+  .setOption = flxb_setOption,
+  .getOutCaps = flxb_getOutCaps,
+  .decode = flxb_decode };
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @brief Initialize this object for tensordec-plugin */
+void
+init_flxb (void)
+{
+  nnstreamer_decoder_probe (&flexBuf);
+}
+
+/** @brief Destruct this object for tensordec-plugin */
+void
+fini_flxb (void)
+{
+  nnstreamer_decoder_exit (flexBuf.modename);
+}
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -96,6 +96,11 @@
     "framerate = " GST_TENSOR_RATE_RANGE
 
 /**
+ * @brief Default static capability for flexbuffers
+ */
+#define GST_FLEXBUF_CAP_DEFAULT "other/flexbuf"
+
+/**
  * @brief Possible data element types of other/tensor.
  */
 typedef enum _nns_tensor_type

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -797,6 +797,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %defattr(-,root,root,-)
 %{_prefix}/lib/nnstreamer/decoders/libnnstreamer_decoder_flatbuf.so
 %{_prefix}/lib/nnstreamer/converters/libnnstreamer_converter_flatbuf.so
+%{_prefix}/lib/nnstreamer/decoders/libnnstreamer_decoder_flexbuf.so
 %endif
 
 # for pytorch

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -798,6 +798,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{_prefix}/lib/nnstreamer/decoders/libnnstreamer_decoder_flatbuf.so
 %{_prefix}/lib/nnstreamer/converters/libnnstreamer_converter_flatbuf.so
 %{_prefix}/lib/nnstreamer/decoders/libnnstreamer_decoder_flexbuf.so
+%{_prefix}/lib/nnstreamer/converters/libnnstreamer_converter_flexbuf.so
 %endif
 
 # for pytorch

--- a/tests/nnstreamer_flexbuf/runTest.sh
+++ b/tests/nnstreamer_flexbuf/runTest.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
+## @file runTest.sh
+## @author Gichan Jang <gichan2.jang@samsung.com>
+## @date Mar 12 2021
+## @brief SSAT Test Cases for flexbuffers subplugin of tensor converter and decoder
+## @details After decoding the tensor into flexbuffer, convert it to tensor(s) again to check if it matches the original
+##
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}"
+fi
+
+# This is compatible with SSAT (https://github.com/myungjoo/SSAT)
+testInit $1
+
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
+else
+    echo "Test Case Generation Started"
+    python ../nnstreamer_converter/generateGoldenTestResult.py 9
+    python3 ../nnstreamer_merge/generateTest.py
+    sopath=$1
+fi
+convertBMP2PNG
+
+PATH_TO_PLUGIN="../../build"
+
+##
+## @brief Execute gstreamer pipeline and compare the output of the pipeline
+## @param $1 Colorspace
+## @param $2 Width
+## @param $3 Height
+## @param $4 Test Case Number
+function do_test() {
+    gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 pattern=13 ! video/x-raw,format=${1},width=${2},height=${3},framerate=5/1 ! \
+    tee name=t ! queue ! multifilesink location=\"raw_${1}_${2}x${3}_%1d.log\"
+    t. ! queue ! tensor_converter ! tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! multifilesink location=\"flexb_${1}_${2}x${3}_%1d.log\" sync=true" ${4} 0 0 $PERFORMANCE
+
+    callCompareTest raw_${1}_${2}x${3}_0.log flexb_${1}_${2}x${3}_0.log "${4}-1" "flexbuf conversion test ${4}-1" 1 0
+    callCompareTest raw_${1}_${2}x${3}_1.log flexb_${1}_${2}x${3}_1.log "${4}-2" "flexbuf conversion test ${4}-2" 1 0
+    callCompareTest raw_${1}_${2}x${3}_2.log flexb_${1}_${2}x${3}_2.log "${4}-3" "flexbuf conversion test ${4}-3" 1 0
+}
+# The width and height of video should be multiple of 4
+do_test BGRx 320 240 1-1
+do_test RGB 320 240 1-2
+do_test GRAY8 320 240 1-3
+
+# audio format S16LE, 8k sample rate, samples per buffer 8000
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=S16LE,rate=8000 ! \
+    tee name=t ! queue ! audioconvert ! tensor_converter frames-per-tensor=8000 ! tensor_decoder mode=flexbuf ! \
+        other/flexbuf ! tensor_converter ! filesink location=\"test.audio8k.s16le.log\" sync=true \
+    t. ! queue ! filesink location=\"test.audio8k.s16le.origin.log\" sync=true" 2-1 0 0 $PERFORMANCE
+callCompareTest test.audio8k.s16le.origin.log test.audio8k.s16le.log 2-2 "Audio8k-s16le Golden Test" 0 0
+
+# audio format U8, 16k sample rate, samples per buffer 8000
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=U8,rate=16000 ! \
+    tee name=t ! queue ! audioconvert ! tensor_converter frames-per-tensor=8000 ! tensor_decoder mode=flexbuf ! \
+        other/flexbuf ! tensor_converter ! filesink location=\"test.audio16k.u8.log\" sync=true \
+    t. ! queue ! filesink location=\"test.audio16k.u8.origin.log\" sync=true" 2-3 0 0 $PERFORMANCE
+callCompareTest test.audio16k.u8.origin.log test.audio16k.u8.log 2-4 "Audio16k-u8 Golden Test" 0 0
+
+# audio format U16LE, 16k sample rate, 2 channels, samples per buffer 8000
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=U16LE,rate=16000,channels=2 ! \
+    tee name=t ! queue ! audioconvert ! tensor_converter frames-per-tensor=8000 ! tensor_decoder mode=flexbuf ! \
+        other/flexbuf ! tensor_converter ! filesink location=\"test.audio16k2c.u16le.log\" sync=true \
+    t. ! queue ! filesink location=\"test.audio16k2c.u16le.origin.log\" sync=true" 2-5 0 0 $PERFORMANCE
+callCompareTest test.audio16k2c.u16le.origin.log test.audio16k2c.u16le.log 2-6 "Audio16k2c-u16le Golden Test" 0 0
+
+# Test other/tensors
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=tensors_mux sync_mode=basepad sync_option=1:50000000 ! tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! multifilesink location=testsynch19_%1d.log \
+    tensor_mux name=tensor_mux0  sync_mode=slowest ! tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! tensors_mux.sink_0 \
+    tensor_mux name=tensor_mux1  sync_mode=slowest ! tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! tensors_mux.sink_1 \
+    multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)10/1\" ! pngdec ! tensor_converter ! tensor_mux0.sink_0 \
+    multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)20/1\" ! pngdec ! tensor_converter ! tensor_mux0.sink_1 \
+    multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensor_mux1.sink_0 \
+    multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)20/1\" ! pngdec ! tensor_converter ! tensor_mux1.sink_1" 3 0 0 $PERFORMANCE
+callCompareTest testsynch19_0.golden testsynch19_0.log 3-1 "Tensor mux Compare 3-1" 1 0
+callCompareTest testsynch19_1.golden testsynch19_1.log 3-2 "Tensor mux Compare 3-2" 1 0
+callCompareTest testsynch19_2.golden testsynch19_2.log 3-3 "Tensor mux Compare 3-3" 1 0
+callCompareTest testsynch19_3.golden testsynch19_3.log 3-4 "Tensor mux Compare 3-4" 1 0
+callCompareTest testsynch19_4.golden testsynch19_4.log 3-5 "Tensor mux Compare 3-5" 1 0
+
+report


### PR DESCRIPTION
Add tensor converter and decoder subplugin of flexbuffer.

Example launch line:
gst-launch-1.0 videotestsrc !  video/x-raw,format=RGB,width=320,height=240 ! tensor_converter ! tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! tensor_decoder mode=direct_video ! videoconvert !  videoscale ! video/x-raw,width=320,height=240 ! xvimagesink


Note: Custom flexbuffer will be supported by callback function and python script.


Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>
