### PR TITLE
Change gboolean comparison

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.cc
@@ -96,7 +96,7 @@ gst_tensor_decoder_protobuf (const GstTensorsConfig *config,
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
 
-  if (FALSE == gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+  if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
     nns_loge ("Cannot map output memory / tensordec-protobuf");
     return GST_FLOW_ERROR;
   }
@@ -127,7 +127,7 @@ gst_tensor_converter_protobuf (GstBuffer *in_buf, gsize *frame_size,
 
   in_mem = gst_buffer_peek_memory (in_buf, 0);
 
-  if (FALSE == gst_memory_map (in_mem, &in_info, GST_MAP_READ)) {
+  if (!gst_memory_map (in_mem, &in_info, GST_MAP_READ)) {
     nns_loge ("Cannot map input memory / tensor_converter_protobuf");
     return NULL;
   }

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
@@ -102,7 +102,7 @@ fbc_convert (GstBuffer *in_buf, gsize *frame_size, guint *frames_in, GstTensorsC
   guint mem_size;
 
   in_mem = gst_buffer_peek_memory (in_buf, 0);
-  if (FALSE == gst_memory_map (in_mem, &in_info, GST_MAP_READ)) {
+  if (!gst_memory_map (in_mem, &in_info, GST_MAP_READ)) {
     nns_loge ("Cannot map input memory / tensor_converter::flatbuf");
     return NULL;
   }

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
@@ -120,7 +120,7 @@ flxc_convert (GstBuffer *in_buf, gsize *frame_size, guint *frames_in, GstTensors
 
   in_mem = gst_buffer_peek_memory (in_buf, 0);
 
-  if (gst_memory_map (in_mem, &in_info, GST_MAP_READ) == FALSE) {
+  if (!gst_memory_map (in_mem, &in_info, GST_MAP_READ)) {
     ml_loge ("Cannot map input memory / tensor_converter::flexbuf.\n");
     return NULL;
   }

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -1058,7 +1058,7 @@ bb_decode (void **pdata, const GstTensorsConfig * config,
     }
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
-  if (FALSE == gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+  if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
     ml_loge ("Cannot map output memory / tensordec-bounding_boxes.\n");
     return GST_FLOW_ERROR;
   }

--- a/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
@@ -161,7 +161,7 @@ dv_decode (void **pdata, const GstTensorsConfig * config,
   } else {
     out_mem = gst_allocator_alloc (NULL, size, NULL);
   }
-  if (FALSE == gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+  if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
     ml_loge ("Cannot map output memory / tensordec-directvideo.\n");
     return GST_FLOW_ERROR;
   }

--- a/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
@@ -131,7 +131,7 @@ fbd_decode (void **pdata, const GstTensorsConfig *config,
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
 
-  if (FALSE == gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+  if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
     nns_loge ("Cannot map gst memory (tensor decoder flatbuf)\n");
     return GST_FLOW_ERROR;
   }

--- a/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
@@ -157,7 +157,7 @@ flxd_decode (void **pdata, const GstTensorsConfig *config,
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
 
-  if (FALSE == gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+  if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
     if (need_alloc)
       gst_allocator_free (NULL, out_mem);
     nns_loge ("Cannot map gst memory (tensor decoder flexbuf)\n");

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
@@ -216,7 +216,7 @@ il_decode (void **pdata, const GstTensorsConfig * config,
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
 
-  if (FALSE == gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+  if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
     ml_loge ("Cannot map output memory / tensordec-imagelabel.\n");
     return GST_FLOW_ERROR;
   }

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
@@ -582,11 +582,11 @@ is_decode (void **pdata, const GstTensorsConfig * config,
   GstMapInfo out_info;
   GstMemory *out_mem;
 
-  if (FALSE == _init_modes (idata) || outbuf == NULL)
+  if (!_init_modes (idata) || outbuf == NULL)
     return GST_FLOW_ERROR;
 
   need_output_alloc = (gst_buffer_get_size (outbuf) == 0);
-  if (TRUE == need_output_alloc) {
+  if (need_output_alloc) {
     out_mem = gst_allocator_alloc (NULL, size, NULL);
   } else {
     if (gst_buffer_get_size (outbuf) < size) {
@@ -594,14 +594,14 @@ is_decode (void **pdata, const GstTensorsConfig * config,
     }
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
-  if (FALSE == gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+  if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
     ml_loge ("Cannot map output memory / tensordec-imagesegment.\n");
     goto error_free;
   }
 
   memset (out_info.data, '\x00', size);
 
-  if (FALSE == check_sanity (idata, config)) {
+  if (!check_sanity (idata, config)) {
     ml_loge ("Invalid input data format detected.\n");
     goto error_unmap;
   }
@@ -610,7 +610,7 @@ is_decode (void **pdata, const GstTensorsConfig * config,
 
   gst_memory_unmap (out_mem, &out_info);
 
-  if (TRUE == need_output_alloc)
+  if (need_output_alloc)
     gst_buffer_append_memory (outbuf, out_mem);
 
   return GST_FLOW_OK;
@@ -618,7 +618,7 @@ is_decode (void **pdata, const GstTensorsConfig * config,
 error_unmap:
   gst_memory_unmap (out_mem, &out_info);
 error_free:
-  if (TRUE == need_output_alloc)
+  if (need_output_alloc)
     gst_allocator_free (NULL, out_mem);
 
   return GST_FLOW_ERROR;

--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -716,7 +716,7 @@ pose_decode (void **pdata, const GstTensorsConfig * config,
     }
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
-  if (FALSE == gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+  if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
     ml_loge ("Cannot map output memory / tensordec-pose.\n");
     return GST_FLOW_ERROR;
   }

--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
@@ -475,7 +475,7 @@ gst_tensor_src_tizensensor_init (GstTensorSrcTIZENSENSOR * self)
     for (i = 0; tizensensorspecs[i].type != SENSOR_LAST; i++) {
       g_assert (g_hash_table_insert (tizensensors,
               GINT_TO_POINTER (tizensensorspecs[i].type),
-              &tizensensorspecs[i].tinfo) == TRUE);
+              &tizensensorspecs[i].tinfo));
       g_assert (tizensensorspecs[i].value_count ==
           tizensensorspecs[i].tinfo.dimension[0]);
     }
@@ -492,15 +492,15 @@ gst_tensor_src_tizensensor_init (GstTensorSrcTIZENSENSOR * self)
 static int
 _ts_clean_up_handle (GstTensorSrcTIZENSENSOR * self)
 {
-  if (TRUE == self->running) {
+  if (self->running) {
     sensor_listener_stop (self->listener);
-    if (self->configured != TRUE)
+    if (!self->configured)
       return -1;
   }
 
   self->running = FALSE;
 
-  if (TRUE == self->configured) {
+  if (self->configured) {
     sensor_destroy_listener (self->listener);
   }
 
@@ -873,7 +873,7 @@ gst_tensor_src_tizensensor_start (GstBaseSrc * src)
   _LOCK (self);
 
   /* 1. Clean it up if there is a previous session */
-  if (TRUE == self->configured) {
+  if (self->configured) {
     ret = _ts_clean_up_handle (self);
     if (ret) {
       GST_ERROR_OBJECT (self,
@@ -890,7 +890,7 @@ gst_tensor_src_tizensensor_start (GstBaseSrc * src)
     retval = FALSE;
     goto exit;
   }
-  g_assert (self->configured == TRUE);
+  g_assert (self->configured);
 
   /* 3. Fire it up! */
   if (sensor_listener_start (self->listener) != 0) {
@@ -940,7 +940,7 @@ gst_tensor_src_tizensensor_stop (GstBaseSrc * src)
     goto exit;
   }
 
-  g_assert (FALSE == self->configured);
+  g_assert (!self->configured);
 
 exit:
   _UNLOCK (self);
@@ -968,7 +968,7 @@ _ts_get_gstcaps_from_conf (GstTensorSrcTIZENSENSOR * self)
 
   spec = self->src_spec;
 
-  if (FALSE == self->configured || SENSOR_ALL == self->type || NULL == spec) {
+  if (!self->configured || SENSOR_ALL == self->type || NULL == spec) {
     retval = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT "; "
       GST_TENSORS_CAP_WITH_NUM ("1"));
   } else {
@@ -1060,7 +1060,7 @@ gst_tensor_src_tizensensor_fixate (GstBaseSrc * src, GstCaps * caps)
 
   cap_tensor = _ts_get_gstcaps_from_conf (self);
 
-  if (TRUE == gst_caps_can_intersect (caps, cap_tensor))
+  if (gst_caps_can_intersect (caps, cap_tensor))
     retval = gst_caps_intersect (caps, cap_tensor);
   gst_caps_unref (cap_tensor);
 
@@ -1142,7 +1142,7 @@ gst_tensor_src_tizensensor_create (GstBaseSrc * src, guint64 offset,
 
   _LOCK (self);
 
-  if (FALSE == self->configured) {
+  if (!self->configured) {
     GST_ERROR_OBJECT (self,
         "Buffer creation requested while the element is not configured. gst_tensor_src_tizensensor_create() cannot proceed if it is not configured.");
     retval = GST_FLOW_ERROR;
@@ -1231,7 +1231,7 @@ gst_tensor_src_tizensensor_fill (GstBaseSrc * src, guint64 offset,
 
   _LOCK (self);
 
-  if (FALSE == self->configured) {
+  if (!self->configured) {
     GST_ERROR_OBJECT (self,
         "gst_tensor_src_tizensensor_fill() cannot proceed if it is not configured.");
     retval = GST_FLOW_ERROR;
@@ -1247,7 +1247,7 @@ gst_tensor_src_tizensensor_fill (GstBaseSrc * src, guint64 offset,
   }
 
   mem = gst_buffer_peek_memory (buffer, 0);
-  if (FALSE == gst_memory_map (mem, &map, GST_MAP_WRITE)) {
+  if (!gst_memory_map (mem, &map, GST_MAP_WRITE)) {
     GST_ERROR_OBJECT (self,
         "gst_tensor_src_tizensensor_fill() cannot map the given buffer for writing data.");
     retval = GST_FLOW_ERROR;

--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -315,10 +315,10 @@ nnsconf_loadconf (gboolean force_reload)
   GKeyFile *key_file = NULL;
   guint i, t;
 
-  if (FALSE == force_reload && TRUE == conf.loaded)
+  if (!force_reload && conf.loaded)
     return TRUE;
 
-  if (TRUE == force_reload && TRUE == conf.loaded) {
+  if (force_reload && conf.loaded) {
     /* Do Clean Up */
     g_free (conf.conffile);
     conf.conffile = NULL;
@@ -583,7 +583,7 @@ nnsconf_dump (gchar * str, gulong size)
   gulong _size = size;
   gint len;
 
-  if (FALSE == conf.loaded)
+  if (!conf.loaded)
     nnsconf_loadconf (FALSE);
 
   len = g_snprintf (cur, _size,
@@ -657,7 +657,7 @@ nnsconf_subplugin_dump (gchar * str, gulong size)
   subplugin_info_s info;
   guint i, j, ret;
 
-  if (FALSE == conf.loaded)
+  if (!conf.loaded)
     nnsconf_loadconf (FALSE);
 
   buf.base = str;

--- a/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
+++ b/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
@@ -575,12 +575,12 @@ gst_tensor_aggregator_concat (GstTensorAggregator * self, GstBuffer * outbuf,
   srcbuf = gst_buffer_copy (outbuf);
   outbuf = gst_buffer_make_writable (outbuf);
 
-  if (FALSE == gst_buffer_map (srcbuf, &src_info, GST_MAP_READ)) {
+  if (!gst_buffer_map (srcbuf, &src_info, GST_MAP_READ)) {
     ml_logf ("Failed to map source buffer with tensor_aggregator.\n");
     gst_buffer_unref (srcbuf);
     return FALSE;
   }
-  if (FALSE == gst_buffer_map (outbuf, &dest_info, GST_MAP_WRITE)) {
+  if (!gst_buffer_map (outbuf, &dest_info, GST_MAP_WRITE)) {
     ml_logf ("Failed to map destination buffer with tensor_aggregator.\n");
     gst_buffer_unmap (srcbuf, &src_info);
     gst_buffer_unref (srcbuf);
@@ -814,7 +814,7 @@ gst_tensor_aggregator_push (GstTensorAggregator * self, GstBuffer * outbuf,
 
   if (gst_tensor_aggregator_check_concat_axis (self, &info)) {
     /** change data in buffer with given axis */
-    if (FALSE == gst_tensor_aggregator_concat (self, outbuf, &info))
+    if (!gst_tensor_aggregator_concat (self, outbuf, &info))
       return GST_FLOW_ERROR;
   }
 

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -174,8 +174,7 @@ gst_tensor_info_is_equal (const GstTensorInfo * i1, const GstTensorInfo * i2)
 {
   guint i;
 
-  if (gst_tensor_info_validate (i1) == FALSE ||
-      gst_tensor_info_validate (i2) == FALSE) {
+  if (!gst_tensor_info_validate (i1) || !gst_tensor_info_validate (i2)) {
     return FALSE;
   }
 

--- a/gst/nnstreamer/tensor_common_pipeline.c
+++ b/gst/nnstreamer/tensor_common_pipeline.c
@@ -305,7 +305,7 @@ gst_tensor_time_sync_buffer_from_collectpad (GstCollectPads * collect,
       case SYNC_SLOWEST:
         /* fall-through */
       case SYNC_BASEPAD:
-        if (FALSE == _gst_tensor_time_sync_buffer_update (&buf, collect, data,
+        if (!_gst_tensor_time_sync_buffer_update (&buf, collect, data,
                 current_time, base_time, sync))
           return FALSE;
         is_empty = (buf == NULL);

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -959,14 +959,14 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
         unsigned int src_idx = 0, dest_idx = 0;
         size_t size, offset;
 
-        if (FALSE == gst_buffer_map (buf, &src_info, GST_MAP_READ)) {
+        if (!gst_buffer_map (buf, &src_info, GST_MAP_READ)) {
           ml_logf ("Cannot map src buffer at tensor_converter/video.\n");
           goto error;
         }
 
         inbuf = gst_buffer_new_and_alloc (frame_size);
         gst_buffer_memset (inbuf, 0, 0, frame_size);
-        if (FALSE == gst_buffer_map (inbuf, &dest_info, GST_MAP_WRITE)) {
+        if (!gst_buffer_map (inbuf, &dest_info, GST_MAP_WRITE)) {
           ml_logf ("Cannot map dest buffer at tensor_converter/video.\n");
           gst_buffer_unmap (buf, &src_info);
           gst_buffer_unref (inbuf);     /* the new buffer is wasted. */
@@ -1013,14 +1013,14 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
         GstMapInfo src_info, dest_info;
         gsize block_size = MIN (buf_size, frame_size);
 
-        if (FALSE == gst_buffer_map (buf, &src_info, GST_MAP_READ)) {
+        if (!gst_buffer_map (buf, &src_info, GST_MAP_READ)) {
           ml_logf ("Cannot map src buffer at tensor_converter/text.\n");
           goto error;
         }
 
         inbuf = gst_buffer_new_and_alloc (frame_size);
         gst_buffer_memset (inbuf, 0, 0, frame_size);
-        if (FALSE == gst_buffer_map (inbuf, &dest_info, GST_MAP_WRITE)) {
+        if (!gst_buffer_map (inbuf, &dest_info, GST_MAP_WRITE)) {
           ml_logf ("Cannot map dest buffer at tensor_converter/text.\n");
           gst_buffer_unmap (buf, &src_info);
           gst_buffer_unref (inbuf);     /* the new buffer is wasted. */
@@ -1972,7 +1972,7 @@ nnstreamer_converter_custom_register (const gchar * name,
   ptr->func = func;
   ptr->data = data;
 
-  if (register_subplugin (NNS_CUSTOM_CONVERTER, name, ptr) == TRUE)
+  if (register_subplugin (NNS_CUSTOM_CONVERTER, name, ptr))
     return 0;
 
   g_free (ptr);

--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -461,7 +461,7 @@ gst_tensordec_process_plugin_options (GstTensorDec * self, guint opnum)
     case PROP_MODE_OPTION ## opnum: \
       g_free (self->option[(opnum) - 1]); \
       self->option[(opnum) - 1] = g_value_dup_string (value); \
-      if (gst_tensordec_process_plugin_options (self, (opnum) - 1) != TRUE) \
+      if (!gst_tensordec_process_plugin_options (self, (opnum) - 1)) \
         GST_ERROR_OBJECT (self, "Configuring option for tensor-decoder failed (option %d = %s)", \
             (opnum), self->option[(opnum) - 1]); \
       break
@@ -706,7 +706,7 @@ gst_tensordec_transform (GstBaseTransform * trans,
 
     for (i = 0; i < num_tensors; i++) {
       in_mem[i] = gst_buffer_peek_memory (inbuf, i);
-      if (FALSE == gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ)) {
+      if (!gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ)) {
         guint j;
         ml_logf ("Failed to map in_mem[%u].\n", i);
 
@@ -962,7 +962,7 @@ nnstreamer_decoder_custom_register (const gchar * name,
   ptr->func = func;
   ptr->data = data;
 
-  if (register_subplugin (NNS_CUSTOM_DECODER, name, ptr) == TRUE)
+  if (register_subplugin (NNS_CUSTOM_DECODER, name, ptr))
     return 0;
 
   g_free (ptr);

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -2312,7 +2312,7 @@ parse_accl_hw_all (const gchar * accelerators,
   use_accl = (gboolean) g_regex_match_simple (regex_accl, accelerators,
       G_REGEX_CASELESS, G_REGEX_MATCH_NOTEMPTY);
   g_free (regex_accl);
-  if (use_accl == TRUE) {
+  if (use_accl) {
     /** Default to auto mode */
     accl = ACCL_AUTO;
     regex_accl_elem =

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
@@ -92,7 +92,7 @@ NNS_custom_easy_register (const char *modelname,
   gst_tensors_info_copy (&ptr->in_info, in_info);
   gst_tensors_info_copy (&ptr->out_info, out_info);
 
-  if (register_subplugin (NNS_EASY_CUSTOM_FILTER, modelname, ptr) == TRUE)
+  if (register_subplugin (NNS_EASY_CUSTOM_FILTER, modelname, ptr))
     return 0;
 
   custom_free_internal_data (ptr);

--- a/gst/nnstreamer/tensor_filter/tensor_filter_single.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_single.c
@@ -140,7 +140,7 @@ g_tensor_filter_single_finalize (GObject * object)
   priv = &spriv->filter_priv;
 
   /** stop if not already stopped */
-  if (priv->configured == TRUE) {
+  if (priv->configured) {
     g_tensor_filter_single_stop (self);
   }
 
@@ -256,7 +256,7 @@ g_tensor_filter_single_start (GTensorFilterSingle * self)
 
   gst_tensor_filter_common_open_fw (priv);
 
-  if (G_UNLIKELY (priv->prop.fw_opened == FALSE))
+  if (G_UNLIKELY (!priv->prop.fw_opened))
     return FALSE;
 
   gst_tensor_filter_load_tensor_info (priv);
@@ -331,7 +331,7 @@ g_tensor_filter_single_invoke (GTensorFilterSingle * self,
   priv = &spriv->filter_priv;
 
   /** start if not already started */
-  if (priv->configured == FALSE) {
+  if (!priv->configured) {
     if (!g_tensor_filter_single_start (self)) {
       return FALSE;
     }
@@ -379,7 +379,7 @@ g_tensor_filter_single_invoke (GTensorFilterSingle * self,
 
 error:
   /* if failed to invoke the model, release allocated memory. */
-  if (spriv->allocate_in_invoke == FALSE && allocate) {
+  if (!spriv->allocate_in_invoke && allocate) {
     for (i = 0; i < priv->prop.output_meta.num_tensors; i++) {
       g_free (output[i].data);
       output[i].data = NULL;

--- a/gst/nnstreamer/tensor_if/gsttensorif.c
+++ b/gst/nnstreamer/tensor_if/gsttensorif.c
@@ -389,7 +389,7 @@ gst_tensor_if_set_property_supplied_value (const GValue * value,
 
   sv->num = num;
   for (i = 0; i < num; i++) {
-    if (is_float == TRUE) {
+    if (is_float) {
       sv->type = _NNS_FLOAT64;
       sv->data[i]._double = g_ascii_strtod (strv[i], NULL);
     } else {
@@ -992,7 +992,7 @@ nnstreamer_if_custom_register (const gchar * name, tensor_if_custom func,
   ptr->func = func;
   ptr->data = data;
 
-  if (register_subplugin (NNS_IF_CUSTOM, name, ptr) == TRUE)
+  if (register_subplugin (NNS_IF_CUSTOM, name, ptr))
     return 0;
 
   g_free (ptr);
@@ -1034,14 +1034,14 @@ gst_tensor_if_check_condition (GstTensorIf * tensor_if, GstBuffer * buf,
     GstTensorMemory in_tensors[NNS_TENSOR_SIZE_LIMIT];
     guint i, j;
 
-    if (FALSE == tensor_if->custom_configured) {
+    if (!tensor_if->custom_configured) {
       nns_loge ("custom condition of the tensor_if is not configured.");
       return FALSE;
     }
 
     for (i = 0; i < tensor_if->in_config.info.num_tensors; i++) {
       in_mem[i] = gst_buffer_peek_memory (buf, i);
-      if (FALSE == gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ)) {
+      if (!gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ)) {
         for (j = 0; j < i; j++)
           gst_memory_unmap (in_mem[j], &in_info[j]);
         GST_WARNING_OBJECT (tensor_if, "Cannot map input memory buffer(%d)\n",
@@ -1095,7 +1095,7 @@ gst_tensor_if_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
     return GST_FLOW_ERROR;
   }
 
-  if (condition_result == TRUE) {
+  if (condition_result) {
     curr_act = tensor_if->act_then;
     curr_act_option = tensor_if->then_option;
     which_srcpad = TIFSP_THEN_PAD;

--- a/gst/nnstreamer/tensor_merge/gsttensormerge.c
+++ b/gst/nnstreamer/tensor_merge/gsttensormerge.c
@@ -474,7 +474,7 @@ gst_tensor_merge_generate_mem (GstTensorMerge * tensor_merge,
 
   for (i = 0; i < num_mem; i++) {
     mem[i] = gst_buffer_peek_memory (tensors_buf, i);
-    if (FALSE == gst_memory_map (mem[i], &mInfo[i], GST_MAP_READ)) {
+    if (!gst_memory_map (mem[i], &mInfo[i], GST_MAP_READ)) {
       ml_logf ("Cannot map input memory buffers (%d)\n", i);
       num_mem = i;
       ret = GST_FLOW_ERROR;
@@ -484,7 +484,7 @@ gst_tensor_merge_generate_mem (GstTensorMerge * tensor_merge,
   }
 
   outMem = gst_allocator_alloc (NULL, outSize, NULL);
-  if (FALSE == gst_memory_map (outMem, &outInfo, GST_MAP_WRITE)) {
+  if (!gst_memory_map (outMem, &outInfo, GST_MAP_WRITE)) {
     gst_allocator_free (NULL, outMem);
     ml_logf ("Cannot map output memory buffer\n");
     ret = GST_FLOW_ERROR;
@@ -805,14 +805,14 @@ gst_tensor_merge_set_property (GObject * object, guint prop_id,
             g_value_get_string (value));
         break;
       }
-      if (FALSE == gst_tensor_merge_set_option_data (tensor_merge)) {
+      if (!gst_tensor_merge_set_option_data (tensor_merge)) {
         tensor_merge->loaded = FALSE;
         ml_logw ("Given mode property is not consistent with its options.\n");
       }
       break;
     case PROP_OPTION:
       tensor_merge->option = g_value_dup_string (value);
-      if (FALSE == gst_tensor_merge_set_option_data (tensor_merge)) {
+      if (!gst_tensor_merge_set_option_data (tensor_merge)) {
         tensor_merge->loaded = FALSE;
         ml_logw ("Given option property is not consistent with its mode.\n");
       }

--- a/gst/nnstreamer/tensor_repo/tensor_reposrc.c
+++ b/gst/nnstreamer/tensor_repo/tensor_reposrc.c
@@ -302,7 +302,7 @@ gst_tensor_reposrc_gen_dummy_buffer (GstTensorRepoSrc * self)
     size = gst_tensor_info_get_size (&self->config.info.info[i]);
     mem = gst_allocator_alloc (NULL, size, NULL);
 
-    if (FALSE == gst_memory_map (mem, &info, GST_MAP_WRITE)) {
+    if (!gst_memory_map (mem, &info, GST_MAP_WRITE)) {
       gst_allocator_free (NULL, mem);
       ml_logf ("Cannot mep gst memory (tensor-repo-src)\n");
       gst_buffer_unref (buf);

--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -1113,7 +1113,7 @@ gst_tensor_src_iio_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
   GstTensorSrcIIO *self;
-  GstStateChangeReturn status;
+  GstStateChangeReturn ret;
   GstState state;
 
   self = GST_TENSOR_SRC_IIO (object);
@@ -1123,9 +1123,9 @@ gst_tensor_src_iio_set_property (GObject * object, guint prop_id,
    * reset the device. To change the properties, user should stop the pipeline
    * and set element state to READY/NULL and then change the properties
    */
-  status = gst_element_get_state (GST_ELEMENT (self), &state, NULL,
+  ret = gst_element_get_state (GST_ELEMENT (self), &state, NULL,
       GST_CLOCK_TIME_NONE);
-  if (status == GST_STATE_CHANGE_FAILURE || status == GST_STATE_CHANGE_ASYNC
+  if (ret == GST_STATE_CHANGE_FAILURE || ret == GST_STATE_CHANGE_ASYNC
       || state == GST_STATE_PLAYING || state == GST_STATE_PAUSED) {
     GST_ERROR_OBJECT (self, "Can only set property in NULL or READY state.");
     return;
@@ -1233,7 +1233,7 @@ gst_tensor_src_iio_set_property (GObject * object, guint prop_id,
             status = FALSE;
             break;
           }
-          if (FALSE == g_hash_table_insert (self->custom_channel_table,
+          if (!g_hash_table_insert (self->custom_channel_table,
                   GINT_TO_POINTER (val), NULL)) {
             /** this means val is duplicated. just skip it, then. */
             ml_logw
@@ -1241,7 +1241,7 @@ gst_tensor_src_iio_set_property (GObject * object, guint prop_id,
                 strv[i]);
           }
         }
-        if (TRUE == status)
+        if (status)
           self->channels_enabled = CHANNELS_ENABLED_CUSTOM;
         g_strfreev (strv);
         break;
@@ -1872,10 +1872,10 @@ gst_tensor_src_iio_setup_scan_channels (GstTensorSrcIIO * self)
       item_in_table = g_hash_table_contains (self->custom_channel_table,
           GINT_TO_POINTER (channel_prop->index));
       channel_en = -1;
-      if (item_in_table == FALSE && channel_prop->enabled == TRUE) {
+      if (!item_in_table && channel_prop->enabled) {
         channel_en = 0;
         channel_prop->enabled = FALSE;
-      } else if (item_in_table != FALSE && channel_prop->enabled == FALSE) {
+      } else if (item_in_table && !channel_prop->enabled) {
         channel_en = 1;
         channel_prop->enabled = TRUE;
       }
@@ -2000,27 +2000,27 @@ gst_tensor_src_iio_start (GstBaseSrc * src)
     goto error_return;
   }
 
-  if (FALSE == gst_tensor_src_iio_setup_device_properties (self)) {
+  if (!gst_tensor_src_iio_setup_device_properties (self)) {
     GST_ERROR_OBJECT (self, "Error setting up IIO device.");
     goto error_return;
   }
 
-  if (FALSE == gst_tensor_src_iio_setup_trigger_properties (self)) {
+  if (!gst_tensor_src_iio_setup_trigger_properties (self)) {
     GST_ERROR_OBJECT (self, "Error setting up IIO trigger for device.");
     goto error_device_free;
   }
 
-  if (FALSE == gst_tensor_src_iio_setup_sampling_frequency (self)) {
+  if (!gst_tensor_src_iio_setup_sampling_frequency (self)) {
     GST_ERROR_OBJECT (self, "Error setting up sampling frequency for device.");
     goto error_trigger_free;
   }
 
-  if (FALSE == gst_tensor_src_iio_setup_scan_channels (self)) {
+  if (!gst_tensor_src_iio_setup_scan_channels (self)) {
     GST_ERROR_OBJECT (self, "Error setting up scan channels for device.");
     goto error_trigger_free;
   }
 
-  if (FALSE == gst_tensor_src_iio_setup_device_buffer (self)) {
+  if (!gst_tensor_src_iio_setup_device_buffer (self)) {
     GST_ERROR_OBJECT (self, "Error setting up data buffer for device.");
     goto error_config_free;
   }
@@ -2291,7 +2291,7 @@ gst_tensor_src_iio_change_state (GstElement * element,
       break;
   }
 
-  if (buffer_state_change_success == FALSE) {
+  if (!buffer_state_change_success) {
     ret = GST_STATE_CHANGE_FAILURE;
   }
 

--- a/gst/nnstreamer/tensor_split/gsttensorsplit.c
+++ b/gst/nnstreamer/tensor_split/gsttensorsplit.c
@@ -419,11 +419,11 @@ gst_tensor_split_get_splited (GstTensorSplit * split, GstBuffer * buffer,
       gst_tensor_get_element_size (split->sink_tensor_conf.info.type);
 
   mem = gst_allocator_alloc (NULL, size, NULL);
-  if (FALSE == gst_memory_map (mem, &dest_info, GST_MAP_WRITE)) {
+  if (!gst_memory_map (mem, &dest_info, GST_MAP_WRITE)) {
     ml_logf ("Cannot map memory for destination buffer.\n");
     return NULL;
   }
-  if (FALSE == gst_buffer_map (buffer, &src_info, GST_MAP_READ)) {
+  if (!gst_buffer_map (buffer, &src_info, GST_MAP_READ)) {
     ml_logf ("Cannot map src-memory to gst buffer at tensor-split.\n");
     gst_memory_unmap (mem, &dest_info);
     return NULL;

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -807,7 +807,7 @@ gst_tensor_transform_set_property (GObject * object, guint prop_id,
     {
       gchar *backup_option = filter->option;
       filter->option = g_value_dup_string (value);
-      if (TRUE == gst_tensor_transform_set_option_data (filter)) {
+      if (gst_tensor_transform_set_option_data (filter)) {
         silent_debug ("Option = %s --> %s\n", backup_option, filter->option);
         g_free (backup_option);
       } else {
@@ -1283,7 +1283,7 @@ gst_tensor_transform_stand (GstTensorTransform * filter,
   switch (filter->data_stand.mode) {
     case STAND_DEFAULT:
     {
-      if (filter->data_stand.per_channel == FALSE) {
+      if (!filter->data_stand.per_channel) {
         for (i = 0; i < num; i++) {
           data_idx = in_element_size * i;
           gst_tensor_data_raw_typecast ((gpointer) (inptr + data_idx),
@@ -1314,7 +1314,7 @@ gst_tensor_transform_stand (GstTensorTransform * filter,
     }
     case STAND_DC_AVERAGE:
     {
-      if (filter->data_stand.per_channel == FALSE) {
+      if (!filter->data_stand.per_channel) {
         for (i = 0; i < num; i++) {
           data_idx = in_element_size * i;
           gst_tensor_data_raw_typecast ((gpointer) (inptr + data_idx),
@@ -1432,7 +1432,7 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
     }
 
     in_mem[i] = gst_buffer_peek_memory (inbuf, i);
-    if (FALSE == gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ)) {
+    if (!gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ)) {
       ml_loge ("Cannot map input buffer to gst-buf at tensor-transform.\n");
       res = GST_FLOW_ERROR;
       goto done;
@@ -1443,7 +1443,7 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
     out_mem[i] = gst_allocator_alloc (NULL, buf_size, NULL);
     gst_buffer_append_memory (outbuf, out_mem[i]);
 
-    if (FALSE == gst_memory_map (out_mem[i], &out_info[i], GST_MAP_READ)) {
+    if (!gst_memory_map (out_mem[i], &out_info[i], GST_MAP_READ)) {
       ml_loge ("Cannot map output buffer to gst-buf at tensor-transform.\n");
       res = GST_FLOW_ERROR;
       goto done;

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -937,8 +937,8 @@ TEST (confCustom, envStr01)
   gchar *f5 = create_null_file (dircf, "custom_mechanism" NNSTREAMER_SO_FILE_EXTENSION);
   gchar *f6 = create_null_file (dircf, "fastfaster" NNSTREAMER_SO_FILE_EXTENSION);
 
-  EXPECT_TRUE (FALSE != g_setenv ("NNSTREAMER_CONF", filename, TRUE));
-  EXPECT_TRUE (nnsconf_loadconf (TRUE) == TRUE);
+  EXPECT_TRUE (g_setenv ("NNSTREAMER_CONF", filename, TRUE));
+  EXPECT_TRUE (nnsconf_loadconf (TRUE));
 
   fn = nnsconf_get_fullpath ("fantastic", NNSCONF_PATH_FILTERS);
   EXPECT_STREQ (fn, f1);

--- a/tests/nnstreamer_converter/unittest_converter.cc
+++ b/tests/nnstreamer_converter/unittest_converter.cc
@@ -34,7 +34,7 @@ GstBuffer * tensor_converter_custom_cb (GstBuffer *in_buf,
 
   data_received++;
   in_mem = gst_buffer_peek_memory (in_buf, 0);
-  if (gst_memory_map (in_mem, &in_info, GST_MAP_READ) == FALSE) {
+  if (!gst_memory_map (in_mem, &in_info, GST_MAP_READ)) {
     ml_loge ("Cannot map input memory / tensor_converter::flexbuf.\n");
     return NULL;
   }

--- a/tests/nnstreamer_decoder/unittest_decoder.cc
+++ b/tests/nnstreamer_decoder/unittest_decoder.cc
@@ -73,7 +73,7 @@ int tensor_decoder_custom_cb (const GstTensorMemory *input,
     out_mem = gst_buffer_get_all_memory (out_buf);
   }
 
-  if (FALSE == gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+  if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
     if (need_alloc)
       gst_allocator_free (NULL, out_mem);
     nns_loge ("Cannot map gst memory (tensor decoder custom)\n");

--- a/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
+++ b/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
@@ -260,7 +260,7 @@ TEST (nnstreamerFilterArmnn, invokeAdvanced)
   model_file = g_build_filename (root_path, "tests", "test_models", "models",
       "mobilenet_v1_1.0_224_quant.tflite", NULL);
   status = g_file_test (model_file, G_FILE_TEST_EXISTS);
-  if (status == FALSE) {
+  if (!status) {
     g_free (model_file);
     ASSERT_EQ (status, TRUE);
   }

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -295,7 +295,7 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, invokeAdvanced)
   model_file = g_build_filename (root_path, "tests", "test_models", "models",
       "mobilenet_v1_1.0_224_quant.tflite", NULL);
   status = g_file_test (model_file, G_FILE_TEST_EXISTS);
-  if (status == FALSE) {
+  if (!status) {
     g_free (model_file);
     ASSERT_EQ (status, TRUE);
   }
@@ -303,7 +303,7 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, invokeAdvanced)
   manifest_file = g_build_filename (
       root_path, "tests", "test_models", "models", "metadata", "MANIFEST", NULL);
   status = g_file_test (manifest_file, G_FILE_TEST_EXISTS);
-  if (status == FALSE) {
+  if (!status) {
     g_free (model_file);
     g_free (manifest_file);
     ASSERT_EQ (status, TRUE);


### PR DESCRIPTION
Never directly compare the contents of a gboolean variable with the values TRUE or FALSE.
Use `if (condition)` to check a gboolean is "true", instead of `if (condition == TRUE)`. Likewise use `if (!condition)` to check a gboolean is "false".
There is no validation when assigning to a gboolean variable and so it could contain any value represented by a gint. This is why the use of if (condition) is recommended.
All non-zero values in C evaluate to "true".

Refer: https://developer.gnome.org/glib/stable/glib-Basic-Types.html#gboolean

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped