### PR TITLE
[Config/Format] tensor format in config

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -87,13 +87,6 @@ extern gboolean
 gst_tensor_info_is_equal (const GstTensorInfo * i1, const GstTensorInfo * i2);
 
 /**
- * @brief Check given info is flexible tensor.
- * @return TRUE if it is flexible.
- */
-extern gboolean
-gst_tensor_info_is_flexible (const GstTensorInfo * info);
-
-/**
  * @brief Copy tensor info up to n elements
  * @note Copied info should be freed with gst_tensor_info_free()
  */
@@ -221,13 +214,6 @@ extern gboolean
 gst_tensors_info_is_equal (const GstTensorsInfo * i1, const GstTensorsInfo * i2);
 
 /**
- * @brief Check given info contains flexible tensor.
- * @return TRUE if it is flexible.
- */
-extern gboolean
-gst_tensors_info_is_flexible (const GstTensorsInfo * info);
-
-/**
  * @brief Copy tensor info
  * @note Copied info should be freed with gst_tensors_info_free()
  */
@@ -290,6 +276,16 @@ gst_tensors_config_is_equal (const GstTensorsConfig * c1,
  */
 extern void
 gst_tensors_config_copy (GstTensorsConfig * dest, const GstTensorsConfig * src);
+
+/**
+ * @brief Macro to check stream format (static tensors for caps negotiation)
+ */
+#define gst_tensors_config_is_static(c) ((c)->format == _NNS_TENSOR_FORMAT_STATIC)
+
+/**
+ * @brief Macro to check stream format (flexible tensors for caps negotiation)
+ */
+#define gst_tensors_config_is_flexible(c) ((c)->format == _NNS_TENSOR_FORMAT_FLEXIBLE)
 
 /**
  * @brief Get tensor caps from tensors config (for other/tensor)

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -229,7 +229,6 @@ typedef struct
                    and some (tensorflow-lite) do not need this. */
   tensor_type type; /**< Type of each element in the tensor. User must designate this. */
   tensor_dim dimension; /**< Dimension. We support up to 4th ranks.  */
-  tensor_format format; /**< Tensor format */
 } GstTensorInfo;
 
 /**
@@ -248,6 +247,7 @@ typedef struct
 typedef struct
 {
   GstTensorsInfo info; /**< tensor info*/
