### PR TITLE
[Fix/Trivial] Fix mem leak in tensordec-pose @open sesame 05/24 16:00

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -296,6 +296,7 @@ pose_load_metadata_from_file (pose_data * pd, const gchar * file_path)
   }
 
   g_strfreev (lines);
+  g_free (contents);
 
   return TRUE;
 }


### PR DESCRIPTION
- Free allocated string in tensordec-pose

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
