### PR TITLE
[TensorFilter] add a property shared-tensor-filter-key

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -155,6 +155,7 @@ typedef struct _GstTensorFilterProperties
   accl_hw *hw_list; /**< accelerators supported by framework intersected with user provided accelerator preference, use in GstTensorFilterFramework V1 only */
   int num_hw;       /**< number of hardare accelerators in the hw_list supported by the framework */
   const char *accl_str; /**< accelerator configuration passed in as parameter, use in GstTensorFilterFramework V0 only */
+  char *shared_tensor_filter_key; /**< the shared instance key to use same model representation */
 
   int latency; /**< The average latency over the recent 10 inferences in microseconds */
   int throughput; /**< The average throughput in the number of outputs per second */


### PR DESCRIPTION
To share the model representation(interpreter for TFLite), a new property is required.
Through this property, users can set the filters that share their model representation.
Additional logics(like checking duplication) will be added later.

The terms: `shared-tensor-filter-key`, `model representation`, are not well-known expressions.
I just named it with their purpose and I couldn't find better alternatives.
If you have any suggestions, please leave a comment.

related to #3114 

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped