### PR TITLE
[Filter] add a hash table for shared key

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -221,7 +221,7 @@ class TFLiteInterpreter
 class TFLiteCore
 {
   public:
-  TFLiteCore ();
+  TFLiteCore (const GstTensorFilterProperties *prop);
   ~TFLiteCore ();
   int init (tflite_option_s *option);
   int loadModel ();
@@ -244,6 +244,8 @@ class TFLiteCore
   TFLiteInterpreter *interpreter;
   TFLiteInterpreter *interpreter_sub;
 
+  gchar *shared_tensor_filter_key;
+  void checkSharedInterpreter (const GstTensorFilterProperties *prop);
   void setAccelerator (const char *accelerators, tflite_delegate_e d);
 };
 
@@ -712,13 +714,21 @@ fail_exit:
 /**
  * @brief	TFLiteCore constructor
  */
-TFLiteCore::TFLiteCore ()
+TFLiteCore::TFLiteCore (const GstTensorFilterProperties *prop)
 {
   num_threads = -1;
   accelerator = ACCL_NONE;
   delegate = TFLITE_DELEGATE_NONE;
   interpreter_sub = nullptr;
-  interpreter = new TFLiteInterpreter ();
+  shared_tensor_filter_key = NULL;
+
+  if (prop->shared_tensor_filter_key) {
+    shared_tensor_filter_key =
+        g_strdup (prop->shared_tensor_filter_key);
+    checkSharedInterpreter (prop);
+  }
+  else
+    interpreter = new TFLiteInterpreter ();
 }
 
 /**
@@ -726,7 +736,59 @@ TFLiteCore::TFLiteCore ()
  */
 TFLiteCore::~TFLiteCore ()
 {
-  delete interpreter;
+  if (shared_tensor_filter_key) {
+    if (nnstreamer_filter_shared_table_remove_this (shared_tensor_filter_key, this)) {
+      if (nnstreamer_filter_referred_list_length (shared_tensor_filter_key) == 0) {
+        /* if there is no more referred instance, remove the key from the shared table */
+        nnstreamer_filter_shared_table_remove (shared_tensor_filter_key);
+        /**
+         * @todo the below g_free () should be moved to the last of ~TFLiteCore () method
+         * To remove it, the has table lookup should be changed. 
+         */
+        g_free (shared_tensor_filter_key);
+        delete interpreter;
+      }
+    }
+  } else {
+    delete interpreter;
+    /** @todo should be removed */
+    g_free (shared_tensor_filter_key);
+  }
+}
+
+/**
+ * @brief	check the shared interpreter
+ * The shared model representation (interpreter) is allocated or shared.
+ * If `shared_tensor_filter_key` is already existed, it will share the TFLiteInterpreter.
+ * in the opposite case, the new TFLiteInterpreter will allocated and registered at the shared table.
+ */
+void
+TFLiteCore::checkSharedInterpreter (const GstTensorFilterProperties * prop)
+{
+  TFLiteInterpreter * ref = (TFLiteInterpreter *) nnstreamer_filter_get_shared_model_representation (shared_tensor_filter_key);
+  if (ref) {
+    if (g_strcmp0 (prop->model_files[0],
+            ref->getModelPath ()) != 0) {
+      ml_loge ("The model paths are different between the tensor filters!");
+      return;
+    }
+    if (!nnstreamer_filter_shared_table_insert (shared_tensor_filter_key, NULL, this)) {
+      ml_loge ("Failed to share the model representation!");
+      return;
+    }
+    interpreter = ref;
+  }
+  else {
+    interpreter = new TFLiteInterpreter ();
+    if (!nnstreamer_filter_shared_table_insert (shared_tensor_filter_key, interpreter, this)) {
+      ml_loge ("Failed to share the model representation!");
+      delete interpreter;
+      return;
+    }
+  }
+
+  ml_logd ("The model representation is shared: key=[%s], num of share: %u",
+      shared_tensor_filter_key, nnstreamer_filter_referred_list_length (shared_tensor_filter_key));
 }
 
 /**
@@ -922,6 +984,12 @@ TFLiteCore::reloadModel (const char *_model_path)
   int err;
   TFLiteInterpreter * interpreter_temp = interpreter;
 
+  if (shared_tensor_filter_key) {
+    /** @todo process should be added if the interpreter is shared */
+    ml_loge ("The reload is not supported with sharing model representation!");
+    return -EROFS;
+  }
+
   if (!g_file_test (_model_path, G_FILE_TEST_IS_REGULAR)) {
     ml_loge ("The path of model file(s), %s, to reload is invalid.", _model_path);
     return -EINVAL;
@@ -1102,7 +1170,7 @@ tflite_loadModelFile (const GstTensorFilterProperties *prop, void **private_data
     tflite_close (prop, private_data);
   }
 
-  core = new TFLiteCore ();
+  core = new TFLiteCore (prop);
   if (core == NULL) {
     g_printerr ("Failed to allocate memory for filter subplugin.");
     return -1;

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -550,6 +550,54 @@ extern accl_hw parse_accl_hw_fill (parse_accl_args accl_args);
  */
 #define parse_accl_hw(...) parse_accl_hw_fill((parse_accl_args){__VA_ARGS__})
 
+/* extern functions for shared model representation table */
+/**
+ * @brief Insert the new shared model representation at the table.
+ * @param[in] key The new key to store at hash table.
+ * @param[in] value The new value to store at hash table.
+ * @param[in] instance The instance that is sharing the model representation. It will be registered at the referred list.
+ * @return 0 if the new key and value are inserted. Others are failed to insert it.
+ */
+extern int
+nnstreamer_filter_shared_table_insert (char *key, void *value, void *instance);
+
+/* extern functions for shared model representation table */
+/**
+ * @brief Remove the shared model representation at the table.
+ * @param[in] key The key to remove the matched value of hash table.
+ * @return TRUE if the new key and value are removed. FALSE if failed to remove it.
+ */
+extern int
+nnstreamer_filter_shared_table_remove (const char *key);
+
+/* extern functions for shared model representation table */
+/**
+ * @brief Remove the instance registered at the referred list of shared model table.
+ * @param[in] key The key to find the matched list of hash table.
+ * @param[in] instance The instance that should be removed from the referred list.
+ * @return TRUE if the new key and value are removed. FALSE if failed to remove it.
+ */
+extern int
+nnstreamer_filter_shared_table_remove_this (const char *key, const void *instance);
+
+/* extern functions for shared model representation table */
+/**
+ * @brief Get the length of the referred list.
+ * @param[in] key The key to find the matched list of hash table.
+ * @return The length of the list. If it is NULL, it returns -1
+ */
+extern int
+nnstreamer_filter_referred_list_length (const char *key);
+
+/* extern functions for shared model representation table */
+/**
+ * @brief Get the shared model representation that is already shared and has the same key.
+ * @param[in] key The key to find the matched shared representation.
+ * @return The model representation. NULL if it is failed.
+ */
+extern void *
+nnstreamer_filter_get_shared_model_representation (const char *key);
+
 #ifdef __cplusplus
 }
 #endif

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -550,53 +550,39 @@ extern accl_hw parse_accl_hw_fill (parse_accl_args accl_args);
  */
 #define parse_accl_hw(...) parse_accl_hw_fill((parse_accl_args){__VA_ARGS__})
 
-/* extern functions for shared model representation table */
-/**
- * @brief Insert the new shared model representation at the table.
- * @param[in] key The new key to store at hash table.
- * @param[in] value The new value to store at hash table.
- * @param[in] instance The instance that is sharing the model representation. It will be registered at the referred list.
- * @return 0 if the new key and value are inserted. Others are failed to insert it.
- */
-extern int
-nnstreamer_filter_shared_table_insert (char *key, void *value, void *instance);
-
-/* extern functions for shared model representation table */
-/**
- * @brief Remove the shared model representation at the table.
- * @param[in] key The key to remove the matched value of hash table.
- * @return TRUE if the new key and value are removed. FALSE if failed to remove it.
- */
-extern int
-nnstreamer_filter_shared_table_remove (const char *key);
-
-/* extern functions for shared model representation table */
-/**
- * @brief Remove the instance registered at the referred list of shared model table.
- * @param[in] key The key to find the matched list of hash table.
- * @param[in] instance The instance that should be removed from the referred list.
- * @return TRUE if the new key and value are removed. FALSE if failed to remove it.
- */
-extern int
-nnstreamer_filter_shared_table_remove_this (const char *key, const void *instance);
-
-/* extern functions for shared model representation table */
-/**
- * @brief Get the length of the referred list.
- * @param[in] key The key to find the matched list of hash table.
- * @return The length of the list. If it is NULL, it returns -1
- */
-extern int
-nnstreamer_filter_referred_list_length (const char *key);
-
-/* extern functions for shared model representation table */
+/* extern functions for shared model representation */
 /**
  * @brief Get the shared model representation that is already shared and has the same key.
+ * @param[in] instance The instance that is sharing the model representation. It will be registered at the referred list.
  * @param[in] key The key to find the matched shared representation.
- * @return The model representation. NULL if it is failed.
+ * @return The model interpreter. NULL if it does not exist.
+ */
+void *
+nnstreamer_filter_shared_model_get (void *instance, const char *key);
+
+/* extern functions for shared model representation */
+/**
+ * @brief Insert the new shared model representation and get the value.
+ * @param[in] instance The instance that is sharing the model representation. It will be registered at the referred list.
+ * @param[in] key The key for shared model.
+ * @param[in] interpreter The interpreter to be shared.
+ * @return The model interpreter inserted. NULL if it is already inserted.
  */
 extern void *
-nnstreamer_filter_get_shared_model_representation (const char *key);
+nnstreamer_filter_shared_model_insert_and_get (void *instance, char *key, void *interpreter);
+
+/* extern functions for shared model representation */
+/**
+ * @brief Remove the instance registered at the referred list of shared model table.
+ *        If referred list is empty, `free_callback` is executed.
+ * @param[in] instance The instance that should be removed from the referred list.
+ * @param[in] key The key to find the shared model.
+ * @param[in] free_callback The callback function to destroy the interpreter, which takes the interpreter as arg.
+ * @return TRUE if the new key and value are removed. FALSE if failed to remove it.
+ */
+extern int
+nnstreamer_filter_shared_model_remove (void *instance, const char *key,
+    void (*free_callback) (void *));
 
 #ifdef __cplusplus
 }

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -92,6 +92,8 @@ static gint _gtfc_setprop_IS_UPDATABLE (GstTensorFilterPrivate * priv,
 static gint _gtfc_setprop_ACCELERATOR (GstTensorFilterPrivate * priv,
     GstTensorFilterProperties * prop, const GValue * value);
 
+static GHashTable *shared_model_table = NULL;
+
 /**
  * @brief GstTensorFilter properties.
  */
@@ -1032,6 +1034,11 @@ gst_tensor_filter_common_free_property (GstTensorFilterPrivate * priv)
       g_free (latency);
     g_queue_free (queue);
   }
+
+  if (shared_model_table) {
+    g_hash_table_destroy (shared_model_table);
+    shared_model_table = NULL;
+  }
 }
 
 /**
@@ -1839,6 +1846,9 @@ _gtfc_setprop_SHARED_TENSOR_FILTER_KEY (GstTensorFilterProperties * prop,
 {
   g_free (prop->shared_tensor_filter_key);
   prop->shared_tensor_filter_key = g_value_dup_string (value);
+
+  if (!shared_model_table)
+    shared_model_table = g_hash_table_new (g_str_hash, g_str_equal);
 
   return 0;
 }
@@ -2785,4 +2795,163 @@ gst_tensor_filter_check_hw_availability (const gchar * name, const accl_hw hw)
   }
 
   return available;
+}
+
+/* extern functions for shared model representation table */
+/**
+ * @brief Insert the new shared model representation at the table.
+ * @param[in] key The new key to store at hash table.
+ * @param[in] value The new value to store at hash table.
+ * @param[in] instance The instance that is sharing the model representation. It will be registered at the referred list.
+ * @return 0 if the new key and value are inserted. Others are failed to insert it.
+ */
+int
+nnstreamer_filter_shared_table_insert (char *key, void *value, void *instance)
+{
+  GstTensorFilterSharedModelRepresenatation *model_rep;
+  gboolean is_existed = FALSE;
+
+  if (!shared_model_table) {
+    ml_loge ("The shared model representation is not supported properly!");
+    return FALSE;
+  }
+  if (!key) {
+    ml_loge ("The key should NOT be NULL!");
+    return FALSE;
+  }
+  if (!instance) {
+    ml_loge ("The instance should NOT be NULL!");
+    return FALSE;
+  }
+
+  model_rep = g_hash_table_lookup (shared_model_table, key);
+  is_existed = model_rep != NULL;
+
+  if (is_existed) {
+    model_rep->referred_list =
+        g_list_append (model_rep->referred_list, instance);
+    return TRUE;
+  } else {
+    if (!value) {
+      ml_loge ("The value should NOT be NULL!");
+      return FALSE;
+    }
+
+    model_rep = (GstTensorFilterSharedModelRepresenatation *)
+        g_malloc0 (sizeof (GstTensorFilterSharedModelRepresenatation));
+    model_rep->shared_interpreter = value;
+    model_rep->referred_list =
+        g_list_append (model_rep->referred_list, instance);
+
+    return g_hash_table_insert (shared_model_table, key, (gpointer) model_rep);
+  }
+}
+
+/* extern functions for shared model representation table */
+/**
+ * @brief remove the shared model representation at the table.
+ * @param[in] key The key to remove the matched value of hash table.
+ * @return 0 if the new key and value are removed. Others are failed to remove it.
+ */
+int
+nnstreamer_filter_shared_table_remove (const char *key)
+{
+  GstTensorFilterSharedModelRepresenatation *value;
+
+  /* search the table with key */
+  if (!shared_model_table) {
+    ml_loge ("The shared model representation is not supported properly!");
+    return FALSE;
+  }
+
+  value = g_hash_table_lookup (shared_model_table, key);
+  if (!value) {
+    ml_loge ("There is no value of the key: %s", key);
+    return FALSE;
+  }
+
+  g_list_free (value->referred_list);
+  return g_hash_table_remove (shared_model_table, key);
+}
+
+/* extern functions for shared model representation table */
+/**
+ * @brief Remove the instance registered at the referred list of shared model table.
+ * @param[in] key The key to find the matched list of hash table.
+ * @param[in] instance The instance that should be removed from the referred list.
+ * @return TRUE if the new key and value are removed. FALSE if failed to remove it.
+ */
+int
+nnstreamer_filter_shared_table_remove_this (const char *key,
+    const void *instance)
+{
+  GstTensorFilterSharedModelRepresenatation *value;
+
+  /* search the table with key */
+  if (!shared_model_table) {
+    ml_loge ("The shared model representation is not supported properly!");
+    return FALSE;
+  }
+
+  value = g_hash_table_lookup (shared_model_table, key);
+  if (!value) {
+    ml_loge ("There is no value of the key: %s", key);
+    return FALSE;
+  }
+
+  /* remove instance from the list */
+  value->referred_list = g_list_remove (value->referred_list, instance);
+  ml_logd ("The referred instance of sharing key: %s has been removed!", key);
+
+  return TRUE;
+}
+
+/* extern functions for shared model representation table */
+/**
+ * @brief Get the length of the referred list.
+ * @param[in] key The key to find the matched list of hash table.
+ * @return The length of the list. If it is NULL, it returns -1
+ */
+int
+nnstreamer_filter_referred_list_length (const char *key)
+{
+  GstTensorFilterSharedModelRepresenatation *value;
+
+  /* search the table with key */
+  if (!shared_model_table) {
+    ml_loge ("The shared model representation is not supported properly!");
+    return -1;
+  }
+  value = g_hash_table_lookup (shared_model_table, key);
+  if (!value) {
+    ml_loge ("There is no value of the key: %s", key);
+    return -1;
+  }
+
+  return g_list_length (value->referred_list);
+}
+
+/* extern functions for shared model representation table */
+/**
+ * @brief Get the shared model representation that is already shared and has the same key.
+ * @param[in] key The key to find the matched shared representation.
+ * @return The model representation. NULL if it is failed.
+ */
+void *
+nnstreamer_filter_get_shared_model_representation (const char *key)
+{
+  GstTensorFilterSharedModelRepresenatation *value;
+
+  /* search the table with key */
+  if (!shared_model_table) {
+    ml_loge ("The shared model representation is not supported properly!");
+    return NULL;
+  }
+  value = g_hash_table_lookup (shared_model_table, key);
+  if (!value) {
+    ml_logi ("There is no value of the key: %s", key);
+    return NULL;
+  }
+
+  return value->shared_interpreter;
 }

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -2872,8 +2872,10 @@ nnstreamer_filter_shared_model_insert_and_get (void *instance, char *key,
   }
 
   g_mutex_lock (&mutex);
-  if (g_hash_table_lookup (shared_model_table, key))
+  if (g_hash_table_lookup (shared_model_table, key)) {
+    g_mutex_unlock (&mutex);
     return NULL;
+  }
   model_rep = (GstTensorFilterSharedModelRepresenatation *)
       g_malloc0 (sizeof (GstTensorFilterSharedModelRepresenatation));
   model_rep->shared_interpreter = interpreter;

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -93,6 +93,7 @@ static gint _gtfc_setprop_ACCELERATOR (GstTensorFilterPrivate * priv,
     GstTensorFilterProperties * prop, const GValue * value);
 
 static GHashTable *shared_model_table = NULL;
+static GMutex mutex;            /* mutex for shared model table */
 
 /**
  * @brief GstTensorFilter properties.
@@ -1036,8 +1037,15 @@ gst_tensor_filter_common_free_property (GstTensorFilterPrivate * priv)
   }
 
   if (shared_model_table) {
+    GList *value = g_hash_table_get_values (shared_model_table);
+    while (value) {
+      GstTensorFilterSharedModelRepresenatation *rep =
+          (GstTensorFilterSharedModelRepresenatation *) value;
+      g_list_free (rep->referred_list);
+    }
     g_hash_table_destroy (shared_model_table);
     shared_model_table = NULL;
+    g_mutex_clear (&mutex);
   }
 }
 
@@ -1847,8 +1855,11 @@ _gtfc_setprop_SHARED_TENSOR_FILTER_KEY (GstTensorFilterProperties * prop,
   g_free (prop->shared_tensor_filter_key);
   prop->shared_tensor_filter_key = g_value_dup_string (value);
 
-  if (!shared_model_table)
-    shared_model_table = g_hash_table_new (g_str_hash, g_str_equal);
+  if (!shared_model_table) {
+    shared_model_table =
+        g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+    g_mutex_init (&mutex);
+  }
 
   return 0;
 }
@@ -2797,95 +2808,97 @@ gst_tensor_filter_check_hw_availability (const gchar * name, const accl_hw hw)
   return available;
 }
 
-/* extern functions for shared model representation table */
+/* extern functions for shared model representation */
 /**
- * @brief Insert the new shared model representation at the table.
- * @param[in] key The new key to store at hash table.
- * @param[in] value The new value to store at hash table.
+ * @brief Get the shared model representation that is already shared and has the same key.
  * @param[in] instance The instance that is sharing the model representation. It will be registered at the referred list.
- * @return 0 if the new key and value are inserted. Others are failed to insert it.
+ * @param[in] key The key to find the matched shared representation.
+ * @return The model interpreter. NULL if it does not exist.
  */
