### PR TITLE
Dist/Deb: add tf2-lite for Ubuntu @open sesame 5/26 20:39

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev,
  python, python3, python3-dev, python3-numpy,
  tensorflow-lite-dev, pytorch, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
+ tensorflow2-lite-dev,
  openvino-dev, openvino-cpu-mkldnn [amd64], libflatbuffers-dev, flatbuffers-compiler,
  protobuf-compiler (>=3.12), libprotobuf-dev [amd64 arm64 armhf],
  tensorflow-dev [amd64], python2.7-dev, flex, bison
@@ -44,15 +45,22 @@ Package: nnstreamer-tensorflow
 Architecture: amd64
 Multi-Arch: same
 Depends: nnstreamer, tensorflow | tensorflow-dev, ${shlibs:Depends}, ${misc:Depends}
-Description: NNStreamer TensorFlow Support
+Description: NNStreamer TensorFlow 1.x Support
  This package allows nnstreamer to support tensorflow. Note that users must make sure that they have installed Tensorflow with compatible C-API (recommended to use the same version). However, having different options (e.g., GPU mode) should not affect the compatibility. When we have stable C-API from Tensorflow, we will release corresponding subplugin as well.
 
 Package: nnstreamer-tensorflow-lite
 Architecture: any
 Multi-Arch: same
 Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
-Description: NNStreamer TensorFlow Lite Support
+Description: NNStreamer TensorFlow Lite 1.x Support
  This package allows nnstreamer to support tensorflow-lite.
+
+Package: nnstreamer-tensorflow2-lite
+Architecture: any
+Multi-Arch: same
+Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer TensorFlow Lite 2.x Support
+ This package allows nnstreamer to support tensorflow-lite 2.x.
 
 Package: nnstreamer-pytorch
 Architecture: any

--- a/debian/nnstreamer-tensorflow2-lite.install
+++ b/debian/nnstreamer-tensorflow2-lite.install
@@ -1,0 +1,1 @@
+/usr/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow2-lite.so

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -206,6 +206,10 @@ if tflite2_support_is_available
   tflite2_compile_args += '-DTFLITE_FLOAT16=1'
   tflite2_compile_args += '-DTFLITE_COMPLEX64=1'
 
+  if cc.has_header('tensorflow2/lite/model.h')
+    tflite2_compile_args += '-DUSE_TENSORFLOW2_HEADER_PATH=1'
+  endif
+
   if get_option('tflite2-gpu-delegate-support')
     # GLES dependency for tflite GPU delegate
     gles_dep = dependency('gles20', required: true)

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -39,23 +39,40 @@
 #include <nnstreamer_conf.h>
 
 #if TFLITE_VERSION_MAJOR >= 2 || TFLITE_VERSION_MINOR >= 13
-#include <tensorflow/lite/kernels/register.h>
-#include <tensorflow/lite/model.h>
+#  if USE_TENSORFLOW2_HEADER_PATH
+#    include <tensorflow2/lite/kernels/register.h>
+#    include <tensorflow2/lite/model.h>
+#  else
+#    include <tensorflow/lite/kernels/register.h>
+#    include <tensorflow/lite/model.h>
+#  endif
 #else
-#include <tensorflow/contrib/lite/kernels/register.h>
-#include <tensorflow/contrib/lite/model.h>
+#  include <tensorflow/contrib/lite/kernels/register.h>
+#  include <tensorflow/contrib/lite/model.h>
 #endif
 
 #ifdef TFLITE_XNNPACK_DELEGATE_SUPPORTED
-#include <tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h>
+#  if USE_TENSORFLOW2_HEADER_PATH
+#    include <tensorflow2/lite/delegates/xnnpack/xnnpack_delegate.h>
+#  else
+#    include <tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h>
+#  endif
 #endif
 
 #ifdef TFLITE_NNAPI_DELEGATE_SUPPORTED
-#include <tensorflow/lite/delegates/nnapi/nnapi_delegate.h>
+#  if USE_TENSORFLOW2_HEADER_PATH
+#    include <tensorflow2/lite/delegates/nnapi/nnapi_delegate.h>
+#  else
+#    include <tensorflow/lite/delegates/nnapi/nnapi_delegate.h>
+#  endif
 #endif
 
 #ifdef TFLITE_GPU_DELEGATE_SUPPORTED
-#include <tensorflow/lite/delegates/gpu/delegate.h>
+#  if USE_TENSORFLOW2_HEADER_PATH
+#    include <tensorflow2/lite/delegates/gpu/delegate.h>
+#  else
+#    include <tensorflow/lite/delegates/gpu/delegate.h>
+#  endif
 #endif
 
 #if !defined(TFLITE_SUBPLUGIN_NAME)


### PR DESCRIPTION
Per the request of #3282, add tf2-lite subpackage for Ubuntu releases.

Note that this requires merges of
https://review.tizen.org/gerrit/#/c/platform/upstream/tensorflow2/+/258437/
and then, refreshes of
https://code.launchpad.net/~nnstreamer/+recipe/tensorflow2-daily

After those, we can test build this commit.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

