### PR TITLE
[TEST] Change timeout of the tensor_if test

### DIFF
--- a/tests/nnstreamer_if/unittest_if.cc
+++ b/tests/nnstreamer_if/unittest_if.cc
@@ -16,7 +16,7 @@
 #include <unittest_util.h>
 #include "../gst/nnstreamer/tensor_if/gsttensorif.h"
 
-#define TEST_TIMEOUT_MS (1000U)
+#define TEST_TIMEOUT_MS (5000U)
 
 static int data_received;
 


### PR DESCRIPTION
Change timeout of the tensor_if test.
Timeout occurs somtimes because of slow speed of the armv7l to save files.

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped