### PR TITLE
[Gst/MQTT] Support timestamp synchronization between nodes and dynamic buffer re-allocation

### DIFF
--- a/gst/mqtt/mqttcommon.h
+++ b/gst/mqtt/mqttcommon.h
@@ -30,6 +30,8 @@
  */
 #define GST_MQTT_MAX_NUM_MEMS   16
 
+#define GST_US_TO_NS_MULTIPLIER 1000
+
 /**
  * @brief Defined a custom data type, GstMQTTMessageHdr
  *
@@ -42,6 +44,11 @@ typedef struct _GstMQTTMessageHdr {
     struct {
       guint num_mems;
       gsize size_mems[GST_MQTT_MAX_NUM_MEMS];
+      gint64 base_time_epoch;
+      gint64 sent_time_epoch;
+      GstClockTime duration;
+      GstClockTime dts;
+      GstClockTime pts;
     };
     guint8 _reserved_hdr[GST_MQTT_LEN_MSG_HDR];
   };

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -60,6 +60,7 @@ typedef enum _mqtt_sink_state_t {
 struct _GstMqttSink {
   GstBaseSink parent;
   guint num_buffers;
+  gsize max_msg_buf_size;
   GQuark gquark_err_tag;
   GError *err;
   gint64 base_time_epoch;

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -62,6 +62,7 @@ struct _GstMqttSink {
   guint num_buffers;
   GQuark gquark_err_tag;
   GError *err;
+  gint64 base_time_epoch;
   gchar *mqtt_client_id;
   gchar *mqtt_host_address;
   gchar *mqtt_host_port;

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -126,7 +126,20 @@ static void cb_memory_wrapped_destroy (void *p);
 
 static GstMQTTMessageHdr *_extract_mqtt_msg_hdr_from (GstMemory * mem,
     GstMemory ** hdr_mem, GstMapInfo * hdr_map_info);
+static void _put_timestamp_on_gst_buf (GstMqttSrc * self,
+    GstMQTTMessageHdr * hdr, GstBuffer * buf);
 
+/**
+ * @brief A utility function to check whether the timestamp marked by _put_timestamp_on_gst_buf () is valid or not
+ */
+static inline gboolean
+_is_gst_buffer_timestamp_valid (GstBuffer * buf)
+{
+  if (!GST_BUFFER_PTS_IS_VALID (buf) && !GST_BUFFER_DTS_IS_VALID (buf) &&
+      !GST_BUFFER_DURATION_IS_VALID (buf))
+    return FALSE;
+  return TRUE;
+}
 
 /** Function defintions */
 /**
@@ -139,6 +152,8 @@ gst_mqtt_src_init (GstMqttSrc * self)
   MQTTAsync_responseOptions respn_opts = MQTTAsync_responseOptions_initializer;
 
   self->gquark_err_tag = g_quark_from_string (TAG_ERR_MQTTSRC);
+
+  gst_base_src_set_live (GST_BASE_SRC (self), TRUE);
 
   /** init mqttsrc properties */
   self->mqtt_client_id = g_strdup (DEFAULT_MQTT_CLIENT_ID);
@@ -164,6 +179,7 @@ gst_mqtt_src_init (GstMqttSrc * self)
   self->is_subscribed = FALSE;
   g_cond_init (&self->mqtt_src_gcond);
   g_mutex_init (&self->mqtt_src_mutex);
+  self->base_time_epoch = GST_CLOCK_TIME_NONE;
 }
 
 /**
@@ -340,6 +356,10 @@ gst_mqtt_src_change_state (GstElement * element, GstStateChange transition)
 {
   GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
   GstMqttSrc *self = GST_MQTT_SRC (element);
+  GstClock *elem_clock;
+  GstClockTime base_time;
+  GstClockTime cur_time;
+  GstClockTimeDiff diff;
 
   switch (transition) {
     case GST_STATE_CHANGE_NULL_TO_READY:
@@ -354,6 +374,16 @@ gst_mqtt_src_change_state (GstElement * element, GstStateChange transition)
       GST_INFO_OBJECT (self, "GST_STATE_CHANGE_READY_TO_PAUSED");
       break;
     case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
+      self->base_time_epoch = GST_CLOCK_TIME_NONE;
+      elem_clock = gst_element_get_clock (element);
+      if (!elem_clock)
+        break;
+      base_time = gst_element_get_base_time (element);
+      cur_time = gst_clock_get_time (elem_clock);
+      gst_object_unref (elem_clock);
+      diff = GST_CLOCK_DIFF (base_time, cur_time);
+      self->base_time_epoch =
+          g_get_real_time () * GST_US_TO_NS_MULTIPLIER - diff;
       GST_INFO_OBJECT (self, "GST_STATE_CHANGE_PAUSED_TO_PLAYING");
       break;
     default:
@@ -462,7 +492,21 @@ static void
 gst_mqtt_src_get_times (GstBaseSrc * basesrc, GstBuffer * buffer,
     GstClockTime * start, GstClockTime * end)
 {
-  return;
+  GstClockTime sync_ts;
+  GstClockTime duration;
+
+  sync_ts = GST_BUFFER_DTS (buffer);
+  duration = GST_BUFFER_DURATION (buffer);
+
+  if (!GST_CLOCK_TIME_IS_VALID (sync_ts))
+    sync_ts = GST_BUFFER_PTS (buffer);
+
+  if (GST_CLOCK_TIME_IS_VALID (sync_ts)) {
+    *start = sync_ts;
+    if (GST_CLOCK_TIME_IS_VALID (duration)) {
+      *end = sync_ts + duration;
+    }
+  }
 }
 
 /**
@@ -496,10 +540,19 @@ gst_mqtt_src_create (GstBaseSrc * basesrc, guint64 offset, guint size,
   g_mutex_unlock (&self->mqtt_src_mutex);
 
   while (elapsed > 0) {
+    /** @todo DEFAULT_MQTT_SUB_TIMEOUT_MIN is too long */
     *buf = g_async_queue_timeout_pop (self->aqueue,
         DEFAULT_MQTT_SUB_TIMEOUT_MIN);
