### PR TITLE
[Gst/MQTT] Fix bugs and and further stabilize the Gst MQTT elements

### DIFF
--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -63,7 +63,7 @@ enum
   DEFAULT_SYNC = FALSE,
   DEFAULT_MQTT_OPT_CLEANSESSION = TRUE,
   DEFAULT_MQTT_OPT_KEEP_ALIVE_INTERVAL = 60,    /* 1 minute */
-  DEFAULT_MQTT_DISCONNECT_TIMEOUT = 3000,       /* 3 secs */
+  DEFAULT_MQTT_DISCONNECT_TIMEOUT = G_TIME_SPAN_SECOND * 3,     /* 3 secs */
   DEFAULT_MQTT_PUB_WAIT_TIMEOUT = 1,    /* 1 secs */
   DEFAULT_MAX_MSG_BUF_SIZE = 0, /* Buffer size is not fixed */
   DEFAULT_MQTT_QOS = 0,         /* fire and forget */
@@ -553,8 +553,7 @@ gst_mqtt_sink_stop (GstBaseSink * basesink)
 
   g_atomic_int_set (&self->mqtt_sink_state, SINK_RENDER_STOPPED);
   while (MQTTAsync_isConnected (self->mqtt_client_handle)) {
-    gint64 end_time = g_get_monotonic_time () +
-        DEFAULT_MQTT_DISCONNECT_TIMEOUT / 10;
+    gint64 end_time = g_get_monotonic_time () + DEFAULT_MQTT_DISCONNECT_TIMEOUT;
     mqtt_sink_state_t cur_state;
 
     MQTTAsync_disconnect (self->mqtt_client_handle, &disconn_opts);

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -694,7 +694,9 @@ gst_mqtt_src_create (GstBaseSrc * basesrc, guint64 offset, guint size,
 
   g_mutex_lock (&self->mqtt_src_mutex);
   while ((!self->is_connected) || (!self->is_subscribed)) {
-    g_cond_wait (&self->mqtt_src_gcond, &self->mqtt_src_mutex);
+    gint64 end_time = g_get_monotonic_time () + G_TIME_SPAN_SECOND;
+
+    g_cond_wait_until (&self->mqtt_src_gcond, &self->mqtt_src_mutex, end_time);
     if (self->err) {
       g_mutex_unlock (&self->mqtt_src_mutex);
       goto ret_flow_err;

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -466,11 +466,16 @@ gst_mqtt_src_change_state (GstElement * element, GstStateChange transition)
           g_get_real_time () * GST_US_TO_NS_MULTIPLIER - diff;
 
       /** This handles the case when the state is changed to PLAYING again */
-      if (self->is_connected && !_subscribe (self)) {
-        GST_ERROR_OBJECT (self, "Failed to re-subscribe to %s",
-            self->mqtt_topic);
+      if (GST_BASE_SRC_IS_STARTED (GST_BASE_SRC (self)) &&
+          (self->is_connected == FALSE)) {
+        int conn = MQTTAsync_reconnect (self->mqtt_client_handle);
 
-        return GST_STATE_CHANGE_FAILURE;
+        if (conn != MQTTASYNC_SUCCESS) {
+          GST_ERROR_OBJECT (self, "Failed to re-subscribe to %s",
+              self->mqtt_topic);
+
+          return GST_STATE_CHANGE_FAILURE;
+        }
       }
       break;
     default:

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -604,7 +604,7 @@ gst_mqtt_src_renegotiate (GstBaseSrc * basesrc)
   }
 
   peercaps = gst_pad_peer_query_caps (GST_BASE_SRC_PAD (basesrc), self->caps);
-  if (peercaps) {
+  if (peercaps && !gst_caps_is_empty (peercaps)) {
     caps = gst_caps_ref (peercaps);
     if (peercaps != self->caps)
       gst_caps_unref (peercaps);
@@ -617,7 +617,6 @@ gst_mqtt_src_renegotiate (GstBaseSrc * basesrc)
       result = TRUE;
     } else {
       fixed_caps = gst_caps_fixate (caps);
-
       if (fixed_caps && gst_caps_is_fixed (fixed_caps)) {
         result = gst_base_src_set_caps (basesrc, fixed_caps);
         if (peercaps == self->caps)


### PR DESCRIPTION
This PR is related to bug fixes and further stabilization of the code. In detail,
- Reduced unnecessary mutex lock operations when changing MQTTSink's internal states. In addition, g_cond_wait is replaced with g_cond_wait_until to avoid possible deadlocks.
- Fixed bugs in the re-negotiation procedure in the MQTTSrc element
- Corrected the timeout in the MQTTSink element to wait for the disconnection to the broker using by MQTTSink
 
Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped