### PR TITLE
[TEST] Fix streambuffers test

### DIFF
--- a/tests/nnstreamer_decoder_python3/runTest.sh
+++ b/tests/nnstreamer_decoder_python3/runTest.sh
@@ -116,8 +116,8 @@ callCompareTest test.audio16k2c.u16le.origin.log test.audio16k2c.u16le.log 2-6 "
 
 # Test other/tensors
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=tensors_mux sync-mode=basepad sync-option=1:50000000 ! tensor_decoder mode=python3 option1=${PATH_TO_SCRIPT} ! other/flexbuf ! tensor_converter ! multifilesink location=testsynch19_%1d.log \
-    tensor_mux name=tensor_mux0  sync-mode=slowest ! queue ! tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! tensors_mux.sink_0 \
-    tensor_mux name=tensor_mux1  sync-mode=slowest ! queue ! tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! tensors_mux.sink_1 \
+    tensor_mux name=tensor_mux0  sync-mode=slowest ! tensors_mux.sink_0 \
+    tensor_mux name=tensor_mux1  sync-mode=slowest ! tensors_mux.sink_1 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)10/1\" ! pngdec ! tensor_converter ! tensor_mux0.sink_0 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)20/1\" ! pngdec ! tensor_converter ! tensor_mux0.sink_1 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensor_mux1.sink_0 \

--- a/tests/nnstreamer_flatbuf/runTest.sh
+++ b/tests/nnstreamer_flatbuf/runTest.sh
@@ -103,9 +103,10 @@ callCompareTest testsynch19_3.golden testsynch19_3.log 4-4 "Tensor mux Compare 4
 callCompareTest testsynch19_4.golden testsynch19_4.log 4-5 "Tensor mux Compare 4-5" 1 0
 
 # test other/tensors
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=tensors_mux sync-mode=basepad sync-option=1:50000000 ! tensor_decoder mode=flatbuf ! other/flatbuf-tensor ! tensor_converter ! multifilesink location=testsynch19_5_%1d.log \
-    tensor_mux name=tensor_mux0  sync-mode=slowest ! tensor_decoder mode=flatbuf ! other/flatbuf-tensor ! tensor_converter ! tensors_mux.sink_0 \
-    tensor_mux name=tensor_mux1  sync-mode=slowest ! tensor_decoder mode=flatbuf ! other/flatbuf-tensor ! tensor_converter ! tensors_mux.sink_1 \
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=tensors_mux sync-mode=basepad sync-option=1:50000000 ! \
+    tensor_decoder mode=flatbuf ! other/flatbuf-tensor ! tensor_converter ! multifilesink location=testsynch19_5_%1d.log \
+    tensor_mux name=tensor_mux0  sync-mode=slowest ! tensors_mux.sink_0 \
+    tensor_mux name=tensor_mux1  sync-mode=slowest ! tensors_mux.sink_1 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)10/1\" ! pngdec ! tensor_converter ! tensor_mux0.sink_0 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)20/1\" ! pngdec ! tensor_converter ! tensor_mux0.sink_1 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensor_mux1.sink_0 \
@@ -115,5 +116,14 @@ callCompareTest testsynch19_1.golden testsynch19_5_1.log 5-2 "Tensor mux Compare
 callCompareTest testsynch19_2.golden testsynch19_5_2.log 5-3 "Tensor mux Compare 5-3" 1 0
 callCompareTest testsynch19_3.golden testsynch19_5_3.log 5-4 "Tensor mux Compare 5-4" 1 0
 callCompareTest testsynch19_4.golden testsynch19_5_4.log 5-5 "Tensor mux Compare 5-5" 1 0
+
+# Consecutive converting test
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=S16LE,rate=8000 ! \
+    tee name=t ! queue ! audioconvert ! tensor_converter frames-per-tensor=8000 ! \
+    tensor_decoder mode=flatbuf ! other/flatbuf-tensor ! tensor_converter ! \
+    tensor_decoder mode=flatbuf ! other/flatbuf-tensor ! tensor_converter ! \
+    tensor_decoder mode=flatbuf ! other/flatbuf-tensor ! tensor_converter ! filesink location=\"test.consecutive.log\" sync=true \
+    t. ! queue ! filesink location=\"test.audio8k.s16le.origin.log\" sync=true" 6 0 0 $PERFORMANCE
+callCompareTest test.audio8k.s16le.origin.log test.consecutive.log 6-1 "Consecutive converting test" 0 0
 
 report

--- a/tests/nnstreamer_flexbuf/runTest.sh
+++ b/tests/nnstreamer_flexbuf/runTest.sh
@@ -74,9 +74,10 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesp
 callCompareTest test.audio16k2c.u16le.origin.log test.audio16k2c.u16le.log 2-6 "Audio16k2c-u16le Golden Test" 0 0
 
 # Test other/tensors
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=tensors_mux sync-mode=basepad sync-option=1:50000000 ! tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! multifilesink location=testsynch19_%1d.log \
-    tensor_mux name=tensor_mux0  sync-mode=slowest ! tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! tensors_mux.sink_0 \
-    tensor_mux name=tensor_mux1  sync-mode=slowest ! tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! tensors_mux.sink_1 \
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=tensors_mux sync-mode=basepad sync-option=1:50000000 ! \
+    tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! multifilesink location=testsynch19_%1d.log \
+    tensor_mux name=tensor_mux0  sync-mode=slowest ! queue ! tensors_mux.sink_0 \
+    tensor_mux name=tensor_mux1  sync-mode=slowest ! queue ! tensors_mux.sink_1 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)10/1\" ! pngdec ! tensor_converter ! tensor_mux0.sink_0 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)20/1\" ! pngdec ! tensor_converter ! tensor_mux0.sink_1 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensor_mux1.sink_0 \
@@ -86,5 +87,14 @@ callCompareTest testsynch19_1.golden testsynch19_1.log 3-2 "Tensor mux Compare 3
 callCompareTest testsynch19_2.golden testsynch19_2.log 3-3 "Tensor mux Compare 3-3" 1 0
 callCompareTest testsynch19_3.golden testsynch19_3.log 3-4 "Tensor mux Compare 3-4" 1 0
 callCompareTest testsynch19_4.golden testsynch19_4.log 3-5 "Tensor mux Compare 3-5" 1 0
+
+# Consecutive converting test
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=S16LE,rate=8000 ! \
+    tee name=t ! queue ! audioconvert ! tensor_converter frames-per-tensor=8000 ! \
+    tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! \
+    tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! \
+    tensor_decoder mode=flexbuf ! other/flexbuf ! tensor_converter ! filesink location=\"test.consecutive.log\" sync=true \
+    t. ! queue ! filesink location=\"test.audio8k.s16le.origin.log\" sync=true" 4 0 0 $PERFORMANCE
+callCompareTest test.audio8k.s16le.origin.log test.consecutive.log 4-1 "Consecutive converting test" 0 0
 
 report

--- a/tests/nnstreamer_protobuf/runTest.sh
+++ b/tests/nnstreamer_protobuf/runTest.sh
@@ -103,9 +103,10 @@ callCompareTest testsynch19_3.golden testsynch19_3.log 4-4 "Tensor mux Compare 4
 callCompareTest testsynch19_4.golden testsynch19_4.log 4-5 "Tensor mux Compare 4-5" 1 0
 
 # test other/tensors
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=tensors_mux sync-mode=basepad sync-option=1:50000000 ! tensor_decoder mode=protobuf ! other/protobuf-tensor ! tensor_converter ! multifilesink location=testsynch19_5_%1d.log \
-    tensor_mux name=tensor_mux0  sync-mode=slowest ! tensor_decoder mode=protobuf ! other/protobuf-tensor ! tensor_converter ! tensors_mux.sink_0 \
-    tensor_mux name=tensor_mux1  sync-mode=slowest ! tensor_decoder mode=protobuf ! other/protobuf-tensor ! tensor_converter ! tensors_mux.sink_1 \
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=tensors_mux sync-mode=basepad sync-option=1:50000000 ! \
+    tensor_decoder mode=protobuf ! other/protobuf-tensor ! tensor_converter ! multifilesink location=testsynch19_5_%1d.log \
+    tensor_mux name=tensor_mux0  sync-mode=slowest ! tensors_mux.sink_0 \
+    tensor_mux name=tensor_mux1  sync-mode=slowest ! tensors_mux.sink_1 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)10/1\" ! pngdec ! tensor_converter ! tensor_mux0.sink_0 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)20/1\" ! pngdec ! tensor_converter ! tensor_mux0.sink_1 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensor_mux1.sink_0 \
@@ -115,5 +116,15 @@ callCompareTest testsynch19_1.golden testsynch19_5_1.log 5-2 "Tensor mux Compare
 callCompareTest testsynch19_2.golden testsynch19_5_2.log 5-3 "Tensor mux Compare 5-3" 1 0
 callCompareTest testsynch19_3.golden testsynch19_5_3.log 5-4 "Tensor mux Compare 5-4" 1 0
 callCompareTest testsynch19_4.golden testsynch19_5_4.log 5-5 "Tensor mux Compare 5-5" 1 0
+
+# Consecutive converting test
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=S16LE,rate=8000 ! \
+    tee name=t ! queue ! audioconvert ! tensor_converter frames-per-tensor=8000 ! \
+    tensor_decoder mode=protobuf ! other/protobuf-tensor ! tensor_converter ! \
+    tensor_decoder mode=protobuf ! other/protobuf-tensor ! tensor_converter ! \
+    tensor_decoder mode=protobuf ! other/protobuf-tensor ! tensor_converter ! filesink location=\"test.consecutive.log\" sync=true \
+    t. ! queue ! filesink location=\"test.audio8k.s16le.origin.log\" sync=true" 6 0 0 $PERFORMANCE
+callCompareTest test.audio8k.s16le.origin.log test.consecutive.log 6-1 "Consecutive converting test" 0 0
+
 
 report


### PR DESCRIPTION
Test fails on arm arch(gbs build) because buffer conversion takes long time.
The order of buffers is important for this test because the frame rate of the filesource is different.
The purpose of the test is to convert other/tensors to stream buffers, so modifies the test.
 *Consecutive use of the python decoder has some problem, I will fix it next PR.

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped
