### PR TITLE
[Tests/GstMQTT] Add skeleton code for MQTT elements' unit test cases

### DIFF
--- a/tests/gstreamer_mqtt/unittest_mqtt.cc
+++ b/tests/gstreamer_mqtt/unittest_mqtt.cc
@@ -1,0 +1,79 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * @file        unittest_mqtt.cc
+ * @date        20 May 2021
+ * @brief       Unit test for GStreamer MQTT elements
+ * @see         https://github.com/nnstreamer/nnstreamer
+ * @author      Wook Song <wook16.song@samsung.com>
+ * @bug         No known bugs
+ */
+
+#include <glib.h>
+#include <gst/check/gstharness.h>
+#include <gst/gst.h>
+#include <gtest/gtest.h>
+
+/**
+ * @brief Test for mqttsink with wrong URL
+ */
+TEST (testMqttSink, sink_push_wrongurl_n)
+{
+  const static gsize data_size = 1024;
+  GstHarness *h = gst_harness_new ("mqttsink");
+  GstBuffer *in_buf;
+  GstFlowReturn ret;
+
+  ASSERT_TRUE (h != NULL);
+
+  g_object_set (h->element, "host", "tcp:://0.0.0.0", "port", "0",
+      "enable-last-sample", (gboolean) FALSE, NULL);
+  in_buf = gst_harness_create_buffer (h, data_size);
+  ret = gst_harness_push (h, in_buf);
+
+  EXPECT_EQ (ret, GST_FLOW_ERROR);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for mqttsrc with wrong URL
+ */
+TEST (testMqttSrc, src_pull_wrongurl_n)
+{
+  GstHarness *h = gst_harness_new ("mqttsrc");
+  GstBuffer *out_buffer;
+
+  ASSERT_TRUE (h != NULL);
+
+  g_object_set (h->element, "host", "tcp:://0.0.0.0", "port", "0", NULL);
+
+  out_buffer = gst_harness_try_pull (h);
+  EXPECT_TRUE (out_buffer == NULL);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Main GTest
+ */
+int
+main (int argc, char **argv)
+{
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
+
+  gst_init (&argc, &argv);
+
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+
+  return result;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -116,6 +116,17 @@ if gtest_dep.found()
 
     test('unittest_join', unittest_join, env: testenv)
 
+    # Run unittest_mqtt
+    if mqtt_support_is_available
+      unittest_mqtt = executable('unittest_mqtt',
+          join_paths('gstreamer_mqtt', 'unittest_mqtt.cc'),
+          dependencies: [nnstreamer_unittest_deps, unittest_util_dep],
+          install: get_option('install-test'),
+          install_dir: unittest_install_dir)
+
+      test('unittest_mqtt', unittest_mqtt, env: testenv)
+    endif
+
   # Run unittest_src_iio
     if build_platform != 'macos'
       unittest_src_iio = executable('unittest_src_iio',


### PR DESCRIPTION
Prior to enabling the dummy operation mode, this PR adds skeleton code for MQTT elements' unit test cases. The corresponding meson build script is also modified to generate and run the executable for the unit tests.

CC: @helloahn 

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped