### PR TITLE
[Test/GstMQTT] Use gstmqtt_mocking_dep instead of gstmqtt_dep

### DIFF
--- a/debian/nnstreamer-misc.install
+++ b/debian/nnstreamer-misc.install
@@ -1,2 +1,1 @@
 /usr/lib/*/gstreamer-1.0/libgstjoin.so
-/usr/lib/*/gstreamer-1.0/libgstmqtt.so

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,7 +18,7 @@ option('flatbuf-support', type: 'feature', value: 'auto')
 option('tensorrt-support', type: 'feature', value: 'auto')
 option('grpc-support', type: 'feature', value: 'auto')
 option('lua-support', type: 'feature', value: 'auto')
-option('mqtt-support', type: 'feature', value: 'auto')
+option('mqtt-support', type: 'feature', value: 'disabled')
 option('tvm-support', type: 'feature', value: 'auto')
 
 # booleans & other options

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -31,7 +31,7 @@
 %define		grpc_support 1
 %define		pytorch_support 0
 %define		caffe2_support 0
-%define		mqtt_support 1
+%define		mqtt_support 0
 %define		lua_support 1
 
 %define		check_test 1

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -120,7 +120,7 @@ if gtest_dep.found()
     if mqtt_support_is_available
       unittest_mqtt_w_helper = executable('unittest_mqtt_w_helper',
           join_paths('gstreamer_mqtt', 'unittest_mqtt_w_helper.cc'),
-          dependencies: [gstmqtt_dep, nnstreamer_unittest_deps, unittest_util_dep],
+          dependencies: [gstmqtt_mocking_dep, nnstreamer_unittest_deps, unittest_util_dep],
           install: get_option('install-test'),
           install_dir: unittest_install_dir)
 


### PR DESCRIPTION
gstmqtt_dep is removed and newly gstmqtt_mocking_dep is declared.
This patch uses gstmqtt_mocking_dep to fix the buildbreak issue.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped


