### PR TITLE
[CodeClean] use util function to free tensor config

### DIFF
--- a/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
+++ b/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
@@ -312,8 +312,8 @@ gst_tensor_aggregator_finalize (GObject * object)
 
   gst_tensor_aggregator_reset (self);
 
-  gst_tensor_info_free (&self->in_config.info);
-  gst_tensor_info_free (&self->out_config.info);
+  gst_tensor_config_free (&self->in_config);
+  gst_tensor_config_free (&self->out_config);
 
   if (self->adapter) {
     g_object_unref (self->adapter);

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -1184,10 +1184,8 @@ gst_tensor_pad_caps_is_flexible (GstPad * pad)
   caps = gst_pad_get_current_caps (pad);
   if (caps) {
     GstStructure *structure = gst_caps_get_structure (caps, 0);
-    const gchar *name = gst_structure_get_name (structure);
 
-    if (name)
-      ret = g_str_equal (name, NNS_MIMETYPE_TENSORS_FLEXIBLE);
+    ret = gst_structure_has_name (structure, NNS_MIMETYPE_TENSORS_FLEXIBLE);
     gst_caps_unref (caps);
   }
 

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -403,7 +403,7 @@ gst_tensor_converter_finalize (GObject * object)
 
   gst_tensor_converter_reset (self);
 
-  gst_tensors_info_free (&self->tensors_config.info);
+  gst_tensors_config_free (&self->tensors_config);
   gst_tensors_info_free (&self->tensors_info);
 
   if (self->adapter) {
@@ -1203,19 +1203,19 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
 
       if (inbuf == NULL) {
         nns_loge ("Failed to convert media to tensors.");
-        gst_tensors_info_free (&new_config.info);
+        gst_tensors_config_free (&new_config);
         goto error;
       }
       frames_in = 1;
       frame_size = gst_buffer_get_size (inbuf);
 
       if (!gst_tensors_config_is_equal (config, &new_config)) {
-        gst_tensors_info_free (&config->info);
+        gst_tensors_config_free (config);
         *config = new_config;
 
         gst_tensor_converter_update_caps (self);
       } else {
-        gst_tensors_info_free (&new_config.info);
+        gst_tensors_config_free (&new_config);
       }
 
       break;

--- a/gst/nnstreamer/tensor_demux/gsttensordemux.c
+++ b/gst/nnstreamer/tensor_demux/gsttensordemux.c
@@ -429,7 +429,7 @@ gst_tensor_demux_get_tensor_pad (GstTensorDemux * tensor_demux,
     }
   }
 
-  gst_tensors_info_free (&config.info);
+  gst_tensors_config_free (&config);
   return tensorpad;
 }
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -933,8 +933,8 @@ gst_tensor_filter_configure_tensor (GstTensorFilter * self,
   }
 
 done:
-  gst_tensors_info_free (&in_config.info);
-  gst_tensors_info_free (&out_config.info);
+  gst_tensors_config_free (&in_config);
+  gst_tensors_config_free (&out_config);
   gst_tensors_info_free (&in_info);
   gst_tensors_info_free (&out_info);
   return priv->configured;
@@ -1094,8 +1094,8 @@ gst_tensor_filter_transform_caps (GstBaseTransform * trans,
   }
 
   silent_debug_caps (result, "to");
-  gst_tensors_info_free (&in_config.info);
-  gst_tensors_info_free (&out_config.info);
+  gst_tensors_config_free (&in_config);
+  gst_tensors_config_free (&out_config);
   return result;
 }
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -1030,8 +1030,8 @@ gst_tensor_filter_common_free_property (GstTensorFilterPrivate * priv)
   gst_tensors_info_free (&prop->input_meta);
   gst_tensors_info_free (&prop->output_meta);
 
-  gst_tensors_info_free (&priv->in_config.info);
-  gst_tensors_info_free (&priv->out_config.info);
+  gst_tensors_config_free (&priv->in_config);
+  gst_tensors_config_free (&priv->out_config);
 
   g_list_free (priv->combi.in_combi);
   g_list_free (priv->combi.out_combi_i);

--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -2034,7 +2034,7 @@ gst_tensor_src_iio_start (GstBaseSrc * src)
   return TRUE;
 
 error_config_free:
-  gst_tensors_info_free (&self->tensors_config->info);
+  gst_tensors_config_free (self->tensors_config);
   g_free (self->tensors_config);
 
   g_list_free_full (self->channels, gst_tensor_src_iio_channel_properties_free);
@@ -2122,7 +2122,7 @@ gst_tensor_src_iio_stop (GstBaseSrc * src)
   close (self->buffer_data_fp->fd);
   g_free (self->buffer_data_fp);
 
-  gst_tensors_info_free (&self->tensors_config->info);
+  gst_tensors_config_free (self->tensors_config);
   g_free (self->tensors_config);
 
   g_list_free_full (self->channels, gst_tensor_src_iio_channel_properties_free);
@@ -2216,7 +2216,7 @@ gst_tensor_src_iio_fixate (GstBaseSrc * src, GstCaps * caps)
     tensor_config.rate_n = self->tensors_config->rate_n;
     tensor_config.rate_d = self->tensors_config->rate_d;
     fixated_caps = gst_tensor_caps_from_config (&tensor_config);
