### PR TITLE
[Fix] Add missing file section in rpm build

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -761,6 +761,8 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 
 %postun -p /sbin/ldconfig
 
+%files
+
 %files core
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
@@ -775,7 +777,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{_libdir}/libnnstreamer.so
 
 %files configuration
-%{_sysconfdir}/nnstreamer.ini
+%config %{_sysconfdir}/nnstreamer.ini
 
 # for tensorflow
 %if 0%{?tensorflow_support}


### PR DESCRIPTION
As nnstreamer mata package was not containing `files` section, it led to
the recent SR fail, this patch resolves the issue.

Also add %config directive to the configuration file

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>


related issue: https://dashboard.tizen.org/index.code?sr=submit/tizen/20210317.111732