### PR TITLE
[Mux/Merge] clear collect pad data

### DIFF
--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -92,8 +92,6 @@ typedef struct _tensor_time_sync_data {
 typedef struct
 {
   GstCollectData collect;
-  GstClockTime pts_timestamp;
-  GstClockTime dts_timestamp;
   GstBuffer *buffer;
   GstPad *pad;
 } GstTensorCollectPadData;
@@ -142,6 +140,14 @@ gst_tensor_time_sync_set_option_data (tensor_time_sync_data * sync);
  */
 extern gboolean
 gst_tensor_time_sync_get_current_time (GstCollectPads * collect, tensor_time_sync_data * sync, GstClockTime * current_time);
+
+/**
+ * @brief A function to be called while processing a flushing event.
+ * It should clear old buffer and reset pad data.
+ * @param collect Collect pad.
+ */
+extern void
+gst_tensor_time_sync_flush (GstCollectPads * collect);
 
 /**
  * @brief  A function call to make tensors from collected pads

--- a/gst/nnstreamer/tensor_common_pipeline.c
+++ b/gst/nnstreamer/tensor_common_pipeline.c
@@ -177,6 +177,29 @@ gst_tensor_time_sync_get_current_time (GstCollectPads * collect,
 }
 
 /**
+ * @brief A function to be called while processing a flushing event.
+ * It should clear old buffer and reset pad data.
+ */
+void
+gst_tensor_time_sync_flush (GstCollectPads * collect)
+{
+  GSList *walk;
+  GstTensorCollectPadData *pad;
+
+  walk = collect->data;
+  while (walk) {
+    pad = (GstTensorCollectPadData *) walk->data;
+
+    if (pad->buffer) {
+      gst_buffer_unref (pad->buffer);
+      pad->buffer = NULL;
+    }
+
+    walk = g_slist_next (walk);
+  }
+}
+
+/**
  * @brief Common code for both
  *        gst_tensor_time_sync_buffer_from_collectpad_SYNC_*
  */

--- a/gst/nnstreamer/tensor_common_pipeline.c
+++ b/gst/nnstreamer/tensor_common_pipeline.c
@@ -57,6 +57,8 @@ gst_tensor_time_sync_get_mode_string (tensor_time_sync_mode mode)
 gboolean
 gst_tensor_time_sync_set_option_data (tensor_time_sync_data * sync)
 {
+  g_return_val_if_fail (sync != NULL, FALSE);
+
   if (sync->mode == SYNC_END || sync->option == NULL)
     return FALSE;
 
@@ -137,6 +139,10 @@ gst_tensor_time_sync_get_current_time (GstCollectPads * collect,
   GSList *walk = NULL;
   guint count, empty_pad;
 
+  g_return_val_if_fail (collect != NULL, FALSE);
+  g_return_val_if_fail (sync != NULL, FALSE);
+  g_return_val_if_fail (current_time != NULL, FALSE);
+
   walk = collect->data;
   count = empty_pad = 0;
 
@@ -185,6 +191,8 @@ gst_tensor_time_sync_flush (GstCollectPads * collect)
 {
   GSList *walk;
   GstTensorCollectPadData *pad;
+
+  g_return_if_fail (collect != NULL);
 
   walk = collect->data;
   while (walk) {
@@ -262,6 +270,12 @@ gst_tensor_time_sync_buffer_from_collectpad (GstCollectPads * collect,
   guint counting, empty_pad;
   GstTensorsConfig in_configs;
   GstClockTime base_time = 0;
+
+  g_return_val_if_fail (collect != NULL, FALSE);
+  g_return_val_if_fail (sync != NULL, FALSE);
+  g_return_val_if_fail (tensors_buf != NULL, FALSE);
+  g_return_val_if_fail (configs != NULL, FALSE);
+  g_return_val_if_fail (is_eos != NULL, FALSE);
 
   walk = collect->data;
   counting = empty_pad = 0;

--- a/gst/nnstreamer/tensor_merge/gsttensormerge.c
+++ b/gst/nnstreamer/tensor_merge/gsttensormerge.c
@@ -261,6 +261,7 @@ gst_tensor_merge_finalize (GObject * object)
   tensor_merge = GST_TENSOR_MERGE (object);
 
   if (tensor_merge->collect) {
+    gst_tensor_time_sync_flush (tensor_merge->collect);
     gst_object_unref (tensor_merge->collect);
     tensor_merge->collect = NULL;
   }
@@ -355,6 +356,8 @@ gst_tensor_merge_sink_event (GstCollectPads * pads, GstCollectData * data,
   switch (GST_EVENT_TYPE (event)) {
     case GST_EVENT_FLUSH_STOP:
       tensor_merge->need_segment = TRUE;
+      tensor_merge->need_set_time = TRUE;
+      gst_tensor_time_sync_flush (tensor_merge->collect);
       break;
     default:
       break;

--- a/gst/nnstreamer/tensor_mux/gsttensormux.c
+++ b/gst/nnstreamer/tensor_mux/gsttensormux.c
@@ -234,6 +234,7 @@ gst_tensor_mux_finalize (GObject * object)
   tensor_mux = GST_TENSOR_MUX (object);
 
   if (tensor_mux->collect) {
+    gst_tensor_time_sync_flush (tensor_mux->collect);
     gst_object_unref (tensor_mux->collect);
     tensor_mux->collect = NULL;
   }
@@ -343,6 +344,8 @@ gst_tensor_mux_sink_event (GstCollectPads * pads, GstCollectData * data,
   switch (GST_EVENT_TYPE (event)) {
     case GST_EVENT_FLUSH_STOP:
       tensor_mux->need_segment = TRUE;
+      tensor_mux->need_set_time = TRUE;
+      gst_tensor_time_sync_flush (tensor_mux->collect);
       break;
     case GST_EVENT_EOS:
       gst_tensor_mux_set_waiting (tensor_mux, FALSE);


### PR DESCRIPTION
Clear old buffer in collect pad data when received flush event.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
