### PR TITLE
[debian] Install nnstreamer shared object file in libdir

### DIFF
--- a/debian/nnstreamer-core.links
+++ b/debian/nnstreamer-core.links
@@ -1,0 +1,1 @@
+/usr/lib/*/gstreamer-1.0/libnnstreamer.so /usr/lib/*/libnnstreamer.so


### PR DESCRIPTION
Install nnstreamer shared object file in libdir.
This fixes build fail of the nnstreamer-api.
https://code.launchpad.net/~gichan-jang/+recipe/ml-api-daily

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
