### PR TITLE
Common: refactor silent_debug() and make it common

### DIFF
--- a/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
+++ b/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
@@ -40,27 +40,7 @@
 #define DBG (!self->silent)
 #endif
 
-/**
- * @brief Macro for debug message.
- */
-#define silent_debug_caps(caps,msg) do { \
-  if (DBG) { \
-    if (caps) { \
-      GstStructure *caps_s; \
-      gchar *caps_s_string; \
-      guint caps_size, caps_idx; \
-      caps_size = gst_caps_get_size (caps);\
-      for (caps_idx = 0; caps_idx < caps_size; caps_idx++) { \
-        caps_s = gst_caps_get_structure (caps, caps_idx); \
-        caps_s_string = gst_structure_to_string (caps_s); \
-        GST_DEBUG_OBJECT (self, msg " = %s", caps_s_string); \
-        g_free (caps_s_string); \
-      } \
-    } \
-  } \
-} while (0)
-
-#define silent_debug_config(c,msg) do { \
+#define silent_debug_config(self,c,msg) do { \
   if (DBG) { \
     if (c) { \
       gchar *dim_str; \
@@ -421,14 +401,14 @@ gst_tensor_aggregator_sink_event (GstPad * pad, GstObject * parent,
       GstCaps *out_caps;
 
       gst_event_parse_caps (event, &in_caps);
-      silent_debug_caps (in_caps, "in-caps");
+      silent_debug_caps (self, in_caps, "in-caps");
 
       if (gst_tensor_aggregator_parse_caps (self, in_caps)) {
         gboolean ret = FALSE;
 
         out_caps =
             gst_tensor_pad_caps_from_config (self->srcpad, &self->out_config);
-        silent_debug_caps (out_caps, "out-caps");
+        silent_debug_caps (self, out_caps, "out-caps");
 
         ret = gst_pad_set_caps (self->srcpad, out_caps);
 
@@ -483,7 +463,7 @@ gst_tensor_aggregator_sink_query (GstPad * pad, GstObject * parent,
       gboolean res = FALSE;
 
       gst_query_parse_accept_caps (query, &caps);
-      silent_debug_caps (caps, "accept-caps");
+      silent_debug_caps (self, caps, "accept-caps");
 
       if (gst_caps_is_fixed (caps)) {
         template_caps = gst_pad_get_pad_template_caps (pad);
@@ -1010,8 +990,8 @@ gst_tensor_aggregator_query_caps (GstTensorAggregator * self, GstPad * pad,
   /* caps from tensor config info */
   caps = gst_tensor_pad_possible_caps_from_config (pad, config);
 
-  silent_debug_caps (caps, "caps");
-  silent_debug_caps (filter, "filter");
+  silent_debug_caps (self, caps, "caps");
+  silent_debug_caps (self, filter, "filter");
 
   if (caps && filter) {
     GstCaps *intersection;
@@ -1082,7 +1062,7 @@ gst_tensor_aggregator_parse_caps (GstTensorAggregator * self,
   self->out_config = config;
   self->tensor_configured = TRUE;
 
-  silent_debug_config (&self->in_config, "in-tensor");
-  silent_debug_config (&self->out_config, "out-tensor");
+  silent_debug_config (self, &self->in_config, "in-tensor");
+  silent_debug_config (self, &self->out_config, "out-tensor");
   return TRUE;
 }

--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -195,5 +195,31 @@ gst_tensor_pad_possible_caps_from_config (GstPad * pad, const GstTensorsConfig *
 extern gboolean
 gst_tensor_pad_caps_is_flexible (GstPad * pad);
 
+/******************************************************
+ ************ Commonly used debugging macros **********
+ ******************************************************
+ */
+/**
+ * @brief Macro for debug message.
+ */
+#define silent_debug(self, ...) do { \
+    if (DBG) { \
+      GST_DEBUG_OBJECT (self, __VA_ARGS__); \
+    } \
+  } while (0)
+
+/**
+ * @brief Macro for capability debug message.
+ */
+#define silent_debug_caps(self, caps, msg) do { \
+  if (DBG) { \
+    if (caps) { \
+      gchar *caps_s_string = gst_caps_to_string (caps); \
+      GST_DEBUG_OBJECT (self, msg " = %s\n", caps_s_string); \
+      g_free (caps_s_string); \
+    } \
+  } \
+} while (0)
+
 G_END_DECLS
 #endif /* __GST_TENSOR_COMMON_H__ */

--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -54,29 +54,6 @@
 #define DBG (!self->silent)
 #endif
 
-#define silent_debug(...) do { \
-    if (DBG) { \
-      GST_DEBUG_OBJECT (self, __VA_ARGS__); \
-    } \
-  } while (0)
-
-#define silent_debug_caps(caps,msg) do {\
-  if (DBG) { \
-    if (caps) { \
-      GstStructure *caps_s; \
-      gchar *caps_s_string; \
-      guint caps_size, caps_idx; \
-      caps_size = gst_caps_get_size (caps);\
-      for (caps_idx = 0; caps_idx < caps_size; caps_idx++) { \
-        caps_s = gst_caps_get_structure (caps, caps_idx); \
-        caps_s_string = gst_structure_to_string (caps_s); \
-        GST_DEBUG_OBJECT (self, msg " = %s\n", caps_s_string); \
-        g_free (caps_s_string); \
-      } \
-    } \
-  } \
-} while (0)
-
 GST_DEBUG_CATEGORY_STATIC (gst_tensordec_debug);
 #define GST_CAT_DEFAULT gst_tensordec_debug
 
@@ -497,7 +474,7 @@ gst_tensordec_set_property (GObject * object, guint prop_id,
 
       /* See if we are using "plugin" */
       if (nnstreamer_decoder_validate (decoder)) {
-        silent_debug ("tensor_decoder plugin mode (%s)\n", mode_string);
+        silent_debug (self, "tensor_decoder plugin mode (%s)\n", mode_string);
 
         if (decoder == self->decoder) {
           /* Already configured??? */
@@ -794,9 +771,9 @@ gst_tensordec_transform_caps (GstBaseTransform * trans,
     self->custom.data = ptr->data;
   }
 
-  silent_debug ("Direction = %d\n", direction);
-  silent_debug_caps (caps, "from");
-  silent_debug_caps (filter, "filter");
+  silent_debug (self, "Direction = %d\n", direction);
+  silent_debug_caps (self, caps, "from");
+  silent_debug_caps (self, filter, "filter");
 
   if (direction == GST_PAD_SINK) {
     /** caps = sinkpad (other/tensor) return = srcpad (media) */
@@ -821,7 +798,7 @@ gst_tensordec_transform_caps (GstBaseTransform * trans,
     result = intersection;
   }
 
-  silent_debug_caps (result, "to");
+  silent_debug_caps (self, result, "to");
 
   GST_DEBUG_OBJECT (self, "Direction[%d] transformed %" GST_PTR_FORMAT
       " into %" GST_PTR_FORMAT, direction, caps, result);
@@ -841,8 +818,8 @@ gst_tensordec_fixate_caps (GstBaseTransform * trans,
 
   self = GST_TENSOR_DECODER_CAST (trans);
 
-  silent_debug_caps (caps, "from caps");
-  silent_debug_caps (othercaps, "from othercaps");
+  silent_debug_caps (self, caps, "from caps");
+  silent_debug_caps (self, othercaps, "from othercaps");
 
   GST_DEBUG_OBJECT (self, "trying to fixate othercaps %" GST_PTR_FORMAT
       " based on caps %" GST_PTR_FORMAT, othercaps, caps);
@@ -898,8 +875,8 @@ gst_tensordec_set_caps (GstBaseTransform * trans,
 {
   GstTensorDec *self = GST_TENSOR_DECODER_CAST (trans);
 
-  silent_debug_caps (incaps, "from incaps");
-  silent_debug_caps (outcaps, "from outcaps");
+  silent_debug_caps (self, incaps, "from incaps");
+  silent_debug_caps (self, outcaps, "from outcaps");
 
   if (gst_tensordec_configure (self, incaps, outcaps)) {
     GstCaps *supposed = gst_tensordec_media_caps_from_tensor (self,

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -74,45 +74,6 @@
 /** @todo rename & move this to better location */
 #define EVENT_NAME_UPDATE_MODEL "evt_update_model"
 
-/**
- * @brief Macro for debug message.
- */
-#define silent_debug(...) do { \
-    if (DBG) { \
-      GST_DEBUG_OBJECT (self, __VA_ARGS__); \
-    } \
-  } while (0)
-
-#define silent_debug_caps(caps,msg) do { \
-  if (DBG) { \
-    if (caps) { \
-      GstStructure *caps_s; \
-      gchar *caps_s_string; \
-      guint caps_size, caps_idx; \
-      caps_size = gst_caps_get_size (caps);\
-      for (caps_idx = 0; caps_idx < caps_size; caps_idx++) { \
-        caps_s = gst_caps_get_structure (caps, caps_idx); \
-        caps_s_string = gst_structure_to_string (caps_s); \
-        GST_DEBUG_OBJECT (self, msg " = %s\n", caps_s_string); \
-        g_free (caps_s_string); \
-      } \
-    } \
-  } \
-} while (0)
-
-#define silent_debug_info(i,msg) do { \
-  if (DBG) { \
-    guint info_idx; \
-    gchar *dim_str; \
-    GST_DEBUG_OBJECT (self, msg " total %d", (i)->num_tensors); \
-    for (info_idx = 0; info_idx < (i)->num_tensors; info_idx++) { \
-      dim_str = gst_tensor_get_dimension_string ((i)->info[info_idx].dimension); \
-      GST_DEBUG_OBJECT (self, "[%d] type=%d dim=%s", info_idx, (i)->info[info_idx].type, dim_str); \
-      g_free (dim_str); \
-    } \
-  } \
-} while (0)
-
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_filter_debug);
 #define GST_CAT_DEFAULT gst_tensor_filter_debug
 
@@ -297,7 +258,7 @@ gst_tensor_filter_set_property (GObject * object, guint prop_id,
   self = GST_TENSOR_FILTER (object);
   priv = &self->priv;
 
-  silent_debug ("Setting property for prop %d.\n", prop_id);
+  silent_debug (self, "Setting property for prop %d.\n", prop_id);
 
   if (!gst_tensor_filter_common_set_property (priv, prop_id, value, pspec))
     G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -316,7 +277,7 @@ gst_tensor_filter_get_property (GObject * object, guint prop_id,
   self = GST_TENSOR_FILTER (object);
   priv = &self->priv;
 
-  silent_debug ("Getting property for prop %d.\n", prop_id);
+  silent_debug (self, "Getting property for prop %d.\n", prop_id);
 
   if (!gst_tensor_filter_common_get_property (priv, prop_id, value, pspec))
     G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -557,7 +518,7 @@ _gst_tensor_filter_transform_validate (GstBaseTransform * trans,
     return GST_FLOW_ERROR;
   }
 
-  silent_debug ("Invoking %s with %s model\n", priv->fw->name,
+  silent_debug (self, "Invoking %s with %s model\n", priv->fw->name,
       GST_STR_NULL (prop->model_files[0]));
 
   /* skip input data when throttling delay is set */
@@ -996,8 +957,8 @@ gst_tensor_filter_transform_caps (GstBaseTransform * trans,
   gst_tensors_config_init (&in_config);
   gst_tensors_config_init (&out_config);
 
-  silent_debug_caps (caps, "from");
-  silent_debug_caps (filter, "filter");
+  silent_debug_caps (self, caps, "from");
+  silent_debug_caps (self, filter, "filter");
 
   if (direction == GST_PAD_SINK)
     pad = GST_BASE_TRANSFORM_SRC_PAD (trans);
@@ -1076,7 +1037,7 @@ gst_tensor_filter_transform_caps (GstBaseTransform * trans,
     result = intersection;
   }
 
-  silent_debug_caps (result, "to");
+  silent_debug_caps (self, result, "to");
   gst_tensors_config_free (&in_config);
   gst_tensors_config_free (&out_config);
   return result;
@@ -1095,9 +1056,9 @@ gst_tensor_filter_fixate_caps (GstBaseTransform * trans,
   self = GST_TENSOR_FILTER_CAST (trans);
   priv = &self->priv;
 
-  silent_debug ("fixate_caps, direction = %d\n", direction);
-  silent_debug_caps (caps, "caps");
-  silent_debug_caps (othercaps, "othercaps");
+  silent_debug (self, "fixate_caps, direction = %d\n", direction);
+  silent_debug_caps (self, caps, "caps");
+  silent_debug_caps (self, othercaps, "othercaps");
 
   /** Removes no-used-variable warning for priv in when DBG is set */
   if (priv->fw == NULL) {
@@ -1114,7 +1075,7 @@ gst_tensor_filter_fixate_caps (GstBaseTransform * trans,
   result = gst_caps_make_writable (result);
   result = gst_caps_fixate (result);
 
-  silent_debug_caps (result, "result");
+  silent_debug_caps (self, result, "result");
   return result;
 }
 
@@ -1133,8 +1094,8 @@ gst_tensor_filter_set_caps (GstBaseTransform * trans,
   self = GST_TENSOR_FILTER_CAST (trans);
   priv = &self->priv;
 
-  silent_debug_caps (incaps, "incaps");
-  silent_debug_caps (outcaps, "outcaps");
+  silent_debug_caps (self, incaps, "incaps");
+  silent_debug_caps (self, outcaps, "outcaps");
 
   if (!gst_tensor_filter_configure_tensor (self, incaps)) {
     GST_ERROR_OBJECT (self, "Failed to configure tensor.");

--- a/gst/nnstreamer/tensor_if/gsttensorif.c
+++ b/gst/nnstreamer/tensor_if/gsttensorif.c
@@ -81,23 +81,6 @@
 #define DBG (!tensor_if->silent)
 #endif
 
-#define silent_debug_caps(caps,msg) do { \
-  if (DBG) { \
-    if (caps) { \
-      GstStructure *caps_s; \
-      gchar *caps_s_string; \
-      guint caps_size, caps_idx; \
-      caps_size = gst_caps_get_size (caps);\
-      for (caps_idx = 0; caps_idx < caps_size; caps_idx++) { \
-        caps_s = gst_caps_get_structure (caps, caps_idx); \
-        caps_s_string = gst_structure_to_string (caps_s); \
-        GST_DEBUG_OBJECT (tensor_if, msg " = %s\n", caps_s_string); \
-        g_free (caps_s_string); \
-      } \
-    } \
-  } \
-} while (0)
-
 /**
  * @brief tensor_if properties
  */
@@ -734,7 +717,7 @@ gst_tensor_if_get_tensor_pad (GstTensorIf * tensor_if,
 
   caps = gst_tensor_pad_caps_from_config (pad, config);
 
-  silent_debug_caps (caps, "out caps");
+  silent_debug_caps (tensor_if, caps, "out caps");
   gst_pad_set_caps (pad, caps);
 
   gst_caps_unref (caps);

--- a/gst/nnstreamer/tensor_merge/gsttensormerge.c
+++ b/gst/nnstreamer/tensor_merge/gsttensormerge.c
@@ -72,15 +72,6 @@ GST_DEBUG_CATEGORY_STATIC (gst_tensor_merge_debug);
 #define DBG (!tensor_merge->silent)
 #endif
 
-/**
- * @brief Macro for debug message.
- */
-#define silent_debug(...) do { \
-    if (DBG) { \
-      GST_DEBUG_OBJECT (tensor_merge, __VA_ARGS__); \
-    } \
-  } while (0)
-
 enum
 {
   PROP_0,
@@ -839,13 +830,13 @@ gst_tensor_merge_set_property (GObject * object, guint prop_id,
       if (tensor_merge->sync.mode == SYNC_END) {
         tensor_merge->sync.mode = SYNC_NOSYNC;
       }
-      silent_debug ("Mode = %d(%s)\n", tensor_merge->sync.mode,
+      silent_debug (tensor_merge, "Mode = %d(%s)\n", tensor_merge->sync.mode,
           gst_tensor_time_sync_get_mode_string (tensor_merge->sync.mode));
       gst_tensor_time_sync_set_option_data (&tensor_merge->sync);
       break;
     case PROP_SYNC_OPTION:
       tensor_merge->sync.option = g_value_dup_string (value);
-      silent_debug ("Option = %s\n", tensor_merge->sync.option);
+      silent_debug (tensor_merge, "Option = %s\n", tensor_merge->sync.option);
       gst_tensor_time_sync_set_option_data (&tensor_merge->sync);
       break;
     default:

--- a/gst/nnstreamer/tensor_mux/gsttensormux.c
+++ b/gst/nnstreamer/tensor_mux/gsttensormux.c
@@ -74,15 +74,6 @@ GST_DEBUG_CATEGORY_STATIC (gst_tensor_mux_debug);
 #define DBG (!tensor_mux->silent)
 #endif
 
-/**
- * @brief Macro for debug message.
- */
-#define silent_debug(...) do { \
-    if (DBG) { \
-      GST_DEBUG_OBJECT (tensor_mux, __VA_ARGS__); \
-    } \
-  } while (0)
-
 enum
 {
   PROP_0,
@@ -382,7 +373,7 @@ gst_tensor_mux_collect_buffer (GstTensorMux * tensor_mux,
     }
 
     tensor_mux->need_set_time = FALSE;
-    silent_debug ("Current Time : %" GST_TIME_FORMAT,
+    silent_debug (tensor_mux, "Current Time : %" GST_TIME_FORMAT,
         GST_TIME_ARGS (tensor_mux->current_time));
   }
 
@@ -619,13 +610,13 @@ gst_tensor_mux_set_property (GObject * object, guint prop_id,
       if (tensor_mux->sync.mode == SYNC_END) {
         tensor_mux->sync.mode = SYNC_SLOWEST;
       }
-      silent_debug ("Mode = %d(%s)\n", tensor_mux->sync.mode,
+      silent_debug (tensor_mux, "Mode = %d(%s)\n", tensor_mux->sync.mode,
           gst_tensor_time_sync_get_mode_string (tensor_mux->sync.mode));
       gst_tensor_time_sync_set_option_data (&tensor_mux->sync);
       break;
     case PROP_SYNC_OPTION:
       tensor_mux->sync.option = g_value_dup_string (value);
-      silent_debug ("Option = %s\n", tensor_mux->sync.option);
+      silent_debug (tensor_mux, "Option = %s\n", tensor_mux->sync.option);
       gst_tensor_time_sync_set_option_data (&tensor_mux->sync);
       break;
     default:

--- a/gst/nnstreamer/tensor_sink/tensor_sink.c
+++ b/gst/nnstreamer/tensor_sink/tensor_sink.c
@@ -41,16 +41,7 @@
 #define DBG (!self->silent)
 #endif
 
-/**
- * @brief Macro for debug message.
- */
-#define silent_debug(...) do { \
-    if (DBG) { \
-      GST_DEBUG_OBJECT (self, __VA_ARGS__); \
-    } \
-  } while (0)
-
-#define silent_debug_timestamp(buf) do { \
+#define silent_debug_timestamp(self, buf) do { \
   if (DBG) { \
     GST_DEBUG_OBJECT (self, "pts = %" GST_TIME_FORMAT, GST_TIME_ARGS (GST_BUFFER_PTS (buf))); \
     GST_DEBUG_OBJECT (self, "dts = %" GST_TIME_FORMAT, GST_TIME_ARGS (GST_BUFFER_DTS (buf))); \
@@ -385,7 +376,7 @@ gst_tensor_sink_event (GstBaseSink * sink, GstEvent * event)
   switch (type) {
     case GST_EVENT_STREAM_START:
       if (gst_tensor_sink_get_emit_signal (self)) {
-        silent_debug ("Emit signal for stream start");
+        silent_debug (self, "Emit signal for stream start");
 
         g_signal_emit (self, _tensor_sink_signals[SIGNAL_STREAM_START], 0);
       }
@@ -393,7 +384,7 @@ gst_tensor_sink_event (GstBaseSink * sink, GstEvent * event)
 
     case GST_EVENT_EOS:
       if (gst_tensor_sink_get_emit_signal (self)) {
-        silent_debug ("Emit signal for eos");
+        silent_debug (self, "Emit signal for eos");
 
         g_signal_emit (self, _tensor_sink_signals[SIGNAL_EOS], 0);
       }
@@ -526,14 +517,15 @@ gst_tensor_sink_render_buffer (GstTensorSink * self, GstBuffer * buffer)
     gst_tensor_sink_set_last_render_time (self, now);
 
     if (gst_tensor_sink_get_emit_signal (self)) {
-      silent_debug ("Emit signal for new data [%" GST_TIME_FORMAT "] rate [%d]",
+      silent_debug (self,
+          "Emit signal for new data [%" GST_TIME_FORMAT "] rate [%d]",
           GST_TIME_ARGS (now), signal_rate);
 
       g_signal_emit (self, _tensor_sink_signals[SIGNAL_NEW_DATA], 0, buffer);
     }
   }
 
-  silent_debug_timestamp (buffer);
+  silent_debug_timestamp (self, buffer);
 }
 
 /**

--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -96,15 +96,6 @@
 #define DBG (!self->silent)
 #endif
 
-/**
- * @brief Macro for debug message.
- */
-#define silent_debug(...) do { \
-    if (DBG) { \
-      GST_DEBUG_OBJECT (self, __VA_ARGS__); \
-    } \
-  } while (0)
-
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_src_iio_debug);
 #define GST_CAT_DEFAULT gst_tensor_src_iio_debug
 
@@ -920,7 +911,7 @@ gst_tensor_src_iio_get_all_channel_info (GstTensorSrcIIO * self,
           g_build_filename (dir_name, channel_prop->name, NULL);
       channel_prop->generic_name =
           gst_tensor_src_iio_get_generic_name (channel_prop->name);
-      silent_debug ("Generic name = %s", channel_prop->generic_name);
+      silent_debug (self, "Generic name = %s", channel_prop->generic_name);
 
       /** find and set the current state */
       filename = g_strdup_printf ("%s%s", channel_prop->base_file, EN_SUFFIX);
@@ -2225,7 +2216,8 @@ gst_tensor_src_iio_fixate (GstBaseSrc * src, GstCaps * caps)
     GST_ERROR_OBJECT (self, "Error creating fixated caps from config.");
     return NULL;
   }
-  silent_debug ("Fixated caps from device = %" GST_PTR_FORMAT, fixated_caps);
+  silent_debug (self, "Fixated caps from device = %" GST_PTR_FORMAT,
+      fixated_caps);
 
   if (gst_caps_can_intersect (caps, fixated_caps)) {
     updated_caps = gst_caps_intersect (caps, fixated_caps);

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -63,32 +63,6 @@
 #define DBG (!filter->silent)
 #endif
 
-/**
- * @brief Macro for debug message.
- */
-#define silent_debug(...) do { \
-    if (DBG) { \
-      GST_DEBUG_OBJECT (filter, __VA_ARGS__); \
-    } \
-  } while (0)
-
-#define silent_debug_caps(caps,msg) do { \
-  if (DBG) { \
-    if (caps) { \
-      GstStructure *caps_s; \
-      gchar *caps_s_string; \
-      guint caps_size, caps_idx; \
-      caps_size = gst_caps_get_size (caps);\
-      for (caps_idx = 0; caps_idx < caps_size; caps_idx++) { \
-        caps_s = gst_caps_get_structure (caps, caps_idx); \
-        caps_s_string = gst_structure_to_string (caps_s); \
-        GST_DEBUG_OBJECT (filter, msg " = %s\n", caps_s_string); \
-        g_free (caps_s_string); \
-      } \
-    } \
-  } \
-} while (0)
-
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_transform_debug);
 #define GST_CAT_DEFAULT gst_tensor_transform_debug
 #define CAPS_STRING GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_MAKE ("{ static, flexible }")
@@ -812,7 +786,8 @@ gst_tensor_transform_set_property (GObject * object, guint prop_id,
       gchar *backup_option = filter->option;
       filter->option = g_value_dup_string (value);
       if (gst_tensor_transform_set_option_data (filter)) {
-        silent_debug ("Option = %s --> %s\n", backup_option, filter->option);
+        silent_debug (filter, "Option = %s --> %s\n", backup_option,
+            filter->option);
         g_free (backup_option);
       } else {
         /* ERROR! Revert the change! */
@@ -825,7 +800,7 @@ gst_tensor_transform_set_property (GObject * object, guint prop_id,
     case PROP_ACCELERATION:
 #ifdef HAVE_ORC
       filter->acceleration = g_value_get_boolean (value);
-      silent_debug ("acceleration = %d\n", filter->acceleration);
+      silent_debug (filter, "acceleration = %d\n", filter->acceleration);
 #else
       GST_WARNING_OBJECT (filter, "Orc acceleration is not supported");
       filter->acceleration = FALSE;
@@ -1713,9 +1688,9 @@ gst_tensor_transform_transform_caps (GstBaseTransform * trans,
 
   filter = GST_TENSOR_TRANSFORM_CAST (trans);
 
-  silent_debug ("Calling TransformCaps, direction = %d\n", direction);
-  silent_debug_caps (caps, "from");
-  silent_debug_caps (filtercap, "filter");
+  silent_debug (filter, "Calling TransformCaps, direction = %d\n", direction);
+  silent_debug_caps (filter, caps, "from");
+  silent_debug_caps (filter, filtercap, "filter");
 
   result = gst_caps_new_empty ();
   for (i = 0; i < gst_caps_get_size (caps); i++) {
@@ -1766,7 +1741,7 @@ gst_tensor_transform_transform_caps (GstBaseTransform * trans,
     result = intersection;
   }
 
-  silent_debug_caps (result, "to");
+  silent_debug_caps (filter, result, "to");
   return result;
 }
 
@@ -1782,9 +1757,9 @@ gst_tensor_transform_fixate_caps (GstBaseTransform * trans,
 
   filter = GST_TENSOR_TRANSFORM_CAST (trans);
 
-  silent_debug ("Calling FixateCaps, direction = %d\n", direction);
-  silent_debug_caps (caps, "caps");
-  silent_debug_caps (othercaps, "othercaps");
+  silent_debug (filter, "Calling FixateCaps, direction = %d\n", direction);
+  silent_debug_caps (filter, caps, "caps");
+  silent_debug_caps (filter, othercaps, "othercaps");
 
   result =
       gst_tensor_transform_transform_caps (trans, direction, caps, othercaps);
@@ -1793,7 +1768,7 @@ gst_tensor_transform_fixate_caps (GstBaseTransform * trans,
   result = gst_caps_make_writable (result);
   result = gst_caps_fixate (result);
 
-  silent_debug_caps (result, "result");
+  silent_debug_caps (filter, result, "result");
   return result;
 }
 
@@ -1813,9 +1788,9 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
 
   filter = GST_TENSOR_TRANSFORM_CAST (trans);
 
-  silent_debug ("Calling SetCaps\n");
-  silent_debug_caps (incaps, "incaps");
-  silent_debug_caps (outcaps, "outcaps");
+  silent_debug (filter, "Calling SetCaps\n");
+  silent_debug_caps (filter, incaps, "incaps");
+  silent_debug_caps (filter, outcaps, "outcaps");
 
   if (!gst_tensor_transform_read_caps (filter, incaps, &in_config) ||
       !gst_tensors_config_validate (&in_config)) {


### PR DESCRIPTION
1. Provide common macro of silent_debug and silent_debug_caps,
 which had been repeatedly defined in each plugin.
2. Refactor the two macros to get "object" as an argument
 so that it wouldn't use implicit argument exceot for "DBG".

The same macros are not touched in /ext directory
because they are not supposed to include "tensor_common.h",
which is an internal header.

@todo There are a few subplugins in /ext (not tensor-filter)
that uses "tensor_common.h". They should be refactored not to
use internal headers so that we can separate them to
independent repo anytime. Although we don't have such plans,
we need to keep them as appropriate examples for users.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
