### PR TITLE
[Test/TVM] Fix gbs test to run only on x86_64

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -734,6 +734,9 @@ export NNSTREAMER_CONVERTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor
 %ifarch aarch64 x86_64
     LD_LIBRARY_PATH=${NNSTREAMER_BUILD_ROOT_PATH}/tests/nnstreamer_filter_edgetpu:. bash %{test_script} ./tests/nnstreamer_filter_edgetpu/unittest_edgetpu
 %endif #ifarch 64
+%ifarch x86_64
+    bash %{test_script} ./tests/nnstreamer_filter_tvm
+%endif
     pushd tests
 
     %ifarch aarch64

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -164,18 +164,6 @@ if gtest_dep.found()
     test('unittest_filter_armnn', unittest_filter_armnn, env: testenv)
   endif
 
-  # TVM unittest
-  if tvm_support_is_available
-    unittest_filter_tvm = executable('unittest_filter_tvm',
-      join_paths('nnstreamer_filter_tvm', 'unittest_filter_tvm.cc'),
-      dependencies: [unittest_util_dep, glib_dep, gst_dep, nnstreamer_dep, gtest_dep],
-      install: get_option('install-test'),
-      install_dir: unittest_install_dir
-    )
-
-    test('unittest_filter_tvm', unittest_filter_tvm, env: testenv)
-  endif
-
   # Lua unittest
   if lua_support_is_available
     unittest_filter_lua = executable('unittest_filter_lua',
@@ -231,6 +219,10 @@ if gtest_dep.found()
 
   if mvncsdk2_support_is_available
     subdir('nnstreamer_filter_mvncsdk2')
+  endif
+
+  if tvm_support_is_available
+    subdir('nnstreamer_filter_tvm')
   endif
 
   if get_option('enable-cppfilter')

--- a/tests/nnstreamer_filter_tvm/meson.build
+++ b/tests/nnstreamer_filter_tvm/meson.build
@@ -1,0 +1,8 @@
+unittest_filter_tvm = executable('unittest_filter_tvm',
+  ['unittest_filter_tvm.cc'],
+  dependencies: [unittest_util_dep, glib_dep, gst_dep, nnstreamer_dep, gtest_dep],
+  install: get_option('install-test'),
+  install_dir: unittest_install_dir
+)
+
+test('unittest_filter_tvm', unittest_filter_tvm, env: testenv)

--- a/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
+++ b/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
@@ -6,6 +6,7 @@
  * @author  Junhwan Kim <jejudo.kim@samsung.com>
  * @see     http://github.com/nnstreamer/nnstreamer
  * @bug     No known bugs
+ * @notes   Currently the test model can be executed only on x86_64
  *
  */
 #include <gtest/gtest.h>


### PR DESCRIPTION
TVM test model is compiled for x86_64, disable test on other architectures
TODO: prepare test models for more target devices

Signed-off-by: Junhwan Kim <jejudo.kim@samsung.com>

```
**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
```