### PR TITLE
[Converter/Decoder] Add error handling code and testcases

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.cc
@@ -39,13 +39,14 @@ gst_tensor_decoder_protobuf (const GstTensorsConfig *config,
   size_t size, outbuf_size;
   nnstreamer::protobuf::Tensors tensors;
   nnstreamer::protobuf::Tensors::frame_rate *fr = NULL;
-  const unsigned int num_tensors = config->info.num_tensors;
+  guint num_tensors;
 
-  if (NULL == outbuf) {
-    ml_loge ("GStreamer internal error : outbuf is empty");
+  if (!config || !input || !outbuf) {
+    ml_loge ("NULL parameter is passed to tensor_decoder::protobuf");
     return GST_FLOW_ERROR;
   }
 
+  num_tensors = config->info.num_tensors;
   if (num_tensors <= 0 || num_tensors > NNS_TENSOR_SIZE_LIMIT) {
     ml_loge ("The number of input tenosrs "
              "exceeds more than NNS_TENSOR_SIZE_LIMIT, %s",
@@ -124,6 +125,11 @@ gst_tensor_converter_protobuf (GstBuffer *in_buf, gsize *frame_size,
   GstBuffer *out_buf;
   guint mem_size;
   gpointer mem_data;
+
+  if (!in_buf || !frame_size || !frames_in || !config) {
+    ml_loge ("NULL parameter is passed to tensor_converter::protobuf");
+    return NULL;
+  }
 
   in_mem = gst_buffer_peek_memory (in_buf, 0);
 

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
@@ -101,6 +101,11 @@ fbc_convert (GstBuffer *in_buf, gsize *frame_size, guint *frames_in, GstTensorsC
   GstMapInfo in_info;
   guint mem_size;
 
+  if (!in_buf || !frame_size || !frames_in || !config) {
+    ml_loge ("NULL parameter is passed to tensor_converter::flatbuf");
+    return NULL;
+  }
+
   in_mem = gst_buffer_peek_memory (in_buf, 0);
   if (FALSE == gst_memory_map (in_mem, &in_info, GST_MAP_READ)) {
     nns_loge ("Cannot map input memory / tensor_converter::flatbuf");

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
@@ -118,6 +118,11 @@ flxc_convert (GstBuffer *in_buf, gsize *frame_size, guint *frames_in, GstTensors
   GstMapInfo in_info;
   guint mem_size;
 
+  if (!in_buf || !frame_size || !frames_in || !config) {
+    ml_loge ("NULL parameter is passed to tensor_converter::flexbuf");
+    return NULL;
+  }
+
   in_mem = gst_buffer_peek_memory (in_buf, 0);
 
   if (gst_memory_map (in_mem, &in_info, GST_MAP_READ) == FALSE) {

--- a/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
@@ -80,7 +80,7 @@ fbd_decode (void **pdata, const GstTensorsConfig *config,
   Tensor_type type;
   GstMapInfo out_info;
   GstMemory *out_mem;
-  unsigned int i, num_tensors = config->info.num_tensors;
+  guint i, num_tensors;
   flatbuffers::uoffset_t fb_size;
   flatbuffers::FlatBufferBuilder builder;
   std::vector<flatbuffers::Offset<Tensor>> tensor_vector;
@@ -89,8 +89,15 @@ fbd_decode (void **pdata, const GstTensorsConfig *config,
   flatbuffers::Offset<flatbuffers::Vector<unsigned char>> input_vector;
   flatbuffers::Offset<Tensor> tensor;
   flatbuffers::Offset<Tensors> tensors;
-  frame_rate fr = frame_rate (config->rate_n, config->rate_d);
+  frame_rate fr;
 
+  if (!config || !input || !outbuf) {
+    ml_loge ("NULL parameter is passed to tensor_decoder::flatbuf");
+    return GST_FLOW_ERROR;
+  }
+
+  num_tensors = config->info.num_tensors;
+  fr = frame_rate (config->rate_n, config->rate_d);
   /* Fill the info in tensor and puth to tensor vector */
   for (i = 0; i < num_tensors; i++) {
     unsigned char *tmp_buf;
@@ -119,8 +126,6 @@ fbd_decode (void **pdata, const GstTensorsConfig *config,
   /* Serialize the data.*/
   builder.Finish (tensors);
   fb_size = builder.GetSize ();
-
-  g_assert (outbuf);
 
   if (gst_buffer_get_size (outbuf) == 0) {
     out_mem = gst_allocator_alloc (NULL, fb_size, NULL);

--- a/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
@@ -112,11 +112,17 @@ flxd_decode (void **pdata, const GstTensorsConfig *config,
 {
   GstMapInfo out_info;
   GstMemory *out_mem;
-  unsigned int i, num_tensors = config->info.num_tensors;
+  guint i, num_tensors;
   gboolean need_alloc;
   size_t flex_size;
   flexbuffers::Builder fbb;
 
+  if (!config || !input || !outbuf) {
+    ml_loge ("NULL parameter is passed to tensor_decoder::flexbuf");
+    return GST_FLOW_ERROR;
+  }
+
+  num_tensors = config->info.num_tensors;
   fbb.Map ([&]() {
     fbb.UInt ("num_tensors", num_tensors);
     fbb.Int ("rate_n", config->rate_n);
@@ -145,7 +151,6 @@ flxd_decode (void **pdata, const GstTensorsConfig *config,
   fbb.Finish ();
   flex_size = fbb.GetSize ();
 
-  g_assert (outbuf);
   need_alloc = (gst_buffer_get_size (outbuf) == 0);
 
   if (need_alloc) {

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_converter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_converter.h
@@ -75,6 +75,15 @@ typedef struct _NNStreamerExternalConverter
 } NNStreamerExternalConverter;
 
 /**
+ * @brief Find converter sub-plugin with the name.
+ * @param[in] name The name of converter sub-plugin.
+ * @return NNStreamerExternalConverter if subplugin is found.
+ *         NULL if not found or the sub-plugin object has an error.
+ */
+extern const NNStreamerExternalConverter *
+nnstreamer_converter_find (const char *name);
+
+/**
  * @brief Converter's sub-plugin should call this function to register itself.
  * @param[in] ex Converter sub-plugin to be registered.
  * @return TRUE if registered. FALSE is failed or duplicated.

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -308,7 +308,7 @@ gst_tensor_converter_class_init (GstTensorConverterClass * klass)
   /* append sub-plugin template caps */
   total = nnsconf_get_subplugin_info (NNSCONF_PATH_CONVERTERS, &info);
   for (i = 0; i < total; i++) {
-    ex = get_subplugin (NNS_SUBPLUGIN_CONVERTER, info.names[i]);
+    ex = nnstreamer_converter_find (info.names[i]);
     if (ex && ex->query_caps)
       gst_caps_append (pad_caps, ex->query_caps (NULL));
   }
@@ -1885,6 +1885,17 @@ gst_tensor_converter_update_caps (GstTensorConverter * self,
 }
 
 /**
+ * @brief Find converter sub-plugin with the name.
+ * @param[in] name The name of converter sub-plugin.
+ * @return NULL if not found or the sub-plugin object has an error.
+ */
+const NNStreamerExternalConverter *
+nnstreamer_converter_find (const char *name)
+{
+  return get_subplugin (NNS_SUBPLUGIN_CONVERTER, name);
+}
+
+/**
  * @brief Converter's external subplugins should call this at init.
  */
 int
@@ -1916,7 +1927,7 @@ findExternalConverter (const char *media_type)
 
   total = nnsconf_get_subplugin_info (NNSCONF_PATH_CONVERTERS, &info);
   for (i = 0; i < total; i++) {
-    ex = get_subplugin (NNS_SUBPLUGIN_CONVERTER, info.names[i]);
+    ex = nnstreamer_converter_find (info.names[i]);
 
     if (ex && ex->query_caps) {
       caps = ex->query_caps (NULL);


### PR DESCRIPTION
 - Add error handling code for tensor converter and decoder subplugins.
 - Add testcases for tensor converter and decoder subplugins.
    
Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped