### PR TITLE
[test/trivial] Fix signed-unsigned compare

### DIFF
--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -1196,7 +1196,7 @@ TEST (commonMetaInfo, initDefaultValue)
 
   EXPECT_EQ (meta.type, _NNS_END);
   EXPECT_EQ (meta.format, _NNS_TENSOR_FORMAT_STATIC);
-  EXPECT_EQ (meta.media_type, _NNS_TENSOR);
+  EXPECT_EQ ((media_type) meta.media_type, _NNS_TENSOR);
   for (i = 0; i < NNS_TENSOR_META_RANK_LIMIT; i++)
     EXPECT_EQ (meta.dimension[i], 0U);
 
@@ -1408,7 +1408,7 @@ TEST (commonMetaInfo, appendHeader)
   EXPECT_EQ (meta1.version, meta2.version);
   EXPECT_EQ (meta2.type, _NNS_INT16);
   EXPECT_EQ (meta2.format, _NNS_TENSOR_FORMAT_FLEXIBLE);
-  EXPECT_EQ (meta2.media_type, _NNS_OCTET);
+  EXPECT_EQ ((media_type) meta2.media_type, _NNS_OCTET);
   EXPECT_EQ (meta2.dimension[0], 300U);
   EXPECT_EQ (meta2.dimension[1], 1U);
 

--- a/tests/nnstreamer_converter/unittest_converter.cc
+++ b/tests/nnstreamer_converter/unittest_converter.cc
@@ -411,10 +411,10 @@ TEST (tensorConverterPython, dynamicDimension)
   EXPECT_NE (structure, nullptr);
   gst_tensor_config_from_structure (&config, structure);
 
-  EXPECT_EQ (24, config.info.dimension[0]);
-  EXPECT_EQ (1, config.info.dimension[1]);
-  EXPECT_EQ (1, config.info.dimension[2]);
-  EXPECT_EQ (1, config.info.dimension[3]);
+  EXPECT_EQ (24U, config.info.dimension[0]);
+  EXPECT_EQ (1U, config.info.dimension[1]);
+  EXPECT_EQ (1U, config.info.dimension[2]);
+  EXPECT_EQ (1U, config.info.dimension[3]);
 
   gst_caps_unref (caps);
 
@@ -427,10 +427,10 @@ TEST (tensorConverterPython, dynamicDimension)
   EXPECT_NE (structure, nullptr);
   gst_tensor_config_from_structure (&config, structure);
 
-  EXPECT_EQ (48, config.info.dimension[0]);
-  EXPECT_EQ (1, config.info.dimension[1]);
-  EXPECT_EQ (1, config.info.dimension[2]);
-  EXPECT_EQ (1, config.info.dimension[3]);
+  EXPECT_EQ (48U, config.info.dimension[0]);
+  EXPECT_EQ (1U, config.info.dimension[1]);
+  EXPECT_EQ (1U, config.info.dimension[2]);
+  EXPECT_EQ (1U, config.info.dimension[3]);
   gst_caps_unref (caps);
 
   EXPECT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_handle), buf_2), GST_FLOW_OK);
@@ -444,16 +444,16 @@ TEST (tensorConverterPython, dynamicDimension)
   EXPECT_NE (structure, nullptr);
   gst_tensor_config_from_structure (&config, structure);
 
-  EXPECT_EQ (24, config.info.dimension[0]);
-  EXPECT_EQ (1, config.info.dimension[1]);
-  EXPECT_EQ (1, config.info.dimension[2]);
-  EXPECT_EQ (1, config.info.dimension[3]);
+  EXPECT_EQ (24U, config.info.dimension[0]);
+  EXPECT_EQ (1U, config.info.dimension[1]);
+  EXPECT_EQ (1U, config.info.dimension[2]);
+  EXPECT_EQ (1U, config.info.dimension[3]);
   gst_caps_unref (caps);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (100000);
 
-  EXPECT_EQ (3, *data_received);
+  EXPECT_EQ (3U, *data_received);
   g_free (data_received);
   gst_object_unref (sink_handle);
   gst_object_unref (appsrc_handle);

--- a/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
+++ b/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
@@ -136,17 +136,17 @@ TEST (nnstreamerFilterTvm, getModelInfo00)
   ret = sp->getModelInfo (NULL, NULL, data, GET_IN_OUT_INFO, &in_info, &out_info);
   EXPECT_EQ (ret, 0);
 
-  EXPECT_EQ (in_info.num_tensors, 1);
-  EXPECT_EQ (in_info.info[0].dimension[0], 3);
-  EXPECT_EQ (in_info.info[0].dimension[1], 640);
-  EXPECT_EQ (in_info.info[0].dimension[2], 480);
-  EXPECT_EQ (in_info.info[0].dimension[3], 1);
+  EXPECT_EQ (in_info.num_tensors, 1U);
+  EXPECT_EQ (in_info.info[0].dimension[0], 3U);
+  EXPECT_EQ (in_info.info[0].dimension[1], 640U);
+  EXPECT_EQ (in_info.info[0].dimension[2], 480U);
+  EXPECT_EQ (in_info.info[0].dimension[3], 1U);
   EXPECT_EQ (in_info.info[0].type, _NNS_FLOAT32);
