### PR TITLE
Revive ARMNN build

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -40,7 +40,20 @@ if armnn_support_is_available
     nnstreamer_filter_armnn_sources += join_paths(meson.current_source_dir(), s)
   endforeach
 
-  nnstreamer_filter_armnn_deps = armnn_support_deps + [glib_dep, gst_dep, nnstreamer_dep]
+  if cxx.has_header('armnnCaffeParser/ICaffeParser.hpp')
+    armnn_caffeparserlib = cxx.find_library('armnnCaffeParser', required: true)
+    armnn_caffe_dep = declare_dependency(compile_args: '-DENABLE_ARMNN_CAFFE=1')
+    armnn_support_deps = armnn_support_deps + [ armnn_caffe_dep, armnn_caffeparserlib ]
+    message('ARMNN subplugin is built with Caffe parser.')
+  endif
+  if cxx.has_header('armnnTfLiteParser/ITfLiteParser.hpp')
+    armnn_tflparserlib = cxx.find_library('armnnTfLiteParser', required: true)
+    armnn_tfl_dep = declare_dependency(compile_args: '-DENABLE_ARMNN_TFLITE=1')
+    armnn_support_deps = armnn_support_deps + [ armnn_tfl_dep, armnn_tflparserlib ]
+    message('ARMNN subplugin is built with TFLite parser.')
+  endif
+
+  nnstreamer_filter_armnn_deps = armnn_support_deps + [glib_dep, gst_dep, nnstreamer_dep ]
 
   armnn_plugin_lib = shared_library('nnstreamer_filter_armnn',
     nnstreamer_filter_armnn_sources,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -222,8 +222,6 @@ ArmNNCore::makeTfNetwork (std::map<std::string, armnn::TensorShape> &input_map,
 
 /**
  * @brief make network with tensorflow-lite parser
- * @param[in] input_map input data map
- * @param[in] output_vec output data vector
  * @return 0 on success, -errno on error
  */
 int

--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -277,8 +277,6 @@ ArmNNCore::makeTfLiteNetwork ()
 #else /* ENABLE_ARMNN_TFLITE */
 /**
  * @brief A dummy function used when tensorflow-lite is not enabled at build-time.
- * @param[in] input_map input data map
- * @param[in] output_vec output data vector
  * @retval -EPERM this returns error always.
  */
 int
@@ -454,13 +452,13 @@ ArmNNCore::getGstTensorType (armnn::DataType armType)
   case armnn::DataType::Float16:
     ml_logw ("Unsupported armnn datatype Float16.");
     break;
-  case armnn::DataType::QuantisedAsymm8:
+  case armnn::DataType::QAsymmU8:
     /** Supported with tflite */
     return _NNS_UINT8;
   case armnn::DataType::Boolean:
     ml_logw ("Unsupported armnn datatype Boolean.");
     break;
-  case armnn::DataType::QuantisedSymm16:
+  case armnn::DataType::QSymmS16:
     ml_logw ("Unsupported armnn datatype QuantisedSym16.");
     break;
   default:

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -23,7 +23,7 @@
 %define		tensorflow_lite_support	1
 %define		tensorflow2_lite_support 1
 %define		tensorflow2_gpu_delegate_support 1
-%define		armnn_support 0
+%define		armnn_support 1
 %define		vivante_support 0
 %define		flatbuf_support 1
 %define		protobuf_support 1
@@ -109,6 +109,7 @@
 %define		edgetpu_support 0
 %define		openvino_support 0
 %define		edgetpu_support 0
+%define		armnn_support 0
 %define		lua_support 0
 %define		mqtt_support 0
 %define		tvm_support 0

--- a/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
+++ b/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
@@ -510,6 +510,10 @@ TEST (nnstreamerFilterArmnn, invokeAdvanced)
   info.info[0].dimension[3] = 1;
 
   ret = sp->open (&prop, &data);
+  if (ret == -EPERM) { /** TFLite Parser is not included in this instance */
+    g_free (model_file);
+    return;
+  }
   EXPECT_EQ (ret, 0);
 
   /** get input/output dimension successfully */
@@ -631,6 +635,16 @@ TEST (nnstreamerFilterArmnn, invoke01)
   output.data = g_malloc (output.size);
 
   ret = sp->open (&prop, &data);
+  if (ret == -EPERM) { /** Caffe Parser Not Included in This System */
+    g_free (data_file);
+    g_free (input.data);
+    g_free (input_uint8_data);
+    g_free (output.data);
+    g_free (prop.output_meta.info[0].name);
+    g_free (prop.input_meta.info[0].name);
+    g_free (model_file);
+    return;
+  }
   EXPECT_EQ (ret, 0);
 
   /** invoke successful */


### PR DESCRIPTION
This commit series reenabled armnn subplugin builds for Tizen and Debian.

Commit 1: There is a Linux distro that has ARMNN parsers partially (Debian/Sid); thus, armnn subplugin should adapt to it at build-time.
Commit 2: Recent ARMNN has deprecated a few type enums that this subplugin uses. Update them.
Commit 3: Reenable Tizen ARMNN build.


Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

This series has the following commits:

commit 6324473f31abbf081f8ee21996d39246ad1343ea (HEAD -> armnn-reenable, github-fork/armnn-reenable)
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Tue Jul 6 11:46:49 2021 +0900

    Tizen: re-enable armnn build.
    
    Provide as many tensor-filter subplugins as possible!
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 25aa51210650eaa08efba6dd33fdbb1d860b0983
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Tue Jul 6 11:45:14 2021 +0900

    ARMNN: update deprecated type enum.
    
    QuantisedAsymm8 and QuantisedSymm16 are deprecated by both
    Tizen and Debian's ARMNN versions.
    Use new enum declarations.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 90c8a89857cf5e26dae17754f32c85d3106b47d2
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Mon Jul 5 19:43:35 2021 +0900

    ARMNN: enable Caffe/TFLite parses only when available
    
    Include Caffe-parser or TFLite-parser only if they are
    available at build-time.
    
    Note that Debian-Sid does not have Caffe-parser ready with
    its ARMNN-devel packages.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

