### PR TITLE
[Converter] Remove memcpy in converter @open sesame 03/30 11:19

### DIFF
--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -808,7 +808,6 @@ _gst_tensor_converter_chain_push (GstTensorConverter * self, GstBuffer * buf)
     if (self->tensors_info.num_tensors > 1) {
       GstMemory *mem;
       GstMapInfo info;
-      gpointer data;
       gsize idx, size;
       guint i;
 
@@ -826,11 +825,8 @@ _gst_tensor_converter_chain_push (GstTensorConverter * self, GstBuffer * buf)
 
       for (i = 0; i < self->tensors_info.num_tensors; ++i) {
         size = gst_tensors_info_get_size (&self->tensors_info, i);
-        data = g_memdup (info.data + idx, size);
+        gst_buffer_append_memory (buffer, gst_memory_share (mem, idx, size));
         idx += size;
-
-        gst_buffer_append_memory (buffer,
-            gst_memory_new_wrapped (0, data, size, 0, size, data, g_free));
       }
 
       gst_memory_unmap (mem, &info);


### PR DESCRIPTION
Remove memory copy in converter.
Memory allocation occurs two times on g_memdup and gst_memory_new_wrapped.
Changed to use gst_memory_share.
No memory copy is performed and the memory region is simply shared.

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped
