### PR TITLE
[tizen] flatbuffers python-support

### DIFF
--- a/gst/nnstreamer/tensor_converter/README.md
+++ b/gst/nnstreamer/tensor_converter/README.md
@@ -57,3 +57,44 @@ For each outgoing frame (on the source pad), there always is a **single** instan
 ```
 $ gst-launch videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! tensor_converter ! tensor_sink
 ```
+
+## Custom converter
+If you want to convert any media type to tensors, You can use custom mode of the tensor converter.
+### code mode
+This is an example of a callback type custom mode.
+```
+// Define custom callback function
+GstBuffer * tensor_converter_custom_cb (GstBuffer *in_buf, void *data, GstTensorsConfig *config) {
+  // Write a code to convert any media type to tensors.
+}
+...
+// Register custom callback function
+nnstreamer_converter_custom_register ("tconv", tensor_converter_custom_cb, NULL);
+...
+// Use the custom tensor converter in a pipeline.
+// E.g., Pipeline of " ... (any media stream) ! tensor_converter mode=custom-code:tconv ! (tensors)... "
+...
+// After everything is done.
+nnstreamer_converter_custom_unregister ("tconv");
+```
+
+### script mode
+* Note: Currently only Python is supported.
+  - If you want to use FlatBuffers Python in Tizen, install package `flatbuffers-python`. It also includes a Flexbuffers Python.
+  - If you want to use Flatbuffers Python in Ubuntu, install package using pip `pip install flatbuffers`. It also includes a Flexbuffers Python.
+
+This is an example of a python script.
+```
+# @file custom_converter_example.py
+import numpy as np
+import nnstreamer_python as nns
+## @brief  User-defined custom converter
+class CustomConverter(object):
+  def convert (self, input_array):
+    ## Write a code to convert any media type to tensors.
+    return (tensors_info, out_array, rate_n, rate_d)
+```
+Example pipeline
+```
+... (any media stream) ! tensor_converter mode=custom-script:custom_converter_example.py ! (tensors) ...
+```

--- a/gst/nnstreamer/tensor_decoder/README.md
+++ b/gst/nnstreamer/tensor_decoder/README.md
@@ -63,3 +63,51 @@ The following properties are suggested and planned.
 $ gst-launch somevideosrc_with_xraw ! tee name=t ! queue ! tensor_converter ! tensor_filter SOME_OPTION ! tensor_decoder output-type=image-label additional-file-1=/tmp/labels.txt ! txt. t. ! queue ! textoverlay name=txt ! autovideosink
 ```
 Note: not tested. not sure if the syntax is correct with ```txt. t. !```. Regard the above as pseudo code.
+
+## Custom decoder
+If you want to convert tensors to any media type, You can use custom mode of the tensor decoder.
+### code mode
+This is an example of a callback type custom mode.
+```
+// Define custom callback function
+int tensor_decoder_custom_cb (const GstTensorMemory *input,
+const GstTensorsConfig *config, void *data, GstBuffer *out_buf) {
+  // Write a code to convert tensors to any media type.
+}
+
+...
+// Register custom callback function
+nnstreamer_decoder_custom_register ("tdec", tensor_decoder_custom_cb, NULL);
+...
+// Use the custom tensor decoder in a pipeline.
+// E.g., Pipeline of " ... (tensors) ! tensor_decoder mode=custom-code option1=tdec ! (any media stream)... "
+...
+// After everything is done.
+nnstreamer_decoder_custom_unregister ("tdec");
+```
+
+### script mode
+* Note: Currently only Python is supported.
+  - If you want to use FlatBuffers Python in Tizen, install package `flatbuffers-python`. It also includes a Flexbuffers Python.
+  - If you want to use Flatbuffers Python in Ubuntu, install package using pip `pip install flatbuffers`. It also includes a Flexbuffers Python.
+
+This is an example of a python script.
+```
+# @file custom_decoder_example.py
+## @brief  User-defined custom decoder
+class CustomDecoder(object):
+## @breif  Python callback: getOutCaps
+  def getOutCaps (self):
+    # Write capability of the media type.
+    return bytes('@CAPS_STRING@', 'UTF-8')
+
+## @breif  Python callback: decode
+  def decode (self, raw_data, in_info, rate_n, rate_d):
+    # return decoded raw data as `bytes` type.
+    return data
+
+```
+Example pipeline
+```
+... (tensors) ! tensor_decoder mode=python3 option1=custom_decoder_example.py ! (any media stream) ...
+```

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -165,6 +165,9 @@ BuildRequires:  pkgconfig(libpng)
 %if 0%{?flatbuf_support}
 # for flatbuffers
 BuildRequires: flatbuffers-devel
+%if 0%{?unit_test}
+BuildRequires: flatbuffers-python
+%endif
 %endif
 %if 0%{?tensorflow_lite_support}
 # for tensorflow-lite
@@ -374,6 +377,7 @@ NNStreamer's tensor_converter and decoder subplugin of Protobuf.
 Summary:	NNStreamer Flatbuf Support
 Requires:	nnstreamer = %{version}-%{release}
 Requires:	flatbuffers
+Recommends: flatbuffers-python
 %description flatbuf
 NNStreamer's tensor_converter and decoder subplugin of flatbuf.
 %endif


### PR DESCRIPTION
flatbuffers python-support for tizen.
This will enable tensor converter and decoder unittest of the python.

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped