### PR TITLE
[tensor_transform] Add "per-channel" option to stand mode

### DIFF
--- a/gst/nnstreamer/tensor_data.h
+++ b/gst/nnstreamer/tensor_data.h
@@ -17,7 +17,6 @@
 #include <tensor_typedef.h>
 
 G_BEGIN_DECLS
-
 /**
  * @brief Structure for tensor data.
  */
@@ -64,7 +63,8 @@ gst_tensor_data_typecast (tensor_data_s * td, tensor_type type);
  * @return TRUE if no error
  */
 extern gboolean
-gst_tensor_data_raw_typecast (gpointer input, tensor_type in_type, gpointer output, tensor_type out_type);
+gst_tensor_data_raw_typecast (gpointer input, tensor_type in_type,
+    gpointer output, tensor_type out_type);
 
 /**
  * @brief Calculate average value of the tensor.
@@ -75,6 +75,45 @@ gst_tensor_data_raw_typecast (gpointer input, tensor_type in_type, gpointer outp
  */
 extern gdouble
 gst_tensor_data_raw_average (gpointer raw, gsize length, tensor_type type);
+
+/**
+ * @brief Calculate average value of the tensor per channel (the first dim).
+ * @param raw pointer of raw tensor data
+ * @param length byte size of raw tensor data
+ * @param type tensor type
+ * @param tensor_dim tensor dimension
+ * @param results double array contains average values of each channel
+ * @return TRUE if no error
+ */
+extern gboolean
+gst_tensor_data_raw_average_per_channel (gpointer raw, gsize length,
+    tensor_type type, tensor_dim dim, gdouble * results);
+
+/**
+ * @brief Calculate standard deviation of the tensor.
+ * @param raw pointer of raw tensor data
+ * @param length byte size of raw tensor data
+ * @param type tensor type
+ * @param average average value of given tensor
+ * @return standard deviation
+ */
+extern gdouble
+gst_tensor_data_raw_std (gpointer raw, gsize length, tensor_type type,
+    gdouble average);
+
+/**
+ * @brief Calculate standard deviation of the tensor per channel (the first dim).
+ * @param raw pointer of raw tensor data
+ * @param length byte size of raw tensor data
+ * @param type tensor type
+ * @param tensor_dim tensor dimension
+ * @param averages average values of given tensor per-channel
+ * @param results double array contains standard deviation of each channel
+ * @return TRUE if no error
+ */
+extern gboolean
+gst_tensor_data_raw_std_per_channel (gpointer raw, gsize length, 
+    tensor_type type, tensor_dim dim, gdouble * averages, gdouble * results);
 
 G_END_DECLS
 #endif /* __NNS_TENSOR_DATA_H__ */

--- a/gst/nnstreamer/tensor_data.h
+++ b/gst/nnstreamer/tensor_data.h
@@ -71,10 +71,12 @@ gst_tensor_data_raw_typecast (gpointer input, tensor_type in_type,
  * @param raw pointer of raw tensor data
  * @param length byte size of raw tensor data
  * @param type tensor type
- * @return average value
+ * @param result double pointer for average value of given tensor. Caller should release allocated memory.
+ * @return TRUE if no error
  */
-extern gdouble
-gst_tensor_data_raw_average (gpointer raw, gsize length, tensor_type type);
+extern gboolean
+gst_tensor_data_raw_average (gpointer raw, gsize length, tensor_type type,
+    gdouble ** result);
 
 /**
  * @brief Calculate average value of the tensor per channel (the first dim).
@@ -82,12 +84,12 @@ gst_tensor_data_raw_average (gpointer raw, gsize length, tensor_type type);
  * @param length byte size of raw tensor data
  * @param type tensor type
  * @param tensor_dim tensor dimension
- * @param results double array contains average values of each channel
+ * @param results double array contains average values of each channel. Caller should release allocated array.
  * @return TRUE if no error
  */
 extern gboolean
 gst_tensor_data_raw_average_per_channel (gpointer raw, gsize length,
-    tensor_type type, tensor_dim dim, gdouble * results);
+    tensor_type type, tensor_dim dim, gdouble ** results);
 
 /**
  * @brief Calculate standard deviation of the tensor.
@@ -95,11 +97,12 @@ gst_tensor_data_raw_average_per_channel (gpointer raw, gsize length,
  * @param length byte size of raw tensor data
  * @param type tensor type
  * @param average average value of given tensor
- * @return standard deviation
+ * @param result double pointer for standard deviation of given tensor. Caller should release allocated memory.
+ * @return TRUE if no error
  */
-extern gdouble
+extern gboolean
 gst_tensor_data_raw_std (gpointer raw, gsize length, tensor_type type,
-    gdouble average);
+    gdouble * average, gdouble ** result);
 
 /**
  * @brief Calculate standard deviation of the tensor per channel (the first dim).
@@ -108,12 +111,12 @@ gst_tensor_data_raw_std (gpointer raw, gsize length, tensor_type type,
  * @param type tensor type
  * @param tensor_dim tensor dimension
  * @param averages average values of given tensor per-channel
- * @param results double array contains standard deviation of each channel
+ * @param results double array contains standard deviation of each channel. Caller should release allocated array.
  * @return TRUE if no error
  */
 extern gboolean
 gst_tensor_data_raw_std_per_channel (gpointer raw, gsize length, 
-    tensor_type type, tensor_dim dim, gdouble * averages, gdouble * results);
+    tensor_type type, tensor_dim dim, gdouble * averages, gdouble ** results);
 
 G_END_DECLS
 #endif /* __NNS_TENSOR_DATA_H__ */

--- a/gst/nnstreamer/tensor_if/gsttensorif.c
+++ b/gst/nnstreamer/tensor_if/gsttensorif.c
@@ -874,7 +874,7 @@ gst_tensor_if_get_tensor_average (GstTensorIf * tensor_if,
 {
   GstMemory *in_mem;
   GstMapInfo in_info;
-  double avg;
+  gdouble *avg = NULL;
   tensor_type type = tensor_if->in_config.info.info[nth].type;
 
   in_mem = gst_buffer_peek_memory (buf, nth);
@@ -883,12 +883,14 @@ gst_tensor_if_get_tensor_average (GstTensorIf * tensor_if,
     return FALSE;
   }
 
-  avg = gst_tensor_data_raw_average (in_info.data, in_info.size, type);
+  gst_tensor_data_raw_average (in_info.data, in_info.size, type, &avg);
 
   gst_memory_unmap (in_mem, &in_info);
 
-  gst_tensor_data_set (cv, _NNS_FLOAT64, &avg);
+  gst_tensor_data_set (cv, _NNS_FLOAT64, avg);
   gst_tensor_data_typecast (cv, type);
+
+  g_free (avg);
   return TRUE;
 }
 

--- a/gst/nnstreamer/tensor_transform/tensor_transform.h
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.h
@@ -127,6 +127,7 @@ typedef struct _tensor_transform_transpose {
 typedef struct _tensor_transform_stand {
   tensor_transform_stand_mode mode;
   tensor_type out_type;
+  gboolean per_channel;
 } tensor_transform_stand;
 
 /**

--- a/tests/transform_stand/checkResult.py
+++ b/tests/transform_stand/checkResult.py
@@ -17,7 +17,7 @@ import struct
 ##
 # @brief Check typecast from typea to typeb with file fna/fnb
 #
-def testStandardization (fna, fnb, typeasize, typebsize,typeapack, typebpack):
+def testStandardization (fna, fnb, typeasize, typebsize, typeapack, typebpack):
   lena = len(fna)
   lenb = len(fnb)
 
@@ -32,7 +32,7 @@ def testStandardization (fna, fnb, typeasize, typebsize,typeapack, typebpack):
     vala = struct.unpack(typeapack, fna[x * typeasize: x * typeasize + typeasize])[0]
     valb = struct.unpack(typebpack, fnb[x * typebsize: x * typebsize + typebsize])[0]
     diff = vala - valb
-    if diff > 0.01 or diff < -0.01:
+    if diff > 0.00001 or diff < -0.00001:
       return 20
   return 0
 

--- a/tests/transform_stand/generateTest.py
+++ b/tests/transform_stand/generateTest.py
@@ -17,7 +17,7 @@ import random
 
 import numpy as np
 
-def saveTestData(filename, width, height):
+def saveTestData(filename, width, height, dc_average=False):
     data = []
 
     for w in range(0,width):
@@ -34,7 +34,10 @@ def saveTestData(filename, width, height):
     a=np.array(data)
     mean = np.mean(a)
     standard = np.std(a)
-    result=abs((a-np.mean(a)) / (np.std(a)+1e-10))
+    if dc_average:
+        result=a-np.mean(a)
+    else:
+        result=abs((a-np.mean(a)) / (np.std(a)+1e-10))
 
     data = []
     for w in range(0,width):
@@ -47,4 +50,22 @@ def saveTestData(filename, width, height):
 
     return result, mean, standard
 
-buf = saveTestData("test_00.dat", 100, 50)
+def saveTestPerChannelData(filename, num_channel, num_sample, dc_average=False):
+    arr = np.random.randn(num_sample, num_channel)
+    with open(filename, 'wb') as f:
+        f.write(arr.astype('f').tobytes())
+
+    means = np.mean(arr, axis=0)
+    result = arr - means
+
+    if dc_average == False:
+        std = np.std(arr, axis=0)
+        result = abs(result / (std + 1e-10))
+
+    with open(filename+".golden", 'wb') as f:
+        f.write(result.astype('f').tobytes())
+
+buf = saveTestData("test_00.dat", 100, 50, False)
+buf = saveTestPerChannelData("test_01.dat", 50, 100, False)
+buf = saveTestData("test_02.dat", 100, 50, True)
+buf = saveTestPerChannelData("test_03.dat", 50, 100, True)

--- a/tests/transform_stand/runTest.sh
+++ b/tests/transform_stand/runTest.sh
@@ -37,6 +37,24 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"test_%02d.d
 
 python3 checkResult.py standardization test_00.dat.golden result_00.log 4 4 f f default
 
-testResult $? 1 "Golden test comparison" 0 1
+testResult $? 1 "Golden test comparison 1" 0 1
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"test_%02d.dat\" caps=\"application/octet-stream\" ! tensor_converter input-dim=50:100:1:1 input-type=float32 ! tensor_transform mode=stand option=default,per-channel:true ! multifilesink location=\"./result_%02d.log\" sync=true" 2 0 0 $PERFORMANCE
+
+python3 checkResult.py standardization test_01.dat.golden result_01.log 4 4 f f default
+
+testResult $? 1 "Golden test comparison 2" 0 1
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"test_%02d.dat\" caps=\"application/octet-stream\" ! tensor_converter input-dim=50:100:1:1 input-type=float32 ! tensor_transform mode=stand option=dc-average:float32 ! multifilesink location=\"./result_%02d.log\" sync=true" 3 0 0 $PERFORMANCE
+
+python3 checkResult.py standardization test_02.dat.golden result_02.log 4 4 f f default
+
+testResult $? 1 "Golden test comparison 3" 0 1
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"test_%02d.dat\" caps=\"application/octet-stream\" ! tensor_converter input-dim=50:100:1:1 input-type=float32 ! tensor_transform mode=stand option=dc-average:float32,per-channel:true ! multifilesink location=\"./result_%02d.log\" sync=true" 4 0 0 $PERFORMANCE
+
+python3 checkResult.py standardization test_03.dat.golden result_03.log 4 4 f f default
+
+testResult $? 1 "Golden test comparison 4" 0 1
 
 report


### PR DESCRIPTION
- "channel" is the first dimension.
- Support channel-wise default and dc-average transform
- Add SSAT testcases for stand

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