+  tensor_format format; /**< tensor stream type */
   int rate_n; /**< framerate is in fraction, which is numerator/denominator */
   int rate_d; /**< framerate is in fraction, which is numerator/denominator */
 } GstTensorsConfig;

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -112,15 +112,8 @@ static GstCaps *
 _get_tensors_caps (const GstTensorsConfig * config)
 {
   GstCaps *caps;
-  tensor_format format = _NNS_TENSOR_FORMAT_STATIC;
 
   caps = gst_caps_from_string (GST_TENSORS_CAP_DEFAULT);
-
-  if (gst_tensors_info_is_flexible (&config->info))
-    format = _NNS_TENSOR_FORMAT_FLEXIBLE;
-
-  gst_caps_set_simple (caps, "format", G_TYPE_STRING,
-      gst_tensor_get_format_string (format), NULL);
 
   if (config->info.num_tensors > 0) {
     gchar *dim_str, *type_str;
@@ -231,8 +224,6 @@ gst_tensor_info_init (GstTensorInfo * info)
 
   info->name = NULL;
   info->type = _NNS_END;
-  /** @note default format is static */
-  info->format = _NNS_TENSOR_FORMAT_STATIC;
 
   for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
     info->dimension[i] = 0;
@@ -282,11 +273,6 @@ gst_tensor_info_validate (const GstTensorInfo * info)
 {
   g_return_val_if_fail (info != NULL, FALSE);
 
-  if (gst_tensor_info_is_flexible (info)) {
-    /* true if given info is flexible format */
-    return TRUE;
-  }
-
   if (info->type == _NNS_END) {
     return FALSE;
   }
@@ -308,10 +294,6 @@ gst_tensor_info_is_equal (const GstTensorInfo * i1, const GstTensorInfo * i2)
     return FALSE;
   }
 
-  if (i1->format != i2->format) {
-    return FALSE;
-  }
-
   if (i1->type != i2->type) {
     return FALSE;
   }
@@ -324,18 +306,6 @@ gst_tensor_info_is_equal (const GstTensorInfo * i1, const GstTensorInfo * i2)
 
   /* matched all */
   return TRUE;
-}
-
-/**
- * @brief Check given info is flexible tensor.
- * @return TRUE if it is flexible.
- */
-gboolean
-gst_tensor_info_is_flexible (const GstTensorInfo * info)
-{
-  g_return_val_if_fail (info != NULL, FALSE);
-
-  return (info->format == _NNS_TENSOR_FORMAT_FLEXIBLE);
 }
 
 /**
@@ -353,7 +323,6 @@ gst_tensor_info_copy_n (GstTensorInfo * dest, const GstTensorInfo * src,
 
   dest->name = g_strdup (src->name);
   dest->type = src->type;
-  dest->format = src->format;
 
   for (i = 0; i < n; i++) {
     dest->dimension[i] = src->dimension[i];
@@ -387,7 +356,6 @@ gst_tensor_info_convert_to_meta (GstTensorInfo * info, GstTensorMetaInfo * meta)
   gst_tensor_meta_info_init (meta);
 
   meta->type = info->type;
-  meta->format = info->format;
 
   for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
     /** @todo handle rank from info.dimension */
@@ -492,11 +460,6 @@ gst_tensors_info_validate (const GstTensorsInfo * info)
 
   g_return_val_if_fail (info != NULL, FALSE);
 
-  if (gst_tensors_info_is_flexible (info)) {
-    /* true if given info is flexible format */
-    return TRUE;
-  }
-
   if (info->num_tensors < 1) {
     return FALSE;
   }
@@ -518,19 +481,11 @@ gboolean
 gst_tensors_info_is_equal (const GstTensorsInfo * i1, const GstTensorsInfo * i2)
 {
   guint i;
-  gboolean compatible, flexible;
 
   g_return_val_if_fail (i1 != NULL, FALSE);
   g_return_val_if_fail (i2 != NULL, FALSE);
 
-  flexible = gst_tensors_info_is_flexible (i1);
-  if (flexible != gst_tensors_info_is_flexible (i2)) {
-    return FALSE;
-  }
-
-  compatible = (i1->num_tensors > 0 && i2->num_tensors > 0) || flexible;
-
-  if (i1->num_tensors != i2->num_tensors || !compatible) {
+  if (i1->num_tensors != i2->num_tensors || i1->num_tensors == 0) {
     return FALSE;
   }
 
@@ -545,29 +500,6 @@ gst_tensors_info_is_equal (const GstTensorsInfo * i1, const GstTensorsInfo * i2)
 }
 
 /**
- * @brief Check given info contains flexible tensor.
- * @return TRUE if it is flexible.
- */
-gboolean
-gst_tensors_info_is_flexible (const GstTensorsInfo * info)
-{
-  guint i, num;
-
-  g_return_val_if_fail (info != NULL, FALSE);
-
-  /* flex-tensor may not have the number of tensors in info struct. */
-  num = MAX (info->num_tensors, 1);
-
-  for (i = 0; i < num; i++) {
-    if (gst_tensor_info_is_flexible (&info->info[i])) {
-      return TRUE;
-    }
-  }
-
-  return FALSE;
-}
-
-/**
  * @brief Copy tensor info
  * @note Copied info should be freed with gst_tensors_info_free()
  */
@@ -579,11 +511,8 @@ gst_tensors_info_copy (GstTensorsInfo * dest, const GstTensorsInfo * src)
   g_return_if_fail (dest != NULL);
   g_return_if_fail (src != NULL);
 
+  gst_tensors_info_init (dest);
   num = dest->num_tensors = src->num_tensors;
-
-  /* If given info is flexible, set max size. */
-  if (gst_tensors_info_is_flexible (src))
-    num = NNS_TENSOR_SIZE_LIMIT;
 
   for (i = 0; i < num; i++) {
     gst_tensor_info_copy (&dest->info[i], &src->info[i]);
@@ -835,6 +764,8 @@ gst_tensors_config_init (GstTensorsConfig * config)
 
   gst_tensors_info_init (&config->info);
 
+  /** @note default format is static */
+  config->format = _NNS_TENSOR_FORMAT_STATIC;
   config->rate_n = -1;
   config->rate_d = -1;
 }
@@ -866,6 +797,16 @@ gst_tensors_config_validate (const GstTensorsConfig * config)
     return FALSE;
   }
 
+  /* tensor stream format */
+  if (config->format >= _NNS_TENSOR_FORMAT_END) {
+    return FALSE;
+  }
+
+  /* cannot check tensor info when tensor is flexible */
+  if (gst_tensors_config_is_flexible (config)) {
+    return TRUE;
+  }
+
   return gst_tensors_info_validate (&config->info);
 }
 
@@ -889,6 +830,15 @@ gst_tensors_config_is_equal (const GstTensorsConfig * c1,
     return FALSE;
   }
 
+  if (c1->format != c2->format || c1->format == _NNS_TENSOR_FORMAT_END) {
+    return FALSE;
+  }
+
+  /* cannot compare tensor info when tensor is flexible */
+  if (gst_tensors_config_is_flexible (c1)) {
+    return TRUE;
+  }
+
   return gst_tensors_info_is_equal (&c1->info, &c2->info);
 }
 
@@ -902,6 +852,7 @@ gst_tensors_config_copy (GstTensorsConfig * dest, const GstTensorsConfig * src)
   g_return_if_fail (src != NULL);
 
   gst_tensors_info_copy (&dest->info, &src->info);
+  dest->format = src->format;
   dest->rate_n = src->rate_n;
   dest->rate_d = src->rate_d;
 }
@@ -918,7 +869,6 @@ gst_tensors_config_from_structure (GstTensorsConfig * config,
 {
   const gchar *name;
   tensor_format format = _NNS_TENSOR_FORMAT_STATIC;
-  guint i;
 
   g_return_val_if_fail (config != NULL, FALSE);
   gst_tensors_config_init (config);
@@ -930,7 +880,6 @@ gst_tensors_config_from_structure (GstTensorsConfig * config,
   if (g_str_equal (name, NNS_MIMETYPE_TENSOR)) {
     /* other/tensor is always static */
     config->info.num_tensors = 1;
-    config->info.info[0].format = _NNS_TENSOR_FORMAT_STATIC;
 
     if (gst_structure_has_field (structure, "dimension")) {
       const gchar *dim_str = gst_structure_get_string (structure, "dimension");
@@ -952,14 +901,7 @@ gst_tensors_config_from_structure (GstTensorsConfig * config,
         GST_WARNING ("Invalid format %s, it should be one of %s.",
             format_str, GST_TENSOR_FORMAT_ALL);
       } else {
-        /**
-         * @note set format in tensors-info
-         * tensor_mux collects buffers from multiple pads.
-         * If one of sink pads in tensor_mux is flexible, output src pad will have flex tensor.
-         * Remove below when the format in tensors-info is unnecessary.
-         */
-        for (i = 0; i < NNS_TENSOR_SIZE_LIMIT; i++)
-          config->info.info[i].format = format;
+        config->format = format;
       }
     }
 
@@ -1086,7 +1028,7 @@ _peer_is_flexible_tensor_caps (GstPad * pad)
   gboolean flexible = FALSE;
 
   if (gst_tensors_config_from_peer (pad, &config, NULL))
-    flexible = gst_tensors_info_is_flexible (&config.info);
+    flexible = gst_tensors_config_is_flexible (&config);
 
   gst_tensors_config_free (&config);
   return flexible;
@@ -1113,7 +1055,7 @@ gst_tensor_pad_caps_from_config (GstPad * pad, const GstTensorsConfig * config)
   templ = gst_pad_get_pad_template_caps (pad);
 
   /* other/tensors (flexible) */
-  is_flexible = gst_tensors_info_is_flexible (&config->info);
+  is_flexible = gst_tensors_config_is_flexible (config);
 
   /* check peer element is flexible */
   if (!is_flexible)
@@ -1169,7 +1111,7 @@ gst_tensor_pad_possible_caps_from_config (GstPad * pad,
   templ = gst_pad_get_pad_template_caps (pad);
 
   /* append caps for static tensor */
-  if (!gst_tensors_info_is_flexible (&config->info)) {
+  if (gst_tensors_config_is_static (config)) {
     /* other/tensor */
     if ((tmp = _get_tensor_caps (config)) != NULL) {
       if (gst_caps_can_intersect (tmp, templ))
@@ -1227,7 +1169,7 @@ gst_tensor_pad_caps_is_flexible (GstPad * pad)
 
     structure = gst_caps_get_structure (caps, 0);
     if (gst_tensors_config_from_structure (&config, structure))
-      ret = gst_tensors_info_is_flexible (&config.info);
+      ret = gst_tensors_config_is_flexible (&config);
 
     gst_caps_unref (caps);
     gst_tensors_config_free (&config);
@@ -1248,7 +1190,7 @@ gst_tensors_caps_from_config (const GstTensorsConfig * config)
 
   g_return_val_if_fail (config != NULL, NULL);
 
-  if (gst_tensors_info_is_flexible (&config->info)) {
+  if (gst_tensors_config_is_flexible (config)) {
     caps = _get_flexible_caps (config);
   } else {
     caps = _get_tensors_caps (config);
@@ -1797,7 +1739,6 @@ gst_tensor_meta_info_convert (GstTensorMetaInfo * meta, GstTensorInfo * info)
   gst_tensor_info_init (info);
 
   info->type = meta->type;
-  info->format = meta->format;
 
   for (i = 0; i < NNS_TENSOR_META_RANK_LIMIT; i++) {
     if (i >= NNS_TENSOR_RANK_LIMIT) {

--- a/gst/nnstreamer/tensor_crop/tensor_crop.c
+++ b/gst/nnstreamer/tensor_crop/tensor_crop.c
@@ -459,7 +459,7 @@ gst_tensor_crop_negotiate (GstTensorCrop * self)
      * Output is always flexible tensor.
      */
     gst_tensors_config_init (&config);
-    config.info.info[0].format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+    config.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
 
     walk = self->collect->data;
     while (walk) {
@@ -491,7 +491,7 @@ gst_tensor_crop_negotiate (GstTensorCrop * self)
  */
 static gboolean
 gst_tensor_crop_prepare_out_meta (GstTensorCrop * self, gpointer buffer,
-    GstTensorMetaInfo * meta, GstTensorInfo * info)
+    GstTensorMetaInfo * meta, GstTensorInfo * info, gboolean * is_flexible)
 {
   GstCaps *caps;
   GstStructure *structure;
@@ -514,8 +514,9 @@ gst_tensor_crop_prepare_out_meta (GstTensorCrop * self, gpointer buffer,
    * @note tensor-crop handles single tensor. Parse first one.
    */
   _info = &config.info.info[0];
+  *is_flexible = gst_tensors_config_is_flexible (&config);
 
-  if (gst_tensor_info_is_flexible (_info)) {
+  if (*is_flexible) {
     /* meta from buffer */
     if (gst_tensor_meta_info_parse_header (meta, buffer)) {
       ret = gst_tensor_meta_info_convert (meta, info);
@@ -639,12 +640,12 @@ gst_tensor_crop_do_cropping (GstTensorCrop * self, GstBuffer * raw,
     return NULL;
   }
 
-  if (!gst_tensor_crop_prepare_out_meta (self, map.data, &meta, &info)) {
+  if (!gst_tensor_crop_prepare_out_meta (self, map.data, &meta,
+          &info, &flexible)) {
     GST_ERROR_OBJECT (self, "Failed to get the output meta.");
     goto done;
   }
 
-  flexible = (info.format == _NNS_TENSOR_FORMAT_FLEXIBLE);
   hsize = flexible ? gst_tensor_meta_info_get_header_size (&meta) : 0;
   dsize = gst_tensor_meta_info_get_data_size (&meta);
   dpos = map.data + hsize;

--- a/gst/nnstreamer/tensor_demux/gsttensordemux.c
+++ b/gst/nnstreamer/tensor_demux/gsttensordemux.c
@@ -324,6 +324,7 @@ gst_tensor_demux_get_tensor_config (GstTensorDemux * tensor_demux,
         &tensor_demux->tensors_config.info.info[nth]);
   }
 
+  config->format = tensor_demux->tensors_config.format;
   config->rate_n = tensor_demux->tensors_config.rate_n;
   config->rate_d = tensor_demux->tensors_config.rate_d;
   return TRUE;
@@ -474,7 +475,7 @@ gst_tensor_demux_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
   UNUSED (pad);
   tensor_demux = GST_TENSOR_DEMUX (parent);
 
-  if (gst_tensors_info_is_flexible (&tensor_demux->tensors_config.info)) {
+  if (gst_tensors_config_is_flexible (&tensor_demux->tensors_config)) {
     /* cannot get exact number of tensors from config */
     num_tensors = gst_buffer_n_memory (buf);
   } else {

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -837,7 +837,7 @@ gst_tensor_filter_configure_tensor (GstTensorFilter * self,
   }
 
   /* flexible tensor case, we cannot get the exact info from caps. */
-  flexible = gst_tensors_info_is_flexible (&in_info);
+  flexible = gst_tensors_config_is_flexible (&in_config);
 
   /** if set-property called and already has info, verify it! */
   if (prop->input_meta.num_tensors > 0) {
@@ -1117,7 +1117,7 @@ gst_tensor_filter_set_caps (GstBaseTransform * trans,
   structure = gst_caps_get_structure (outcaps, 0);
   gst_tensors_config_from_structure (&config, structure);
 
-  if (gst_tensors_info_is_flexible (&config.info)) {
+  if (gst_tensors_config_is_flexible (&config)) {
     GST_INFO_OBJECT (self, "Output tensor is flexible.");
   } else if (!gst_tensors_config_is_equal (&priv->out_config, &config)) {
     GST_ERROR_OBJECT (self, "Invalid outcaps.");

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -2247,11 +2247,6 @@ gst_tensor_filter_common_get_out_info (GstTensorFilterPrivate * priv,
 
   gst_tensors_info_init (out);
 
-  if (gst_tensors_info_is_flexible (in)) {
-    nns_logw ("Given input info is flexible, cannot get output info.");
-    return FALSE;
-  }
-
   if (!gst_tensors_info_validate (in)) {
     nns_logw ("Given input info is invalid, cannot get output info.");
     return FALSE;

--- a/gst/nnstreamer/tensor_mux/gsttensormux.c
+++ b/gst/nnstreamer/tensor_mux/gsttensormux.c
@@ -450,19 +450,19 @@ gst_tensor_mux_chain_flex_tensor (GstTensorMux * tensor_mux, GstBuffer * buf)
   GstTensorMetaInfo meta;
   guint i;
 
+  /* If input is flexible, do nothing. It is already flexible tensor. */
+  if (gst_tensors_config_is_flexible (&tensor_mux->tensors_config))
+    return buf;
+
   info = &tensor_mux->tensors_config.info;
   buffer = gst_buffer_new ();
 
   for (i = 0; i < info->num_tensors; i++) {
     mem = gst_buffer_peek_memory (buf, i);
 
-    if (gst_tensor_info_is_flexible (&info->info[i])) {
-      mem = gst_memory_ref (mem);
-    } else {
-      /* append header */
-      gst_tensor_info_convert_to_meta (&info->info[i], &meta);
-      mem = gst_tensor_meta_info_append_header (&meta, mem);
-    }
+    /* append header */
+    gst_tensor_info_convert_to_meta (&info->info[i], &meta);
+    mem = gst_tensor_meta_info_append_header (&meta, mem);
 
     gst_buffer_append_memory (buffer, mem);
   }

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -1546,7 +1546,7 @@ gst_tensor_transform_read_caps (GstTensorTransform * filter,
     return FALSE;
   }
 
-  return gst_tensors_info_validate (&config->info);
+  return gst_tensors_config_validate (config);
 }
 
 /**
@@ -1705,9 +1705,9 @@ gst_tensor_transform_transform_caps (GstBaseTransform * trans,
 
     gst_tensors_config_from_structure (&in_config, structure);
 
-    if (gst_tensors_info_is_flexible (&in_config.info)) {
+    if (gst_tensors_config_is_flexible (&in_config)) {
       /* output caps is also flexible */
-      out_config.info.info[0].format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+      out_config.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
     } else {
       for (j = 0; j < in_config.info.num_tensors; j++) {
         gst_tensor_transform_convert_dimension (filter, direction,
@@ -1787,23 +1787,23 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
   silent_debug_caps (filter, incaps, "incaps");
   silent_debug_caps (filter, outcaps, "outcaps");
 
-  if (!gst_tensor_transform_read_caps (filter, incaps, &in_config) ||
-      !gst_tensors_config_validate (&in_config)) {
+  if (!gst_tensor_transform_read_caps (filter, incaps, &in_config)) {
     GST_ERROR_OBJECT (filter, "Cannot read cap of incaps\n");
     goto error;
   }
 
-  if (!gst_tensor_transform_read_caps (filter, outcaps, &out_config) ||
-      !gst_tensors_config_validate (&out_config)) {
+  if (!gst_tensor_transform_read_caps (filter, outcaps, &out_config)) {
     GST_ERROR_OBJECT (filter, "Cannot read cap of outcaps\n");
     goto error;
   }
 
-  in_flexible = gst_tensors_info_is_flexible (&in_config.info);
-  out_flexible = gst_tensors_info_is_flexible (&out_config.info);
+  in_flexible = gst_tensors_config_is_flexible (&in_config);
+  out_flexible = gst_tensors_config_is_flexible (&out_config);
 
   /* compare type and dimension */
   gst_tensors_config_init (&config);
+  config.format = out_config.format;
+
   config.rate_n = in_config.rate_n;
   config.rate_d = in_config.rate_d;
   config.info.num_tensors = in_config.info.num_tensors;

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -578,58 +578,6 @@ TEST (commonTensorInfo, equal05_n)
 }
 
 /**
- * @brief Test for same tensors info.
- */
-TEST (commonTensorInfo, equal06_p)
-{
-  GstTensorsInfo info1, info2;
-
-  fill_tensors_info_for_test (&info1, &info2);
-
-  /* compare flexible tensor */
-  info1.info[1].format = info2.info[1].format = _NNS_TENSOR_FORMAT_FLEXIBLE;
-  EXPECT_TRUE (gst_tensors_info_is_equal (&info1, &info2));
-
-  /* compare flexible tensor (size 0) */
-  gst_tensors_info_init (&info1);
-  gst_tensors_info_init (&info2);
-
-  info1.info[0].format = info2.info[0].format = _NNS_TENSOR_FORMAT_FLEXIBLE;
-  EXPECT_TRUE (gst_tensors_info_is_equal (&info1, &info2));
-}
-
-/**
- * @brief Test for same tensors info.
- */
-TEST (commonTensorInfo, equal07_n)
-{
-  GstTensorsInfo info1, info2;
-
-  fill_tensors_info_for_test (&info1, &info2);
-
-  /* change format, this should not be compatible */
-  info2.info[1].format = _NNS_TENSOR_FORMAT_FLEXIBLE;
-
-  EXPECT_FALSE (gst_tensors_info_is_equal (&info1, &info2));
-}
-
-/**
- * @brief Test for same tensors info.
- */
-TEST (commonTensorInfo, equal08_n)
-{
-  GstTensorsInfo info1, info2;
-
-  fill_tensors_info_for_test (&info1, &info2);
-
-  /* change format, this should not be compatible */
-  info1.info[0].format = _NNS_TENSOR_FORMAT_FLEXIBLE;
-  info2.info[1].format = _NNS_TENSOR_FORMAT_FLEXIBLE;
-
-  EXPECT_FALSE (gst_tensors_info_is_equal (&info1, &info2));
-}
-
-/**
  * @brief Test for getting size of the tensor info with invalid param.
  */
 TEST (commonTensorInfo, sizeInvalidParam_n)
@@ -913,6 +861,36 @@ TEST (commonTensorsConfig, equal08_n)
   GstTensorsConfig conf;
   gst_tensors_config_init (&conf);
   EXPECT_FALSE (gst_tensors_config_is_equal (&conf, NULL));
+}
+
+/**
+ * @brief Test for same tensors config.
+ */
+TEST (commonTensorsConfig, equal09_p)
+{
+  GstTensorsConfig conf1, conf2;
+
+  fill_tensors_config_for_test (&conf1, &conf2);
+
+  /* compare flexible tensor */
+  conf1.format = conf2.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+
+  EXPECT_TRUE (gst_tensors_config_is_equal (&conf1, &conf2));
+}
+
+/**
+ * @brief Test for same tensors config.
+ */
+TEST (commonTensorsConfig, equal10_n)
+{
+  GstTensorsConfig conf1, conf2;
+
+  fill_tensors_config_for_test (&conf1, &conf2);
+
+  /* change format, this should not be compatible */
+  conf2.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+
+  EXPECT_FALSE (gst_tensors_config_is_equal (&conf1, &conf2));
 }
 
 /**
@@ -1376,7 +1354,6 @@ TEST (commonMetaInfo, convertMeta)
 
   gst_tensor_info_init (&info1);
   info1.type = _NNS_INT16;
-  info1.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
   gst_tensor_parse_dimension ("300:1", info1.dimension);
 
   ret = gst_tensor_info_convert_to_meta (&info1, &meta);
@@ -1387,7 +1364,6 @@ TEST (commonMetaInfo, convertMeta)
   EXPECT_TRUE (ret);
 
   EXPECT_EQ (info2.type, _NNS_INT16);
-  EXPECT_EQ (info2.format, _NNS_TENSOR_FORMAT_FLEXIBLE);
   EXPECT_EQ (info2.dimension[0], 300U);
   EXPECT_EQ (info2.dimension[1], 1U);
 }
@@ -1403,7 +1379,6 @@ TEST (commonMetaInfo, convertMetaInvalidParam01_n)
 
   gst_tensor_info_init (&info);
   info.type = _NNS_UINT16;
-  info.format = _NNS_TENSOR_FORMAT_STATIC;
   gst_tensor_parse_dimension ("100:1", info.dimension);
 
   ret = gst_tensor_info_convert_to_meta (NULL, &meta);

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -320,7 +320,7 @@ _new_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
       g_test_data.test_failed = TRUE;
     }
 
-    if (gst_tensors_info_is_flexible (&g_test_data.tensors_config.info)) {
+    if (gst_tensors_config_is_flexible (&g_test_data.tensors_config)) {
       /**
        * Cannot get data type and shape from caps.
        * For the test, set type uint8 and dim with buffer size.
@@ -422,10 +422,9 @@ _test_src_push_timer_cb (gpointer user_data)
   gst_object_unref (pad);
 
   if (is_flexible) {
-    info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
-
     /* add header when pushing flexible tensor */
     gst_tensor_info_convert_to_meta (&info, &meta);
+    meta.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
     hsize = gst_tensor_meta_info_get_header_size (&meta);
     dsize += hsize;
   }
@@ -1502,7 +1501,7 @@ TEST (tensorStreamTest, muxFlexTensors)
 
   /** check tensors config for flex tensor */
   EXPECT_TRUE (gst_tensors_config_validate (&g_test_data.tensors_config));
-  EXPECT_TRUE (gst_tensors_info_is_flexible (&g_test_data.tensors_config.info));
+  EXPECT_TRUE (gst_tensors_config_is_flexible (&g_test_data.tensors_config));
   EXPECT_EQ (g_test_data.tensors_config.info.num_tensors, 2U);
 
   for (i = 0; i < g_test_data.tensors_config.info.num_tensors; i++) {
@@ -1517,12 +1516,14 @@ TEST (tensorStreamTest, muxFlexTensors)
   EXPECT_EQ (g_test_data.meta[0].dimension[0], 3U);
   EXPECT_EQ (g_test_data.meta[0].dimension[1], 160U);
   EXPECT_EQ (g_test_data.meta[0].dimension[2], 120U);
+  EXPECT_EQ (g_test_data.meta[0].format, _NNS_TENSOR_FORMAT_STATIC);
   EXPECT_EQ ((media_type) g_test_data.meta[0].media_type, _NNS_TENSOR);
 
   EXPECT_EQ (g_test_data.meta[1].type, _NNS_UINT8);
   EXPECT_EQ (g_test_data.meta[1].dimension[0], 3U);
   EXPECT_EQ (g_test_data.meta[1].dimension[1], 160U);
   EXPECT_EQ (g_test_data.meta[1].dimension[2], 120U);
+  EXPECT_EQ (g_test_data.meta[1].format, _NNS_TENSOR_FORMAT_STATIC);
   EXPECT_EQ ((media_type) g_test_data.meta[1].media_type, _NNS_VIDEO);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1558,7 +1559,7 @@ TEST (tensorStreamTest, demuxFlexTensors)
 
   /** check tensor config for flex tensor */
   EXPECT_TRUE (gst_tensors_config_validate (&g_test_data.tensors_config));
-  EXPECT_TRUE (gst_tensors_info_is_flexible (&g_test_data.tensors_config.info));
+  EXPECT_TRUE (gst_tensors_config_is_flexible (&g_test_data.tensors_config));
   EXPECT_EQ (g_test_data.tensors_config.info.num_tensors, 1U);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[0], _calc_expected_buffer_size (0));
   EXPECT_EQ (g_test_data.tensors_config.rate_n, 30);
@@ -3188,7 +3189,7 @@ TEST (tensorStreamTest, flexOnSink)
 
   /** check buffer size from tensors config */
   EXPECT_TRUE (gst_tensors_config_validate (&g_test_data.tensors_config));
-  EXPECT_TRUE (gst_tensors_info_is_flexible (&g_test_data.tensors_config.info));
+  EXPECT_TRUE (gst_tensors_config_is_flexible (&g_test_data.tensors_config));
   EXPECT_EQ (g_test_data.tensors_config.info.num_tensors, 1U);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[0], _calc_expected_buffer_size (0));
   EXPECT_EQ (g_test_data.tensors_config.rate_n, 10);
@@ -3239,7 +3240,7 @@ TEST (tensorStreamTest, staticToFlex)
 
   /** check buffer size from tensors config */
   EXPECT_TRUE (gst_tensors_config_validate (&g_test_data.tensors_config));
-  EXPECT_TRUE (gst_tensors_info_is_flexible (&g_test_data.tensors_config.info));
+  EXPECT_TRUE (gst_tensors_config_is_flexible (&g_test_data.tensors_config));
   EXPECT_EQ (g_test_data.tensors_config.info.num_tensors, 2U);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[0], _calc_expected_buffer_size (0));
   EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[0], _calc_expected_buffer_size (1));
@@ -3249,10 +3250,12 @@ TEST (tensorStreamTest, staticToFlex)
   /* check meta info */
   EXPECT_EQ (g_test_data.meta[0].type, _NNS_INT32);
   EXPECT_EQ (g_test_data.meta[0].dimension[0], 2U);
+  EXPECT_EQ (g_test_data.meta[0].format, _NNS_TENSOR_FORMAT_STATIC);
   EXPECT_EQ ((media_type) g_test_data.meta[0].media_type, _NNS_OCTET);
 
   EXPECT_EQ (g_test_data.meta[1].type, _NNS_INT8);
   EXPECT_EQ (g_test_data.meta[1].dimension[0], 2U);
+  EXPECT_EQ (g_test_data.meta[1].format, _NNS_TENSOR_FORMAT_STATIC);
   EXPECT_EQ ((media_type) g_test_data.meta[1].media_type, _NNS_OCTET);
 
   EXPECT_FALSE (g_test_data.test_failed);


### PR DESCRIPTION
Set tensor format from caps struct.
tensor stream has single format, so format in tensor-info struct is unnecessary.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
