### PR TITLE
[CodeQuality] add NULL checker after allocations

### DIFF
--- a/ext/nnstreamer/tensor_source/tensor_src_grpc.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_grpc.c
@@ -290,6 +290,7 @@ _grpc_callback (void *obj, void *data)
   GST_BUFFER_PTS (buffer) = timestamp;
 
   item = g_new0 (GstDataQueueItem, 1);
+  g_assert (item != NULL);
   item->object = GST_MINI_OBJECT (buffer);
   item->size = gst_buffer_get_size (buffer);
   item->visible = TRUE;
@@ -343,6 +344,7 @@ gst_tensor_src_grpc_init (GstTensorSrcGRPC * self)
   self->out = 0;
 
   self->priv = g_new0 (grpc_private, 1);
+  g_assert (self->priv != NULL);
   grpc_config_init (self);
 
   GST_OBJECT_FLAG_UNSET (self, GST_TENSOR_SRC_GRPC_CONFIGURED);

--- a/gst/nnstreamer/tensor_if/gsttensorif.c
+++ b/gst/nnstreamer/tensor_if/gsttensorif.c
@@ -380,6 +380,7 @@ gst_tensor_if_set_property_supplied_value (const GValue * value,
   }
 
   param = g_value_get_string (value);
+  g_assert (param != NULL);
   strv = g_strsplit_set (param, delimiters, -1);
   num = g_strv_length (strv);
 


### PR DESCRIPTION
Like others, NULL checker after memory allocations have been added.

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped