### PR TITLE
[Fix/Filter] Fix tensors info initialization

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
@@ -142,8 +142,8 @@ edgetpu_subplugin::edgetpu_subplugin ()
       device_type (edgetpu_subplugin_device_type::DEFAULT),
       model_interpreter (nullptr), edgetpu_context (nullptr), model (nullptr)
 {
-  inputInfo.num_tensors = 0;
-  outputInfo.num_tensors = 0;
+  gst_tensors_info_init (std::addressof (inputInfo));
+  gst_tensors_info_init (std::addressof (outputInfo));
   /** Nothing to do. Just let it have an empty instance */
 }
 
@@ -170,10 +170,10 @@ edgetpu_subplugin::cleanup ()
 
   if (model_path)
     delete model_path;
+  gst_tensors_info_free (std::addressof (inputInfo));
+  gst_tensors_info_free (std::addressof (outputInfo));
 
   model_path = nullptr;
-  inputInfo.num_tensors = 0;
-  outputInfo.num_tensors = 0;
   empty_model = true;
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
@@ -120,8 +120,8 @@ snpe_subplugin::snpe_subplugin ()
       runtime_list (zdl::DlSystem::Runtime_t::CPU), use_cpu_fallback (false),
       container (nullptr), snpe (nullptr)
 {
-  inputInfo.num_tensors = 0;
-  outputInfo.num_tensors = 0;
+  gst_tensors_info_init (std::addressof (inputInfo));
+  gst_tensors_info_init (std::addressof (outputInfo));
   input_tensors.reserve (NNS_TENSOR_RANK_LIMIT);
 #if (DBG)
   invoke_time_total = total_frames = 0;
@@ -148,6 +148,8 @@ snpe_subplugin::cleanup ()
 
   if (model_path)
     delete model_path;
+  gst_tensors_info_free (std::addressof (inputInfo));
+  gst_tensors_info_free (std::addressof (outputInfo));
 
   runtime_list.clear ();
   input_tensors.clear ();
@@ -155,8 +157,6 @@ snpe_subplugin::cleanup ()
   output_tensor_map.clear ();
 
   model_path = nullptr;
-  inputInfo.num_tensors = 0;
-  outputInfo.num_tensors = 0;
   empty_model = true;
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tvm.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tvm.cc
@@ -85,8 +85,8 @@ tvm_subplugin::tvm_subplugin ()
     : tensor_filter_subplugin (), empty_model (true), model_path (nullptr),
       device (DLDevice{ kDLCPU, 0 }), mod_factory (nullptr), gmod (nullptr)
 {
-  inputInfo.num_tensors = 0;
-  outputInfo.num_tensors = 0;
+  gst_tensors_info_init (std::addressof (inputInfo));
+  gst_tensors_info_init (std::addressof (outputInfo));
 }
 
 /**
@@ -101,10 +101,10 @@ tvm_subplugin::cleanup () noexcept
 
   input_tensor_list.clear ();
   output_tensor_list.clear ();
+  gst_tensors_info_free (std::addressof (inputInfo));
+  gst_tensors_info_free (std::addressof (outputInfo));
 
   model_path = nullptr;
-  inputInfo.num_tensors = 0;
-  outputInfo.num_tensors = 0;
   empty_model = true;
 }
 


### PR DESCRIPTION
[Fix/Filter] Fix tensors info initialization

- Internal tensors-info is not correctly initialized for some sub filters, causing incompatible format error.

Signed-off-by: Junhwan Kim <jejudo.kim@samsung.com>



