### PR TITLE
[Format] clang format for typecast

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,6 +47,7 @@ PenaltyBreakString: 100
 PenaltyExcessCharacter: 1
 PenaltyReturnTypeOnItsOwnLine: 20
 PointerBindsToType: false
+SpaceAfterCStyleCast: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: Always
 SpaceInEmptyParentheses: false


### PR DESCRIPTION
add space when using c-style typecast.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
