### PR TITLE
[Gst/MQTT] Add buildable skeleton codes for MQTT plugins 

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -35,7 +35,7 @@ override_dh_auto_clean:
 override_dh_auto_configure:
 	mkdir -p ${BUILDDIR}
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
-	-Denable-edgetpu=true -Denable-openvino=true -Dgrpc-support=disabled  \
+	-Denable-edgetpu=true -Denable-openvino=true -Dgrpc-support=disabled -Dmqtt-support=disabled \
 	-Denable-tizen=false -Denable-test=true -Dinstall-test=true ${BUILDDIR}
 
 override_dh_auto_build:

--- a/gst/meson.build
+++ b/gst/meson.build
@@ -1,2 +1,3 @@
-subdir('nnstreamer')
 subdir('join')
+subdir('mqtt')
+subdir('nnstreamer')

--- a/gst/meson.build
+++ b/gst/meson.build
@@ -1,3 +1,5 @@
 subdir('join')
-subdir('mqtt')
+if mqtt_support_is_available
+  subdir('mqtt')
+endif
 subdir('nnstreamer')

--- a/gst/mqtt/meson.build
+++ b/gst/mqtt/meson.build
@@ -1,0 +1,26 @@
+mqtt_plugin_srcs = [
+  join_paths(meson.current_source_dir(), 'mqttsink.c'),
+  join_paths(meson.current_source_dir(), 'mqttsrc.c'),
+  join_paths(meson.current_source_dir(), 'mqttelements.c'),
+]
+
+gstmqtt_shared = shared_library('gstmqtt',
+  mqtt_plugin_srcs,
+  dependencies: [glib_dep, gst_dep, gst_base_dep],
+  install: false,
+  install_dir: plugins_install_dir
+)
+
+gstmqtt_static = static_library('gstmqtt',
+  mqtt_plugin_srcs,
+  dependencies: [glib_dep, gst_dep, gst_base_dep],
+  install: false,
+  install_dir: nnstreamer_libdir
+)
+
+gstmqtt_lib = gstmqtt_shared
+if get_option('default_library') == 'static'
+  gstmqtt_lib = gstmqtt_static
+endif
+
+gstmqtt_dep = declare_dependency(link_with: gstmqtt_lib)

--- a/gst/mqtt/mqttcommon.h
+++ b/gst/mqtt/mqttcommon.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Wook Song <wook16.song@samsung.com>
+ */
+/**
+ * @file    mqttcommon.h
+ * @date    08 Mar 2021
+ * @brief   Common macros and utility functions for GStreamer MQTT plugins
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifndef __GST_MQTT_COMMON_H__
+#define __GST_MQTT_COMMON_H__
+
+#ifndef GST_MQTT_PACKAGE
+#define GST_MQTT_PACKAGE "GStreamer MQTT Plugins"
+#endif /* GST_MQTT_PACKAGE */
+
+#define GST_MQTT_ELEM_NAME_SINK "mqttsink"
+#define GST_MQTT_ELEM_NAME_SRC "mqttsrc"
+
+#endif /* !__GST_MQTT_COMMON_H__ */

