### PR TITLE
[Test] Fix the Svace issue

### DIFF
--- a/tests/tizen_sensor/unittest_tizen_sensor.cc
+++ b/tests/tizen_sensor/unittest_tizen_sensor.cc
@@ -368,7 +368,7 @@ TEST (tizensensorAsSource, virtualSensorCreate06_n)
   pipe = gst_parse_launch (pipeline, &err);
 
   if (pipe) {
-    gst_element_set_state (pipe, GST_STATE_PAUSED);
+    ret = gst_element_set_state (pipe, GST_STATE_PAUSED);
     failed = (ret == GST_STATE_CHANGE_FAILURE);
     gst_object_unref (pipe);
   } else {
@@ -396,7 +396,7 @@ TEST (tizensensorAsSource, virtualSensorCreate07_n)
   pipe = gst_parse_launch (pipeline, &err);
 
   if (pipe) {
-    gst_element_set_state (pipe, GST_STATE_PAUSED);
+    ret = gst_element_set_state (pipe, GST_STATE_PAUSED);
     failed = (ret == GST_STATE_CHANGE_FAILURE);
     gst_object_unref (pipe);
   } else {


### PR DESCRIPTION
ret variable is used without initialization. This patch fixes the bug.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


