### PR TITLE
Refactor/GRPC: remove duplicated codes

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_grpc.h
+++ b/ext/nnstreamer/extra/nnstreamer_grpc.h
@@ -61,6 +61,24 @@ typedef struct {
   GstTensorsConfig *config;
 } grpc_config;
 
+/** @brief gRPC private data */
+typedef struct {
+  grpc_config config;
+  void * instance;
+} grpc_private;
+
+enum
+{
+  PROP_0,
+  PROP_SILENT,
+  PROP_SERVER,
+  PROP_BLOCKING,
+  PROP_IDL,
+  PROP_HOST,
+  PROP_PORT,
+  PROP_OUT,
+};
+
 /**
  * @brief C++ wrappers for gRPC per-IDL codes
  */
@@ -78,6 +96,9 @@ void grpc_stop (void * instance);
 
 gboolean grpc_send (void * instance, GstBuffer * buffer);
 int grpc_get_listening_port (void * instance);
+
+gboolean _check_hostname (gchar * str);
+void grpc_common_set_property (GObject * self, gboolean * silent, grpc_private * grpc, guint prop_id, const GValue * value, GParamSpec * pspec);
 
 #ifdef __cplusplus
 }

--- a/ext/nnstreamer/tensor_sink/tensor_sink_grpc.c
+++ b/ext/nnstreamer/tensor_sink/tensor_sink_grpc.c
@@ -98,24 +98,6 @@ static GstStaticPadTemplate sinktemplate = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS (CAPS_STRING));
 
-enum
-{
-  PROP_0,
-  PROP_SILENT,
-  PROP_SERVER,
-  PROP_BLOCKING,
-  PROP_IDL,
-  PROP_HOST,
-  PROP_PORT,
-  PROP_OUT,
-};
-
-/** gRPC private data */
-typedef struct {
-  grpc_config config;
-  void * instance;
-} grpc_private;
-
 #define GET_GRPC_PRIVATE(arg) (grpc_private *) (arg->priv)
 
 /** GObject method implementation */
@@ -162,15 +144,13 @@ gst_tensor_sink_grpc_class_init (GstTensorSinkGRPCClass * klass)
   /* install properties */
   g_object_class_install_property (gobject_class, PROP_SILENT,
       g_param_spec_boolean ("silent", "Silent",
-        "Dont' produce verbose output",
-        DEFAULT_PROP_SILENT,
-        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+          "Dont' produce verbose output",
+          DEFAULT_PROP_SILENT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_SERVER,
       g_param_spec_boolean ("server", "Server",
-        "Specify its working mode either server or client",
-        DEFAULT_PROP_SERVER,
-        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+          "Specify its working mode either server or client",
+          DEFAULT_PROP_SERVER, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_BLOCKING,
       g_param_spec_boolean ("blocking", "Blocking",
@@ -193,9 +173,8 @@ gst_tensor_sink_grpc_class_init (GstTensorSinkGRPCClass * klass)
 
   g_object_class_install_property (gobject_class, PROP_OUT,
       g_param_spec_uint ("out", "Out",
-        "The number of output messages generated",
-        0, G_MAXUINT, 0,
-        G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
+          "The number of output messages generated",
+          0, G_MAXUINT, 0, G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
 
   gst_element_class_add_static_pad_template (gstelement_class, &sinktemplate);
 
@@ -272,8 +251,8 @@ gst_tensor_sink_grpc_finalize (GObject * gobject)
 static gboolean
 gst_tensor_sink_grpc_setcaps (GstBaseSink * sink, GstCaps * caps)
 {
-  GstTensorSinkGRPC * self;
-  GstStructure * structure;
+  GstTensorSinkGRPC *self;
+  GstStructure *structure;
 
   self = GST_TENSOR_SINK_GRPC (sink);
 
@@ -295,30 +274,16 @@ gst_tensor_sink_grpc_setcaps (GstBaseSink * sink, GstCaps * caps)
 static GstFlowReturn
 gst_tensor_sink_grpc_render (GstBaseSink * sink, GstBuffer * buf)
 {
-  GstTensorSinkGRPC * self = GST_TENSOR_SINK_GRPC (sink);
+  GstTensorSinkGRPC *self = GST_TENSOR_SINK_GRPC (sink);
   grpc_private *grpc = GET_GRPC_PRIVATE (self);
   gboolean ret;
 
-  g_return_val_if_fail (
-      GST_OBJECT_FLAG_IS_SET (self, GST_TENSOR_SINK_GRPC_STARTED),
-      GST_FLOW_FLUSHING);
+  g_return_val_if_fail (GST_OBJECT_FLAG_IS_SET (self,
+          GST_TENSOR_SINK_GRPC_STARTED), GST_FLOW_FLUSHING);
 
   ret = grpc_send (grpc->instance, buf);
 
   return ret ? GST_FLOW_OK : GST_FLOW_ERROR;
-}
-
-/**
- * @brief check the validity of hostname string
- */
-static gboolean
-_check_hostname (gchar * str)
-{
-  if (g_strcmp0 (str, "localhost") == 0 ||
-      g_hostname_is_ip_address (str))
-    return TRUE;
-
-  return FALSE;
 }
 
 /**
@@ -328,7 +293,7 @@ static void
 gst_tensor_sink_grpc_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
-  GstTensorSinkGRPC * self;
+  GstTensorSinkGRPC *self;
   grpc_private *grpc;
 
   g_return_if_fail (GST_IS_TENSOR_SINK_GRPC (object));
@@ -336,59 +301,7 @@ gst_tensor_sink_grpc_set_property (GObject * object, guint prop_id,
   self = GST_TENSOR_SINK_GRPC (object);
   grpc = GET_GRPC_PRIVATE (self);
 
-  switch (prop_id) {
-    case PROP_SILENT:
-      self->silent = g_value_get_boolean (value);
-      silent_debug ("Set silent = %d", self->silent);
-      break;
-    case PROP_SERVER:
-      grpc->config.is_server = g_value_get_boolean (value);
-      silent_debug ("Set server = %d", grpc->config.is_server);
-      break;
-    case PROP_BLOCKING:
-      grpc->config.is_blocking = g_value_get_boolean (value);
-      silent_debug ("Set blocking = %d", grpc->config.is_blocking);
-      break;
-    case PROP_IDL:
-    {
-      const gchar * idl_str = g_value_get_string (value);
-
-      if (idl_str) {
-        grpc_idl idl = grpc_get_idl (idl_str);
-        if (idl != GRPC_IDL_NONE) {
-          grpc->config.idl = idl;
-          silent_debug ("Set idl = %s", idl_str);
-        } else {
-          ml_loge ("Invalid IDL string provided: %s", idl_str);
-        }
-      }
-      break;
-    }
-    case PROP_HOST:
-    {
-      gchar * host;
-
-      if (!g_value_get_string (value))
-        break;
-
-      host = g_value_dup_string (value);
-      if (_check_hostname (host)) {
-        g_free (grpc->config.host);
-        grpc->config.host = host;
-        silent_debug ("Set host = %s", grpc->config.host);
-      } else {
-        g_free (host);
-      }
-      break;
-    }
-    case PROP_PORT:
-      grpc->config.port = g_value_get_int (value);
-      silent_debug ("Set port = %d", grpc->config.port);
-      break;
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-      break;
-  }
+  grpc_common_set_property (object, &self->silent, grpc, prop_id, value, pspec);
 }
 
 /**
@@ -398,7 +311,7 @@ static void
 gst_tensor_sink_grpc_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec)
 {
-  GstTensorSinkGRPC * self;
+  GstTensorSinkGRPC *self;
   grpc_private *grpc;
 
   g_return_if_fail (GST_IS_TENSOR_SINK_GRPC (object));


### PR DESCRIPTION
grpc-sink and grpc-src have duplicated codes. Remove them.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

