### PR TITLE
[Filter/tvm] set input without memory copy

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -393,6 +393,13 @@ gst_tensor_get_type_string (tensor_type type);
 extern GstCaps *
 gst_tensors_get_pad_caps (GstPad * pad, const GstTensorsConfig * config);
 
+
+/**
+ * @brief set alignment that default allocator would align to
+ * @param alignment bytes of alignment
+ */
+extern void gst_tensor_alloc_init (gsize alignment);
+
 /**
  * @brief Find the index value of the given key string array
  * @return Corresponding index

--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -34,7 +34,8 @@ nnst_common_sources = [
   'nnstreamer_subplugin.c',
   'tensor_common.c',
   'tensor_common_pipeline.c',
-  'tensor_data.c'
+  'tensor_data.c',
+  'tensor_allocator.c'
 ]
 
 foreach s : nnst_common_sources

--- a/gst/nnstreamer/tensor_allocator.c
+++ b/gst/nnstreamer/tensor_allocator.c
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Junhwan Kim <jejudo.kim@samsung.com>
+ *
+ * @file    tensor_allocator.c
+ * @date    12 May 2021
+ * @brief   Allocator for memory alignment
+ * @author  Junhwan Kim <jejudo.kim@samsung.com>
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @bug     No known bugs
+ *
+ */
+
+#include <gst/gst.h>
+#include "nnstreamer_plugin_api.h"
+
+#define GST_TENSOR_ALLOCATOR "GstTensorAllocator"
+
+static gsize gst_tensor_allocator_alignment = 0;
+
+/**
+ * @brief struct for type GstTensorAllocator
+ */
+typedef struct
+{
+  GstAllocator parent;
+} GstTensorAllocator;
+
+/**
+ * @brief struct for class GstTensorAllocatorClass
+ */
+typedef struct
+{
+  GstAllocatorClass parent_class;
+} GstTensorAllocatorClass;
+
+
+static GType gst_tensor_allocator_get_type (void);
+G_DEFINE_TYPE (GstTensorAllocator, gst_tensor_allocator, GST_TYPE_ALLOCATOR);
+
+/**
+ * @brief   allocation wrapper that binds alignment parameter
+ */
+static GstMemory *
+_alloc (GstAllocator * allocator, gsize size, GstAllocationParams * params)
+{
+  GstAllocator *sysmem_alloc;
+  GstAllocatorClass *sysmem_aclass;
+  GstAllocationParams *_params;
+
+  sysmem_alloc = gst_allocator_find (GST_ALLOCATOR_SYSMEM);
+  sysmem_aclass = GST_ALLOCATOR_GET_CLASS (sysmem_alloc);
+  _params = gst_allocation_params_copy (params);
+  _params->align = gst_tensor_allocator_alignment;
+
+  return sysmem_aclass->alloc (allocator, size, _params);
+}
+
+/**
+ * @brief class initization for GstTensorAllocatorClass
+ */
+static void
+gst_tensor_allocator_class_init (GstTensorAllocatorClass * klass)
+{
+  GstAllocatorClass *allocator_class, *sysmem_aclass;
+  GstAllocator *sysmem_alloc;
+
+  allocator_class = (GstAllocatorClass *) klass;
+  sysmem_alloc = gst_allocator_find (GST_ALLOCATOR_SYSMEM);
+  sysmem_aclass = GST_ALLOCATOR_GET_CLASS (sysmem_alloc);
+
+  allocator_class->alloc = _alloc;
+  allocator_class->free = sysmem_aclass->free;
+}
+
+/**
+ * @brief initialzation for GstTensorAllocator
+ */
+static void
+gst_tensor_allocator_init (GstTensorAllocator * allocator)
+{
+  GstAllocator *sysmem_alloc, *alloc;
+
+  alloc = GST_ALLOCATOR_CAST (allocator);
+  sysmem_alloc = gst_allocator_find (GST_ALLOCATOR_SYSMEM);
+
+  alloc->mem_type = sysmem_alloc->mem_type;
+  alloc->mem_map = sysmem_alloc->mem_map;
+  alloc->mem_unmap = sysmem_alloc->mem_unmap;
+  alloc->mem_copy = sysmem_alloc->mem_copy;
+  alloc->mem_share = sysmem_alloc->mem_share;
+  alloc->mem_is_span = sysmem_alloc->mem_is_span;
+}
+
+/**
+ * @brief set alignment that default allocator would align to
+ * @param alignment bytes of alignment
+ */
+void
+gst_tensor_alloc_init (gsize alignment)
+{
+  GstAllocator *allocator;
+
+  gst_tensor_allocator_alignment = alignment;
+
+  /* no alignment */
+  if (alignment == 0) {
+    gst_allocator_set_default (gst_allocator_find (GST_ALLOCATOR_SYSMEM));
+    return;
+  }
+
+  allocator = gst_allocator_find (GST_TENSOR_ALLOCATOR);
+  /* allocator already set */
+  if (allocator == NULL) {
+    allocator = g_object_new (gst_tensor_allocator_get_type (), NULL);
+    gst_allocator_register (GST_TENSOR_ALLOCATOR, allocator);
+  }
+  gst_allocator_set_default (allocator);
+}

--- a/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
+++ b/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
@@ -13,20 +13,19 @@
 #include <gst/gst.h>
 #include <unittest_util.h>
 
-#include <nnstreamer_plugin_api.h>
 #include <nnstreamer_plugin_api_filter.h>
 
 /**
  * @brief Set tensor filter properties
  */
 static void
-_SetFilterProp (GstTensorFilterProperties *prop, const gchar * name, const gchar **models)
+_SetFilterProp (GstTensorFilterProperties *prop, const gchar *name, const gchar **models)
 {
   memset (prop, 0, sizeof (GstTensorFilterProperties));
   prop->fwname = name;
   prop->fw_opened = 0;
   prop->model_files = models;
-  prop->num_models = g_strv_length ((gchar**)models);
+  prop->num_models = g_strv_length ((gchar **) models);
 }
 
 /**
@@ -360,8 +359,11 @@ TEST (nnstreamerFilterTvm, invoke00)
   };
 
   output.size = input.size = sizeof (float) * 3 * 640 * 480 * 1;
-  input.data = g_malloc (input.size);
-  output.data = g_malloc (output.size);
+
+  /* alloc input data without alignment */
+  input.data = malloc (input.size);
+  output.data = malloc (output.size);
+
   memset (input.data, 0, input.size);
 
   const GstTensorFilterFramework *sp = nnstreamer_filter_find ("tvm");


### PR DESCRIPTION

- Fix `set_input` to `set_input_zero_copy`
- Requires input data to be aligned by 128 (https://github.com/apache/tvm/pull/3416#discussion_r301917977)

Signed-off-by: Junhwan Kim <jejudo.kim@samsung.com>