### PR TITLE
[Debian] fix debian control for TVM @open sesame 06/10 10:17 

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  tensorflow2-lite-dev,
  openvino-dev, openvino-cpu-mkldnn [amd64], libflatbuffers-dev, flatbuffers-compiler,
  protobuf-compiler (>=3.12), libprotobuf-dev [amd64 arm64 armhf],
- tensorflow-dev [amd64], python2.7-dev, flex, bison
+ tensorflow-dev [amd64], python2.7-dev, flex, bison, tvm-runtime-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer
 
@@ -96,6 +96,13 @@ Multi-Arch: same
 Depends: nnstreamer, openvino, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer OpenVino support
  This package allows nnstreamer to support OpenVino.
+
+Package: nnstreamer-tvm
+Architecture: any
+Multi-Arch: same
+Depends: nnstreamer, tvm-runtime, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer TVM support
+ This package allows nnstreamer to support TVM
 
 Package: nnstreamer-protobuf
 Architecture: any

--- a/debian/nnstreamer-tvm.install
+++ b/debian/nnstreamer-tvm.install
@@ -1,0 +1,1 @@
+/usr/lib/nnstreamer/filters/libnnstreamer_filter_tvm.so

--- a/meson.build
+++ b/meson.build
@@ -174,20 +174,6 @@ if not get_option('snpe-support').disabled()
   endif
 endif
 
-# tvm
-tvm_dep = dependency('', required: false)
-dlpack_dep = dependency('', required: false)
-if not get_option('tvm-support').disabled()
-  tvm_dep = dependency('tvm', required: false)
-  dlpack_dep = dependency('dlpack', required: false)
-  if not tvm_dep.found()
-    tvm_dep = cxx.find_library('tvm', required: get_option('tvm-support'))
-  endif
-  if not dlpack_dep.found()
-    dlpack_dep = cxx.find_library('dlpack', required: get_option('tvm-support'))
-  endif
-endif
-
 # tensorrt
 nvinfer_dep = dependency('', required: false)
 nvparsers_dep = dependency('', required: false)
@@ -322,7 +308,8 @@ features = {
     'extra_deps': [ pahomqttc_dep ]
   },
   'tvm-support': {
-    'extra_deps': [ tvm_dep, dlpack_dep ]
+    'target': 'tvm_runtime',
+    'project_args': { 'ENABLE_TVM' : 1 }
   }
 }
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -168,7 +168,7 @@ if gtest_dep.found()
   if tvm_support_is_available
     unittest_filter_tvm = executable('unittest_filter_tvm',
       join_paths('nnstreamer_filter_tvm', 'unittest_filter_tvm.cc'),
-      dependencies: [unittest_util_dep, glib_dep, gst_dep, nnstreamer_dep, gtest_dep, tvm_dep],
+      dependencies: [unittest_util_dep, glib_dep, gst_dep, nnstreamer_dep, gtest_dep],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )


### PR DESCRIPTION
This patch adds debian packaging for TVM filter
Fix meson.build corresponding to tvm-dev package

Signed-off-by: Junhwan Kim <jejudo.kim@samsung.com>



**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
