### PR TITLE
[filter/log] Log filter statistics when the mode is enabled

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -412,6 +412,9 @@ record_statistics (GstTensorFilterPrivate * priv)
       priv->prop.latency = (gint) avg_latency;
     else
       priv->prop.latency = -1;
+
+    ml_logi ("[%s] Invoke took %.3f ms", priv->prop.model_files[0],
+        (*latency) / 1000.0);
   }
 
   if (priv->throughput_mode > 0) {
@@ -429,6 +432,9 @@ record_statistics (GstTensorFilterPrivate * priv)
 
     /* note that it's a 1000x larger value than actual throughput */
     priv->prop.throughput = throughput_int;
+
+    ml_logi ("[%s] Throughput: %.2f FPS", priv->prop.model_files[0],
+        throughput_int / 1000.0);
   }
 
   /**


### PR DESCRIPTION
- Log latency and throughput values when the mode is enabled
- This resloves issue #3186

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