-    if (*buf || self->err)
+    if (*buf) {
+      /** This buffer is comming from the past. Drop it */
+      if (!_is_gst_buffer_timestamp_valid (*buf)) {
+        elapsed = self->mqtt_sub_timeout;
+        continue;
+      }
       break;
+    } else if (self->err) {
+      break;
+    }
     elapsed = elapsed - DEFAULT_MQTT_SUB_TIMEOUT_MIN;
   }
 
@@ -737,7 +790,8 @@ cb_mqtt_on_message_arrived (void *context, char *topic_name, int topic_len,
     gst_buffer_append_memory (buffer, each_memory);
     offset += each_size;
   }
-
+  /** Timestamp synchronization */
+  _put_timestamp_on_gst_buf (self, mqtt_msg_hdr, buffer);
   g_async_queue_push (self->aqueue, buffer);
 
   gst_memory_unmap (hdr_mem, &hdr_map_info);
@@ -774,8 +828,9 @@ cb_mqtt_on_connect (void *context, MQTTAsync_successData * response)
   g_cond_broadcast (&self->mqtt_src_gcond);
   g_mutex_unlock (&self->mqtt_src_mutex);
 
+  self->mqtt_respn_opts.subscribeOptions.retainHandling = 1;
   /** @todo Support QoS option */
-  ret = MQTTAsync_subscribe (self->mqtt_client_handle, self->mqtt_topic, 1,
+  ret = MQTTAsync_subscribe (self->mqtt_client_handle, self->mqtt_topic, 0,
       &self->mqtt_respn_opts);
   if (ret != MQTTASYNC_SUCCESS) {
     g_printerr ("Failed to start subscribe, return code %d\n", ret);
@@ -855,4 +910,32 @@ _extract_mqtt_msg_hdr_from (GstMemory * mem, GstMemory ** hdr_mem,
   }
 
   return (GstMQTTMessageHdr *) hdr_map_info->data;
+}
+
+/**
+  * @brief A utility function to put the timestamp information
+  *        onto a GstBuffer-typed buffer using the given packet header
+  */
+static void
+_put_timestamp_on_gst_buf (GstMqttSrc * self, GstMQTTMessageHdr * hdr,
+    GstBuffer * buf)
+{
+  gint64 diff_base_epoch = hdr->base_time_epoch - self->base_time_epoch;
+
+  buf->pts = GST_CLOCK_TIME_NONE;
+  buf->dts = GST_CLOCK_TIME_NONE;
+  buf->duration = GST_CLOCK_TIME_NONE;
+
+  if (hdr->sent_time_epoch < self->base_time_epoch)
+    return;
+
+  if (hdr->pts != GST_CLOCK_TIME_NONE) {
+    buf->pts = hdr->pts + diff_base_epoch;
+  }
+
+  if (hdr->dts != GST_CLOCK_TIME_NONE) {
+    buf->dts = hdr->dts + diff_base_epoch;
+  }
+
+  buf->duration = hdr->duration;
 }

--- a/gst/mqtt/mqttsrc.h
+++ b/gst/mqtt/mqttsrc.h
@@ -47,6 +47,7 @@ struct _GstMqttSrc {
   GstBaseSrc parent;
   GQuark gquark_err_tag;
   GError *err;
+  gint64 base_time_epoch;
   gchar *mqtt_client_id;
   gchar *mqtt_host_address;
   gchar *mqtt_host_port;


### PR DESCRIPTION
This PR addresses #3196, which is timestamp synchronization between MQTT pipeline nodes. Other changes included in this PR as follows:
- Introduce a new property, max-buffer-size
  - Using this property, mqttsink could exploit a static-sized buffer instead of dynamically allocating buffers according to the changes of incoming buffer' size.
- Support dynamic buffer re-allocation when the static-sized buffer mode is disabled
  - To handle the case when the size of an incoming buffer is larger than the existing dynamically allocated one, mqttsink frees the existing buffer and re-allocates a new buffer.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