-    gst_tensor_info_free (&tensor_config.info);
+    gst_tensor_config_free (&tensor_config);
   } else {
     fixated_caps = gst_tensors_caps_from_config (self->tensors_config);
   }

--- a/gst/nnstreamer/tensor_split/gsttensorsplit.c
+++ b/gst/nnstreamer/tensor_split/gsttensorsplit.c
@@ -188,6 +188,7 @@ gst_tensor_split_remove_src_pads (GstTensorSplit * split)
   split->srcpads = NULL;
   split->num_tensors = 0;
   split->num_srcpads = 0;
+  gst_tensor_config_free (&split->sink_tensor_conf);
 }
 
 /**

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -6015,8 +6015,8 @@ TEST (testStreamBuffers, tensorsNormal)
       gst_memory_unmap (mem, &info);
     }
 
-    gst_tensors_info_free (&config.info);
-    gst_tensors_info_free (&check_config.info);
+    gst_tensors_config_free (&config);
+    gst_tensors_config_free (&check_config);
     gst_buffer_unref (dec_out_buf);
     gst_buffer_unref (conv_out_buf);
   }
@@ -6060,7 +6060,7 @@ TEST (testDecoderSubplugins, flatbufInvalidParam1_n)
   dec_out_buf = gst_buffer_new ();
   EXPECT_EQ (GST_FLOW_ERROR, fb_dec->decode (NULL, &config, NULL, dec_out_buf));
 
-  gst_tensors_info_free (&config.info);
+  gst_tensors_config_free (&config);
   gst_buffer_unref (dec_out_buf);
 }
 
@@ -6100,7 +6100,7 @@ TEST (testConverterSubplugins, flatbufInvalidParam0_n)
   conv_out_buf = fb_conv->convert (NULL, &config, NULL);
 
   EXPECT_TRUE (NULL == conv_out_buf);
-  gst_tensors_info_free (&config.info);
+  gst_tensors_config_free (&config);
 }
 
 /**
@@ -6123,7 +6123,7 @@ TEST (testConverterSubplugins, flatbufInvalidParam1_n)
   conv_out_buf = fb_conv->convert (in_buf, NULL, NULL);
 
   EXPECT_TRUE (NULL == conv_out_buf);
-  gst_tensors_info_free (&config.info);
+  gst_tensors_config_free (&config);
   gst_buffer_unref (in_buf);
 }
 
@@ -6165,7 +6165,7 @@ TEST (testDecoderSubplugins, protobufInvalidParam1_n)
   dec_out_buf = gst_buffer_new ();
   EXPECT_EQ (GST_FLOW_ERROR, pb_dec->decode (NULL, &config, NULL, dec_out_buf));
 
-  gst_tensors_info_free (&config.info);
+  gst_tensors_config_free (&config);
   gst_buffer_unref (dec_out_buf);
 }
 
@@ -6205,7 +6205,7 @@ TEST (testConverterSubplugins, protobufInvalidParam0_n)
   conv_out_buf = pb_conv->convert (NULL, &config, NULL);
 
   EXPECT_TRUE (NULL == conv_out_buf);
-  gst_tensors_info_free (&config.info);
+  gst_tensors_config_free (&config);
 }
 
 /**
@@ -6227,7 +6227,7 @@ TEST (testConverterSubplugins, protobufInvalidParam1_n)
   conv_out_buf = pb_conv->convert (in_buf, NULL, NULL);
 
   EXPECT_TRUE (NULL == conv_out_buf);
-  gst_tensors_info_free (&config.info);
+  gst_tensors_config_free (&config);
   gst_buffer_unref (in_buf);
 }
 
@@ -6270,7 +6270,7 @@ TEST (testDecoderSubplugins, flexbufInvalidParam1_n)
   dec_out_buf = gst_buffer_new ();
   EXPECT_EQ (GST_FLOW_ERROR, flx_dec->decode (NULL, &config, NULL, dec_out_buf));
 
-  gst_tensors_info_free (&config.info);
+  gst_tensors_config_free (&config);
   gst_buffer_unref (dec_out_buf);
 }
 
@@ -6310,7 +6310,7 @@ TEST (testConverterSubplugins, flexbufInvalidParam0_n)
   conv_out_buf = flx_conv->convert (NULL, &config, NULL);
 
   EXPECT_TRUE (NULL == conv_out_buf);
-  gst_tensors_info_free (&config.info);
+  gst_tensors_config_free (&config);
 }
 
 /**
@@ -6332,7 +6332,7 @@ TEST (testConverterSubplugins, flexbufInvalidParam1_n)
   conv_out_buf = flx_conv->convert (in_buf, NULL, NULL);
 
   EXPECT_TRUE (NULL == conv_out_buf);
-  gst_tensors_info_free (&config.info);
+  gst_tensors_config_free (&config);
   gst_buffer_unref (in_buf);
 }
 


### PR DESCRIPTION
Code clean, use common util function to free tensor config struct.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
