### PR TITLE
Refactoring tensor-filter (lower CC and elaborated error messages)

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -540,9 +540,14 @@ _gst_tensor_filter_transform_validate (GstBaseTransform * trans,
     return GST_BASE_TRANSFORM_FLOW_DROPPED;
 
   if (!outbuf) {
+    GST_ELEMENT_ERROR (self, RESOURCE, FAILED, ("outbuf is null."),
+        ("%s:%s:%d", __FILE__, __func__, __LINE__));
     return GST_FLOW_ERROR;
   }
   if (gst_buffer_get_size (outbuf) != 0) {
+    GST_ELEMENT_ERROR (self, RESOURCE, FAILED, ("outbuf size is not zero."),
+        ("%s:%s:%d. size = %zu", __FILE__, __func__, __LINE__,
+            gst_buffer_get_size (outbuf)));
     return GST_FLOW_ERROR;
   }
 
@@ -560,7 +565,8 @@ unknown_framework:
   g_error
       ("\nA nnstreamer extension is not installed or framework property of tensor_filter is incorrect: [%s] is not found.\n\n",
       prop->fwname);
-  GST_ELEMENT_ERROR (self, CORE, NOT_IMPLEMENTED, (NULL),
+  GST_ELEMENT_ERROR (self, LIBRARY, FAILED,
+      ("framework (filter subplugin) is not found or not configured"),
       ("framework not configured"));
   return GST_FLOW_ERROR;
 unknown_model:


### PR DESCRIPTION
commit 0a03667f52b39d77c9df0e6cf1c487c2c4bebb62 (HEAD -> refactor/cc/0527_1)
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Thu May 27 19:56:11 2021 +0900

    Tensor-filter: elaborate error messages with invoke.
    
    The runtime error messages of tensor-filter are not
    meeting the standard. Elaborate the messages with
    enough information for debugging.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 9d6534487e2c4ffe3f24202702e44fd14f0ecf0d
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Thu May 27 19:41:54 2021 +0900

    Tensor-filter: reduce CC by separating parameter checks.
    
    Separate parameter check subrountine to reduce CC, which is
    mentioned by "SAM".
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