-int
-nnstreamer_filter_shared_table_insert (char *key, void *value, void *instance)
+void *
+nnstreamer_filter_shared_model_get (void *instance, const char *key)
 {
   GstTensorFilterSharedModelRepresenatation *model_rep;
-  gboolean is_existed = FALSE;
 
   if (!shared_model_table) {
     ml_loge ("The shared model representation is not supported properly!");
-    return FALSE;
+    return NULL;
   }
-  if (!key) {
-    ml_loge ("The key should NOT be NULL!");
-    return FALSE;
+  g_mutex_lock (&mutex);
+  model_rep = g_hash_table_lookup (shared_model_table, key);
+  if (!model_rep) {
+    ml_logi ("There is no value of the key: %s", key);
+    g_mutex_unlock (&mutex);
+    return NULL;
+  }
+  if (!g_list_find (model_rep->referred_list, instance))
+    model_rep->referred_list =
+        g_list_append (model_rep->referred_list, instance);
+  g_mutex_unlock (&mutex);
+
+  return model_rep->shared_interpreter;
+}
+
+/* extern functions for shared model representation */
+/**
+ * @brief Insert the new shared model representation and get the value.
+ * @param[in] instance The instance that is sharing the model representation. It will be registered at the referred list.
+ * @param[in] key The key for shared model.
+ * @param[in] interpreter The interpreter to be shared.
+ * @return The model interpreter inserted. NULL if it is already inserted.
+ */
+void *
+nnstreamer_filter_shared_model_insert_and_get (void *instance, char *key,
+    void *interpreter)
+{
+  GstTensorFilterSharedModelRepresenatation *model_rep;
+
+  /* validate arguments */
+  if (!shared_model_table) {
+    ml_loge ("The shared model representation is not supported properly!");
+    return NULL;
   }
   if (!instance) {
     ml_loge ("The instance should NOT be NULL!");
-    return FALSE;
+    return NULL;
+  }
+  if (!key) {
+    ml_loge ("The key should NOT be NULL!");
+    return NULL;
+  }
+  if (!interpreter) {
+    ml_loge ("The interpreter should NOT be NULL!");
+    return NULL;
   }
 
-  model_rep = g_hash_table_lookup (shared_model_table, key);
-  is_existed = model_rep != NULL;
-
-  if (is_existed) {
-    model_rep->referred_list =
-        g_list_append (model_rep->referred_list, instance);
-    return TRUE;
-  } else {
-    if (!value) {
-      ml_loge ("The value should NOT be NULL!");
-      return FALSE;
-    }
-
-    model_rep = (GstTensorFilterSharedModelRepresenatation *)
-        g_malloc0 (sizeof (GstTensorFilterSharedModelRepresenatation));
-    model_rep->shared_interpreter = value;
-    model_rep->referred_list =
-        g_list_append (model_rep->referred_list, instance);
-
-    return g_hash_table_insert (shared_model_table, key, (gpointer) model_rep);
-  }
+  g_mutex_lock (&mutex);
+  if (g_hash_table_lookup (shared_model_table, key))
+    return NULL;
+  model_rep = (GstTensorFilterSharedModelRepresenatation *)
+      g_malloc0 (sizeof (GstTensorFilterSharedModelRepresenatation));
+  model_rep->shared_interpreter = interpreter;
+  model_rep->referred_list = g_list_append (model_rep->referred_list, instance);
+  g_hash_table_insert (shared_model_table, g_strdup (key),
+      (gpointer) model_rep);
+  g_mutex_unlock (&mutex);
+  return interpreter;
 }
 
-/* extern functions for shared model representation table */
-/**
- * @brief remove the shared model representation at the table.
- * @param[in] key The key to remove the matched value of hash table.
- * @return 0 if the new key and value are removed. Others are failed to remove it.
- */
-int
-nnstreamer_filter_shared_table_remove (const char *key)
-{
-  GstTensorFilterSharedModelRepresenatation *value;
-
-  /* search the table with key */
-  if (!shared_model_table) {
-    ml_loge ("The shared model representation is not supported properly!");
-    return FALSE;
-  }
-
-  value = g_hash_table_lookup (shared_model_table, key);
-  if (!value) {
-    ml_loge ("There is no value of the key: %s", key);
-    return FALSE;
-  }
-
-  g_list_free (value->referred_list);
-  return g_hash_table_remove (shared_model_table, key);
-}
-
-/* extern functions for shared model representation table */
+/* extern functions for shared model representation */
 /**
  * @brief Remove the instance registered at the referred list of shared model table.
- * @param[in] key The key to find the matched list of hash table.
+ *        If referred list is empty, `free_callback` is executed.
  * @param[in] instance The instance that should be removed from the referred list.
+ * @param[in] key The key to find the shared model.
+ * @param[in] free_callback The callback function to destroy the interpreter, which takes the interpreter as arg.
  * @return TRUE if the new key and value are removed. FALSE if failed to remove it.
  */
 int
-nnstreamer_filter_shared_table_remove_this (const char *key,
-    const void *instance)
+nnstreamer_filter_shared_model_remove (void *instance, const char *key,
+    void (*free_callback) (void *))
 {
-  GstTensorFilterSharedModelRepresenatation *value;
+  GstTensorFilterSharedModelRepresenatation *model_rep;
+  int ret = TRUE;
 
   /* search the table with key */
   if (!shared_model_table) {
@@ -2893,65 +2906,25 @@ nnstreamer_filter_shared_table_remove_this (const char *key,
     return FALSE;
   }
 
-  value = g_hash_table_lookup (shared_model_table, key);
-  if (!value) {
+  g_mutex_lock (&mutex);
+  model_rep = g_hash_table_lookup (shared_model_table, key);
+  if (!model_rep) {
     ml_loge ("There is no value of the key: %s", key);
+    g_mutex_unlock (&mutex);
     return FALSE;
   }
 
   /* remove instance from the list */
-  value->referred_list = g_list_remove (value->referred_list, instance);
+  model_rep->referred_list = g_list_remove (model_rep->referred_list, instance);
   ml_logd ("The referred instance of sharing key: %s has been removed!", key);
 
-  return TRUE;
-}
-
-/* extern functions for shared model representation table */
-/**
- * @brief Get the length of the referred list.
- * @param[in] key The key to find the matched list of hash table.
- * @return The length of the list. If it is NULL, it returns -1
- */
-int
-nnstreamer_filter_referred_list_length (const char *key)
-{
-  GstTensorFilterSharedModelRepresenatation *value;
-
-  /* search the table with key */
-  if (!shared_model_table) {
-    ml_loge ("The shared model representation is not supported properly!");
-    return -1;
+  /* remove key from table if list is empty */
+  if (g_list_length (model_rep->referred_list) == 0) {
+    if (free_callback)
+      free_callback (model_rep->shared_interpreter);
+    ret = g_hash_table_remove (shared_model_table, key);
   }
-  value = g_hash_table_lookup (shared_model_table, key);
-  if (!value) {
-    ml_loge ("There is no value of the key: %s", key);
-    return -1;
-  }
+  g_mutex_unlock (&mutex);
 
-  return g_list_length (value->referred_list);
-}
-
-/* extern functions for shared model representation table */
-/**
- * @brief Get the shared model representation that is already shared and has the same key.
- * @param[in] key The key to find the matched shared representation.
- * @return The model representation. NULL if it is failed.
- */
-void *
-nnstreamer_filter_get_shared_model_representation (const char *key)
-{
-  GstTensorFilterSharedModelRepresenatation *value;
-
-  /* search the table with key */
-  if (!shared_model_table) {
-    ml_loge ("The shared model representation is not supported properly!");
-    return NULL;
-  }
-  value = g_hash_table_lookup (shared_model_table, key);
-  if (!value) {
-    ml_logi ("There is no value of the key: %s", key);
-    return NULL;
-  }
-
-  return value->shared_interpreter;
+  return ret;
 }

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -100,6 +100,14 @@ typedef struct _GstTensorFilterCombination
 } GstTensorFilterCombination;
 
 /**
+ * @brief Data Structure to store shared table
+ */
+typedef struct {
+  void *shared_interpreter; /**< the model representation for each sub-plugins */
+  GList *referred_list; /**< the referred list about the instances sharing the same key */
+} GstTensorFilterSharedModelRepresenatation;
+
+/**
  * @brief Structure definition for common tensor-filter properties.
  */
 typedef struct _GstTensorFilterPrivate


### PR DESCRIPTION
to manage the shared model representation, a new hash table is required.

TFLite shared model representation reduced memory as below.
```
[share]
MAX RSS: 212172
MAX PSS: 202508

[not share]
MAX RSS: 353576
MAX PSS: 278325
```

+ reload is not supported yet.

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped