### PR TITLE
[Converter] Fix mem leak of the converter

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.cc
@@ -69,7 +69,7 @@ gst_tensor_decoder_protobuf (const GstTensorsConfig *config,
 
     name = config->info.info[i].name;
     if (name == NULL) {
-      tensor->set_name ("Anonymous");
+      tensor->set_name ("");
     } else {
       tensor->set_name (name);
     }
@@ -144,7 +144,9 @@ gst_tensor_converter_protobuf (GstBuffer *in_buf, gsize *frame_size,
 
   for (guint i = 0; i < config->info.num_tensors; i++) {
     const nnstreamer::protobuf::Tensor *tensor = &tensors.tensor (i);
-    config->info.info[i].name = g_strdup (tensor->name ().c_str ());
+    const gchar *name = tensor->name ().c_str ();
+
+    config->info.info[i].name = (name && strlen (name) > 0) ? g_strdup (name) : NULL;
     config->info.info[i].type = (tensor_type)tensor->type ();
     for (guint j = 0; j < NNS_TENSOR_RANK_LIMIT; j++) {
       config->info.info[i].dimension[j] = tensor->dimension (j);

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
@@ -125,8 +125,9 @@ fbc_convert (GstBuffer *in_buf, gsize *frame_size, guint *frames_in, GstTensorsC
 
   for (guint i = 0; i < config->info.num_tensors; i++) {
     gsize offset;
+    const gchar *name = tensor->Get (i)->name ()->str ().c_str ();
 
-    config->info.info[i].name = g_strdup (tensor->Get (i)->name ()->str ().c_str ());
+    config->info.info[i].name = (name && strlen (name) > 0) ? g_strdup (name) : NULL;
     config->info.info[i].type = (tensor_type)tensor->Get (i)->type ();
     tensor_data = tensor->Get (i)->data ();
 

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
@@ -142,7 +142,9 @@ flxc_convert (GstBuffer *in_buf, gsize *frame_size, guint *frames_in, GstTensors
     gchar * tensor_key = g_strdup_printf ("tensor_%d", i);
     gsize offset;
     flexbuffers::Vector tensor = tensors[tensor_key].AsVector ();
-    config->info.info[i].name = g_strdup (tensor[0].AsString ().c_str ());
+    const gchar *name = tensor[0].AsString ().c_str ();
+
+    config->info.info[i].name = (name && strlen (name) > 0) ? g_strdup (name) : NULL;
     config->info.info[i].type = (tensor_type) tensor[1].AsInt32 ();
 
     flexbuffers::TypedVector dim = tensor[2].AsTypedVector ();

--- a/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
@@ -99,7 +99,7 @@ fbd_decode (void **pdata, const GstTensorsConfig *config,
     name = config->info.info[i].name;
 
     if (name == NULL)
-      tensor_name = builder.CreateString ("Anonymous");
+      tensor_name = builder.CreateString ("");
     else
       tensor_name = builder.CreateString (name);
 


### PR DESCRIPTION
A memory leak occurred because the name of the tensor was not released.
Free the name of the tensor and set the default name as "" instead of "Anonymous"

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped