### PR TITLE
[Coverage/Tools] Ignore coverage report of source codes in tools

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -771,7 +771,7 @@ find . -name "CMakeCXXCompilerId*.gcda" -delete
 # Generate report
 lcov -t 'NNStreamer Unit Test Coverage' -o unittest.info -c -d . -b $(pwd) --no-external
 # Exclude generated files (e.g., Orc, Protobuf) and device-dependent filters.
-lcov -r unittest.info "*/*-orc.*" "*/tests/*" "*/meson*/*" "*/*@sha/*" "*/*_openvino*" "*/*_edgetpu*" "*/*_movidius_ncsdk2*" "*/*.so.p/*" -o unittest-filtered.info
+lcov -r unittest.info "*/*-orc.*" "*/tests/*" "*/tools/*" "*/meson*/*" "*/*@sha/*" "*/*_openvino*" "*/*_edgetpu*" "*/*_movidius_ncsdk2*" "*/*.so.p/*" -o unittest-filtered.info
 # Visualize the report
 genhtml -o result unittest-filtered.info -t "nnstreamer %{version}-%{release} ${VCS}" --ignore-errors source -p ${RPM_BUILD_DIR}
 


### PR DESCRIPTION
This patch makes the coverage analyzer ignore the reports of source
codes in tools. We don't need to add unittests for tools.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

