### PR TITLE
[fix/lua] Fix covertiy/svace issues issued in lua source code

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_lua.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_lua.cc
@@ -226,7 +226,7 @@ tensor_newindex (lua_State* L)
 static int
 expose_tensor (lua_State* L, lua_tensor *tensor)
 {
-  lua_tensor **ptensor = (lua_tensor **) lua_newuserdata (L, sizeof (lua_tensor **));
+  lua_tensor **ptensor = (lua_tensor **) lua_newuserdata (L, sizeof (lua_tensor *));
   *ptensor = tensor;
   luaL_getmetatable (L, "lua_tensor");
   lua_setmetatable (L, -2);

--- a/tests/nnstreamer_filter_lua/unittest_filter_lua.cc
+++ b/tests/nnstreamer_filter_lua/unittest_filter_lua.cc
@@ -473,7 +473,7 @@ TEST (nnstreamerFilterLua, invoke01_n)
   EXPECT_EQ (ret, 0);
   EXPECT_NE (data, nullptr);
 
-  output.size = input.size = 1;
+  output.size = input.size = sizeof (float) * 1;
 
   input.data = g_malloc (input.size);
   output.data = g_malloc (output.size);
@@ -551,8 +551,8 @@ TEST (nnstreamerFilterLua, invoke03)
   output.size = input.size = sizeof (uint8_t) * 3 * 640 * 480 * 1;
 
   /* alloc input data without alignment */
-  input.data = malloc (input.size);
-  output.data = malloc (output.size);
+  input.data = g_malloc (input.size);
+  output.data = g_malloc (output.size);
 
   memset (input.data, 0, input.size);
 
@@ -612,8 +612,8 @@ end
   output.size = input.size = sizeof (uint8_t) * 3 * 100 * 100 * 1;
 
   /* alloc input data without alignment */
-  input.data = malloc (input.size);
-  output.data = malloc (output.size);
+  input.data = g_malloc (input.size);
+  output.data = g_malloc (output.size);
 
   memset (input.data, 0, input.size);
 
@@ -672,8 +672,8 @@ end
   output.size = input.size = sizeof (uint8_t) * 3 * 100 * 100 * 1;
 
   /* alloc input data without alignment */
-  input.data = malloc (input.size);
-  output.data = malloc (output.size);
+  input.data = g_malloc (input.size);
+  output.data = g_malloc (output.size);
 
   memset (input.data, 0, input.size);
 
@@ -725,8 +725,8 @@ TEST (nnstreamerFilterLua, reload00)
   output.size = input.size = sizeof (uint8_t) * 3 * 640 * 480 * 1;
 
   /* alloc input data without alignment */
-  input.data = malloc (input.size);
-  output.data = malloc (output.size);
+  input.data = g_malloc (input.size);
+  output.data = g_malloc (output.size);
 
   memset (input.data, 0, input.size);
 
@@ -856,8 +856,8 @@ end
   output.size = input.size = sizeof (uint8_t) * 3 * 100 * 100 * 1;
 
   /* alloc input data without alignment */
-  input.data = malloc (input.size);
-  output.data = malloc (output.size);
+  input.data = g_malloc (input.size);
+  output.data = g_malloc (output.size);
 
   memset (input.data, 0, input.size);
 


### PR DESCRIPTION
- Use `g_malloc` instead of `malloc` to abort program when malloc fails
- Give correct size to `lua_newuserdata`

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
