### PR TITLE
[aggregator/converter] Fix when GST_EVENT_FLUSH_*

### DIFF
--- a/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
+++ b/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
@@ -292,6 +292,10 @@ gst_tensor_aggregator_init (GstTensorAggregator * self)
   self->frames_dim = DEFAULT_FRAMES_DIMENSION;
   self->concat = DEFAULT_CONCAT;
 
+  self->tensor_configured = FALSE;
+  gst_tensor_config_init (&self->in_config);
+  gst_tensor_config_init (&self->out_config);
+
   self->adapter = gst_adapter_new ();
   gst_tensor_aggregator_reset (self);
 }
@@ -307,6 +311,9 @@ gst_tensor_aggregator_finalize (GObject * object)
   self = GST_TENSOR_AGGREGATOR (object);
 
   gst_tensor_aggregator_reset (self);
+
+  gst_tensor_info_free (&self->in_config.info);
+  gst_tensor_info_free (&self->out_config.info);
 
   if (self->adapter) {
     g_object_unref (self->adapter);
@@ -971,13 +978,10 @@ gst_tensor_aggregator_change_state (GstElement * element,
 static void
 gst_tensor_aggregator_reset (GstTensorAggregator * self)
 {
+  /* remove all buffers from adapter */
   if (self->adapter) {
     gst_adapter_clear (self->adapter);
   }
-
-  self->tensor_configured = FALSE;
-  gst_tensor_config_init (&self->in_config);
-  gst_tensor_config_init (&self->out_config);
 }
 
 /**

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -371,9 +371,10 @@ gst_tensor_converter_init (GstTensorConverter * self)
   self->custom.data = NULL;
 
   gst_tensors_info_init (&self->tensors_info);
+  gst_tensors_config_init (&self->tensors_config);
+  self->tensors_configured = FALSE;
 
   self->adapter = gst_adapter_new ();
-  g_assert (self->adapter != NULL);
   gst_tensor_converter_reset (self);
 }
 
@@ -388,6 +389,9 @@ gst_tensor_converter_finalize (GObject * object)
   self = GST_TENSOR_CONVERTER (object);
 
   gst_tensor_converter_reset (self);
+
+  gst_tensors_info_free (&self->tensors_config.info);
+  gst_tensors_info_free (&self->tensors_info);
 
   if (self->adapter) {
     g_object_unref (self->adapter);
@@ -1153,13 +1157,10 @@ gst_tensor_converter_change_state (GstElement * element,
 static void
 gst_tensor_converter_reset (GstTensorConverter * self)
 {
+  /* remove all buffers from adapter */
   if (self->adapter) {
     gst_adapter_clear (self->adapter);
   }
-
-  self->tensors_configured = FALSE;
-  gst_tensors_info_free (&self->tensors_config.info);
-  gst_tensors_config_init (&self->tensors_config);
 
   self->have_segment = FALSE;
   self->need_segment = FALSE;


### PR DESCRIPTION
- Do not reset tensor config when flush event occurs, just clear the buffers

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
