### PR TITLE
[TCM] workaround: Exclude tensorFilterCustomEasy.inCodeFunc01

### DIFF
--- a/.ahub/tcchecker-tca/config.yaml
+++ b/.ahub/tcchecker-tca/config.yaml
@@ -16,6 +16,8 @@ test:
         - functionName:
             starts:
               - 'TEST'
+        - excludes :
+            - tensorFilterCustomEasy.inCodeFunc01
  
     negativeTestCase:
       - condition:


### PR DESCRIPTION
Because of TCM parser error, tensorFilterCustomEasy.inCodeFunc01 test
case is counted as Assertion case. This patch temporarily excludes it as
a workaround.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped


