### PR TITLE
[TEST] Change state change timeout

### DIFF
--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 #define _print_log(...) if (DBG) g_message (__VA_ARGS__)
 
-#define UNITTEST_STATECHANGE_TIMEOUT (500U)
+#define UNITTEST_STATECHANGE_TIMEOUT (1000U)
 #define TEST_DEFAULT_SLEEP_TIME (10000U)
 #define TEST_TIMEOUT_LIMIT (10000000U) /* 10 secs */
 


### PR DESCRIPTION
Change UNITTEST_STATECHANGE_TIMEOUT of the unit test util from 500 ms to 1,000 ms.
For cppFilterObj_base03 test, it takes an average of 700 ms to change the state in the armv7l arch.

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped