### PR TITLE
[Common] remove tensor-config struct

### DIFF
--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
@@ -969,27 +969,18 @@ _ts_get_gstcaps_from_conf (GstTensorSrcTIZENSENSOR * self)
   spec = self->src_spec;
 
   if (!self->configured || SENSOR_ALL == self->type || NULL == spec) {
-    retval = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT "; "
-      GST_TENSORS_CAP_WITH_NUM ("1"));
+    retval = gst_pad_get_pad_template_caps (GST_BASE_SRC_PAD (self));
   } else {
-    GstTensorConfig tensor_config;
     GstTensorsConfig tensors_config;
-
-    gst_tensor_config_init (&tensor_config);
 
     gst_tensors_config_init (&tensors_config);
     tensors_config.info.num_tensors = 1;
-
-    gst_tensor_info_copy (&tensor_config.info, spec);
-    tensor_config.rate_n = self->freq_n;
-    tensor_config.rate_d = self->freq_d;
-
-    retval = gst_tensor_caps_from_config (&tensor_config);
 
     gst_tensor_info_copy (&tensors_config.info.info[0], spec);
     tensors_config.rate_n = self->freq_n;
     tensors_config.rate_d = self->freq_d;
 
+    retval = gst_tensor_caps_from_config (&tensors_config);
     gst_caps_append (retval, gst_tensors_caps_from_config (&tensors_config));
   }
 

--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -235,47 +235,6 @@ extern void
 gst_tensors_info_copy (GstTensorsInfo * dest, const GstTensorsInfo * src);
 
 /**
- * @brief Initialize the tensor config info structure
- * @param config tensor config structure to be initialized
- */
-extern void
-gst_tensor_config_init (GstTensorConfig * config);
-
-/**
- * @brief Free allocated data in tensor config structure
- * @param config tensor config structure
- */
-extern void
-gst_tensor_config_free (GstTensorConfig * config);
-
-/**
- * @brief Check the tensor is all configured
- * @param config tensor config structure
- * @return TRUE if configured
- */
-extern gboolean
-gst_tensor_config_validate (const GstTensorConfig * config);
-
-/**
- * @brief Compare tensor config info
- * @param TRUE if equal
- */
-extern gboolean
-gst_tensor_config_is_equal (const GstTensorConfig * c1,
-    const GstTensorConfig * c2);
-
-/**
- * @brief Parse structure and set tensor config info (for other/tensor)
- * @param config tensor config structure to be filled
- * @param structure structure to be interpreted
- * @note Change dimention if tensor contains N frames.
- * @return TRUE if no error
- */
-extern gboolean
-gst_tensor_config_from_structure (GstTensorConfig *config,
-    const GstStructure *structure);
-
-/**
  * @brief Parse structure and set tensors config (for other/tensors)
  * @param config tensors config structure to be filled
  * @param structure structure to be interpreted
@@ -333,12 +292,12 @@ extern void
 gst_tensors_config_copy (GstTensorsConfig * dest, const GstTensorsConfig * src);
 
 /**
- * @brief Get tensor caps from tensor config (for other/tensor)
- * @param config tensor config info
+ * @brief Get tensor caps from tensors config (for other/tensor)
+ * @param config tensors config info
  * @return caps for given config
  */
 extern GstCaps *
-gst_tensor_caps_from_config (const GstTensorConfig * config);
+gst_tensor_caps_from_config (const GstTensorsConfig * config);
 
 /**
  * @brief Get caps from tensors config (for other/tensors)

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -243,16 +243,6 @@ typedef struct
 } GstTensorsInfo;
 
 /**
- * @brief Internal data structure for configured tensor info (for other/tensor).
- */
-typedef struct
-{
-  GstTensorInfo info; /**< tensor info*/
-  int rate_n; /**< framerate is in fraction, which is numerator/denominator */
-  int rate_d; /**< framerate is in fraction, which is numerator/denominator */
-} GstTensorConfig;
-
-/**
  * @brief Internal data structure for configured tensors info (for other/tensors).
  */
 typedef struct

--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -2208,15 +2208,7 @@ gst_tensor_src_iio_fixate (GstBaseSrc * src, GstCaps * caps)
   self = GST_TENSOR_SRC_IIO_CAST (src);
 
   if (self->is_tensor) {
-    GstTensorConfig tensor_config;
-
-    gst_tensor_config_init (&tensor_config);
-    gst_tensor_info_copy (&tensor_config.info,
-        &(self->tensors_config->info.info[0]));
-    tensor_config.rate_n = self->tensors_config->rate_n;
-    tensor_config.rate_d = self->tensors_config->rate_d;
-    fixated_caps = gst_tensor_caps_from_config (&tensor_config);
-    gst_tensor_config_free (&tensor_config);
+    fixated_caps = gst_tensor_caps_from_config (self->tensors_config);
   } else {
     fixated_caps = gst_tensors_caps_from_config (self->tensors_config);
   }

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -1743,14 +1743,7 @@ gst_tensor_transform_transform_caps (GstBaseTransform * trans,
     out_config.info.num_tensors = in_config.info.num_tensors;
 
     if (gst_structure_has_name (structure, NNS_MIMETYPE_TENSOR)) {
-      GstTensorConfig tensor_config;
-
-      gst_tensor_config_init (&tensor_config);
-      tensor_config.info = out_config.info.info[0];
-      tensor_config.rate_n = out_config.rate_n;
-      tensor_config.rate_d = out_config.rate_d;
-
-      gst_caps_append (result, gst_tensor_caps_from_config (&tensor_config));
+      gst_caps_append (result, gst_tensor_caps_from_config (&out_config));
     } else {
       gst_caps_append (result, gst_tensors_caps_from_config (&out_config));
     }

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -816,26 +816,6 @@ TEST (commonTensorsInfo, getNameInvalidParam1_n)
 }
 
 /**
- * @brief Test for same tensor config.
- */
-TEST (commonTensorConfig, equal07_n)
-{
-  GstTensorConfig conf;
-  gst_tensor_config_init (&conf);
-  EXPECT_FALSE (gst_tensor_config_is_equal (NULL, &conf));
-}
-
-/**
- * @brief Test for same tensor config.
- */
-TEST (commonTensorConfig, equal08_n)
-{
-  GstTensorConfig conf;
-  gst_tensor_config_init (&conf);
-  EXPECT_FALSE (gst_tensor_config_is_equal (NULL, &conf));
-}
-
-/**
  * @brief Test for same tensors config.
  */
 TEST (commonTensorsConfig, equal01_p)
@@ -936,37 +916,6 @@ TEST (commonTensorsConfig, equal08_n)
 }
 
 /**
- * @brief Test for validating of the tensor config with invalid param.
- */
-TEST (commonTensorConfig, validateInvalidParam0_n)
-{
-  EXPECT_FALSE (gst_tensor_config_validate (NULL));
-}
-
-/**
- * @brief Test for validating of the tensor config with invalid param.
- */
-TEST (commonTensorConfig, validateInvalidParam1_n)
-{
-  GstTensorConfig conf;
-  gst_tensor_config_init (&conf);
-  conf.rate_n = 1;
-
-  EXPECT_FALSE (gst_tensor_config_validate (NULL));
-}
-
-/**
- * @brief Test for validating of the tensor config with invalid param.
- */
-TEST (commonTensorConfig, validateInvalidParam2_n)
-{
-  GstTensorConfig conf;
-  gst_tensor_config_init (&conf);
-  conf.rate_d = 1;
-  EXPECT_FALSE (gst_tensor_config_validate (NULL));
-}
-
-/**
  * @brief Test for validating of the tensors config with invalid param.
  */
 TEST (commonTensorsConfig, validateInvalidParam0_n)
@@ -995,26 +944,6 @@ TEST (commonTensorsConfig, validateInvalidParam2_n)
   gst_tensors_config_init (&conf);
   conf.rate_d = 1;
   EXPECT_FALSE (gst_tensors_config_validate (NULL));
-}
-
-/**
- * @brief Test for getting config from strucrure with invalid param.
- */
-TEST (commonTensorConfig, fromStructreInvalidParam0_n)
-{
-  GstStructure structure;
-
-  EXPECT_FALSE (gst_tensor_config_from_structure (NULL, &structure));
-}
-
-/**
- * @brief Test for getting config from strucrure with invalid param.
- */
-TEST (commonTensorConfig, fromStructreInvalidParam1_n)
-{
-  GstTensorConfig conf;
-  gst_tensor_config_init (&conf);
-  EXPECT_FALSE (gst_tensor_config_from_structure (&conf, NULL));
 }
 
 /**

--- a/tests/nnstreamer_converter/unittest_converter.cc
+++ b/tests/nnstreamer_converter/unittest_converter.cc
@@ -410,12 +410,12 @@ TEST (tensorConverterPython, dynamicDimension)
   structure = gst_caps_get_structure (caps, 0);
   EXPECT_NE (structure, nullptr);
   gst_tensors_config_from_structure (&config, structure);
-
+  EXPECT_EQ (1U, config.info.num_tensors);
   EXPECT_EQ (24U, config.info.info[0].dimension[0]);
   EXPECT_EQ (1U, config.info.info[0].dimension[1]);
   EXPECT_EQ (1U, config.info.info[0].dimension[2]);
   EXPECT_EQ (1U, config.info.info[0].dimension[3]);
-
+  gst_tensors_config_free (&config);
   gst_caps_unref (caps);
 
   EXPECT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_handle), buf_1), GST_FLOW_OK);
@@ -426,11 +426,12 @@ TEST (tensorConverterPython, dynamicDimension)
   structure = gst_caps_get_structure (caps, 0);
   EXPECT_NE (structure, nullptr);
   gst_tensors_config_from_structure (&config, structure);
-
+  EXPECT_EQ (1U, config.info.num_tensors);
   EXPECT_EQ (48U, config.info.info[0].dimension[0]);
   EXPECT_EQ (1U, config.info.info[0].dimension[1]);
   EXPECT_EQ (1U, config.info.info[0].dimension[2]);
   EXPECT_EQ (1U, config.info.info[0].dimension[3]);
+  gst_tensors_config_free (&config);
   gst_caps_unref (caps);
 
   EXPECT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_handle), buf_2), GST_FLOW_OK);
@@ -443,11 +444,12 @@ TEST (tensorConverterPython, dynamicDimension)
   structure = gst_caps_get_structure (caps, 0);
   EXPECT_NE (structure, nullptr);
   gst_tensors_config_from_structure (&config, structure);
-
+  EXPECT_EQ (1U, config.info.num_tensors);
   EXPECT_EQ (24U, config.info.info[0].dimension[0]);
   EXPECT_EQ (1U, config.info.info[0].dimension[1]);
   EXPECT_EQ (1U, config.info.info[0].dimension[2]);
   EXPECT_EQ (1U, config.info.info[0].dimension[3]);
+  gst_tensors_config_free (&config);
   gst_caps_unref (caps);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, TEST_TIMEOUT_MS), 0);

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -76,7 +76,7 @@
     g_object_set (h->element, "acceleration", (gboolean)accel, NULL);          \
     /** input tensor info */                                                   \
     gst_tensors_config_init (&config);                                         \
-    config.info.num_tensors = 1;                                               \
+    config.info.num_tensors = 1U;                                              \
     config.info.info[0].type = from_nns_t;                                     \
     gst_tensor_parse_dimension (str (size), config.info.info[0].dimension);    \
     config.rate_n = 0;                                                         \
@@ -1117,7 +1117,7 @@ TEST (testTensorTransform, arithmetic1)
 
   /* input tensor info */
   gst_tensors_config_init (&config);
-  config.info.num_tensors = 1;
+  config.info.num_tensors = 1U;
   config.info.info[0].type = _NNS_FLOAT32;
   gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
   config.rate_n = 0;
@@ -1189,7 +1189,7 @@ TEST (testTensorTransform, arithmetic1Accel)
 
   /* input tensor info */
   gst_tensors_config_init (&config);
-  config.info.num_tensors = 1;
+  config.info.num_tensors = 1U;
   config.info.info[0].type = _NNS_FLOAT32;
   gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
   config.rate_n = 0;
@@ -1261,7 +1261,7 @@ TEST (testTensorTransform, arithmetic2)
 
   /* input tensor info */
   gst_tensors_config_init (&config);
-  config.info.num_tensors = 1;
+  config.info.num_tensors = 1U;
   config.info.info[0].type = _NNS_FLOAT64;
   gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
   config.rate_n = 0;
@@ -1333,7 +1333,7 @@ TEST (testTensorTransform, arithmetic2Accel)
 
   /* input tensor info */
   gst_tensors_config_init (&config);
-  config.info.num_tensors = 1;
+  config.info.num_tensors = 1U;
   config.info.info[0].type = _NNS_FLOAT64;
   gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
   config.rate_n = 0;
@@ -1406,7 +1406,7 @@ TEST (testTensorTransform, arithmetic3)
 
   /* input tensor info */
   gst_tensors_config_init (&config);
-  config.info.num_tensors = 1;
+  config.info.num_tensors = 1U;
   config.info.info[0].type = _NNS_UINT8;
   gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
   config.rate_n = 0;
@@ -1482,7 +1482,7 @@ TEST (testTensorTransform, arithmetic3Accel)
 
   /* input tensor info */
   gst_tensors_config_init (&config);
-  config.info.num_tensors = 1;
+  config.info.num_tensors = 1U;
   config.info.info[0].type = _NNS_UINT8;
   gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
   config.rate_n = 0;
@@ -1558,7 +1558,7 @@ TEST (testTensorTransform, arithmetic4)
 
   /* input tensor info */
   gst_tensors_config_init (&config);
-  config.info.num_tensors = 1;
+  config.info.num_tensors = 1U;
   config.info.info[0].type = _NNS_UINT8;
   gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
   config.rate_n = 0;
@@ -1636,7 +1636,7 @@ TEST (testTensorTransform, arithmetic4Accel)
 
   /* input tensor info */
   gst_tensors_config_init (&config);
-  config.info.num_tensors = 1;
+  config.info.num_tensors = 1U;
   config.info.info[0].type = _NNS_UINT8;
   gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
   config.rate_n = 0;
@@ -1712,7 +1712,7 @@ TEST (testTensorTransform, arithmetic5)
 
   /* input tensor info */
   gst_tensors_config_init (&config);
-  config.info.num_tensors = 1;
+  config.info.num_tensors = 1U;
   config.info.info[0].type = _NNS_UINT8;
   gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
   config.rate_n = 0;
@@ -1788,7 +1788,7 @@ TEST (testTensorTransform, arithmetic5Accel)
 
   /* input tensor info */
   gst_tensors_config_init (&config);
-  config.info.num_tensors = 1;
+  config.info.num_tensors = 1U;
   config.info.info[0].type = _NNS_UINT8;
   gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
   config.rate_n = 0;
@@ -1861,7 +1861,7 @@ TEST (testTensorTransform, arithmeticChangeOptionString)
 
   /* input tensor info */
   gst_tensors_config_init (&config);
-  config.info.num_tensors = 1;
+  config.info.num_tensors = 1U;
   config.info.info[0].type = _NNS_FLOAT32;
   gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
   config.rate_n = 0;
@@ -4506,7 +4506,7 @@ TEST_REQUIRE_TFLITE (testTensorFilter, reopenTFlite01)
   GstHarness *h;
   GstBuffer *in_buf, *out_buf;
   gsize in_size, out_size;
-  GstTensorConfig config;
+  GstTensorsConfig config;
   gchar *str_launch_line, *prop_string;
 
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
@@ -4529,13 +4529,14 @@ TEST_REQUIRE_TFLITE (testTensorFilter, reopenTFlite01)
   g_free (str_launch_line);
 
   /* input tensor info */
-  gst_tensor_config_init (&config);
-  config.info.type = _NNS_UINT8;
-  gst_tensor_parse_dimension ("3:224:224:1", config.info.dimension);
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("3:224:224:1", config.info.info[0].dimension);
   config.rate_n = 0;
   config.rate_d = 1;
 
-  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
 
   /* playing state */
   wait_for_element_state (h->element, GST_STATE_PLAYING);
@@ -4634,7 +4635,7 @@ TEST_REQUIRE_TFLITE (testTensorFilter, reloadTFliteSetProperty)
   GstHarness *h;
   GstBuffer *in_buf, *out_buf;
   gsize in_size, out_size;
-  GstTensorConfig config;
+  GstTensorsConfig config;
   gboolean prop_updatable;
   gchar *str_launch_line, *prop_string;
 
@@ -4663,13 +4664,14 @@ TEST_REQUIRE_TFLITE (testTensorFilter, reloadTFliteSetProperty)
   g_free (str_launch_line);
 
   /* input tensor info */
-  gst_tensor_config_init (&config);
-  config.info.type = _NNS_UINT8;
-  gst_tensor_parse_dimension ("3:224:224:1", config.info.dimension);
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("3:224:224:1", config.info.info[0].dimension);
   config.rate_n = 0;
   config.rate_d = 1;
 
-  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
 
   /* playing state */
   wait_for_element_state (h->element, GST_STATE_PLAYING);

--- a/tests/nnstreamer_source/unittest_src_iio.cc
+++ b/tests/nnstreamer_source/unittest_src_iio.cc
@@ -1249,7 +1249,7 @@ TEST (testTensorSrcIio, dataVerifyTrigger)
   GstCaps *caps;
   GstPad *src_pad;
   GstStructure *structure;
-  GstTensorConfig config;
+  GstTensorsConfig config;
   gint num_scan_elements;
   /** Make device */
   dev0 = make_full_device (data_value, data_bits);
@@ -1281,14 +1281,15 @@ TEST (testTensorSrcIio, dataVerifyTrigger)
 
   /** Default has merge channels enabled */
   EXPECT_STREQ (gst_structure_get_name (structure), "other/tensor");
-  EXPECT_EQ (gst_tensor_config_from_structure (&config, structure), TRUE);
+  EXPECT_EQ (gst_tensors_config_from_structure (&config, structure), TRUE);
   EXPECT_EQ (config.rate_n, samp_freq);
   EXPECT_EQ (config.rate_d, 1);
-  EXPECT_EQ (config.info.type, _NNS_FLOAT32);
-  EXPECT_EQ (config.info.dimension[0], (guint)num_scan_elements);
-  EXPECT_EQ (config.info.dimension[1], 1U);
-  EXPECT_EQ (config.info.dimension[2], 1U);
-  EXPECT_EQ (config.info.dimension[3], 1U);
+  EXPECT_EQ (config.info.num_tensors, 1U);
+  EXPECT_EQ (config.info.info[0].type, _NNS_FLOAT32);
+  EXPECT_EQ (config.info.info[0].dimension[0], (guint)num_scan_elements);
+  EXPECT_EQ (config.info.info[0].dimension[1], 1U);
+  EXPECT_EQ (config.info.info[0].dimension[2], 1U);
+  EXPECT_EQ (config.info.info[0].dimension[3], 1U);
 
   gst_object_unref (src_iio);
   gst_object_unref (src_pad);
@@ -1331,7 +1332,7 @@ TEST (testTensorSrcIio, dataVerifyCustomChannels)
   GstCaps *caps;
   GstPad *src_pad;
   GstStructure *structure;
-  GstTensorConfig config;
+  GstTensorsConfig config;
   data_value = DATA;
   data_bits = 16;
   /** Make device */
@@ -1363,14 +1364,15 @@ TEST (testTensorSrcIio, dataVerifyCustomChannels)
 
   /** Default has merge channels enabled */
   EXPECT_STREQ (gst_structure_get_name (structure), "other/tensor");
-  EXPECT_EQ (gst_tensor_config_from_structure (&config, structure), TRUE);
+  EXPECT_EQ (gst_tensors_config_from_structure (&config, structure), TRUE);
   EXPECT_EQ (config.rate_n, samp_freq);
   EXPECT_EQ (config.rate_d, 1);
-  EXPECT_EQ (config.info.type, _NNS_FLOAT32);
-  EXPECT_EQ (config.info.dimension[0], 2U);
-  EXPECT_EQ (config.info.dimension[1], 1U);
-  EXPECT_EQ (config.info.dimension[2], 1U);
-  EXPECT_EQ (config.info.dimension[3], 1U);
+  EXPECT_EQ (config.info.num_tensors, 1U);
+  EXPECT_EQ (config.info.info[0].type, _NNS_FLOAT32);
+  EXPECT_EQ (config.info.info[0].dimension[0], 2U);
+  EXPECT_EQ (config.info.info[0].dimension[1], 1U);
+  EXPECT_EQ (config.info.info[0].dimension[2], 1U);
+  EXPECT_EQ (config.info.info[0].dimension[3], 1U);
 
   gst_object_unref (src_iio);
   gst_object_unref (src_pad);


### PR DESCRIPTION
Remove tensor-config struct (for single tensor) and replace it to tensors-config.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