-  EXPECT_EQ (out_info.num_tensors, 1);
-  EXPECT_EQ (out_info.info[0].dimension[0], 3);
-  EXPECT_EQ (out_info.info[0].dimension[1], 640);
-  EXPECT_EQ (out_info.info[0].dimension[2], 480);
-  EXPECT_EQ (out_info.info[0].dimension[3], 1);
+  EXPECT_EQ (out_info.num_tensors, 1U);
+  EXPECT_EQ (out_info.info[0].dimension[0], 3U);
+  EXPECT_EQ (out_info.info[0].dimension[1], 640U);
+  EXPECT_EQ (out_info.info[0].dimension[2], 480U);
+  EXPECT_EQ (out_info.info[0].dimension[3], 1U);
   EXPECT_EQ (out_info.info[0].type, _NNS_FLOAT32);
 
   sp->close (&prop, &data);

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -5934,7 +5934,7 @@ TEST_REQUIRE_TFLITE (testTensorFilter, flexToFlex)
     EXPECT_EQ (meta.type, _NNS_UINT8);
     EXPECT_EQ (meta.dimension[0], 1001U);
     EXPECT_EQ (meta.dimension[1], 1U);
-    EXPECT_EQ (meta.media_type, _NNS_TENSOR);
+    EXPECT_EQ ((media_type) meta.media_type, _NNS_TENSOR);
 
     data_size = gst_tensor_meta_info_get_header_size (&meta);
     data_size += gst_tensor_meta_info_get_data_size (&meta);

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -1555,13 +1555,13 @@ TEST (tensorStreamTest, muxFlexTensors)
   EXPECT_EQ (g_test_data.meta[0].dimension[0], 3U);
   EXPECT_EQ (g_test_data.meta[0].dimension[1], 160U);
   EXPECT_EQ (g_test_data.meta[0].dimension[2], 120U);
-  EXPECT_EQ (g_test_data.meta[0].media_type, _NNS_TENSOR);
+  EXPECT_EQ ((media_type) g_test_data.meta[0].media_type, _NNS_TENSOR);
 
   EXPECT_EQ (g_test_data.meta[1].type, _NNS_UINT8);
   EXPECT_EQ (g_test_data.meta[1].dimension[0], 3U);
   EXPECT_EQ (g_test_data.meta[1].dimension[1], 160U);
   EXPECT_EQ (g_test_data.meta[1].dimension[2], 120U);
-  EXPECT_EQ (g_test_data.meta[1].media_type, _NNS_VIDEO);
+  EXPECT_EQ ((media_type) g_test_data.meta[1].media_type, _NNS_VIDEO);
 
   EXPECT_FALSE (g_test_data.test_failed);
   _free_test_data (option);
@@ -1609,7 +1609,7 @@ TEST (tensorStreamTest, demuxFlexTensors)
   EXPECT_EQ (g_test_data.meta[0].dimension[0], 3U);
   EXPECT_EQ (g_test_data.meta[0].dimension[1], 320U);
   EXPECT_EQ (g_test_data.meta[0].dimension[2], 240U);
-  EXPECT_EQ (g_test_data.meta[0].media_type, _NNS_VIDEO);
+  EXPECT_EQ ((media_type) g_test_data.meta[0].media_type, _NNS_VIDEO);
 
   EXPECT_FALSE (g_test_data.test_failed);
   _free_test_data (option);
@@ -3339,7 +3339,7 @@ TEST (tensorStreamTest, flexOnSink)
   EXPECT_EQ (g_test_data.meta[0].type, _NNS_UINT8);
   EXPECT_EQ (g_test_data.meta[0].dimension[0], 10U);
   EXPECT_EQ (g_test_data.meta[0].format, _NNS_TENSOR_FORMAT_FLEXIBLE);
-  EXPECT_EQ (g_test_data.meta[0].media_type, _NNS_TENSOR);
+  EXPECT_EQ ((media_type) g_test_data.meta[0].media_type, _NNS_TENSOR);
 
   EXPECT_FALSE (g_test_data.test_failed);
   _free_test_data (option);
@@ -3392,11 +3392,11 @@ TEST (tensorStreamTest, staticToFlex)
   /* check meta info */
   EXPECT_EQ (g_test_data.meta[0].type, _NNS_INT32);
   EXPECT_EQ (g_test_data.meta[0].dimension[0], 2U);
-  EXPECT_EQ (g_test_data.meta[0].media_type, _NNS_OCTET);
+  EXPECT_EQ ((media_type) g_test_data.meta[0].media_type, _NNS_OCTET);
 
   EXPECT_EQ (g_test_data.meta[1].type, _NNS_INT8);
   EXPECT_EQ (g_test_data.meta[1].dimension[0], 2U);
-  EXPECT_EQ (g_test_data.meta[1].media_type, _NNS_OCTET);
+  EXPECT_EQ ((media_type) g_test_data.meta[1].media_type, _NNS_OCTET);
 
   EXPECT_FALSE (g_test_data.test_failed);
   _free_test_data (option);


### PR DESCRIPTION
- Fix gtest signed-unsigned compare cases
- Change unittest_converter.cc CRLF -> LF

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
