### PR TITLE
Refactor/GRPC: remove duplicated get-property codes

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_grpc.h
+++ b/ext/nnstreamer/extra/nnstreamer_grpc.h
@@ -99,6 +99,7 @@ int grpc_get_listening_port (void * instance);
 
 gboolean _check_hostname (gchar * str);
 void grpc_common_set_property (GObject * self, gboolean * silent, grpc_private * grpc, guint prop_id, const GValue * value, GParamSpec * pspec);
+void grpc_common_get_property (GObject * self, gboolean silent, guint out, grpc_private * grpc, guint prop_id, GValue * value, GParamSpec * pspec);
 
 #ifdef __cplusplus
 }

--- a/ext/nnstreamer/extra/nnstreamer_grpc_common.cc
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_common.cc
@@ -365,3 +365,47 @@ grpc_common_set_property (GObject * self, gboolean * silent,
       break;
   }
 }
+
+/**
+ * @brief get-prop common for both grpc elements
+ */
+void
+grpc_common_get_property (GObject * self, gboolean silent, guint out,
+    grpc_private * grpc, guint prop_id, GValue * value, GParamSpec * pspec)
+{
+  switch (prop_id) {
+    case PROP_SILENT:
+      g_value_set_boolean (value, silent);
+      break;
+    case PROP_SERVER:
+      g_value_set_boolean (value, grpc->config.is_server);
+      break;
+    case PROP_BLOCKING:
+      g_value_set_boolean (value, grpc->config.is_blocking);
+      break;
+    case PROP_IDL:
+      switch (grpc->config.idl) {
+        case GRPC_IDL_PROTOBUF:
+          g_value_set_string (value, "protobuf");
+          break;
+        case GRPC_IDL_FLATBUF:
+          g_value_set_string (value, "flatbuf");
+          break;
+        default:
+          break;
+      }
+      break;
+    case PROP_HOST:
+      g_value_set_string (value, grpc->config.host);
+      break;
+    case PROP_PORT:
+      g_value_set_int (value, grpc->config.port);
+      break;
+    case PROP_OUT:
+      g_value_set_uint (value, out);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (self, prop_id, pspec);
+      break;
+  }
+}

--- a/ext/nnstreamer/tensor_sink/tensor_sink_grpc.c
+++ b/ext/nnstreamer/tensor_sink/tensor_sink_grpc.c
@@ -319,41 +319,7 @@ gst_tensor_sink_grpc_get_property (GObject * object, guint prop_id,
   self = GST_TENSOR_SINK_GRPC (object);
   grpc = GET_GRPC_PRIVATE (self);
 
-  switch (prop_id) {
-    case PROP_SILENT:
-      g_value_set_boolean (value, self->silent);
-      break;
-    case PROP_SERVER:
-      g_value_set_boolean (value, grpc->config.is_server);
-      break;
-    case PROP_BLOCKING:
-      g_value_set_boolean (value, grpc->config.is_blocking);
-      break;
-    case PROP_IDL:
-      switch (grpc->config.idl) {
-        case GRPC_IDL_PROTOBUF:
-          g_value_set_string (value, "protobuf");
-          break;
-        case GRPC_IDL_FLATBUF:
-          g_value_set_string (value, "flatbuf");
-          break;
-        default:
-          break;
-      }
-      break;
-    case PROP_HOST:
-      g_value_set_string (value, grpc->config.host);
-      break;
-    case PROP_PORT:
-      g_value_set_int (value, grpc->config.port);
-      break;
-    case PROP_OUT:
-      g_value_set_uint (value, self->out);
-      break;
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-      break;
-  }
+  grpc_common_get_property (object, self->silent, self->out, grpc, prop_id, value, pspec);
 }
 
 /**

--- a/ext/nnstreamer/tensor_source/tensor_src_grpc.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_grpc.c
@@ -510,39 +510,6 @@ gst_tensor_src_grpc_get_property (GObject * object, guint prop_id,
   self = GST_TENSOR_SRC_GRPC (object);
   grpc = GET_GRPC_PRIVATE (self);
 
-  switch (prop_id) {
-    case PROP_SILENT:
-      g_value_set_boolean (value, self->silent);
-      break;
-    case PROP_SERVER:
-      g_value_set_boolean (value, grpc->config.is_server);
-      break;
-    case PROP_BLOCKING:
-      g_value_set_boolean (value, grpc->config.is_blocking);
-      break;
-    case PROP_IDL:
-      switch (grpc->config.idl) {
-        case GRPC_IDL_PROTOBUF:
-          g_value_set_string (value, "protobuf");
-          break;
-        case GRPC_IDL_FLATBUF:
-          g_value_set_string (value, "flatbuf");
-          break;
-        default:
-          break;
-      }
-      break;
-    case PROP_HOST:
-      g_value_set_string (value, grpc->config.host);
-      break;
-    case PROP_PORT:
-      g_value_set_int (value, grpc->config.port);
-      break;
-    case PROP_OUT:
-      g_value_set_uint (value, self->out);
-      break;
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-      break;
-  }
+  grpc_common_get_property (object, self->silent, self->out, grpc, prop_id,
+      value, pspec);
 }


### PR DESCRIPTION
grpc-sink and grpc-src have duplicated codes of get-property.
Remove them.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

