### PR TITLE
[Conf/Subplugin] get registered subplugins

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -227,6 +227,11 @@ _get_subplugin_with_type (nnsconf_type_path type, gchar *** name,
     return FALSE;
   }
 
+  if (!conf.loaded) {
+    ml_loge ("Configuration file is not loaded.");
+    return FALSE;
+  }
+
   /* Easy custom uses the configuration of custom */
   if (type == NNSCONF_PATH_EASY_CUSTOM_FILTERS)
     type = NNSCONF_PATH_CUSTOM_FILTERS;

--- a/gst/nnstreamer/nnstreamer_subplugin.h
+++ b/gst/nnstreamer/nnstreamer_subplugin.h
@@ -59,6 +59,15 @@ extern const void *
 get_subplugin (subpluginType type, const char *name);
 
 /**
+ * @brief Get the list of registered subplugins.
+ * @param[in] type Subplugin Type
+ * @return The list of subplugin name
+ * @note Caller should free the returned value using g_strfreev()
+ */
+extern gchar **
+get_all_subplugins (subpluginType type);
+
+/**
  * @brief Register the subplugin. If duplicated name exists, it is rejected.
  * @param[in] type Subplugin Type
  * @param[in] name Subplugin Name. The filename should be subplugin_prefixes[type]${name}.so

--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -588,10 +588,14 @@ gst_tensordec_get_property (GObject * object, guint prop_id,
       PROP_READ_OPTION (9);
     case PROP_SUBPLUGINS:
     {
-      subplugin_info_s sinfo;
+      gchar **str_array = get_all_subplugins (NNS_SUBPLUGIN_DECODER);
 
-      nnsconf_get_subplugin_info (NNSCONF_PATH_DECODERS, &sinfo);
-      g_value_take_string (value, g_strjoinv (",", sinfo.names));
+      if (str_array) {
+        g_value_take_string (value, g_strjoinv (",", str_array));
+        g_strfreev (str_array);
+      } else {
+        g_value_set_string (value, "");
+      }
       break;
     }
     default:

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -2033,24 +2033,14 @@ gst_tensor_filter_common_get_property (GstTensorFilterPrivate * priv,
       break;
     case PROP_SUBPLUGINS:
     {
-      GString *subplugins;
-      subplugin_info_s sinfo;
-      guint i, total;
+      gchar **str_array = get_all_subplugins (NNS_SUBPLUGIN_FILTER);
 
-      subplugins = g_string_new (NULL);
-
-      /* add custom */
-      /** @todo Let's not hardcode default subplugins */
-      g_string_append (subplugins, "custom,custom-easy");
-
-      total = nnsconf_get_subplugin_info (NNSCONF_PATH_FILTERS, &sinfo);
-
-      for (i = 0; i < total; ++i) {
-        g_string_append (subplugins, ",");
-        g_string_append (subplugins, sinfo.names[i]);
+      if (str_array) {
+        g_value_take_string (value, g_strjoinv (",", str_array));
+        g_strfreev (str_array);
+      } else {
+        g_value_set_string (value, "");
       }
-
-      g_value_take_string (value, g_string_free (subplugins, FALSE));
       break;
     }
     case PROP_ACCELERATOR:


### PR DESCRIPTION
Util function to get registrable subplugins list.

If conf file is not loaded (or does not exists), nnstreamer cannot get the subplugin list from configuration.
In this case (e.g., Android), conveter cannot set the pad template from subplugins, and will make negotiation failure.

To prevent this error, get subplugins from table and conf file.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