--- a/gst/mqtt/mqttelements.c
+++ b/gst/mqtt/mqttelements.c
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Wook Song <wook16.song@samsung.com>
+ */
+/**
+ * @file    mqttsink.c
+ * @date    09 Mar 2021
+ * @brief   Register sub-plugins included in libgstmqtt
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#include <gst/gst.h>
+
+#include "mqttcommon.h"
+#include "mqttsink.h"
+#include "mqttsrc.h"
+
+/**
+ * @brief The entry point of the GStreamer MQTT plugin
+ */
+static gboolean
+plugin_init (GstPlugin * plugin)
+{
+  if (!gst_element_register (plugin, GST_MQTT_ELEM_NAME_SINK, GST_RANK_NONE,
+          GST_TYPE_MQTT_SINK)) {
+    return FALSE;
+  }
+
+  if (!gst_element_register (plugin, GST_MQTT_ELEM_NAME_SRC, GST_RANK_NONE,
+          GST_TYPE_MQTT_SRC)) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+#ifndef PACKAGE
+#define PACKAGE GST_MQTT_PACKAGE
+#endif
+
+GST_PLUGIN_DEFINE (GST_VERSION_MAJOR, GST_VERSION_MINOR, mqtt,
+    "A collection of GStreamer plugins to support MQTT",
+    plugin_init, VERSION, "LGPL", PACKAGE,
+    "https://github.com/nnstreamer/nnstreamer")

--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -19,6 +19,9 @@
 
 #include "mqttsink.h"
 
+static GstStaticPadTemplate sink_pad_template = GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
+
 #define gst_mqtt_sink_parent_class parent_class
 G_DEFINE_TYPE (GstMqttSink, gst_mqtt_sink, GST_TYPE_BASE_SINK);
 
@@ -29,7 +32,16 @@ enum
 {
   PROP_0,
 
+  PROP_NUM_BUFFERS,
+
   PROP_LAST
+};
+
+enum
+{
+  DEFAULT_NUM_BUFFERS = -1,
+  DEFAULT_QOS = TRUE,
+  DEFAULT_SYNC = FALSE,
 };
 
 /** Function prototype declarations */
@@ -52,6 +64,8 @@ gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * buffer);
 static GstFlowReturn
 gst_mqtt_sink_render_list (GstBaseSink * basesink, GstBufferList * list);
 static gboolean gst_mqtt_sink_event (GstBaseSink * basesink, GstEvent * event);
