### PR TITLE
[Tests/GstMQTT] Fix failure in GstMQTT test cases @open sesame 07/07 13:30

### DIFF
--- a/debian/nnstreamer-misc.install
+++ b/debian/nnstreamer-misc.install
@@ -1,1 +1,2 @@
 /usr/lib/*/gstreamer-1.0/libgstjoin.so
+/usr/lib/*/gstreamer-1.0/libgstmqtt.so

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,7 +18,7 @@ option('flatbuf-support', type: 'feature', value: 'auto')
 option('tensorrt-support', type: 'feature', value: 'auto')
 option('grpc-support', type: 'feature', value: 'auto')
 option('lua-support', type: 'feature', value: 'auto')
-option('mqtt-support', type: 'feature', value: 'disabled')
+option('mqtt-support', type: 'feature', value: 'auto')
 option('tvm-support', type: 'feature', value: 'auto')
 
 # booleans & other options

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -31,7 +31,7 @@
 %define		grpc_support 1
 %define		pytorch_support 0
 %define		caffe2_support 0
-%define		mqtt_support 0
+%define		mqtt_support 1
 %define		lua_support 1
 
 %define		check_test 1

--- a/tests/gstreamer_mqtt/unittest_mqtt_w_helper.cc
+++ b/tests/gstreamer_mqtt/unittest_mqtt_w_helper.cc
@@ -203,6 +203,9 @@ void _set_ts_gst_mqtt_message_hdr (GstElement *elm, GstMQTTMessageHdr *hdr,
   diff = GST_CLOCK_DIFF (base_time, cur_time);
   hdr->base_time_epoch = g_get_real_time () * GST_US_TO_NS_MULTIPLIER - diff;
   hdr->sent_time_epoch = hdr->base_time_epoch + diff_sent;
+
+  hdr->pts = 0;
+  hdr->dts = 0;
   hdr->duration = duration;
 }
 

--- a/tests/gstreamer_mqtt/unittest_mqtt_w_helper.cc
+++ b/tests/gstreamer_mqtt/unittest_mqtt_w_helper.cc
@@ -385,7 +385,7 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch0)
   gchar *topic_name = g_strdup ("test_topic");
   gchar *str_pipeline = g_strdup_printf (
       "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d ! "
-      "capsfilter caps=%s ! videoconvert ! videoscale ! fakevideosink",
+      "capsfilter caps=%s ! videoconvert ! videoscale ! fakesink",
       topic_name, 1, caps_str);
   GError *err = NULL;
   GstElement *pipeline;
@@ -458,7 +458,7 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch1)
   gchar *topic_name = g_strdup ("test_topic");
   gchar *str_pipeline = g_strdup_printf (
       "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d ! "
-      "capsfilter caps=%s ! videoconvert ! videoscale ! fakevideosink",
+      "capsfilter caps=%s ! videoconvert ! videoscale ! fakesink",
       topic_name, 2, caps_str);
   GError *err = NULL;
   GstElement *pipeline;
@@ -545,7 +545,7 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch0_n)
   gchar *topic_name = g_strdup ("test_topic");
   gchar *str_pipeline = g_strdup_printf (
       "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d ! "
-      "capsfilter caps=%s ! videoconvert ! videoscale ! fakevideosink",
+      "capsfilter caps=%s ! videoconvert ! videoscale ! fakesink",
       topic_name, 1, caps_str);
   GError *err = NULL;
   GstElement *pipeline;
@@ -620,7 +620,7 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch1_n)
   gchar *topic_name = g_strdup ("test_topic");
   gchar *str_pipeline = g_strdup_printf (
       "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d ! "
-      "capsfilter caps=%s ! videoconvert ! videoscale ! fakevideosink",
+      "capsfilter caps=%s ! videoconvert ! videoscale ! fakesink",
       topic_name, 1, caps_str);
   GError *err = NULL;
   GstElement *pipeline;
@@ -696,7 +696,7 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch2)
   gchar *topic_name = g_strdup ("test_topic");
   gchar *str_pipeline = g_strdup_printf (
       "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d ! "
-      "capsfilter caps=%s ! videoconvert ! videoscale ! fakevideosink",
+      "capsfilter caps=%s ! videoconvert ! videoscale ! fakesink",
       topic_name, 1, caps_str);
   GError *err = NULL;
   GstElement *pipeline;

--- a/tests/gstreamer_mqtt/unittest_mqtt_w_helper.cc
+++ b/tests/gstreamer_mqtt/unittest_mqtt_w_helper.cc
@@ -384,9 +384,10 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch0)
   gchar *caps_str = g_strdup ("video/x-raw,width=640,height=320,format=RGB");
   gchar *topic_name = g_strdup ("test_topic");
   gchar *str_pipeline = g_strdup_printf (
-      "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d ! "
+      "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d "
+      "sub-timeout=%" G_GINT64_FORMAT " ! "
       "capsfilter caps=%s ! videoconvert ! videoscale ! fakesink",
-      topic_name, 1, caps_str);
+      topic_name, 1, G_TIME_SPAN_MINUTE, caps_str);
   GError *err = NULL;
   GstElement *pipeline;
   GstStateChangeReturn ret;
@@ -457,9 +458,10 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch1)
   gchar *caps_str = g_strdup ("video/x-raw,width=640,height=320,format=RGB");
   gchar *topic_name = g_strdup ("test_topic");
   gchar *str_pipeline = g_strdup_printf (
-      "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d ! "
+      "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d "
+      "sub-timeout=%" G_GINT64_FORMAT " ! "
       "capsfilter caps=%s ! videoconvert ! videoscale ! fakesink",
-      topic_name, 2, caps_str);
+      topic_name, 2, G_TIME_SPAN_MINUTE, caps_str);
   GError *err = NULL;
   GstElement *pipeline;
   GstStateChangeReturn ret;
@@ -544,9 +546,10 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch0_n)
   gchar *caps_str = g_strdup ("video/x-raw,width=640,height=320,format=RGB");
   gchar *topic_name = g_strdup ("test_topic");
   gchar *str_pipeline = g_strdup_printf (
-      "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d ! "
+      "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d "
+      "sub-timeout=%" G_GINT64_FORMAT " ! "
       "capsfilter caps=%s ! videoconvert ! videoscale ! fakesink",
-      topic_name, 1, caps_str);
+      topic_name, 1, G_TIME_SPAN_MINUTE, caps_str);
   GError *err = NULL;
   GstElement *pipeline;
   GstStateChangeReturn ret;
@@ -619,9 +622,10 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch1_n)
   gchar *caps_str = g_strdup ("video/x-raw,width=640,height=320,format=RGB");
   gchar *topic_name = g_strdup ("test_topic");
   gchar *str_pipeline = g_strdup_printf (
-      "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d ! "
+      "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d "
+      "sub-timeout=%" G_GINT64_FORMAT " ! "
       "capsfilter caps=%s ! videoconvert ! videoscale ! fakesink",
-      topic_name, 1, caps_str);
+      topic_name, 1, G_TIME_SPAN_MINUTE, caps_str);
   GError *err = NULL;
   GstElement *pipeline;
   GstStateChangeReturn ret;
@@ -695,9 +699,10 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch2)
   gchar *caps_str = g_strdup ("video/x-raw,width=640,height=320,format=RGB");
   gchar *topic_name = g_strdup ("test_topic");
   gchar *str_pipeline = g_strdup_printf (
-      "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d ! "
+      "mqttsrc sub-topic=%s debug=true is-live=true num-buffers=%d "
+      "sub-timeout=%" G_GINT64_FORMAT " ! "
       "capsfilter caps=%s ! videoconvert ! videoscale ! fakesink",
-      topic_name, 1, caps_str);
+      topic_name, 1, G_TIME_SPAN_MINUTE, caps_str);
   GError *err = NULL;
   GstElement *pipeline;
   GstStateChangeReturn ret;

--- a/tests/gstreamer_mqtt/unittest_mqtt_w_helper.cc
+++ b/tests/gstreamer_mqtt/unittest_mqtt_w_helper.cc
@@ -209,7 +209,7 @@ void _set_ts_gst_mqtt_message_hdr (GstElement *elm, GstMQTTMessageHdr *hdr,
 /**
  * @brief Test for mqttsink with GstMqttTestHelper (push a GstBuffer)
  */
-TEST (testMqttSink, sinkPush0)
+TEST (testMqttSinkWithHelper, sinkPush0)
 {
   GstHarness *h = gst_harness_new ("mqttsink");
   GstFlowReturn ret;
@@ -227,7 +227,7 @@ TEST (testMqttSink, sinkPush0)
 /**
  * @brief Test for mqttsink with GstMqttTestHelper (Push multiple GstBuffers with num-buffers)
  */
-TEST (testMqttSink, sinkPush1)
+TEST (testMqttSinkWithHelper, sinkPush1)
 {
   GstHarness *h = gst_harness_new ("mqttsink");
   GstFlowReturn ret;
@@ -250,7 +250,7 @@ TEST (testMqttSink, sinkPush1)
 /**
  * @brief Test for mqttsink with GstMqttTestHelper (MQTTAsync_send failure case)
  */
-TEST (testMqttSink, sinkPush0_n)
+TEST (testMqttSinkWithHelper, sinkPush0_n)
 {
   const static gsize data_size = 1024;
   GstHarness *h = gst_harness_new ("mqttsink");
@@ -275,7 +275,7 @@ TEST (testMqttSink, sinkPush0_n)
 /**
  * @brief Test for mqttsink with GstMqttTestHelper (MQTTAsync_disconnect failure case)
  */
-TEST (testMqttSink, sinkPush1_n)
+TEST (testMqttSinkWithHelper, sinkPush1_n)
 {
   const static gsize data_size = 1024;
   GstHarness *h = gst_harness_new ("mqttsink");
@@ -300,7 +300,7 @@ TEST (testMqttSink, sinkPush1_n)
 /**
  * @brief Test for mqttsink with GstMqttTestHelper (Push an empty buffer)
  */
-TEST (testMqttSink, sinkPush2_n)
+TEST (testMqttSinkWithHelper, sinkPush2_n)
 {
   GstHarness *h;
   GstBuffer *in_buf;
@@ -323,7 +323,7 @@ TEST (testMqttSink, sinkPush2_n)
 /**
  * @brief Test for mqttsink with GstMqttTestHelper (Push GstBuffers more then num-buffers)
  */
-TEST (testMqttSink, sinkPush3_n)
+TEST (testMqttSinkWithHelper, sinkPush3_n)
 {
   GstHarness *h = gst_harness_new ("mqttsink");
   GstFlowReturn ret;
@@ -378,7 +378,7 @@ static void _gen_dummy_mqtt_msg (MQTTAsync_message *msg, GstMQTTMessageHdr *hdr,
 /**
  * @brief Test mqttsrc using a proper pipeline description #1
  */
-TEST (testMqttSrc, srcNormalLaunch0)
+TEST (testMqttSrcWithHelper, srcNormalLaunch0)
 {
   const gsize len_buf = 1024;
   gchar *caps_str = g_strdup ("video/x-raw,width=640,height=320,format=RGB");
@@ -451,7 +451,7 @@ TEST (testMqttSrc, srcNormalLaunch0)
 /**
  * @brief Test mqttsrc using a proper pipeline description #2 (dynamically re-negotiating GstCaps)
  */
-TEST (testMqttSrc, srcNormalLaunch1)
+TEST (testMqttSrcWithHelper, srcNormalLaunch1)
 {
   const gsize len_buf = 1024;
   gchar *caps_str = g_strdup ("video/x-raw,width=640,height=320,format=RGB");
@@ -538,7 +538,7 @@ TEST (testMqttSrc, srcNormalLaunch1)
 /**
  * @brief Fail test case for mqttsrc #0 (MQTTAsync_subscribe failure case)
  */
-TEST (testMqttSrc, srcNormalLaunch0_n)
+TEST (testMqttSrcWithHelper, srcNormalLaunch0_n)
 {
   const gsize len_buf = 1024;
   gchar *caps_str = g_strdup ("video/x-raw,width=640,height=320,format=RGB");
@@ -613,7 +613,7 @@ TEST (testMqttSrc, srcNormalLaunch0_n)
 /**
  * @brief Fail test case for mqttsrc #1 (MQTTAsync_disconnect failure case)
  */
-TEST (testMqttSrc, srcNormalLaunch1_n)
+TEST (testMqttSrcWithHelper, srcNormalLaunch1_n)
 {
   const gsize len_buf = 1024;
   gchar *caps_str = g_strdup ("video/x-raw,width=640,height=320,format=RGB");
@@ -689,7 +689,7 @@ TEST (testMqttSrc, srcNormalLaunch1_n)
 /**
  * @brief Fail test case for mqttsrc #2 (MQTTAsync_unsubscribe failure case)
  */
-TEST (testMqttSrc, srcNormalLaunch2)
+TEST (testMqttSrcWithHelper, srcNormalLaunch2)
 {
   const gsize len_buf = 1024;
   gchar *caps_str = g_strdup ("video/x-raw,width=640,height=320,format=RGB");


### PR DESCRIPTION
To revert a78ad73ddc2d7068f8818f1c025a21e085e6b675, this PR fixes the test cases for GstMQTT mentioned in #3378.

In detail, it is confirmed that the following cases are fixed:
- Tizen GBS (i586)
   - Stuck at ```testMqttSrc.srcNormalLaunch1```
- Ubuntu Pdebuild: 
```
   [  FAILED  ] 5 tests, listed below:
   [  FAILED  ] testMqttSrc.srcNormalLaunch0
   [  FAILED  ] testMqttSrc.srcNormalLaunch1
   [  FAILED  ] testMqttSrc.srcNormalLaunch0_n
   [  FAILED  ] testMqttSrc.srcNormalLaunch1_n
   [  FAILED  ] testMqttSrc.srcNormalLaunch2
```

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

