### PR TITLE
[Common/MemFlag] remove read-only flag

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.cc
@@ -121,8 +121,8 @@ ServiceImplFlatbuf::_get_buffer_from_tensors (Message<Tensors> &msg,
     gsize size = VectorLength (tensor->data ());
     gpointer new_data = g_memdup (data, size);
 
-    memory = gst_memory_new_wrapped (GST_MEMORY_FLAG_READONLY,
-        new_data, size, 0, size, new_data, g_free);
+    memory = gst_memory_new_wrapped ((GstMemoryFlags) 0, new_data, size,
+        0, size, new_data, g_free);
     gst_buffer_append_memory (*buffer, memory);
   }
 }

--- a/ext/nnstreamer/extra/nnstreamer_grpc_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_protobuf.cc
@@ -115,8 +115,8 @@ ServiceImplProtobuf::_get_buffer_from_tensors (Tensors &tensors,
     gsize size = tensor->data ().length ();
     gpointer new_data = g_memdup (data, size);
 
-    memory = gst_memory_new_wrapped (GST_MEMORY_FLAG_READONLY,
-        new_data, size, 0, size, new_data, g_free);
+    memory = gst_memory_new_wrapped ((GstMemoryFlags) 0, new_data, size,
+        0, size, new_data, g_free);
     gst_buffer_append_memory (*buffer, memory);
   }
 }

--- a/ext/nnstreamer/extra/nnstreamer_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.cc
@@ -160,8 +160,8 @@ gst_tensor_converter_protobuf (GstBuffer *in_buf, GstTensorsConfig *config, void
     mem_size = tensor->data ().length ();
     mem_data = g_memdup (tensor->data ().c_str (), mem_size);
 
-    out_mem = gst_memory_new_wrapped (
-        GST_MEMORY_FLAG_READONLY, mem_data, mem_size, 0, mem_size, NULL, NULL);
+    out_mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, mem_data, mem_size,
+        0, mem_size, NULL, NULL);
 
     gst_buffer_append_memory (out_buf, out_mem);
   }

--- a/ext/nnstreamer/tensor_converter/tensor_converter_python3.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_python3.cc
@@ -191,8 +191,8 @@ PYConverterCore::convert (GstBuffer *in_buf, GstTensorsConfig *config)
       mem_size = PyArray_SIZE (output_array);
       mem_data = g_memdup ((guint8 *) PyArray_DATA (output_array), mem_size);
 
-      out_mem = gst_memory_new_wrapped (GST_MEMORY_FLAG_READONLY, mem_data,
-          mem_size, 0, mem_size, mem_data, g_free);
+      out_mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, mem_data, mem_size,
+          0, mem_size, mem_data, g_free);
       gst_buffer_append_memory (out_buf, out_mem);
 
     }

--- a/tests/nnstreamer_converter/unittest_converter.cc
+++ b/tests/nnstreamer_converter/unittest_converter.cc
@@ -68,8 +68,8 @@ tensor_converter_custom_cb (GstBuffer *in_buf,
     mem_size = tensor_data.size ();
     mem_data = g_memdup (tensor_data.data (), mem_size);
 
-    out_mem = gst_memory_new_wrapped (GST_MEMORY_FLAG_READONLY, mem_data,
-        mem_size, 0, mem_size, mem_data, g_free);
+    out_mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, mem_data, mem_size,
+        0, mem_size, mem_data, g_free);
 
     gst_buffer_append_memory (out_buf, out_mem);
     g_free (tensor_key);

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -2835,8 +2835,8 @@ TEST (testTensorConverter, flexToStaticInvalidBuffer1_n)
   data = g_malloc0 (data_size);
   gst_tensor_meta_info_update_header (&meta, data);
 
-  mem = gst_memory_new_wrapped (
-      GST_MEMORY_FLAG_READONLY, data, data_size, 0, data_size, data, g_free);
+  mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, data, data_size,
+      0, data_size, data, g_free);
   gst_buffer_append_memory (in_buf, mem);
 
   EXPECT_NE (gst_harness_push (h, in_buf), GST_FLOW_OK);
@@ -2887,8 +2887,8 @@ TEST (testTensorConverter, flexToStaticInvalidBuffer2_n)
   data = g_malloc0 (data_size);
   gst_tensor_meta_info_update_header (&meta, data);
 
-  mem = gst_memory_new_wrapped (
-      GST_MEMORY_FLAG_READONLY, data, data_size, 0, data_size, data, g_free);
+  mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, data, data_size,
+      0, data_size, data, g_free);
   gst_buffer_append_memory (in_buf, mem);
 
   /* 2nd mem block (invalid size) */
@@ -2899,8 +2899,8 @@ TEST (testTensorConverter, flexToStaticInvalidBuffer2_n)
   data = g_malloc0 (data_size);
   gst_tensor_meta_info_update_header (&meta, data);
 
-  mem = gst_memory_new_wrapped (
-      GST_MEMORY_FLAG_READONLY, data, data_size, 0, data_size, data, g_free);
+  mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, data, data_size,
+      0, data_size, data, g_free);
   gst_buffer_append_memory (in_buf, mem);
 
   EXPECT_NE (gst_harness_push (h, in_buf), GST_FLOW_OK);
@@ -5784,8 +5784,8 @@ TEST_REQUIRE_TFLITE (testTensorFilter, flexInvalidBuffer1_n)
   data = g_malloc0 (data_size);
   gst_tensor_meta_info_update_header (&meta, data);
 
-  mem = gst_memory_new_wrapped (
-      GST_MEMORY_FLAG_READONLY, data, data_size, 0, data_size, data, g_free);
+  mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, data, data_size,
+      0, data_size, data, g_free);
   gst_buffer_append_memory (in_buf, mem);
 
   /* 2nd mem block (invalid, unnecessary block) */
@@ -5796,8 +5796,8 @@ TEST_REQUIRE_TFLITE (testTensorFilter, flexInvalidBuffer1_n)
   data = g_malloc0 (data_size);
   gst_tensor_meta_info_update_header (&meta, data);
 
-  mem = gst_memory_new_wrapped (
-      GST_MEMORY_FLAG_READONLY, data, data_size, 0, data_size, data, g_free);
+  mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, data, data_size,
+      0, data_size, data, g_free);
   gst_buffer_append_memory (in_buf, mem);
 
   EXPECT_NE (gst_harness_push (h, in_buf), GST_FLOW_OK);
@@ -5849,8 +5849,8 @@ TEST_REQUIRE_TFLITE (testTensorFilter, flexInvalidBuffer2_n)
   data = g_malloc0 (data_size);
   gst_tensor_meta_info_update_header (&meta, data);
 
-  mem = gst_memory_new_wrapped (
-      GST_MEMORY_FLAG_READONLY, data, data_size, 0, data_size, data, g_free);
+  mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, data, data_size,
+      0, data_size, data, g_free);
   gst_buffer_append_memory (in_buf, mem);
 
   EXPECT_NE (gst_harness_push (h, in_buf), GST_FLOW_OK);
@@ -5907,8 +5907,8 @@ TEST_REQUIRE_TFLITE (testTensorFilter, flexToFlex)
   data = g_malloc0 (data_size);
   gst_tensor_meta_info_update_header (&meta, data);
 
-  mem = gst_memory_new_wrapped (
-      GST_MEMORY_FLAG_READONLY, data, data_size, 0, data_size, data, g_free);
+  mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, data, data_size,
+      0, data_size, data, g_free);
   gst_buffer_append_memory (in_buf, mem);
 
   EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);


### PR DESCRIPTION
remove unnecessary read-only flag when creating memory block with raw data.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
