### PR TITLE
[TizenSensor] init sensor type

### DIFF
--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
@@ -443,6 +443,7 @@ gst_tensor_src_tizensensor_init (GstTensorSrcTIZENSENSOR * self)
   self->running = FALSE;
   self->freq_n = DEFAULT_PROP_FREQ_N;
   self->freq_d = DEFAULT_PROP_FREQ_D;
+  self->type = SENSOR_ALL;
 
   g_mutex_init (&self->lock);
 


### PR DESCRIPTION
set init value of sensor type. 'all' means no specific sensor and if user does not set type in pipeline, it will be failed.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
