### PR TITLE
[RPM] Add virtual conf package @open sesame 03/23 14:18

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -128,6 +128,7 @@ Source1001:	nnstreamer.manifest
 ## Define requirements ##
 Requires: nnstreamer-core = %{version}-%{release}
 Requires: nnstreamer-configuration = %{version}-%{release}
+Recommends: nnstreamer-default-configuration = %{version}-%{release}
 
 ## Define build requirements ##
 BuildRequires:	gstreamer-devel
@@ -276,10 +277,12 @@ Summary: NNStreamer core package
 NNStreamer is a set of gstreamer plugins to support general neural networks
 and their plugins in a gstreamer stream, this package is core package without configuration
 
-%package configuration
+%package default-configuration
 Summary: NNStreamer global configuration
-%description configuration
-NNStreamer's configuration setup for the end user.
+Provides: nnstreamer-configuration = %{version}-%{release}
+Conflicts: nnstreamer-test-devel
+%description default-configuration
+NNStreamer's global configuration setup for the end user.
 
 # for tensorflow
 %if 0%{?tensorflow_support}
@@ -387,7 +390,7 @@ NNStreamer's tensor_fliter subplugin of caffe2
 
 %package devel
 Summary:	Development package for custom tensor operator developers (tensor_filter/custom)
-Requires:	nnstreamer-core = %{version}-%{release}
+Requires:	nnstreamer = %{version}-%{release}
 Requires:	glib2-devel
 Requires:	gstreamer-devel
 %description devel
@@ -411,7 +414,8 @@ Static library package of nnstreamer-devel.
 %package test-devel
 Summary: Development package to provide testable environment of a subplugin (tensor_filter/custom)
 Requires: nnstreamer-devel = %{version}-%{release}
-Conflicts: nnstreamer-configuration
+Provides: nnstreamer-configuration = %{version}-%{release}
+Conflicts: nnstreamer-default-configuration
 %description test-devel
 Development package to provide testable environment of NNStreamer sub-plugin.
 This package enables testable environment of NNStreamer sub-plugin by making nnstreamer to recognize NNSTREAMER_CONF_PATH to steer a sub-plugin path to a custom path.
@@ -778,7 +782,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{gstlibdir}/libnnstreamer.so
 %{_libdir}/libnnstreamer.so
 
-%files configuration
+%files default-configuration
 %config %{_sysconfdir}/nnstreamer.ini
 
 # for tensorflow


### PR DESCRIPTION
Add virtual conf package to resolve build dependency issue as suggested
in https://github.com/nnstreamer/api/pull/21#issuecomment-804599118

With this patch, it is now possible to install devel package with
`/etc/nntrainer.ini` or the packager choose to use `test-devel` when
building.

See also nnstreamer/nntrainer#1034

**Evaluation Method**
Cross building with nntrainer package

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Cc: Myungjoo Ham <myungjoo.ham@samsung.com>
Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
