### PR TITLE
[Tools/Parser] Update meson script and resolve build errors @open sesame 05/10 19:06

### DIFF
--- a/tools/development/parser/meson.build
+++ b/tools/development/parser/meson.build
@@ -1,5 +1,3 @@
-cc = meson.get_compiler('c')
-
 # Find flex, configure lex generator
 flex_cdata = configuration_data()
 
@@ -47,8 +45,6 @@ else
   message('bison version @0@ >= @1@: YES'.format(bversion, bison_min_version))
 endif
 
-
-
 bison_cdata.set('BISON', bison.path())
 bison_cdata.set('BISON_ARGS', '')
 
@@ -57,6 +53,9 @@ gen_grammar = configure_file(input : 'gen_grammar.py.in',
   configuration : bison_cdata)
 
 # Custom targets
+pymod = import('python')
+python3 = pymod.find_installation('python3')
+
 parser = custom_target('parselex',
   input : 'parse.l',
   output : ['lex.priv_gst_parse_yy.c', 'parse_lex.h'],
@@ -68,4 +67,21 @@ grammar = custom_target('parsegrammar',
   output : ['grammar.tab.c', 'grammar.tab.h'],
   command : [python3, gen_grammar, '@OUTPUT0@', '@OUTPUT1@', '@INPUT@'],
   depends : [parser],
+)
+
+# Top-level parser app
+toplevel_srcs = [
+  parser,
+  grammar,
+  'types.c',
+  'toplevel.c'
+]
+toplevel_deps = [
+  glib_dep,
+  gobject_dep
+]
+toplevel = executable('nnstreamer-parser', toplevel_srcs,
+  dependencies: toplevel_deps,
+  install: true,
+  install_dir: join_paths(get_option('prefix'), get_option('bindir')),
 )

--- a/tools/development/parser/parse.l
+++ b/tools/development/parser/parse.l
@@ -8,7 +8,7 @@
 #include <string.h>
 
 #include <glib/gprintf.h>
-#include <glib/glib.h>
+#include <glib.h>
 
 #include "types.h"
 #include "grammar.tab.h"
@@ -33,7 +33,7 @@
    embedded-NUL case for now. We know yytext is NUL-terminated. */
 #define ECHO g_fprintf(yyout, "%s", yytext)
 
-#define PRINT(...) g_printinfo (__VA_ARGS__)
+#define PRINT(...) g_debug (__VA_ARGS__)
 
 %}
 
