### PR TITLE
[Split/Merge/Aggregator] caps template for single tensor

### DIFF
--- a/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
+++ b/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
@@ -426,7 +426,8 @@ gst_tensor_aggregator_sink_event (GstPad * pad, GstObject * parent,
       if (gst_tensor_aggregator_parse_caps (self, in_caps)) {
         gboolean ret = FALSE;
 
-        out_caps = gst_tensors_caps_from_config (&self->out_config);
+        out_caps =
+            gst_tensor_pad_caps_from_config (self->srcpad, &self->out_config);
         silent_debug_caps (out_caps, "out-caps");
 
         ret = gst_pad_set_caps (self->srcpad, out_caps);

--- a/gst/nnstreamer/tensor_merge/gsttensormerge.c
+++ b/gst/nnstreamer/tensor_merge/gsttensormerge.c
@@ -105,20 +105,23 @@ static const gchar *gst_tensor_merge_linear_string[] = {
 };
 
 /**
+ * @brief Template caps string.
+ */
+#define CAPS_STRING GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_WITH_NUM ("1")
+
+/**
  * @brief the capabilities of the inputs and outputs.
  * describe the real formats here.
  */
 static GstStaticPadTemplate src_templ = GST_STATIC_PAD_TEMPLATE ("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT)
-    );
+    GST_STATIC_CAPS (CAPS_STRING));
 
 static GstStaticPadTemplate sink_templ = GST_STATIC_PAD_TEMPLATE ("sink_%u",
     GST_PAD_SINK,
     GST_PAD_REQUEST,
-    GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT)
-    );
+    GST_STATIC_CAPS (CAPS_STRING));
 
 static gboolean gst_tensor_merge_src_event (GstPad * pad, GstObject * parent,
     GstEvent * event);
@@ -618,7 +621,7 @@ gst_tensor_merge_set_src_caps (GstTensorMerge * tensor_merge)
 
     /** Internal Logic Error? */
     g_assert (gst_tensors_config_validate (&config));
-    newcaps = gst_tensors_caps_from_config (&config);
+    newcaps = gst_tensor_pad_caps_from_config (tensor_merge->srcpad, &config);
 
     if (gst_pad_set_caps (tensor_merge->srcpad, newcaps)) {
       tensor_merge->negotiated = TRUE;

--- a/gst/nnstreamer/tensor_split/gsttensorsplit.c
+++ b/gst/nnstreamer/tensor_split/gsttensorsplit.c
@@ -67,20 +67,23 @@ enum
 };
 
 /**
+ * @brief Template caps string.
+ */
+#define CAPS_STRING GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_WITH_NUM ("1")
+
+/**
  * @brief the capabilities of the inputs and outputs.
  * describe the real formats here.
  */
 static GstStaticPadTemplate src_templ = GST_STATIC_PAD_TEMPLATE ("src_%u",
     GST_PAD_SRC,
     GST_PAD_SOMETIMES,
-    GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT)
-    );
+    GST_STATIC_CAPS (CAPS_STRING));
 
 static GstStaticPadTemplate sink_templ = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT)
-    );
+    GST_STATIC_CAPS (CAPS_STRING));
 
 static GstFlowReturn gst_tensor_split_chain (GstPad * pad, GstObject * parent,
     GstBuffer * buf);
@@ -349,7 +352,7 @@ gst_tensor_split_get_tensor_pad (GstTensorSplit * split, GstBuffer * inbuf,
   pad_config.rate_n = split->sink_tensor_conf.rate_n;
   pad_config.rate_d = split->sink_tensor_conf.rate_d;
 
-  caps = gst_tensors_caps_from_config (&pad_config);
+  caps = gst_tensor_pad_caps_from_config (pad, &pad_config);
 
   gst_pad_set_caps (pad, caps);
   gst_element_add_pad (GST_ELEMENT_CAST (split), pad);


### PR DESCRIPTION
Modify pad caps template - other/tensors with num 1.
Set src-pad caps using peer caps.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
