### PR TITLE
pkgconfig: add nnstreamer-internal for API developers.

### DIFF
--- a/debian/nnstreamer-dev-internal.install
+++ b/debian/nnstreamer-dev-internal.install
@@ -1,3 +1,4 @@
 /usr/include/nnstreamer/nnstreamer_internal.h
 /usr/include/nnstreamer/nnstreamer_log.h
 /usr/include/nnstreamer/tensor_filter_single.h
+/usr/lib/*/pkgconfig/nnstreamer-internal.pc

--- a/meson.build
+++ b/meson.build
@@ -475,6 +475,10 @@ configure_file(input: 'nnstreamer.pc.in', output: 'nnstreamer.pc',
   install_dir: join_paths(nnstreamer_libdir, 'pkgconfig'),
   configuration: nnstreamer_install_conf
 )
+configure_file(input: 'nnstreamer-internal.pc.in', output: 'nnstreamer-internal.pc',
+  install_dir: join_paths(nnstreamer_libdir, 'pkgconfig'),
+  configuration: nnstreamer_install_conf
+)
 
 # Build nnstreamer (common, plugins)
 subdir('gst')

--- a/nnstreamer-internal.pc.in
+++ b/nnstreamer-internal.pc.in
@@ -1,4 +1,4 @@
-# Package Information for pkg-config, for nnstreamer sub-plugin and custom plugin writers
+# Package Information for pkg-config, for developers using nnstreamer internal details.
 
 prefix=@PREFIX@
 exec_prefix=@EXEC_PREFIX@
@@ -6,9 +6,9 @@ libdir=@LIB_INSTALL_DIR@
 includedir=@INCLUDE_INSTALL_DIR@
 test_templatedir=@TEST_TEMPLATE_DIR@ # test template dir to be used
 
-Name: nnstreamer
-Description: Dev Kit of Neural Network Suite (NNStreamer) for GStreamer
+Name: nnstreamer-internal
+Description: Dev Kit of NNStreamer API implementation
 Version: @VERSION@
-Requires:
+Requires: nnstreamer
 Libs: -L${libdir} -lnnstreamer
 Cflags: -I${includedir}/nnstreamer

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -425,7 +425,10 @@ Requires:	nnstreamer = %{version}-%{release}
 Requires:	glib2-devel
 Requires:	gstreamer-devel
 %description devel
-Development package for custom tensor operator developers (tensor_filter/custom).
+Development package for subplugin or custom filter developers.
+Developers may add support for new hardware accelerators or neural network
+frameworks, or introduce new data types and their converters for tensors.
+However, applications or service developers generally do not need this.
 This contains corresponding header files and .pc pkgconfig file.
 
 %package devel-internal
@@ -433,7 +436,7 @@ Summary:    Development package to access internal functions of NNStreamer
 Requires:   nnstreamer-devel = %{version}-%{release}
 %description devel-internal
 Development package to access internal functions of NNStreamer.
-This may be used by API packages.
+This may be used by API packages, which wrap nnstreamer features.
 In most cases, custom-filter or subplugin authors do not need this internal devel package; however, if they want to access more internal functions, they may need this.
 
 %package devel-static

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -926,6 +926,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{_includedir}/nnstreamer/nnstreamer_internal.h
 %{_includedir}/nnstreamer/nnstreamer_log.h
 %{_includedir}/nnstreamer/tensor_filter_single.h
+%{_libdir}/pkgconfig/nnstreamer-internal.pc
 
 %files devel-static
 %{_libdir}/*.a


### PR DESCRIPTION
API package requires to refer to additional headers that devel is not supposed to export.
Such files are exported with "internal-devel" package.
Add a new pkgconfig file for this additional devel package so that the build-dependency can be
resolved with pkgconfig as well.



commit 83967265053c6dc353813078b221cccb381e9d54 (HEAD -> fix/3230, github-fork/fix/3230)
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Wed Jun 23 10:41:20 2021 +0900

    pkgconfig: add nnstreamer-internal for API developers.
    
    API developers require additional headers than subplugin writers,
    which is packaged as "nnstreamer-internal".
    With this additional pkgconfig file, such dependency can be met.
    
    Fixes #3230
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 3fb7f9e3285f32dc41d9f514199a0d41be7781de
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Wed Jun 23 10:36:04 2021 +0900

    Dist/spec: update pkg desc of devel/devel-internal
    
    The role of devel package has been expanded since the
    introduction. Update the descriptions.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
