### PR TITLE
[Gst/MQTT] Support dynamic Caps re-negotiation according to the Caps information sent from the other node @open sesame 05/19 13:00

### DIFF
--- a/gst/mqtt/mqttcommon.h
+++ b/gst/mqtt/mqttcommon.h
@@ -21,8 +21,8 @@
 #define GST_MQTT_ELEM_NAME_SINK "mqttsink"
 #define GST_MQTT_ELEM_NAME_SRC "mqttsrc"
 
-#define GST_MQTT_LEN_MSG_HDR    512
-
+#define GST_MQTT_LEN_MSG_HDR          1024
+#define GST_MQTT_MAX_LEN_GST_CPAS_STR 512
 /**
  * @brief GST_BUFFER_MEM_MAX in gstreamer/gstbuffer.c is 16. To represent each
  *        size of the memory block that the GstBuffer contains, GST_MQTT_MAX_NUM_MEMS
@@ -49,6 +49,7 @@ typedef struct _GstMQTTMessageHdr {
       GstClockTime duration;
       GstClockTime dts;
       GstClockTime pts;
+      gchar gst_caps_str[GST_MQTT_MAX_LEN_GST_CPAS_STR];
     };
     guint8 _reserved_hdr[GST_MQTT_LEN_MSG_HDR];
   };

--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -657,11 +657,6 @@ gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * in_buf)
 
   /** Allocate a message buffer */
   if ((!self->mqtt_msg_buf) && (self->mqtt_msg_buf_size == 0)) {
-    if (!_mqtt_set_msg_buf_hdr (in_buf, &self->mqtt_msg_hdr)) {
-      ret = GST_FLOW_ERROR;
-      goto ret_with;
-    }
-
     if (self->max_msg_buf_size == 0) {
       self->mqtt_msg_buf_size = in_buf_size + GST_MQTT_LEN_MSG_HDR;
     } else {
@@ -682,13 +677,15 @@ gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * in_buf)
       ret = GST_FLOW_ERROR;
       goto ret_with;
     }
-
-    msg_pub = self->mqtt_msg_buf;
-    memcpy (msg_pub, &self->mqtt_msg_hdr, sizeof (self->mqtt_msg_hdr));
-  } else {
-    msg_pub = self->mqtt_msg_buf;
   }
 
+  msg_pub = self->mqtt_msg_buf;
+
+  if (!_mqtt_set_msg_buf_hdr (in_buf, &self->mqtt_msg_hdr)) {
+    ret = GST_FLOW_ERROR;
+    goto ret_with;
+  }
+  memcpy (msg_pub, &self->mqtt_msg_hdr, sizeof (self->mqtt_msg_hdr));
   _put_timestamp_to_msg_buf_hdr (self, in_buf, (GstMQTTMessageHdr *) msg_pub);
 
   in_buf_mem = gst_buffer_get_all_memory (in_buf);

--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -371,8 +371,14 @@ gst_mqtt_sink_class_finalize (GObject * object)
   GstMqttSink *self = GST_MQTT_SINK (object);
 
   g_free (self->mqtt_host_address);
+  self->mqtt_host_address = NULL;
   g_free (self->mqtt_host_port);
+  self->mqtt_host_port = NULL;
   g_free (self->mqtt_client_handle);
+  self->mqtt_client_handle = NULL;
+  g_free (self->mqtt_msg_buf);
+  self->mqtt_msg_buf = NULL;
+
   if (self->err)
     g_error_free (self->err);
   if (self->in_caps)

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -59,6 +59,7 @@ typedef enum _mqtt_sink_state_t {
  */
 struct _GstMqttSink {
   GstBaseSink parent;
+  GstCaps *in_caps;
   guint num_buffers;
   gsize max_msg_buf_size;
   GQuark gquark_err_tag;

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -82,6 +82,7 @@ gst_mqtt_src_change_state (GstElement * element, GstStateChange transition);
 static gboolean gst_mqtt_src_start (GstBaseSrc * basesrc);
 static gboolean gst_mqtt_src_stop (GstBaseSrc * basesrc);
 static GstCaps *gst_mqtt_src_get_caps (GstBaseSrc * basesrc, GstCaps * filter);
+static gboolean gst_mqtt_src_renegotiate (GstBaseSrc * basesrc);
 
 static void
 gst_mqtt_src_get_times (GstBaseSrc * basesrc, GstBuffer * buffer,
@@ -180,6 +181,7 @@ gst_mqtt_src_init (GstMqttSrc * self)
   g_cond_init (&self->mqtt_src_gcond);
   g_mutex_init (&self->mqtt_src_mutex);
   self->base_time_epoch = GST_CLOCK_TIME_NONE;
+  self->caps = NULL;
 }
 
 /**
@@ -342,6 +344,8 @@ gst_mqtt_src_class_finalize (GObject * object)
   g_free (self->mqtt_host_port);
   if (self->err)
     g_error_free (self->err);
+  if (self->caps)
+    gst_caps_unref (self->caps);
 
   g_clear_pointer (&self->aqueue, g_async_queue_unref);
 
@@ -469,7 +473,7 @@ gst_mqtt_src_stop (GstBaseSrc * basesrc)
 static GstCaps *
 gst_mqtt_src_get_caps (GstBaseSrc * basesrc, GstCaps * filter)
 {
-  GstPad *pad = basesrc->srcpad;
+  GstPad *pad = GST_BASE_SRC_PAD (basesrc);
   GstCaps *cur_caps = gst_pad_get_current_caps (pad);
   GstCaps *caps = gst_caps_new_any ();
 
@@ -483,6 +487,69 @@ gst_mqtt_src_get_caps (GstBaseSrc * basesrc, GstCaps * filter)
   }
 
   return caps;
+}
+
+/**
+ * @brief Do negotiation procedure again if it needed
+ */
+static gboolean
+gst_mqtt_src_renegotiate (GstBaseSrc * basesrc)
+{
+  GstMqttSrc *self = GST_MQTT_SRC (basesrc);
+  GstCaps *caps = NULL;
+  GstCaps *peercaps = NULL;
+  GstCaps *thiscaps;
+  gboolean result = FALSE;
+  GstCaps *fixed_caps = NULL;
+
+  if (self->caps == NULL || gst_caps_is_any (self->caps))
+    goto no_nego_needed;
+
+  thiscaps = gst_pad_query_caps (GST_BASE_SRC_PAD (basesrc), NULL);
+  if (thiscaps && gst_caps_is_equal (self->caps, thiscaps)) {
+    gst_caps_unref (thiscaps);
+    goto no_nego_needed;
+  }
+
+  peercaps = gst_pad_peer_query_caps (GST_BASE_SRC_PAD (basesrc), self->caps);
+  if (peercaps) {
+    caps = gst_caps_ref (peercaps);
+    if (peercaps != self->caps)
+      gst_caps_unref (peercaps);
+  } else {
+    caps = gst_caps_ref (self->caps);
+  }
+
+  if (caps && !gst_caps_is_empty (caps)) {
+    if (gst_caps_is_any (caps)) {
+      result = TRUE;
+    } else {
+      fixed_caps = gst_caps_fixate (caps);
+
+      if (fixed_caps && gst_caps_is_fixed (fixed_caps)) {
+        result = gst_base_src_set_caps (basesrc, fixed_caps);
+        if (peercaps == self->caps)
+          gst_caps_unref (fixed_caps);
+      }
+    }
+    gst_caps_unref (caps);
+  } else {
+    result = FALSE;
+    if (caps && gst_caps_is_empty (caps))
+      gst_caps_unref (caps);
+  }
+
+  if (thiscaps)
+    gst_caps_unref (thiscaps);
+
+  return result;
+
+no_nego_needed:
+  {
+    GST_DEBUG_OBJECT (self, "no negotiation needed");
+
+    return TRUE;
+  }
 }
 
 /**
@@ -752,6 +819,7 @@ cb_mqtt_on_message_arrived (void *context, char *topic_name, int topic_len,
   GstMemory *recieved_mem;
   GstMemory *hdr_mem;
   GstBuffer *buffer;
+  GstCaps *recv_caps;
   GstMqttSrc *self;
   gsize offset;
   guint i;
@@ -779,6 +847,18 @@ cb_mqtt_on_message_arrived (void *context, char *topic_name, int topic_len,
     goto ret_unref_recieved_mem;
   }
 
+  recv_caps = gst_caps_from_string (mqtt_msg_hdr->gst_caps_str);
+  if (recv_caps) {
+    GstBaseSrc *basesrc = GST_BASE_SRC (self);
+
+    if (!self->caps) {
+      gst_caps_take (&self->caps, recv_caps);
+    } else if (!gst_caps_is_equal (self->caps, recv_caps)) {
+      gst_caps_replace (&self->caps, recv_caps);
+    }
+    gst_mqtt_src_renegotiate (basesrc);
+  }
+
   buffer = gst_buffer_new ();
   offset = GST_MQTT_LEN_MSG_HDR;
   for (i = 0; i < mqtt_msg_hdr->num_mems; ++i) {
@@ -790,6 +870,7 @@ cb_mqtt_on_message_arrived (void *context, char *topic_name, int topic_len,
     gst_buffer_append_memory (buffer, each_memory);
     offset += each_size;
   }
+
   /** Timestamp synchronization */
   _put_timestamp_on_gst_buf (self, mqtt_msg_hdr, buffer);
   g_async_queue_push (self->aqueue, buffer);

--- a/gst/mqtt/mqttsrc.h
+++ b/gst/mqtt/mqttsrc.h
@@ -45,6 +45,7 @@ typedef struct _GstMqttSrcClass GstMqttSrcClass;
  */
 struct _GstMqttSrc {
   GstBaseSrc parent;
+  GstCaps *caps;
   GQuark gquark_err_tag;
   GError *err;
   gint64 base_time_epoch;


### PR DESCRIPTION
The purpose of this PR is to support just-in-time capability negotiation in the GStreamer pipeline using the capability information included in the message to which the other pipeline node sent.

In detail, this PR contains the following changes:
For the mqttsink, 
 - The message header is modified to include a string representation of the fixated GstCaps.
 For the mqttsrc,
 - A procedure extracting the GstCaps information from the incoming header is added.
 - According to the extracted GstCaps information, the pipeline tries to negotiation the capabilities just before processing the first buffer.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped