### PR TITLE
[Doc] Fix title to comply hotdoc rule

### DIFF
--- a/Documentation/profiling-android-pipeline.md
+++ b/Documentation/profiling-android-pipeline.md
@@ -1,5 +1,5 @@
 ---
-title: [Android] Profiling NNStreamer Pipeline with GstShark
+title: Profiling Android NNStreamer Pipeline with GstShark
 ...
 
 # [Android] Profiling NNStreamer Pipeline with GstShark


### PR DESCRIPTION
Fix title to comply hotdoc rule.
Special characters are not allowed in the hotdoc title.

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
