### PR TITLE
[SparseTensor] Define SparseTensor and API @open sesame 07/06 09:45

### DIFF
--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -264,6 +264,14 @@ typedef struct
 } GstTensorsConfig;
 
 /**
+ * @brief Internal data structure for sparse tensor info
+ */
+typedef struct
+{
+  uint32_t nnz; /**< the number of "non-zero" elements */
+} GstSparseTensorInfo;
+
+/**
  * @brief Data structure to describe a tensor data.
  * This represents the basic information of a memory block for tensor stream.
  *
@@ -281,6 +289,14 @@ typedef struct
   uint32_t dimension[NNS_TENSOR_META_RANK_LIMIT];
   uint32_t format;
   uint32_t media_type;
+
+  /**
+   * @brief Union of the required information for processing each tensor "format".
+   */
+  union {
+    GstSparseTensorInfo sparse_info;
+  };
+
 } GstTensorMetaInfo;
 
 #endif /*__GST_TENSOR_TYPEDEF_H__*/

--- a/gst/nnstreamer/tensor_sparse/tensor_sparse_util.h
+++ b/gst/nnstreamer/tensor_sparse/tensor_sparse_util.h
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer / NNStreamer Sparse Tensor support
+ * Copyright (C) 2021 Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ */
+/**
+ * @file	tensor_sparse_util.h
+ * @date	06 Jul 2021
+ * @brief	Util functions for tensor_sparse encoder and decoder.
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#ifndef __GST_TENSOR_SPARSE_UTIL_H__
+#define __GST_TENSOR_SPARSE_UTIL_H__
+
+#include <gst/gst.h>
+#include <tensor_common.h>
+
+/**
+ * @brief NYI. Make dense tensor with input sparse tensor.
+ * @param[in,out] meta tensor meta structure to be updated
+ * @param[in] in pointer of input sparse tensor data
+ * @param[out] out pointer of output dense tensor data. Assume that it's already allocated.
+ * @return TRUE if no error
+ */
+extern gboolean
+gst_tensor_sparse_to_dense (GstTensorMetaInfo * meta, gpointer in, gpointer out);
+
+/**
+ * @brief NYI. Make sparse tensor with input dense tensor.
+ * @param[in,out] meta tensor meta structure to be updated
+ * @param[in] in pointer of input dense tensor data
+ * @param[out] out pointer of output sparse tensor data. Assume that it's already allocated.
+ * @param TRUE if no error
+ */
+extern gboolean
+gst_tensor_sparse_from_dense (GstTensorMetaInfo * meta, gpointer in, gpointer out);
+
+#endif /* __GST_TENSOR_SPARSE_UTIL_H__ */


### PR DESCRIPTION
- Define a tensor_format for SparseTensor
- Define a info structure for SparseTensor which has "length" of non-zero elements
- Add a internal header `tensor_sparse_util.h` for util functions that will be used in related elements
- Add a union in GstTensorMetaInfo for SparseTensor

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped


SparseTensor

SparseTensors could be more efficient on processing of tensors that contain a lot of zero values.
I'll adopt the coordinate list (COO) format for encoding it, same as other NN frameworks.

The COO encoding for sparse tensors is comprised of:  (REF: https://www.tensorflow.org/guide/sparse_tensor)

1. values: A 1D tensor with shape [N] containing all nonzero values.
2. indices: A 2D tensor with shape [N, rank], containing the indices of the nonzero values.
3. dense_shape: A 1D tensor with shape [rank], specifying the shape of the tensor.

For example a Tensor
```
[[1, 0, 0, 0]
 [0, 0, 2, 0]
 [0, 0, 0, 0]]
```
can be encoded as
```
SparseTensor(values=[1, 2], indices=[[0, 0], [1, 2]], dense_shape=[3, 4])
```

In our project, a SparseTensor should be encoded with these information:
```cpp
tensor_type   data_type;
tensor_dim    dense_shape;
unsigned int  nnz; /* the number of non-zero elements */
data_type     values[nnz];
unsigned int  indices[nnz][RANK_LIMIT];
```

Since data_type and dense_shape are could be represented in `GstTensorMetaInfo`,
Add a `GstSparseTensorInfo`, and let it have the `nnz`.
The values and indices are stored in a single memory chunk, and the `length` information would be used for parsing the buffer.

