### PR TITLE
[Tools/Parser] Convert gst pipeline to pbtxt (w/ mediapipe demo site)

### DIFF
--- a/tools/development/parser/convert.c
+++ b/tools/development/parser/convert.c
@@ -1,0 +1,150 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer Pipeline from/to PBTxt Converter Parser
+ * Copyright (C) 2021 MyungJoo Ham <myungjoo.ham@samsung.com>
+ * Copyright (C) 2021 Dongju Chae <dongju.chae@samsung.com>
+ */
+/**
+ * @file    convert.c
+ * @date    13 May 2021
+ * @brief   GStreamer pipeline from/to pbtxt converter
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @author  Dongju Chae <dongju.chae@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#include "convert.h"
+#include <glib/gprintf.h>
+
+GData *datalist;
+
+#define GET_NODE_INDEX(elem)\
+  g_slist_index (g_datalist_get_data (&datalist, elem->element), elem)
+
+/**
+ * @brief Get a node name (ignore index 0)
+ */
+static gchar *
+pbtxt_get_node_name (_Element *elem)
+{
+  gint index = GET_NODE_INDEX (elem);
+
+  /* Internal error: the parsing wasn't successful due to unknown errors */
+  g_assert (index >= 0);
+
+  if (index == 0)
+    return g_strdup_printf ("%s", elem->element);
+  else
+    return g_strdup_printf ("%s_%d", elem->element, index + 1);
+}
+
+/**
+ * @brief Print input stream of node
+ */
+static void
+pbtxt_print_node_input_stream (gpointer data, gpointer user_data)
+{
+  _Pad *pad = (_Pad *) data;
+  gchar *pad_name;
+
+  g_return_if_fail (pad != NULL);
+
+  if (g_slist_length (pad->peer->parent->sink_pads) == 0) {
+    /* assume that any src has only one pad */
+    pad_name = pbtxt_get_node_name (pad->peer->parent);
+  } else {
+    pad_name = g_strdup_printf ("%s_%d_%d",
+        pad->peer->parent->element,
+        GET_NODE_INDEX (pad->peer->parent),
+        g_slist_index (pad->peer->parent->src_pads, pad->peer));
+  }
+
+  g_printf ("\tinput_stream: \"%s\"\n", pad_name);
+  g_free (pad_name);
+}
+
+/**
+ * @brief Print output stream of node
+ */
+static void
+pbtxt_print_node_output_stream (gpointer data, gpointer user_data)
+{
+  _Pad *pad = (_Pad *) data;
+  gchar *pad_name;
+
+  g_return_if_fail (pad != NULL);
+
+  if (g_slist_length (pad->peer->parent->src_pads) == 0) {
+    /* assume that any sink has only one pad */
+    pad_name = pbtxt_get_node_name (pad->peer->parent);
+  } else {
+    pad_name = g_strdup_printf ("%s_%d_%d",
+        pad->parent->element,
+        GET_NODE_INDEX (pad->parent),
+        g_slist_index (pad->parent->src_pads, pad));
+  }
+
+  g_printf ("\toutput_stream: \"%s\"\n", pad_name);
+  g_free (pad_name);
+}
+
+/** @brief Print pbtxt nodes */
+static void
+pbtxt_print_node (gpointer data, gpointer user_data)
+{
+  _Element *elem = (_Element *) data;
+
+  g_return_if_fail (elem != NULL);
+
+  if (g_slist_length (elem->src_pads) == 0 ||
+      g_slist_length (elem->sink_pads) == 0)
+    return;
+
+  g_printf ("\nnode: {\n\tcalculator: \"%sCalculator\"\n", elem->element);
+  g_slist_foreach (elem->sink_pads, pbtxt_print_node_input_stream, NULL);
+  g_slist_foreach (elem->src_pads, pbtxt_print_node_output_stream, NULL);
+  g_printf ("}\n");
+
+  /* TODO: Filling 'node_options' for detail element info. */
+}
+
+/**
+ * @brief Prepare conversion checking nodes
+ */
+static void
+pbtxt_prepare (gpointer data, gpointer user_data)
+{
+  _Element *elem = (_Element *) data;
+  GSList *list;
+
+  g_return_if_fail (elem != NULL);
+
+  list = g_datalist_get_data (&datalist, elem->element);
+  list = g_slist_append (list, elem);
+  g_datalist_set_data (&datalist, elem->element, list);
+
+  if (g_slist_length (elem->sink_pads) == 0) {
+    gchar *name = pbtxt_get_node_name (elem);
+    g_printf ("input_stream: \"%s\"\n", name);
+    g_free (name);
+  }
+
+  if (g_slist_length (elem->src_pads) == 0) {
+    gchar *name = pbtxt_get_node_name (elem);
+    g_printf ("output_stream: \"%s\"\n", name);
+    g_free (name);
+  }
+}
+
+/** @brief Convert gst pipeline to pbtxt */
+void convert_to_pbtxt (_Element *pipeline)
+{
+  g_return_if_fail (pipeline != NULL);
+
+  g_datalist_init (&datalist);
+
+  g_slist_foreach (pipeline->elements, pbtxt_prepare, NULL);
+  g_slist_foreach (pipeline->elements, pbtxt_print_node, NULL);
+
+  g_datalist_clear (&datalist);
+}

--- a/tools/development/parser/convert.h
+++ b/tools/development/parser/convert.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer Pipeline from/to PBTxt Converter Parser
+ * Copyright (C) 2021 MyungJoo Ham <myungjoo.ham@samsung.com>
+ * Copyright (C) 2021 Dongju Chae <dongju.chae@samsung.com>
+ */
+/**
+ * @file    convert.h
+ * @date    13 May 2021
+ * @brief   GStreamer pipeline from/to pbtxt converter
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @author  Dongju Chae <dongju.chae@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifndef __GST_PARSE_CONVERT_H__
+#define __GST_PARSE_CONVERT_H__
+
+#include "types.h"
+
+void convert_to_pbtxt (_Element *pipeline);
+
+#endif

--- a/tools/development/parser/grammar.y
+++ b/tools/development/parser/grammar.y
@@ -261,7 +261,7 @@ gst_parse_perform_link (link_t *link, graph_t *graph)
   g_assert (__GST_IS_ELEMENT (src));
   g_assert (__GST_IS_ELEMENT (sink));
 
-  g_info ("linking " PRETTY_PAD_NAME_FMT " to " PRETTY_PAD_NAME_FMT " (%u/%u)\n",
+  g_debug ("linking " PRETTY_PAD_NAME_FMT " to " PRETTY_PAD_NAME_FMT " (%u/%u)\n",
       PRETTY_PAD_NAME_ARGS (src, link->src.name),
       PRETTY_PAD_NAME_ARGS (sink, link->sink.name),
       g_slist_length (srcs), g_slist_length (sinks));
@@ -719,7 +719,7 @@ priv_gst_parse_launch (const gchar *str, GError **error, _ParseContext *ctx,
   yydebug = 1;
 #endif
 
-  g_info ("The given string: %s\n", str);
+  g_debug ("The given string: %s\n", str);
 
   if (yyparse (scanner, &g) != 0) {
     SET_ERROR (error, GST2PBTXT_PARSE_ERROR_SYNTAX,
@@ -733,7 +733,7 @@ priv_gst_parse_launch (const gchar *str, GError **error, _ParseContext *ctx,
   priv_gst_parse_yylex_destroy (scanner);
   g_free (dstr);
 
-  g_info ("got %u elements and %u links\n",
+  g_debug ("got %u elements and %u links\n",
       g.chain ? g_slist_length (g.chain->elements) : 0,
       g_slist_length (g.links));
 
@@ -756,7 +756,7 @@ priv_gst_parse_launch (const gchar *str, GError **error, _ParseContext *ctx,
 
   /* put all elements in our bin if necessary */
   if (g.chain->elements->next) {
-    bin = __GST_BIN_CAST (nnstparser_gstbin_make ("bin", NULL));
+    bin = __GST_BIN_CAST (nnstparser_gstbin_make ("pipeline", NULL));
     g_assert (bin);
 
     for (walk = g.chain->elements; walk; walk = walk->next) {

--- a/tools/development/parser/meson.build
+++ b/tools/development/parser/meson.build
@@ -74,7 +74,8 @@ toplevel_srcs = [
   parser,
   grammar,
   'types.c',
-  'toplevel.c'
+  'toplevel.c',
+  'convert.c'
 ]
 toplevel_deps = [
   glib_dep,

--- a/tools/development/parser/toplevel.c
+++ b/tools/development/parser/toplevel.c
@@ -19,6 +19,7 @@
 #include <glib.h>
 
 #include "types.h"
+#include "convert.h"
 
 #define INPUT_MAXLEN (512)
 
@@ -88,6 +89,7 @@ main (int argc, char *argv[])
   GOptionContext *context;
   char input_str[INPUT_MAXLEN] = {'\x00'};
   GLogLevelFlags log_flags;
+  _Element *pipeline;
 
   context = g_option_context_new (
       "- Prototxt to/from GStreamer Pipeline Converver");
@@ -105,7 +107,7 @@ main (int argc, char *argv[])
   }
 
   if (!get_input_string (input_str)) {
-    g_printerr ("Unable to get input string\n");
+    g_printerr ("Unable to get an input string for GStreamer pipeline\n");
     return -1;
   }
 
@@ -116,7 +118,14 @@ main (int argc, char *argv[])
 
   g_log_set_handler (NULL, log_flags, log_handler, NULL);
 
-  priv_gst_parse_launch (input_str, NULL, NULL, __PARSE_FLAG_NONE);
+  pipeline = priv_gst_parse_launch (input_str, NULL, NULL, __PARSE_FLAG_NONE);
+  if (pipeline == NULL) {
+    g_printerr ("Unable to parse the given pipeline string");
+    return -1;
+  }
+
+  convert_to_pbtxt (pipeline);
+  nnstparser_element_unref (pipeline);
 
   return 0;
 }

--- a/tools/development/parser/types.h
+++ b/tools/development/parser/types.h
@@ -43,7 +43,7 @@ typedef enum {
 typedef struct _chain_t chain_t;
 
 /** @brief Simplified GST-Element */
-typedef struct {
+typedef struct _Element_t {
   objectTypeId id;
   elementSpecialType specialType;
 
@@ -54,11 +54,25 @@ typedef struct {
   union {
     GSList *elements; /**< _GstBin type uses this */
   };
+
+  GSList *src_pads;
+  GSList *sink_pads;
 } _Element;
+
+/** @brief Simplified GST-Pad */
+typedef struct _Pad_t {
+  gchar *name;
+  _Element *parent;
+  struct _Pad_t *peer;
+} _Pad;
 
 /** @brief Make simplified element */
 extern _Element *
 nnstparser_element_make (const gchar *element, const gchar *name);
+
+/** @brief Make simplified pad */
+extern _Pad *
+nnstparser_pad_make (_Element *parent, const gchar *name);
 
 /** @brief pipeline element/pad reference */
 typedef struct {


### PR DESCRIPTION
This patch converts gst pipeline to pbtxt. It also works on mediapipe demo site.
You can check the example pipeline in the https://viz.mediapipe.dev/

**Usage**
```
$ echo "fakesrc ! tensor_filter ! fakesink " |\
   ./build/tools/development/parser/nnstreamer-parser

input_stream: "fakesrc"
output_stream: "fakesink"

node: {
        calculator: "tensor_filterCalculator"
        input_stream: "fakesrc"
        output_stream: "fakesink"
}
```
![simple](https://user-images.githubusercontent.com/48666767/118096340-3105c100-b40c-11eb-9713-54debfb9ba24.png)
```
$ echo "fakesrc ! tensor_filter ! tee name=t ! queue ! fakesink t. ! queue ! fakesink" |\
   ./build/tools/development/parser/nnstreamer-parser 

input_stream: "fakesrc"
output_stream: "fakesink"
output_stream: "fakesink_2"

node: {
        calculator: "tensor_filterCalculator"
        input_stream: "fakesrc"
        output_stream: "tensor_filter_0_0"
}

node: {
        calculator: "teeCalculator"
        input_stream: "tensor_filter_0_0"
        output_stream: "tee_0_0"
        output_stream: "tee_0_1"
}

node: {
        calculator: "queueCalculator"
        input_stream: "tee_0_0"
        output_stream: "fakesink"
}

node: {
        calculator: "queueCalculator"
        input_stream: "tee_0_1"
        output_stream: "fakesink_2"
}
```
![complex](https://user-images.githubusercontent.com/48666767/118096346-33681b00-b40c-11eb-8609-f87fc23b9112.png)

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>