@@ -75,7 +75,7 @@ _link ([!:][[:space:]]*{_caps}([[:space:]]*(";"[[:space:]]*{_caps})*[[:space:]]*
 
 {_assignment} {
     /* "=" */
-    PRINT ("ASSIGNMENT: %s", yytext);
+    PRINT ("ASSIGNMENT: %s\n", yytext);
     yylval->ss = g_strdup (yytext);
     BEGIN (INITIAL);
     return ASSIGNMENT;
@@ -83,14 +83,14 @@ _link ([!:][[:space:]]*{_caps}([[:space:]]*(";"[[:space:]]*{_caps})*[[:space:]]*
 
 {_padref} {
     yytext++;
-    PRINT ("PADREF: %s", yytext);
+    PRINT ("PADREF: %s\n", yytext);
     yylval->ss = g_strdup (yytext);
     BEGIN (INITIAL);
     return PADREF;
 }
 
 {_ref} {
-    PRINT ("REF: %s", yytext);
+    PRINT ("REF: %s\n", yytext);
     yylval->ss = g_strdup (yytext);
     BEGIN (INITIAL);
     return REF;
@@ -100,14 +100,14 @@ _link ([!:][[:space:]]*{_caps}([[:space:]]*(";"[[:space:]]*{_caps})*[[:space:]]*
     gchar *pos = yytext;
     while (!g_ascii_isspace (*pos) && (*pos != '.')) pos++;
     *pos = '\0';
-    PRINT ("BINREF: %s", yytext);
+    PRINT ("BINREF: %s\n", yytext);
     yylval->ss = g_strdup (yytext);
     BEGIN (INITIAL);
     return BINREF;
 }
 
 {_identifier} {
-    PRINT ("IDENTIFIER: %s", yytext);
+    PRINT ("IDENTIFIER: %s\n", yytext);
     yylval->ss = g_strdup (yytext);
     BEGIN (INITIAL);
     return IDENTIFIER;
@@ -118,7 +118,7 @@ _link ([!:][[:space:]]*{_caps}([[:space:]]*(";"[[:space:]]*{_caps})*[[:space:]]*
     gchar op;
     gboolean link_all;
 
-    PRINT ("LINK: %s", yytext);
+    PRINT ("LINK: %s\n", yytext);
     /* First char is a link operator */
     link_all = (*c == ':');
     c++;
@@ -144,16 +144,16 @@ _link ([!:][[:space:]]*{_caps}([[:space:]]*(";"[[:space:]]*{_caps})*[[:space:]]*
     return link_all ? LINK_ALL : LINK;
 }
 {_url} {
-  PRINT ("URL: %s", yytext);
+  PRINT ("URL: %s\n", yytext);
   yylval->ss = g_strdup (yytext);
   gst_parse_unescape (yylval->ss);
   BEGIN (INITIAL);
   return PARSE_URL;
 }
 
-{_operator} { PRINT ("OPERATOR: [%s]", yytext); return *yytext; }
+{_operator} { PRINT ("OPERATOR: [%s]\n", yytext); return *yytext; }
 
-[[:space:]]+ { PRINT ("SPACE: [%s]", yytext); }
+[[:space:]]+ { PRINT ("SPACE: [%s]\n", yytext); }
 
 . {
     PRINT ("Invalid Lexer element: %s\n", yytext);

--- a/tools/development/parser/toplevel.c
+++ b/tools/development/parser/toplevel.c
@@ -1,0 +1,122 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer Pipeline from/to PBTxt Converter Parser
+ * Copyright (C) 2021 MyungJoo Ham <myungjoo.ham@samsung.com>
+ * Copyright (C) 2021 Dongju Chae <dongju.chae@samsung.com>
+ */
+/**
+ * @file    toplevel.c
+ * @date    27 Apr 2021
+ * @brief   Top-level program to parse gst pipeline and pbtxt
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @author  Dongju Chae <dongju.chae@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#include <stdio.h>
+
+#define G_LOG_USE_STRUCTURED 1
+#include <glib.h>
+
+#include "types.h"
+
+#define INPUT_MAXLEN (512)
+
+static gboolean from_pbtxt = FALSE;
+static gboolean verbose = FALSE;
+
+static GOptionEntry entries[] =
+{
+  { "from-pbtxt", 'p', 0, G_OPTION_ARG_NONE, &from_pbtxt, "From pbtxt to gst pipeline", NULL },
+  { "verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose, "Enable verbose messages", NULL },
+  { NULL }
+};
+
+/** @brief Get input string for parsing */
+static gboolean
+get_input_string (char *str)
+{
+  GIOChannel *channel = g_io_channel_unix_new (fileno (stdin));
+  GIOStatus status;
+  gboolean ret = TRUE;
+  GError *error = NULL;
+  gsize length;
+
+  status = g_io_channel_set_encoding (channel, "UTF-8", &error);
+  if (status == G_IO_STATUS_ERROR) {
+    g_printerr ("Error detected while setting encoding: %s\n",
+        error->message);
+    g_error_free (error);
+    ret = FALSE;
+    goto out;
+  }
+
+  status = g_io_channel_read_chars (channel, str, INPUT_MAXLEN, &length, &error);
+  if (status == G_IO_STATUS_ERROR) {
+    g_printerr ("Error detected while reading an input string: %s\n",
+        error->message);
+    g_error_free (error);
+    ret = FALSE;
+    goto out;
+  }
+
+  if (status != G_IO_STATUS_NORMAL) {
+    ret = FALSE;
+    goto out;
+  }
+
+  str[length - 1] = '\x00';
+
+out:
+  g_io_channel_shutdown (channel, TRUE, NULL);
+  return ret;
+}
+
+/** @brief Log handler */
+static void
+log_handler (const gchar *log_domain, GLogLevelFlags log_level,
+    const gchar *message, gpointer user_data)
+{
+  g_printerr ("%s", message);
+}
+
+/** @brief Main routine for this program */
+int
+main (int argc, char *argv[])
+{
+  GError *error = NULL;
+  GOptionContext *context;
+  char input_str[INPUT_MAXLEN] = {'\x00'};
+  GLogLevelFlags log_flags;
+
+  context = g_option_context_new (
+      "- Prototxt to/from GStreamer Pipeline Converver");
+  g_option_context_add_main_entries (context, entries, NULL);
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("Option parsing failed: %s\n", error->message);
+    g_error_free (error);
+    return -1;
+  }
+  g_option_context_free (context);
+
+  if (from_pbtxt) {
+    g_print ("NYI: pbtxt-to-gstpipe conversion\n");
+    return 0;
+  }
+
+  if (!get_input_string (input_str)) {
+    g_printerr ("Unable to get input string\n");
+    return -1;
+  }
+
+  /* all messages from glib */
+  log_flags = G_LOG_LEVEL_MASK | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION;
+  if (!verbose)
+    log_flags &= ~G_LOG_LEVEL_DEBUG;
+
+  g_log_set_handler (NULL, log_flags, log_handler, NULL);
+
+  priv_gst_parse_launch (input_str, NULL, NULL, __PARSE_FLAG_NONE);
+
+  return 0;
+}

--- a/tools/development/parser/types.c
+++ b/tools/development/parser/types.c
@@ -73,7 +73,7 @@ nnstparser_element_unref (_Element * element)
   g_assert (element);
 
   if (element->refcount <= 0) {
-    g_printerr ("ERROR! Refcounter is broken: %s.", __func__);
+    g_critical ("ERROR! Refcounter is broken: %s.", __func__);
   }
   g_assert (element->refcount > 0);
 
@@ -95,7 +95,7 @@ nnstparser_element_ref (_Element * element)
   g_assert (element);
 
   if (element->refcount <= 0) {
-    g_printerr ("ERROR! Refcounter is broken: %s.", __func__);
+    g_critical ("ERROR! Refcounter is broken: %s.", __func__);
   }
   g_assert (element->refcount > 0);
 

--- a/tools/development/parser/types.c
+++ b/tools/development/parser/types.c
@@ -79,6 +79,8 @@ nnstparser_element_unref (_Element * element)
 
   element->refcount--;
   if (element->refcount <= 0) {
+    g_free (element->element);
+    g_free (element->name);
     g_free (element);
     return NULL;
   }
@@ -89,7 +91,7 @@ nnstparser_element_unref (_Element * element)
 /**
  * @brief Ref an element
  */
-void
+_Element *
 nnstparser_element_ref (_Element * element)
 {
   g_assert (element);
@@ -100,6 +102,8 @@ nnstparser_element_ref (_Element * element)
   g_assert (element->refcount > 0);
 
   element->refcount++;
+
+  return element;
 }
 
 /**
@@ -109,39 +113,65 @@ _Element *
 nnstparser_element_from_uri (_URIType type, const gchar * uri,
     const gchar * elementname, void **error)
 {
-  _Element ret = g_malloc (sizeof (_Element));
+  _Element *ret = g_new0 (_Element, 1);
 
   g_assert (type == GST_URI_SINK || type == GST_URI_SRC);
 
   ret->specialType = (type == GST_URI_SINK) ? eST_URI_SINK : eST_URI_SRC;
-  ret->element = g_strdup (url);
+  ret->element = g_strdup (uri);
   ret->name = g_strdup (elementname);
   ret->refcount = 1;
   return ret;
 }
 
 /**
+ * @brief Substitutes GST's gst_element_link_pads_filtered ()
+ */
+gboolean
+nnstparser_element_link_pads_filtered (_Element *src, const gchar *src_pad,
+    _Element *dst, const gchar *dst_pad, gchar *filter)
+{
+  /* NYI */
+}
+
+/**
  * @brief Substitutes GST's gst_bin_get_by_name ()
  */
 _Element *
-nnstparser_bin_get_by_name (_Bin * bin, const gchar * name)
+nnstparser_bin_get_by_name (_Element * bin, const gchar * name)
 {
+  /* NYI */
 }
 
 /**
  * @brief Substitutes GST's gst_bin_get_by_name_recurse_up ()
  */
 _Element *
-nnstparser_bin_get_by_name_recurse_up (_Bin * bin, const gchar * name)
+nnstparser_bin_get_by_name_recurse_up (_Element * bin, const gchar * name)
 {
   _Element *result;
 
   g_return_val_if_fail (__GST_IS_BIN (bin), NULL);
   g_return_val_if_fail (name != NULL, NULL);
 
-  result = gst_bin_get_by_name (bin, name);
+  result = nnstparser_bin_get_by_name (bin, name);
 
   if (!result) {
-    ///////////////// WORKING HERE. May need to analyze gst object parent structure
+    /* NYI: May need to analyze gst object parent structure */
   }
+}
+
+/**
+ * @brief Substitutes GST's gst_bin_add ()
+ */
+gboolean
+nnstparser_bin_add (_Element * bin, _Element * element)
+{
+  g_return_val_if_fail (bin != NULL, FALSE);
+  g_return_val_if_fail (__GST_IS_BIN (bin), FALSE);
+  g_return_val_if_fail (element != NULL, FALSE);
+
+  bin->elements = g_slist_append (bin->elements, element);
+
+  return TRUE;
 }

--- a/tools/development/parser/types.h
+++ b/tools/development/parser/types.h
@@ -147,8 +147,6 @@ gst_parse_unescape (gchar *str)
   walk = str;
   in_quotes = FALSE;
 
-  GST_DEBUG ("unescaping %s", str);
-
   while (*walk) {
     if (*walk == '\\' && !in_quotes) {
       walk++;


### PR DESCRIPTION
This patch updates meson script and resolve build errors.
Please note that delayed links are not considered here.  

It also provides the toplevel program using the parser (i.e., `nnstreamer-parser`)
The below shows its usage example.
```
$ echo "fakesrc name=src ! fakesink name=sink" | ./build/tools/development/parser/nnstreamer-parser

The given string: fakesrc name=src ! fakesink name=sink
got 2 elements and 1 links
linking some pad of fakesrc named src to some pad of fakesink named sink (0/0)
```

TODO LIST
- **gst --> pbtxt**
  Supporting delayed links (e.g., queue)
  Converting graph to pbtxt
- **pbtxt --> gst**
  Implementing pbtxt parser
  Converting graph to gst pipeline
- Porting to be available in the python script

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>