### PR TITLE
tests/nnstreamer_repo_dynamicity: Fix unittest_repo binary path handling

### DIFF
--- a/tests/nnstreamer_repo_dynamicity/runTest.sh
+++ b/tests/nnstreamer_repo_dynamicity/runTest.sh
@@ -34,12 +34,12 @@ convertBMP2PNG
 if [[ ! -z "${UNITTEST_DIR}" ]]; then
     TESTBINDIR="${UNITTEST_DIR}"
 elif [ ! -d "${PATH_TO_PLUGIN}" ] && [ ! -d "${UNITTEST_DIR}" ]; then
-    TESTBINDIR="/usr/lib/nnstreamer/unittest"
+    TESTBINDIR="/usr/bin/unittest-nnstreamer/tests"
 else
-    TESTBINDIR="../../build/tests"
+    TESTBINDIR="../../build/tests/nnstreamer_repo_dynamicity"
 fi
 
-${TESTBINDIR}/nnstreamer_repo_dynamicity/unittest_repo --gst-plugin-path=../../build
+${TESTBINDIR}/unittest_repo --gst-plugin-path=../../build
 
 callCompareTest testsequence_1.golden tensorsequence01_1.log 1-1 "Compare 1-1" 1 0
 callCompareTest testsequence_2.golden tensorsequence01_2.log 1-2 "Compare 1-2" 1 0


### PR DESCRIPTION
In case the unit tests are run from their installed directory,
unittest_repo binary can't be found in this case because install test
directory path and unittest_repo binary location are invalid.

This fixes regression introduced by bfb6630ff and 0c02456ba

Signed-off-by: Xavier Roumegue <xavier.roumegue@nxp.com>


**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed []Skipped
2. Run test: [* ]Passed [ ]Failed []Skipped


