### PR TITLE
[Tests/GRPC] Skip GRPC tests on the qemu/arm environment either  @open sesame 07/17 18:00

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -782,11 +782,11 @@ export NNSTREAMER_CONVERTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor
 %endif
     pushd tests
 
-    %ifarch aarch64
+    %ifarch %arm aarch64
     ## @todo Workaround for QEMU compatibility issue. Newer qemu may be ok with this.
-    export SKIP_QEMU_ARM64_INCOMPATIBLE_TESTS=1
+    export SKIP_QEMU_ARM_INCOMPATIBLE_TESTS=1
     %else
-    export SKIP_QEMU_ARM64_INCOMPATIBLE_TESTS=0
+    export SKIP_QEMU_ARM_INCOMPATIBLE_TESTS=0
     %endif
 
     ssat -n -p=1 --summary summary.txt -cn _n

--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -19,8 +19,8 @@ fi
 testInit $1
 
 # Skip test on qemu env.
-if [[ "$SKIP_QEMU_ARM64_INCOMPATIBLE_TESTS" == "1" ]]; then
-  echo "Skip ssat tests on qemu/arm64 env."
+if [[ "$SKIP_QEMU_ARM_INCOMPATIBLE_TESTS" == "1" ]]; then
+  echo "Skip ssat tests on qemu/arm and qemu/arm64 environments."
   report
   exit
 fi


### PR DESCRIPTION
This PR is related to #3391.

Since some system calls required by GRPC are not supported on qemu/arm as well, this patch blocks SSAT-based GRPC test cases' running on such environments.

See also: https://github.com/nnstreamer/nnstreamer/pull/3054

How to reproduce: Use ```gst-launch-1.0``` instead of ```gstTest```
For example, 

https://github.com/nnstreamer/nnstreamer/blob/f77cf18467e6e321bbe8776d2c8ebb4999771623/tests/nnstreamer_grpc/runTest.sh#L96-L98
to 
```bash
96  GST_PLUGIN_PATH=${PATH_TO_PLUGIN} gst-launch-1.0 tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} blocking=${BLOCKING} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log
97  sleep 1 
98  GST_PLUGIN_PATH=${PATH_TO_PLUGIN} gst-launch-1.0 videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL} blocking=${BLOCKING}
```

then, the error messages are as follows:
```
[   56s] E0712 02:46:50.335207963   11817 cpu_linux.cc:41]            Error determining current CPU: Function not implemented
[   56s] 
[   56s] Unsupported setsockopt level=1 optname=15
[   56s] E0712 02:46:50.366926613   11817 socket_utils_common_posix.cc:222] check for SO_REUSEPORT: {"created":"@1626058010.365998002","description":"Protocol not available","errno":92,"file":"/home/abuild/rpmbuild/BUILD/grpc-1.35.0/src/core/lib/iomgr/socket_utils_common_posix.cc","file_line":198,"os_error":"Protocol not available","syscall":"setsockopt(SO_REUSEPORT)"}
```

Signed-off-by: Wook Song <wook16.song@samsung.com>