### PR TITLE
[Decoders] fix the mem leaks of the external decoders @open sesame 04/29 13:06 

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.cc
@@ -99,6 +99,7 @@ gst_tensor_decoder_protobuf (const GstTensorsConfig *config,
 
   if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
     nns_loge ("Cannot map output memory / tensordec-protobuf");
+    gst_memory_unref (out_mem);
     return GST_FLOW_ERROR;
   }
 
@@ -106,9 +107,10 @@ gst_tensor_decoder_protobuf (const GstTensorsConfig *config,
 
   gst_memory_unmap (out_mem, &out_info);
 
-  if (gst_buffer_get_size (outbuf) == 0) {
+  if (outbuf_size == 0)
     gst_buffer_append_memory (outbuf, out_mem);
-  }
+  else
+    gst_memory_unref (out_mem);
 
   return GST_FLOW_OK;
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
@@ -137,6 +137,7 @@ fbd_decode (void **pdata, const GstTensorsConfig *config,
   }
 
   if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+    gst_memory_unref (out_mem);
     nns_loge ("Cannot map gst memory (tensor decoder flatbuf)\n");
     return GST_FLOW_ERROR;
   }
@@ -147,6 +148,8 @@ fbd_decode (void **pdata, const GstTensorsConfig *config,
 
   if (gst_buffer_get_size (outbuf) == 0)
     gst_buffer_append_memory (outbuf, out_mem);
+  else
+    gst_memory_unref (out_mem);
 
   return GST_FLOW_OK;
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
@@ -162,8 +162,7 @@ flxd_decode (void **pdata, const GstTensorsConfig *config,
   }
 
   if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
-    if (need_alloc)
-      gst_allocator_free (NULL, out_mem);
+    gst_memory_unref (out_mem);
     nns_loge ("Cannot map gst memory (tensor decoder flexbuf)\n");
     return GST_FLOW_ERROR;
   }
@@ -174,6 +173,8 @@ flxd_decode (void **pdata, const GstTensorsConfig *config,
 
   if (need_alloc)
     gst_buffer_append_memory (outbuf, out_mem);
+  else
+    gst_memory_unref (out_mem);
 
   return GST_FLOW_OK;
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
@@ -218,6 +218,7 @@ il_decode (void **pdata, const GstTensorsConfig * config,
 
   if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
     ml_loge ("Cannot map output memory / tensordec-imagelabel.\n");
+    gst_memory_unref (out_mem);
     return GST_FLOW_ERROR;
   }
 
@@ -227,6 +228,8 @@ il_decode (void **pdata, const GstTensorsConfig * config,
 
   if (gst_buffer_get_size (outbuf) == 0)
     gst_buffer_append_memory (outbuf, out_mem);
+  else
+    gst_memory_unref (out_mem);
 
   return GST_FLOW_OK;
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
@@ -612,14 +612,15 @@ is_decode (void **pdata, const GstTensorsConfig * config,
 
   if (need_output_alloc)
     gst_buffer_append_memory (outbuf, out_mem);
+  else
+    gst_memory_unref (out_mem);
 
   return GST_FLOW_OK;
 
 error_unmap:
   gst_memory_unmap (out_mem, &out_info);
 error_free:
-  if (need_output_alloc)
-    gst_allocator_free (NULL, out_mem);
+  gst_memory_unref (out_mem);
 
   return GST_FLOW_ERROR;
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -717,6 +717,7 @@ pose_decode (void **pdata, const GstTensorsConfig * config,
     out_mem = gst_buffer_get_all_memory (outbuf);
   }
   if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
+    gst_memory_unref (out_mem);
     ml_loge ("Cannot map output memory / tensordec-pose.\n");
     return GST_FLOW_ERROR;
   }
@@ -780,6 +781,9 @@ pose_decode (void **pdata, const GstTensorsConfig * config,
   gst_memory_unmap (out_mem, &out_info);
   if (gst_buffer_get_size (outbuf) == 0)
     gst_buffer_append_memory (outbuf, out_mem);
+  else
+    gst_memory_unref (out_mem);
+
   return GST_FLOW_OK;
 }
 

--- a/tests/nnstreamer_decoder/unittest_decoder.cc
+++ b/tests/nnstreamer_decoder/unittest_decoder.cc
@@ -76,8 +76,7 @@ tensor_decoder_custom_cb (const GstTensorMemory *input,
   }
 
   if (!gst_memory_map (out_mem, &out_info, GST_MAP_WRITE)) {
-    if (need_alloc)
-      gst_allocator_free (NULL, out_mem);
+    gst_memory_unref (out_mem);
     nns_loge ("Cannot map gst memory (tensor decoder custom)\n");
     return GST_FLOW_ERROR;
   }
@@ -88,6 +87,8 @@ tensor_decoder_custom_cb (const GstTensorMemory *input,
 
   if (need_alloc)
     gst_buffer_append_memory (out_buf, out_mem);
+  else
+    gst_memory_unref (out_mem);
 
   return GST_FLOW_OK;
 }


### PR DESCRIPTION
Since the ref count is raised when `gst_buffer_get_all_memory ()` is used,
`gst_memory_unref ()` has to be called after using the memory.
Furthermore, if the process is finished with an unexpected error,
the allocated memory has to be released.

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped