### PR TITLE
[FIX][debian] Install the link of nnstreamer lib

### DIFF
--- a/debian/nnstreamer-core.install
+++ b/debian/nnstreamer-core.install
@@ -4,4 +4,5 @@
 /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_image_labeling.so
 /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_direct_video.so
 /usr/lib/nnstreamer/filters/libnnstreamer_filter_cpp.so
+/usr/lib/*/libnnstreamer.so
 /usr/lib/*/gstreamer-1.0/libnnstreamer.so

--- a/debian/nnstreamer-core.links
+++ b/debian/nnstreamer-core.links
@@ -1,1 +1,0 @@
-/usr/lib/*/gstreamer-1.0/libnnstreamer.so /usr/lib/*/libnnstreamer.so


### PR DESCRIPTION
Install symlink of nnstreamer shared object in libdir.
This fixes build fail of the nnstreamer-api.
https://code.launchpad.net/~gichan-jang/+recipe/ml-api-daily

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped