### PR TITLE
[Doc] Change menu tree name of contributing doc.

### DIFF
--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -1,5 +1,5 @@
 ---
-title: Contributing
+title: How to contribute
 ...
 
 # How to Contribute

--- a/Documentation/hotdoc/sitemap.txt
+++ b/Documentation/hotdoc/sitemap.txt
@@ -2,7 +2,6 @@ index.md
 	doc-index.md
 		coding-convention.md
 		component-description.md
-		contributing.md
 		doxygen-documentation.md
 		edge-ai.md
 		features-per-distro.md
@@ -18,6 +17,7 @@ index.md
 			gst-launch-script-example.md
 		how-to-use-testcases.md
 		how-to-write-testcase.md
+		contributing.md
 		nnstreamer_capi.md
 		products.md
 		writing-subplugin-tensor-filter.md


### PR DESCRIPTION
Change menu tree name of Documentation/contributing.md.
Related issue: #3100

Before:
![image](https://user-images.githubusercontent.com/56856496/114360161-b13bcb00-9baf-11eb-976e-ea3c18083d41.png)

After:
![image](https://user-images.githubusercontent.com/56856496/114360358-e3e5c380-9baf-11eb-8738-e2168bb060a4.png)

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped