### PR TITLE
[Tests/Converter] Fix -Werror=sign-compare error

### DIFF
--- a/tests/nnstreamer_converter/unittest_converter.cc
+++ b/tests/nnstreamer_converter/unittest_converter.cc
@@ -134,7 +134,7 @@ TEST (tensorConverterCustom, normal0)
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (1000000);
 
-  EXPECT_EQ (1, *received);
+  EXPECT_EQ (1U, *received);
   _wait_pipeline_save_files (tmp_tensor_raw, content1, len1, 230400, TEST_TIMEOUT_MS);
   _wait_pipeline_save_files (tmp_flex_to_tensor, content2, len2, 230400, TEST_TIMEOUT_MS);
   EXPECT_EQ (len1, len2);


### PR DESCRIPTION
This patch fixes a build error related to -Werror=sign-compare. Note that this error occurs while building the source code using gcc-7.5.

Signed-off-by: Wook Song <wook16.song@samsung.com>

```bash
[233/241] Compiling C++ object 'tests/59830eb@@unittest_converter@exe/nnstreamer_converter_unittest_converter.cc.o'.
FAILED: tests/59830eb@@unittest_converter@exe/nnstreamer_converter_unittest_converter.cc.o 
ccache c++ -Itests/59830eb@@unittest_converter@exe -Itests -I../tests -Igst/nnstreamer -I../gst/nnstreamer -Igst/nnstreamer/./include/ -I../gst/nnstreamer/./include/ -Igst/nnstreamer/tensor_transform -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/gstreamer-1.0 -I/usr/include/orc-0.4 -I/usr/src/gtest -I/usr/src/gtest/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -Werror -std=c++14 -g '-DVERSION="1.7.1"' '-DVERSION_MAJOR="1"' '-DVERSION_MINOR="7"' '-DVERSION_MICRO="1"' -Wwrite-strings -Wformat -Wformat-nonliteral -Wformat-security -Winit-self -Waddress -Wno-multichar -Wvla -Wpointer-arith -DENABLE_TENSORFLOW=1 -DENABLE_TENSORFLOW_LITE=1 -DHAVE_ORC=1 -DENABLE_FLATBUF=1 -Wredundant-decls -pthread -MD -MQ 'tests/59830eb@@unittest_converter@exe/nnstreamer_converter_unittest_converter.cc.o' -MF 'tests/59830eb@@unittest_converter@exe/nnstreamer_converter_unittest_converter.cc.o.d' -o 'tests/59830eb@@unittest_converter@exe/nnstreamer_converter_unittest_converter.cc.o' -c ../tests/nnstreamer_converter/unittest_converter.cc
In file included from ../tests/nnstreamer_converter/unittest_converter.cc:10:0:
/usr/src/gtest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = unsigned int]’:
/usr/src/gtest/include/gtest/gtest.h:1421:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = unsigned int; bool lhs_is_null_literal = false]’
../tests/nnstreamer_converter/unittest_converter.cc:137:3:   required from here
/usr/src/gtest/include/gtest/gtest.h:1392:11: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
cc1plus: all warnings being treated as errors
[237/241] Compiling C++ object 'tests/nnstreamer_filter_extensions_common/b8951fb@@unittest_tizen_python3-set@exe/meson-generated_.._unittest_tizen_python3-set.cc.o'.
ninja: build stopped: subcommand failed.
```

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped