### PR TITLE
[Filter/Lua] Add Lua tensor_filter subplugin

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -315,8 +315,10 @@ features = {
     'extra_deps': [ grpc_dep, gpr_dep, grpcpp_dep ]
   },
   'lua-support': {
+    # TODO: support various Lua versions
     'target': 'lua',
-    'project_args': { 'ENABLE_LUA' : 1}
+    'target_alt': 'lua5.1',
+    'project_args': { 'ENABLE_LUA': 1 }
   },
   'mqtt-support': {
     'extra_deps': [ pahomqttc_dep ]

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -96,6 +96,7 @@
 %define		pytorch_support 0
 %define		caffe2_support 0
 %define		tensorflow_support 0
+%define		lua_support 0
 %endif
 
 # DA requested to remove unnecessary module builds
@@ -104,6 +105,7 @@
 %define		edgetpu_support 0
 %define		openvino_support 0
 %define		edgetpu_support 0
+%define		lua_support 0
 %endif
 
 # Release unit test suite as a subpackage only if check_test is enabled.

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -32,6 +32,7 @@
 %define		pytorch_support 0
 %define		caffe2_support 0
 %define		mqtt_support 0
+%define		lua_support 1
 
 %define		check_test 1
 %define		release_test 1
@@ -259,6 +260,10 @@ BuildRequires:	pytorch-devel
 BuildRequires:	pytorch-devel
 %endif
 
+%if 0%{?lua_support}
+BuildRequires:	lua-devel
+%endif
+
 # Unit Testing Uses SSAT (hhtps://github.com/myungjoo/SSAT.git)
 %if 0%{?unit_test}
 BuildRequires:	ssat >= 1.1.0
@@ -402,6 +407,16 @@ Requires:	nnstreamer = %{version}-%{release}
 Requires:	pytorch
 %description caffe2
 NNStreamer's tensor_fliter subplugin of caffe2
+%endif
+
+# for lua
+%if 0%{?lua_support}
+%package lua
+Summary:	NNStreamer lua Support
+Requires:	nnstreamer = %{version}-%{release}
+Requires:	lua
+%description lua
+NNStreamer's tensor_fliter subplugin of lua
 %endif
 
 %package devel
@@ -656,6 +671,13 @@ Provides additional gstreamer plugins for nnstreamer pipelines
 %define enable_mqtt -Dmqtt-support=disabled
 %endif
 
+# Support lua
+%if 0%{?lua_support}
+%define enable_lua -Dlua-support=enabled
+%else
+%define enable_lua -Dlua-support=disabled
+%endif
+
 %prep
 rm -rf ./build
 %setup -q
@@ -684,7 +706,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir
 	%{enable_tizen} %{element_restriction} -Denable-env-var=false -Denable-symbolic-link=false \
 	%{enable_tf_lite} %{enable_tf2_lite} %{enable_tf} %{enable_pytorch} %{enable_caffe2} %{enable_python3} \
 	%{enable_nnfw_runtime} %{enable_mvncsdk2} %{enable_openvino} %{enable_armnn} %{enable_edgetpu}  %{enable_vivante} %{enable_flatbuf} \
-	%{enable_tizen_sensor} %{enable_mqtt} %{enable_test} %{enable_test_coverage} %{install_test} \
+	%{enable_tizen_sensor} %{enable_mqtt} %{enable_lua} %{enable_test} %{enable_test_coverage} %{install_test} \
 	build
 
 ninja -C build %{?_smp_mflags}
@@ -870,6 +892,14 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_caffe2.so
+%endif
+
+# for lua
+%if 0%{?lua_support}
+%files lua
+%manifest nnstreamer.manifest
+%defattr(-,root,root,-)
+%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_lua.so
 %endif
 
 %files devel

--- a/tests/nnstreamer_filter_lua/runTest.sh
+++ b/tests/nnstreamer_filter_lua/runTest.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
+## @file runTest.sh
+## @author Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+## @date Jun 3 2021
+## @brief SSAT Test Cases for NNStreamer tensor_filter::lua
+##
+
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
+"
+fi
+
+# This is compatible with SSAT (https://github.com/myungjoo/SSAT)
+testInit $1
+
+PATH_TO_PLUGIN="../../build"
+# Check lua libraies are built
+if [[ -d $PATH_TO_PLUGIN ]]; then
+    ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
+    if [[ -d ${ini_path} ]]; then
+        check=$(ls ${ini_path} | grep lua.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find lua shared lib"
+            report
+            exit
+        fi
+    else
+        echo "Cannot find ${ini_path}"
+        report exit
+    fi
+else
+    echo "No build directory"
+    report
+    exit
+fi
+
+PATH_TO_PASSTHROUGH_MODEL="../test_models/models/passthrough.lua"
+PATH_TO_SCALER_MODEL="../test_models/models/scaler.lua"
+
+# Passthrough test
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=lua model=\"${PATH_TO_PASSTHROUGH_MODEL}\" ! filesink location=\"testcase1.passthrough.log\" sync=true t. ! queue ! filesink location=\"testcase1.direct.log\" sync=true" 1 0 0 $PERFORMANCE
+callCompareTest testcase1.direct.log testcase1.passthrough.log 1 "Compare 1" 0 0
+
+# Passthrough -> Scaler test
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=lua model=\"${PATH_TO_PASSTHROUGH_MODEL}\" ! tensor_filter framework=lua model=\"${PATH_TO_SCALER_MODEL}\" ! filesink location=\"testcase2.scaled.log\" sync=true t. ! queue ! filesink location=\"testcase2.direct.log\" sync=true" 2 0 0 $PERFORMANCE
+python3 ../nnstreamer_filter_python3/checkScaledTensor.py testcase2.direct.log 640 480 testcase2.scaled.log 320 240 3
+testResult $? 2 "Golden test comparison" 0 1
+
+rm *.log
+
+report

--- a/tests/nnstreamer_filter_lua/runTest.sh
+++ b/tests/nnstreamer_filter_lua/runTest.sh
@@ -53,6 +53,13 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/
 python3 ../nnstreamer_filter_python3/checkScaledTensor.py testcase2.direct.log 640 480 testcase2.scaled.log 320 240 3
 testResult $? 2 "Golden test comparison" 0 1
 
+# Passthrough test with given string script
+PASSTHROUGH_SCRIPT="inputTensorInfo = {dim = {3, 299, 299, 1}, type = 'uint8_t' } outputTensorInfo = {dim = {3, 299, 299, 1}, type = 'uint8_t' } function nnstreamer_invoke() input = input_tensor() output = output_tensor() for i=1,3*299*299 do output[i] = input[i] end end"
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=299,height=299,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=lua model=\"${PASSTHROUGH_SCRIPT}\" ! filesink location=\"testcase3.passthrough.log\" sync=true t. ! queue ! filesink location=\"testcase3.direct.log\" sync=true" 3 0 0 $PERFORMANCE
+callCompareTest testcase3.direct.log testcase3.passthrough.log 1 "Compare 2" 0 0
+
+
 rm *.log
 
 report

--- a/tests/test_models/models/passthrough.lua
+++ b/tests/test_models/models/passthrough.lua
@@ -1,0 +1,30 @@
+-- passthrough.lua
+
+inputTensorInfo = {
+  dim = {3, 640, 480, 1},
+  type = "uint8_t",
+}
+
+outputTensorInfo = {
+  dim = {3, 640, 480, 1},
+  type = "uint8_t",
+}
+
+iC = inputTensorInfo["dim"][1]
+iW = inputTensorInfo["dim"][2]
+iH = inputTensorInfo["dim"][3]
+iN = inputTensorInfo["dim"][4]
+
+oC = outputTensorInfo["dim"][1]
+oW = outputTensorInfo["dim"][2]
+oH = outputTensorInfo["dim"][3]
+oN = outputTensorInfo["dim"][4]
+
+function nnstreamer_invoke()
+  input = input_tensor()
+  output = output_tensor()
+
+  for i=1,oC*oW*oH*oN do
+    output[i] = input[i]
+  end
+end

--- a/tests/test_models/models/scaler.lua
+++ b/tests/test_models/models/scaler.lua
@@ -1,0 +1,47 @@
+-- scaler.lua
+
+inputTensorInfo = {
+  dim = {3, 640, 480, 1},
+  type = "uint8_t",
+}
+
+outputTensorInfo = {
+  dim = {3, 320, 240, 1},
+  type = "uint8_t",
+}
+
+iC = inputTensorInfo["dim"][1]
+iW = inputTensorInfo["dim"][2]
+iH = inputTensorInfo["dim"][3]
+iN = inputTensorInfo["dim"][4]
+
+oC = outputTensorInfo["dim"][1]
+oW = outputTensorInfo["dim"][2]
+oH = outputTensorInfo["dim"][3]
+oN = outputTensorInfo["dim"][4]
+
+function nnstreamer_invoke()
+  input = input_tensor()
+  output = output_tensor()
+
+  for n=1,oN do
+    for h=1,oH do
+      for w=1,oW do
+        for c=1,oC do
+          outIndex = (n - 1) * oH * oW * oC
+          outIndex = outIndex + (h - 1) * oW * oC
+          outIndex = outIndex + (w - 1) * oC
+          outIndex = outIndex + c
+
+          inputIndex = (n - 1) * iH * iW * iC
+          inputIndex = inputIndex + (math.floor((h - 1) * (iH / oH))) * iW * iC
+          inputIndex = inputIndex + (math.floor((w - 1) * (iW / oW))) * iC
+          inputIndex = inputIndex + c
+
+          output[outIndex] = input[inputIndex]
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
- Add Lua filter working with Lua5.1
- For now, it only supports num_tensors == 1 for input/output and only supports uint8 type
- Add SSAT testcases
- Enable Lua filter in Tizen

TODO (in upcoming PR) :
- scale for num_tensors > 1
- Support various tensor type


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
