### PR TITLE
[Caps/Format] add tensor format in caps

### DIFF
--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -45,7 +45,6 @@
 
 #define NNS_MIMETYPE_TENSOR "other/tensor"
 #define NNS_MIMETYPE_TENSORS "other/tensors"
-#define NNS_MIMETYPE_TENSORS_FLEXIBLE "other/tensors-flexible"
 
 /**
  * @brief This value, 16, can be checked with gst_buffer_get_max_memory(),
@@ -101,7 +100,7 @@
  */
 #define GST_TENSORS_CAP_WITH_NUM(num) \
     NNS_MIMETYPE_TENSORS ", " \
-    "num_tensors = " num ", " \
+    "format = (string) static, num_tensors = " num ", " \
     "framerate = " GST_TENSOR_RATE_RANGE
 
 /**
@@ -116,7 +115,7 @@
  * The maximum number of tensors in a buffer is 16 (NNS_TENSOR_SIZE_LIMIT).
  */
 #define GST_TENSORS_FLEX_CAP_DEFAULT \
-    NNS_MIMETYPE_TENSORS_FLEXIBLE
+    GST_TENSORS_CAP_MAKE ("flexible")
 
 /**
  * @brief Default static capability for Protocol Buffers

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -293,7 +293,7 @@ gst_tensor_converter_class_init (GstTensorConverterClass * klass)
   /* set src pad template */
   pad_caps =
       gst_caps_from_string (GST_TENSOR_CAP_DEFAULT ";"
-      GST_TENSORS_CAP_DEFAULT ";" GST_TENSORS_FLEX_CAP_DEFAULT);
+      GST_TENSORS_CAP_MAKE ("{ static, flexible }"));
 
   pad_template = gst_pad_template_new ("src", GST_PAD_SRC, GST_PAD_ALWAYS,
       pad_caps);

--- a/gst/nnstreamer/tensor_crop/tensor_crop.c
+++ b/gst/nnstreamer/tensor_crop/tensor_crop.c
@@ -93,7 +93,8 @@ enum
 static GstStaticPadTemplate raw_template = GST_STATIC_PAD_TEMPLATE ("raw",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_FLEX_CAP_DEFAULT));
+    GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT ";"
+        GST_TENSORS_CAP_MAKE ("{ static, flexible }")));
 
 /**
  * @brief Template for sink pad (crop info).

--- a/gst/nnstreamer/tensor_demux/gsttensordemux.c
+++ b/gst/nnstreamer/tensor_demux/gsttensordemux.c
@@ -74,12 +74,12 @@ GST_DEBUG_CATEGORY_STATIC (gst_tensor_demux_debug);
 /**
  * @brief Default caps string for sink pad.
  */
-#define CAPS_STRING_SINK GST_TENSORS_CAP_DEFAULT ";" GST_TENSORS_FLEX_CAP_DEFAULT
+#define CAPS_STRING_SINK GST_TENSORS_CAP_MAKE ("{ static, flexible }")
 
 /**
  * @brief Default caps string for src pad.
  */
-#define CAPS_STRING_SRC GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_DEFAULT ";" GST_TENSORS_FLEX_CAP_DEFAULT
+#define CAPS_STRING_SRC GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_MAKE ("{ static, flexible }")
 
 enum
 {

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -119,7 +119,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_tensor_filter_debug);
 /**
  * @brief Default caps string for both sink and source pad.
  */
-#define CAPS_STRING GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_DEFAULT ";" GST_TENSORS_FLEX_CAP_DEFAULT
+#define CAPS_STRING GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_MAKE ("{ static, flexible }")
 
 /**
  * @brief The capabilities of the inputs

--- a/gst/nnstreamer/tensor_mux/gsttensormux.c
+++ b/gst/nnstreamer/tensor_mux/gsttensormux.c
@@ -94,12 +94,12 @@ enum
 /**
  * @brief Default caps string for sink pad.
  */
-#define CAPS_STRING_SINK GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_DEFAULT ";" GST_TENSORS_FLEX_CAP_DEFAULT
+#define CAPS_STRING_SINK GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_MAKE ("{ static, flexible }")
 
 /**
  * @brief Default caps string for src pad.
  */
-#define CAPS_STRING_SRC GST_TENSORS_CAP_DEFAULT ";" GST_TENSORS_FLEX_CAP_DEFAULT
+#define CAPS_STRING_SRC GST_TENSORS_CAP_MAKE ("{ static, flexible }")
 
 /**
  * @brief the capabilities of the inputs and outputs.

--- a/gst/nnstreamer/tensor_sink/tensor_sink.c
+++ b/gst/nnstreamer/tensor_sink/tensor_sink.c
@@ -246,7 +246,7 @@ gst_tensor_sink_class_init (GstTensorSinkClass * klass)
 
   /** pad template */
   pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT ";"
-      GST_TENSORS_CAP_DEFAULT ";" GST_TENSORS_FLEX_CAP_DEFAULT);
+      GST_TENSORS_CAP_MAKE ("{ static, flexible }"));
   pad_template = gst_pad_template_new ("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
       pad_caps);
   gst_element_class_add_pad_template (element_class, pad_template);

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -91,7 +91,7 @@
 
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_transform_debug);
 #define GST_CAT_DEFAULT gst_tensor_transform_debug
-#define CAPS_STRING GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_DEFAULT ";" GST_TENSORS_FLEX_CAP_DEFAULT
+#define CAPS_STRING GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_MAKE ("{ static, flexible }")
 #define REGEX_DIMCHG_OPTION "^([0-3]):([0-3])$"
 #define REGEX_TYPECAST_OPTION "(^[u]?int(8|16|32|64)$|^float(32|64)$)"
 #define REGEX_TRANSPOSE_OPTION "^(?:([0-2]):(?!.*\\1)){3}3$"
@@ -1833,6 +1833,11 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
   out_flexible = gst_tensors_info_is_flexible (&out_config.info);
 
   /* compare type and dimension */
+  gst_tensors_config_init (&config);
+  config.rate_n = in_config.rate_n;
+  config.rate_d = in_config.rate_d;
+  config.info.num_tensors = in_config.info.num_tensors;
+
   if (!in_flexible) {
     for (i = 0; i < in_config.info.num_tensors; i++) {
       if (!gst_tensor_transform_convert_dimension (filter, GST_PAD_SINK,
@@ -1843,10 +1848,6 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
       }
     }
   }
-
-  config.rate_n = in_config.rate_n;
-  config.rate_d = in_config.rate_d;
-  config.info.num_tensors = in_config.info.num_tensors;
 
   if (out_flexible) {
     GST_INFO_OBJECT (filter, "Output tensor is flexible.");

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -754,17 +754,17 @@ _setup_pipeline (TestOption &option)
     break;
   case TEST_TYPE_FLEX_TENSOR_1:
     str_pipeline = g_strdup_printf (
-        "appsrc name=appsrc caps=other/tensors-flexible,framerate=(fraction)10/1 ! tensor_sink name=test_sink");
+        "appsrc name=appsrc caps=other/tensors,format=flexible,framerate=(fraction)10/1 ! tensor_sink name=test_sink");
     break;
   case TEST_TYPE_FLEX_TENSOR_2:
     str_pipeline = g_strdup_printf (
         "appsrc name=appsrc caps=application/octet-stream,framerate=(fraction)10/1 ! "
         "tensor_converter name=convert input-dim=2,2 input-type=int32,int8 ! "
-        "other/tensors-flexible ! tensor_sink name=test_sink");
+        "other/tensors,format=flexible ! tensor_sink name=test_sink");
     break;
   case TEST_TYPE_FLEX_TENSOR_3:
     str_pipeline = g_strdup_printf (
-        "appsrc name=appsrc caps=other/tensors-flexible,framerate=(fraction)10/1 ! "
+        "appsrc name=appsrc caps=other/tensors,format=flexible,framerate=(fraction)10/1 ! "
         "tensor_converter name=convert input-dim=10 input-type=int8 ! tensor_sink name=test_sink");
     break;
   case TEST_TYPE_TENSORS_MUX_1:
@@ -780,7 +780,7 @@ _setup_pipeline (TestOption &option)
     str_pipeline = g_strdup_printf (
         "tensor_mux name=mux ! tensor_sink name=test_sink "
         "videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_0 "
-        "videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! other/tensors-flexible ! mux.sink_1",
+        "videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! other/tensors,format=flexible ! mux.sink_1",
         option.num_buffers, option.num_buffers);
     break;
   case TEST_TYPE_TENSORS_MUX_3:
@@ -788,7 +788,7 @@ _setup_pipeline (TestOption &option)
     str_pipeline = g_strdup_printf (
         "tensor_mux name=mux ! tensor_demux name=demux "
         "videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_0 "
-        "videotestsrc num-buffers=%d ! video/x-raw,width=320,height=240,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! other/tensors-flexible ! mux.sink_1 "
+        "videotestsrc num-buffers=%d ! video/x-raw,width=320,height=240,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! other/tensors,format=flexible ! mux.sink_1 "
         "demux.src_0 ! queue ! tensor_sink "
         "demux.src_1 ! queue ! tensor_sink name=test_sink",
         option.num_buffers, option.num_buffers);
@@ -796,19 +796,19 @@ _setup_pipeline (TestOption &option)
   case TEST_TYPE_TENSORS_FLEX_NEGO_FAILED_1:
     /** tensor_mux nego failure case */
     str_pipeline = g_strdup_printf (
-        "tensor_mux name=mux ! other/tensors ! tensor_sink name=test_sink "
+        "tensor_mux name=mux ! other/tensors,format=static ! tensor_sink name=test_sink "
         "videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_0 "
-        "videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! other/tensors-flexible ! mux.sink_1",
+        "videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! other/tensors,format=flexible ! mux.sink_1",
         option.num_buffers, option.num_buffers);
     break;
   case TEST_TYPE_TENSORS_FLEX_NEGO_FAILED_2:
     /** tensor_demux nego failure case */
     str_pipeline = g_strdup_printf (
-        "tensor_mux name=mux ! other/tensors-flexible ! tensor_demux name=demux "
+        "tensor_mux name=mux ! other/tensors,format=flexible ! tensor_demux name=demux "
         "videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_0 "
         "videotestsrc num-buffers=%d ! video/x-raw,width=320,height=240,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_1 "
         "demux.src_0 ! queue ! tensor_sink "
-        "demux.src_1 ! queue ! other/tensors ! tensor_sink name=test_sink",
+        "demux.src_1 ! queue ! other/tensors,format=static ! tensor_sink name=test_sink",
         option.num_buffers, option.num_buffers);
     break;
   case TEST_TYPE_TENSORS_MIX_1:
@@ -879,8 +879,7 @@ _setup_pipeline (TestOption &option)
     /** other/tensor out, caps are specifed*/
     str_pipeline = g_strdup_printf (
         "videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
-        "tensor_converter ! other/tensor,dimension=(string)3:160:120:1,type=(string)uint8,framerate=(fraction)30/1 ! "
-        "tensor_sink name=test_sink async=false",
+        "tensor_converter ! other/tensor,format=static ! tensor_sink name=test_sink async=false",
         option.num_buffers, fps);
     break;
   case TEST_TYPE_TENSOR_CAP_2:
@@ -894,8 +893,7 @@ _setup_pipeline (TestOption &option)
     /** other/tensors, caps are specifed (num_tensors is 1) */
     str_pipeline = g_strdup_printf (
         "videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
-        "tensor_converter ! other/tensors,num_tensors=1,dimensions=(string)3:160:120:1, types=(string)uint8, framerate=(fraction)30/1 ! "
-        "tensor_sink name=test_sink async=false",
+        "tensor_converter ! other/tensors,format=static ! tensor_sink name=test_sink async=false",
         option.num_buffers, fps);
     break;
   case TEST_TYPE_TENSORS_CAP_2:


### PR DESCRIPTION
Add tensor format in caps.
Fix pad template with flex tensor and remove old mimetype.
Now caps string for flex-tensor has framerate field.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