+static gint gst_mqtt_sink_get_num_buffers (GstMqttSink * self);
+static void gst_mqtt_sink_set_num_buffers (GstMqttSink * self, gint num);
 
 /**
  * @brief Initialize GstMqttSink object
@@ -59,7 +73,14 @@ static gboolean gst_mqtt_sink_event (GstBaseSink * basesink, GstEvent * event);
 static void
 gst_mqtt_sink_init (GstMqttSink * self)
 {
-  /** @todo */
+  GstBaseSink *basesink = GST_BASE_SINK (self);
+
+  /** init mqttsink properties */
+  self->num_buffers = DEFAULT_NUM_BUFFERS;
+
+  /** init basesink properties */
+  gst_base_sink_set_qos_enabled (basesink, DEFAULT_QOS);
+  gst_base_sink_set_sync (basesink, DEFAULT_SYNC);
 }
 
 /**
@@ -79,6 +100,12 @@ gst_mqtt_sink_class_init (GstMqttSinkClass * klass)
   gobject_class->get_property = gst_mqtt_sink_get_property;
   gobject_class->finalize = gst_mqtt_sink_class_finalize;
 
+  g_object_class_install_property (gobject_class, PROP_NUM_BUFFERS,
+      g_param_spec_int ("num-buffers", "num-buffers",
+          "Number of (remaining) buffers to accept until sending EOS event (-1 = no limit)",
+          -1, G_MAXINT, DEFAULT_NUM_BUFFERS,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
   gstelement_class->change_state = gst_mqtt_sink_change_state;
 
   gstbasesink_class->start = GST_DEBUG_FUNCPTR (gst_mqtt_sink_start);
@@ -93,6 +120,8 @@ gst_mqtt_sink_class_init (GstMqttSinkClass * klass)
       "MQTT sink", "Sink/MQTT",
       "Publish incoming data streams as a MQTT topic",
       "Wook Song <wook16.song@samsung.com>");
+  gst_element_class_add_static_pad_template (gstelement_class,
+      &sink_pad_template);
 }
 
 /**
@@ -102,7 +131,12 @@ static void
 gst_mqtt_sink_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
+  GstMqttSink *self = GST_MQTT_SINK (object);
+
   switch (prop_id) {
+    case PROP_NUM_BUFFERS:
+      gst_mqtt_sink_set_num_buffers (self, g_value_get_int (value));
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -116,7 +150,12 @@ static void
 gst_mqtt_sink_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec)
 {
+  GstMqttSink *self = GST_MQTT_SINK (object);
+
   switch (prop_id) {
+    case PROP_NUM_BUFFERS:
+      g_value_set_int (value, gst_mqtt_sink_get_num_buffers (self));
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -139,6 +178,36 @@ static GstStateChangeReturn
 gst_mqtt_sink_change_state (GstElement * element, GstStateChange transition)
 {
   GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+  GstMqttSink *mqttsink = GST_MQTT_SINK (element);
+
+  switch (transition) {
+    case GST_STATE_CHANGE_NULL_TO_READY:
+      GST_INFO_OBJECT (mqttsink, "GST_STATE_CHANGE_NULL_TO_READY");
+      break;
+    case GST_STATE_CHANGE_READY_TO_PAUSED:
+      GST_INFO_OBJECT (mqttsink, "GST_STATE_CHANGE_READY_TO_PAUSED");
+      break;
+    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
+      GST_INFO_OBJECT (mqttsink, "GST_STATE_CHANGE_PAUSED_TO_PLAYING");
+      break;
+    default:
+      break;
+  }
+
+  ret = GST_ELEMENT_CLASS (parent_class)->change_state (element, transition);
+
+  switch (transition) {
+    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
+      GST_INFO_OBJECT (mqttsink, "GST_STATE_CHANGE_PLAYING_TO_PAUSED");
+      break;
+    case GST_STATE_CHANGE_PAUSED_TO_READY:
+      GST_INFO_OBJECT (mqttsink, "GST_STATE_CHANGE_PAUSED_TO_READY");
+      break;
+    case GST_STATE_CHANGE_READY_TO_NULL:
+      GST_INFO_OBJECT (mqttsink, "GST_STATE_CHANGE_READY_TO_NULL");
+    default:
+      break;
+  }
 
   return ret;
 }
@@ -167,7 +236,25 @@ gst_mqtt_sink_stop (GstBaseSink * basesink)
 static gboolean
 gst_mqtt_sink_query (GstBaseSink * basesink, GstQuery * query)
 {
-  return TRUE;
+  gboolean ret = FALSE;
+
+  switch (GST_QUERY_TYPE (query)) {
+    case GST_QUERY_SEEKING:{
+      GstFormat fmt;
+
+      /* GST_QUERY_SEEKING is not supported */
+      gst_query_parse_seeking (query, &fmt, NULL, NULL, NULL);
+      gst_query_set_seeking (query, fmt, FALSE, 0, -1);
+      ret = TRUE;
+      break;
+    }
+    default:{
+      ret = GST_BASE_SINK_CLASS (parent_class)->query (basesink, query);
+      break;
+    }
+  }
+
+  return ret;
 }
 
 /**
@@ -176,7 +263,22 @@ gst_mqtt_sink_query (GstBaseSink * basesink, GstQuery * query)
 static GstFlowReturn
 gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * buffer)
 {
+  GstMqttSink *mqttsink = GST_MQTT_SINK (basesink);
+
+  GST_OBJECT_LOCK (mqttsink);
+  if (mqttsink->num_buffers == 0)
+    goto ret_eos;
+
+  if (mqttsink->num_buffers != -1)
+    mqttsink->num_buffers -= 1;
+  GST_OBJECT_UNLOCK (mqttsink);
+
   return GST_FLOW_OK;
+ret_eos:
+  {
+    GST_OBJECT_UNLOCK (mqttsink);
+    return GST_FLOW_EOS;
+  }
 }
 
 /**
@@ -186,7 +288,19 @@ gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * buffer)
 static GstFlowReturn
 gst_mqtt_sink_render_list (GstBaseSink * basesink, GstBufferList * list)
 {
-  return GST_FLOW_OK;
+  guint num_buffers = gst_buffer_list_length (list);
+  GstFlowReturn ret;
+  GstBuffer *buffer;
+  guint i;
+
+  for (i = 0; i < num_buffers; ++i) {
+    buffer = gst_buffer_list_get (list, i);
+    ret = gst_mqtt_sink_render (basesink, buffer);
+    if (ret != GST_FLOW_OK)
+      break;
+  }
+
+  return ret;
 }
 
 /**
@@ -195,5 +309,40 @@ gst_mqtt_sink_render_list (GstBaseSink * basesink, GstBufferList * list)
 static gboolean
 gst_mqtt_sink_event (GstBaseSink * basesink, GstEvent * event)
 {
-  return TRUE;
+  GstEventType type = GST_EVENT_TYPE (event);
+  gboolean ret = FALSE;
+
+  switch (type) {
+    default:
+      ret = GST_BASE_SINK_CLASS (parent_class)->event (basesink, event);
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief Getter for the 'num-buffers' property.
+ */
+static gint
+gst_mqtt_sink_get_num_buffers (GstMqttSink * self)
+{
+  gint num_buffers;
+
+  GST_OBJECT_LOCK (self);
+  num_buffers = self->num_buffers;
+  GST_OBJECT_UNLOCK (self);
+
+  return num_buffers;
+}
+
+/**
+ * @brief Setter for the 'num-buffers' property
+ */
+static void
+gst_mqtt_sink_set_num_buffers (GstMqttSink * self, gint num)
+{
+  GST_OBJECT_LOCK (self);
+  self->num_buffers = num;
+  GST_OBJECT_UNLOCK (self);
 }

--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -1,0 +1,199 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Wook Song <wook16.song@samsung.com>
+ */
+/**
+ * @file    mqttsink.c
+ * @date    08 Mar 2021
+ * @brief   Publish incoming data streams as a MQTT topic
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <gst/base/gstbasesink.h>
+
+#include "mqttsink.h"
+
+#define gst_mqtt_sink_parent_class parent_class
+G_DEFINE_TYPE (GstMqttSink, gst_mqtt_sink, GST_TYPE_BASE_SINK);
+
+GST_DEBUG_CATEGORY_STATIC (gst_mqtt_sink_debug);
+#define GST_CAT_DEFAULT gst_mqtt_sink_debug
+
+enum
+{
+  PROP_0,
+
+  PROP_LAST
+};
+
+/** Function prototype declarations */
+static void
+gst_mqtt_sink_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec);
+static void
+gst_mqtt_sink_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec);
+static void gst_mqtt_sink_class_finalize (GObject * object);
+
+static GstStateChangeReturn
+gst_mqtt_sink_change_state (GstElement * element, GstStateChange transition);
+
+static gboolean gst_mqtt_sink_start (GstBaseSink * basesink);
+static gboolean gst_mqtt_sink_stop (GstBaseSink * basesink);
+static gboolean gst_mqtt_sink_query (GstBaseSink * basesink, GstQuery * query);
+static GstFlowReturn
+gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * buffer);
+static GstFlowReturn
+gst_mqtt_sink_render_list (GstBaseSink * basesink, GstBufferList * list);
+static gboolean gst_mqtt_sink_event (GstBaseSink * basesink, GstEvent * event);
+
+/**
+ * @brief Initialize GstMqttSink object
+ */
+static void
+gst_mqtt_sink_init (GstMqttSink * self)
+{
+  /** @todo */
+}
+
+/**
+ * @brief Initialize GstMqttSinkClass object
+ */
+static void
+gst_mqtt_sink_class_init (GstMqttSinkClass * klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
+  GstBaseSinkClass *gstbasesink_class = GST_BASE_SINK_CLASS (klass);
+
+  GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, GST_MQTT_ELEM_NAME_SINK, 0,
+      "MQTT sink");
+
+  gobject_class->set_property = gst_mqtt_sink_set_property;
+  gobject_class->get_property = gst_mqtt_sink_get_property;
+  gobject_class->finalize = gst_mqtt_sink_class_finalize;
+
+  gstelement_class->change_state = gst_mqtt_sink_change_state;
+
+  gstbasesink_class->start = GST_DEBUG_FUNCPTR (gst_mqtt_sink_start);
+  gstbasesink_class->stop = GST_DEBUG_FUNCPTR (gst_mqtt_sink_stop);
+  gstbasesink_class->query = GST_DEBUG_FUNCPTR (gst_mqtt_sink_query);
+  gstbasesink_class->render = GST_DEBUG_FUNCPTR (gst_mqtt_sink_render);
+  gstbasesink_class->render_list =
+      GST_DEBUG_FUNCPTR (gst_mqtt_sink_render_list);
+  gstbasesink_class->event = GST_DEBUG_FUNCPTR (gst_mqtt_sink_event);
+
+  gst_element_class_set_static_metadata (gstelement_class,
+      "MQTT sink", "Sink/MQTT",
+      "Publish incoming data streams as a MQTT topic",
+      "Wook Song <wook16.song@samsung.com>");
+}
+
+/**
+ * @brief The setter for the mqttsink's properties
+ */
+static void
+gst_mqtt_sink_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  switch (prop_id) {
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief The getter for the mqttsink's properties
+ */
+static void
+gst_mqtt_sink_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  switch (prop_id) {
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief Finalize GstMqttSinkClass object
+ */
+static void
+gst_mqtt_sink_class_finalize (GObject * object)
+{
+  G_OBJECT_CLASS (parent_class)->finalize (object);
+}
+
+/**
+ * @brief Handle mqttsink's state change
+ */
+static GstStateChangeReturn
+gst_mqtt_sink_change_state (GstElement * element, GstStateChange transition)
+{
+  GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+
+  return ret;
+}
+
+/**
+ * @brief Start mqttsink, called when state changed null to ready
+ */
+static gboolean
+gst_mqtt_sink_start (GstBaseSink * basesink)
+{
+  return TRUE;
+}
+
+/**
+ * @brief Stop mqttsink, called when state changed ready to null
+ */
+static gboolean
+gst_mqtt_sink_stop (GstBaseSink * basesink)
+{
+  return TRUE;
+}
+
+/**
+ * @brief Perform queries on the element
+ */
+static gboolean
+gst_mqtt_sink_query (GstBaseSink * basesink, GstQuery * query)
+{
+  return TRUE;
+}
+
+/**
+ * @brief The callback to process each buffer receiving on the sink pad
+ */
+static GstFlowReturn
+gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * buffer)
+{
+  return GST_FLOW_OK;
+}
+
+/**
+ * @brief The callback to process GstBufferList (instead of a single buffer)
+ *        on the sink pad
+ */
+static GstFlowReturn
+gst_mqtt_sink_render_list (GstBaseSink * basesink, GstBufferList * list)
+{
+  return GST_FLOW_OK;
+}
+
+/**
+ * @brief Handle events arriving on the sink pad
+ */
+static gboolean
+gst_mqtt_sink_event (GstBaseSink * basesink, GstEvent * event)
+{
+  return TRUE;
+}

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -43,6 +43,7 @@ typedef struct _GstMqttSinkClass GstMqttSinkClass;
  */
 struct _GstMqttSink {
   GstBaseSink parent;
+  guint num_buffers;
 };
 
 /**

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Wook Song <wook16.song@samsung.com>
+ */
+/**
+ * @file    mqttsink.h
+ * @date    08 Mar 2021
+ * @brief   Publish incoming data streams as a MQTT topic
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifndef __GST_MQTT_SINK_H__
+#define __GST_MQTT_SINK_H__
+#include <gst/base/gstbasesink.h>
+#include <gst/gst.h>
+
+#include "mqttcommon.h"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_MQTT_SINK \
+    (gst_mqtt_sink_get_type())
+#define GST_MQTT_SINK(obj) \
+    (G_TYPE_CHECK_INSTANCE_CAST ((obj), GST_TYPE_MQTT_SINK, GstMqttSink))
+#define GST_IS_MQTT_SINK(obj) \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GST_TYPE_MQTT_SINK))
+#define GST_MQTT_SINK_CAST(obj) \
+    ((GstMqttSink *) obj)
+#define GST_MQTT_SINK_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_CAST ((klass), GST_TYPE_MQTT_SINK, GstMqttSinkClass))
+#define GST_IS_MQTT_SINK_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_TYPE ((klass), GST_TYPE_MQTT_SINK))
+
+typedef struct _GstMqttSink GstMqttSink;
+typedef struct _GstMqttSinkClass GstMqttSinkClass;
+
+/**
+ * @brief GstMqttSink data structure.
+ *
+ * GstMqttSink inherits GstBaseSink.
+ */
+struct _GstMqttSink {
+  GstBaseSink parent;
+};
+
+/**
+ * @brief GstMqttSinkClass data structure.
+ *
+ * GstMqttSinkClass inherits GstBaseSinkClass.
+ */
+struct _GstMqttSinkClass {
+  GstBaseSinkClass parent_class;
+};
+
+GType gst_mqtt_sink_get_type (void);
+
+G_END_DECLS
+#endif /* !__GST_MQTT_SINK_H__ */

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -1,0 +1,227 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Wook Song <wook16.song@samsung.com>
+ */
+/**
+ * @file    mqttsrc.c
+ * @date    08 Mar 2021
+ * @brief   Subscribe a MQTT topic and push incoming data to the GStreamer pipeline
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <gst/base/gstbasesrc.h>
+
+#include "mqttsrc.h"
+
+#define gst_mqtt_src_parent_class parent_class
+G_DEFINE_TYPE (GstMqttSrc, gst_mqtt_src, GST_TYPE_BASE_SRC);
+
+GST_DEBUG_CATEGORY_STATIC (gst_mqtt_src_debug);
+#define GST_CAT_DEFAULT gst_mqtt_src_debug
+
+enum
+{
+  PROP_0,
+
+  PROP_LAST
+};
+
+
+/** Function prototype declarations */
+static void
+gst_mqtt_src_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec);
+static void
+gst_mqtt_src_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec);
+static void gst_mqtt_src_class_finalize (GObject * object);
+
+static GstStateChangeReturn
+gst_mqtt_src_change_state (GstElement * element, GstStateChange transition);
+
+static gboolean gst_mqtt_src_start (GstBaseSrc * basesrc);
+static gboolean gst_mqtt_src_stop (GstBaseSrc * basesrc);
+static gboolean gst_mqtt_src_event (GstBaseSrc * basesrc, GstEvent * event);
+static gboolean gst_mqtt_src_set_caps (GstBaseSrc * basesrc, GstCaps * caps);
+static GstCaps *gst_mqtt_src_get_caps (GstBaseSrc * basesrc, GstCaps * filter);
+static GstCaps *gst_mqtt_src_fixate (GstBaseSrc * basesrc, GstCaps * caps);
+static void
+gst_mqtt_src_get_times (GstBaseSrc * basesrc, GstBuffer * buffer,
+    GstClockTime * start, GstClockTime * end);
+static gboolean gst_mqtt_src_get_size (GstBaseSrc * basesrc, guint64 * size);
+static gboolean gst_mqtt_src_is_seekable (GstBaseSrc * basesrc);
+static GstFlowReturn
+gst_mqtt_src_create (GstBaseSrc * basesrc, guint64 offset, guint size,
+    GstBuffer ** buf);
+static GstFlowReturn
+gst_mqtt_src_alloc (GstBaseSrc * basesrc, guint64 offset, guint size,
+    GstBuffer ** buf);
+static GstFlowReturn
+gst_mqtt_src_fill (GstBaseSrc * basesrc, guint64 offset, guint size,
+    GstBuffer * buf);
+
+/** Function defintions */
+static void
+gst_mqtt_src_init (GstMqttSrc * self)
+{
+  /** @todo */
+}
+
+static void
+gst_mqtt_src_class_init (GstMqttSrcClass * klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
+  GstBaseSrcClass *gstbasesrc_class = GST_BASE_SRC_CLASS (klass);
+
+  GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, GST_MQTT_ELEM_NAME_SRC, 0,
+      "MQTT src");
+
+  gobject_class->set_property = gst_mqtt_src_set_property;
+  gobject_class->get_property = gst_mqtt_src_get_property;
+  gobject_class->finalize = gst_mqtt_src_class_finalize;
+
+  gstelement_class->change_state =
+      GST_DEBUG_FUNCPTR (gst_mqtt_src_change_state);
+  gst_element_class_set_static_metadata (gstelement_class,
+      "MQTT Source",
+      "Source/MQTT",
+      "Subscribe a MQTT topic and push incoming data to the GStreamer pipeline",
+      "Wook Song <wook16.song@samsung.com>");
+
+  gstbasesrc_class->start = GST_DEBUG_FUNCPTR (gst_mqtt_src_start);
+  gstbasesrc_class->stop = GST_DEBUG_FUNCPTR (gst_mqtt_src_stop);
+  gstbasesrc_class->event = GST_DEBUG_FUNCPTR (gst_mqtt_src_event);
+  gstbasesrc_class->set_caps = GST_DEBUG_FUNCPTR (gst_mqtt_src_set_caps);
+  gstbasesrc_class->get_caps = GST_DEBUG_FUNCPTR (gst_mqtt_src_get_caps);
+  gstbasesrc_class->fixate = GST_DEBUG_FUNCPTR (gst_mqtt_src_fixate);
+  gstbasesrc_class->get_times = GST_DEBUG_FUNCPTR (gst_mqtt_src_get_times);
+  gstbasesrc_class->get_size = GST_DEBUG_FUNCPTR (gst_mqtt_src_get_size);
+  gstbasesrc_class->is_seekable = GST_DEBUG_FUNCPTR (gst_mqtt_src_is_seekable);
+  gstbasesrc_class->create = GST_DEBUG_FUNCPTR (gst_mqtt_src_create);
+  gstbasesrc_class->alloc = GST_DEBUG_FUNCPTR (gst_mqtt_src_alloc);
+  gstbasesrc_class->fill = GST_DEBUG_FUNCPTR (gst_mqtt_src_fill);
+}
+
+static void
+gst_mqtt_src_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  switch (prop_id) {
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+gst_mqtt_src_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  switch (prop_id) {
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+gst_mqtt_src_class_finalize (GObject * object)
+{
+  G_OBJECT_CLASS (parent_class)->finalize (object);
+}
+
+static GstStateChangeReturn
+gst_mqtt_src_change_state (GstElement * element, GstStateChange transition)
+{
+  GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+
+  return ret;
+}
+
+static gboolean
+gst_mqtt_src_start (GstBaseSrc * basesrc)
+{
+  return TRUE;
+}
+
+static gboolean
+gst_mqtt_src_stop (GstBaseSrc * basesrc)
+{
+  return TRUE;
+}
+
+static gboolean
+gst_mqtt_src_event (GstBaseSrc * basesrc, GstEvent * event)
+{
+  return TRUE;
+}
+
+static gboolean
+gst_mqtt_src_set_caps (GstBaseSrc * basesrc, GstCaps * caps)
+{
+  return TRUE;
+}
+
+static GstCaps *
+gst_mqtt_src_get_caps (GstBaseSrc * basesrc, GstCaps * filter)
+{
+  GstCaps *caps = gst_caps_new_empty ();
+
+  return caps;
+}
+
+static GstCaps *
+gst_mqtt_src_fixate (GstBaseSrc * basesrc, GstCaps * caps)
+{
+  caps = gst_caps_make_writable (caps);
+  caps = GST_BASE_SRC_CLASS (parent_class)->fixate (basesrc, caps);
+
+  return caps;
+}
+
+static void
+gst_mqtt_src_get_times (GstBaseSrc * basesrc, GstBuffer * buffer,
+    GstClockTime * start, GstClockTime * end)
+{
+  return;
+}
+
+static gboolean
+gst_mqtt_src_get_size (GstBaseSrc * basesrc, guint64 * size)
+{
+  return TRUE;
+}
+
+static gboolean
+gst_mqtt_src_is_seekable (GstBaseSrc * basesrc)
+{
+  return TRUE;
+}
+
+static GstFlowReturn
+gst_mqtt_src_create (GstBaseSrc * basesrc, guint64 offset, guint size,
+    GstBuffer ** buf)
+{
+  return GST_FLOW_OK;
+}
+
+static GstFlowReturn
+gst_mqtt_src_alloc (GstBaseSrc * basesrc, guint64 offset, guint size,
+    GstBuffer ** buf)
+{
+  return GST_FLOW_OK;
+}
+
+static GstFlowReturn
+gst_mqtt_src_fill (GstBaseSrc * basesrc, guint64 offset, guint size,
+    GstBuffer * buf)
+{
+  return GST_FLOW_OK;
+}

--- a/gst/mqtt/mqttsrc.h
+++ b/gst/mqtt/mqttsrc.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Wook Song <wook16.song@samsung.com>
+ */
+/**
+ * @file    mqttsrc.h
+ * @date    08 Mar 2021
+ * @brief   Subscribe a MQTT topic and push incoming data to the GStreamer pipeline
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifndef __GST_MQTT_SRC_H__
+#define __GST_MQTT_SRC_H__
+#include <gst/base/gstbasesrc.h>
+#include <gst/gst.h>
+
+#include "mqttcommon.h"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_MQTT_SRC \
+    (gst_mqtt_src_get_type())
+#define GST_MQTT_SRC(obj) \
+    (G_TYPE_CHECK_INSTANCE_CAST ((obj), GST_TYPE_MQTT_SRC, GstMqttSrc))
+#define GST_IS_MQTT_SRC(obj)  \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GST_TYPE_MQTT_SRC))
+#define GST_MQTT_SRC_CAST(obj) \
+    ((GstMqttSrc *) obj)
+#define GST_MQTT_SRC_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_CAST ((klass), GST_TYPE_MQTT_SRC, GstMqttSrcClass))
+#define GST_IS_MQTT_SRC_CLASS(klass) \
+    (G_TYPE_CHECK_CLASS_TYPE ((klass), GST_TYPE_MQTT_SRC))
+
+typedef struct _GstMqttSrc GstMqttSrc;
+typedef struct _GstMqttSrcClass GstMqttSrcClass;
+
+struct _GstMqttSrc {
+  GstBaseSrc parent;
+};
+
+struct _GstMqttSrcClass {
+  GstBaseSrcClass parent_class;
+};
+
+GType gst_mqtt_src_get_type (void);
+
+G_END_DECLS
+#endif /* !__GST_MQTT_SRC_H__ */

--- a/meson.build
+++ b/meson.build
@@ -223,6 +223,12 @@ if not get_option('grpc-support').disabled()
   grpcpp_dep = dependency('grpc++', required: false)
 endif
 
+# mqtt (paho.mqtt.c)
+pahomqttc_dep = dependency('', required: false)
+if not get_option('mqtt-support').disabled()
+  pahomqttc_dep = dependency('paho-mqtt-c', required: false)
+endif
+
 # features registration to be controlled
 #
 # register feature as follows
@@ -297,6 +303,9 @@ features = {
   'lua-support': {
     'target': 'lua',
     'project_args': { 'ENABLE_LUA' : 1}
+  },
+  'mqtt-support': {
+    'extra_deps': [ pahomqttc_dep ]
   }
 }
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,6 +18,7 @@ option('flatbuf-support', type: 'feature', value: 'auto')
 option('tensorrt-support', type: 'feature', value: 'auto')
 option('grpc-support', type: 'feature', value: 'auto')
 option('lua-support', type: 'feature', value: 'auto')
+option('mqtt-support', type: 'feature', value: 'auto')
 
 # booleans & other options
 option('enable-test', type: 'boolean', value: true)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -31,6 +31,7 @@
 %define		grpc_support 1
 %define		pytorch_support 0
 %define		caffe2_support 0
+%define		mqtt_support 0
 
 %define		check_test 1
 %define		release_test 1
@@ -635,6 +636,13 @@ Provides additional gstreamer plugins for nnstreamer pipelines
 %define enable_flatbuf -Dflatbuf-support=disabled
 %endif
 
+# Support mqtt
+%if 0%{?mqtt_support}
+%define enable_mqtt -Dmqtt-support=enabled
+%else
+%define enable_mqtt -Dmqtt-support=disabled
+%endif
+
 %prep
 rm -rf ./build
 %setup -q
@@ -663,7 +671,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir
 	%{enable_tizen} %{element_restriction} -Denable-env-var=false -Denable-symbolic-link=false \
 	%{enable_tf_lite} %{enable_tf2_lite} %{enable_tf} %{enable_pytorch} %{enable_caffe2} %{enable_python3} \
 	%{enable_nnfw_runtime} %{enable_mvncsdk2} %{enable_openvino} %{enable_armnn} %{enable_edgetpu}  %{enable_vivante} %{enable_flatbuf} \
-	%{enable_tizen_sensor} %{enable_test} %{enable_test_coverage} %{install_test} \
+	%{enable_tizen_sensor} %{enable_mqtt} %{enable_test} %{enable_test_coverage} %{install_test} \
 	build
 
 ninja -C build %{?_smp_mflags}


### PR DESCRIPTION
This PR adds skeleton codes for GStreamer plugins that enable GStreamer/NNStreamer pipelines to publish and subscribe MQTT topics. By default, the build option for the MQTT plugins is disabled for the Ubuntu and Tizen platforms to avoid CI build break. 

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped