### PR TITLE
[Spec] Remove flatbuffers-python recommends section

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -394,7 +394,9 @@ NNStreamer's tensor_converter and decoder subplugin of Protobuf.
 Summary:	NNStreamer Flatbuf Support
 Requires:	nnstreamer = %{version}-%{release}
 Requires:	flatbuffers
+%if "%{?profile}" != "tv"
 Recommends: flatbuffers-python
+%endif
 %description flatbuf
 NNStreamer's tensor_converter and decoder subplugin of flatbuf.
 %endif


### PR DESCRIPTION
Because of the security issue, VD does not use the script language.
Moreover, VD officially uses Python 3.5 for debugging purposes but the
latest Tizen 6.5 uses Python 3.9. Because of this reason, 'Recommends:
flatbuffers-python' section should be removed for VD build infra.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped


### Before (Normal build)
```bash
$ rpm -q --recommends nnstreamer-flatbuf-1.7.2-0.armv7l.rpm
flatbuffers-python
```
### After (VD build)
```
$ rpm -q --recommends nnstreamer-flatbuf-1.7.2-0.armv7l.rpm
```