### PR TITLE
[Filter] support flex tensor

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -2223,6 +2223,11 @@ gst_tensor_filter_common_get_out_info (GstTensorFilterPrivate * priv,
 
   gst_tensors_info_init (out);
 
+  if (gst_tensors_info_is_flexible (in)) {
+    nns_logw ("Given input info is flexible, cannot get output info.");
+    return FALSE;
+  }
+
   if (!gst_tensors_info_validate (in)) {
     nns_logw ("Given input info is invalid, cannot get output info.");
     return FALSE;


### PR DESCRIPTION
Add pad template to support flex tensor in tensor-filter.

If incoming tensor is flexible, tensor-filter cannot get the meta from caps.
In this case, tensor-filter gets model info from subplugin and compares buffer size in transform().
That means, if the model handles non-static info (e.g., set-dimension with input info), it cannot support flex tensor.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
