### PR TITLE
[Converter/subplugins] Fix use after free

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.cc
@@ -149,7 +149,8 @@ gst_tensor_converter_protobuf (GstBuffer *in_buf, GstTensorsConfig *config, void
 
   for (guint i = 0; i < config->info.num_tensors; i++) {
     const nnstreamer::protobuf::Tensor *tensor = &tensors.tensor (i);
-    const gchar *name = tensor->name ().c_str ();
+    std::string _name = tensor->name ();
+    const gchar *name = _name.c_str ();
 
     config->info.info[i].name = (name && strlen (name) > 0) ? g_strdup (name) : NULL;
     config->info.info[i].type = (tensor_type)tensor->type ();

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
@@ -128,7 +128,8 @@ fbc_convert (GstBuffer *in_buf, GstTensorsConfig *config, void *priv_data)
 
   for (guint i = 0; i < config->info.num_tensors; i++) {
     gsize offset;
-    const gchar *name = tensor->Get (i)->name ()->str ().c_str ();
+    std::string _name = tensor->Get (i)->name ()->str ();
+    const gchar *name = _name.c_str ();
 
     config->info.info[i].name = (name && strlen (name) > 0) ? g_strdup (name) : NULL;
     config->info.info[i].type = (tensor_type)tensor->Get (i)->type ();

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
@@ -145,7 +145,8 @@ flxc_convert (GstBuffer *in_buf, GstTensorsConfig *config, void *priv_data)
     gchar * tensor_key = g_strdup_printf ("tensor_%d", i);
     gsize offset;
     flexbuffers::Vector tensor = tensors[tensor_key].AsVector ();
-    const gchar *name = tensor[0].AsString ().c_str ();
+    flexbuffers::String _name = tensor[0].AsString ();
+    const gchar *name = _name.c_str ();
 
     config->info.info[i].name = (name && strlen (name) > 0) ? g_strdup (name) : NULL;
     config->info.info[i].type = (tensor_type) tensor[1].AsInt32 ();


### PR DESCRIPTION
The internal representation of temporary of type std::string is freed by its destructor.
Copy the std::string to avoid use after free.

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped