### PR TITLE
Build: create libnnstreamer.so symlink in meson.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -50,5 +50,4 @@ override_dh_auto_install:
 
 override_dh_install:
 	dh_install --sourcedir=debian/tmp --list-missing
-	dh_link usr/lib/$(DEB_HOST_MULTIARCH)/gstreamer-1.0/libnnstreamer.so  usr/lib/$(DEB_HOST_MULTIARCH)/libnnstreamer.so
 # Add --fail-missing option after adding *.install files for all subpackages.

--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -80,6 +80,18 @@ nnstreamer_shared = shared_library('nnstreamer',
   install_dir: plugins_install_dir
 )
 
+## @todo target name using method name() (since 0.54.0)
+# target_name = nnstreamer_shared.name()
+libpath_split = nnstreamer_shared.full_path().split('/')
+target_name = libpath_split[libpath_split.length() - 1]
+
+meson.add_install_script(
+  'sh', '-c',
+  'ln -fs @0@ @1@@2@'.format(
+    join_paths(plugins_install_dir, target_name),
+    '${DESTDIR}',
+    join_paths(nnstreamer_libdir, target_name)))
+
 nnstreamer_static = static_library('nnstreamer',
   nnstreamer_sources,
   dependencies: nnstreamer_base_deps,

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -722,11 +722,7 @@ python tools/development/count_test_cases.py build tests/summary.txt
 %endif #if unit_test
 
 %install
-DESTDIR=%{buildroot} ninja -C build %{?_smp_mflags} install
-
-pushd %{buildroot}%{_libdir}
-ln -sf %{gstlibdir}/libnnstreamer.so libnnstreamer.so
-popd
+DESTDIR=%{buildroot} ninja -C build install
 
 mkdir -p %{buildroot}%{_bindir}
 pushd %{buildroot}%{_bindir}


### PR DESCRIPTION
Instead of creating symlinks in packaging (RPM/DEB),
create symlinks at meson so that local-build & user-install
works appropriately.

Fixes #3316
CC: @smohantty

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

