### PR TITLE
[Build/Deb] dependency to NNFW @open sesame 06/21 13:48

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  tensorflow-dev [amd64],
  pytorch, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
  openvino-dev, openvino-cpu-mkldnn [amd64],
+ nnfw-dev [amd64],
  tvm-runtime-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer
@@ -99,6 +100,13 @@ Multi-Arch: same
 Depends: nnstreamer, openvino, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer OpenVino support
  This package allows nnstreamer to support OpenVino.
+
+Package: nnstreamer-nnfw
+Architecture: amd64
+Multi-Arch: same
+Depends: nnstreamer, nnfw, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer NNFW (ONE) support
+ This package allows nnstreamer to support NNFW (ONE, On-Device Neural Engine).
 
 Package: nnstreamer-tvm
 Architecture: any

--- a/debian/control.ubuntu.ppa
+++ b/debian/control.ubuntu.ppa
@@ -8,6 +8,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev,
  python, python3, python3-dev, python3-numpy,
+ nnfw-dev [amd64],
  tensorflow-lite-dev, pytorch, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
  tensorflow2-lite-dev,
  openvino-dev, openvino-cpu-mkldnn [amd64], libflatbuffers-dev, flatbuffers-compiler,
@@ -96,6 +97,13 @@ Multi-Arch: same
 Depends: nnstreamer, openvino, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer OpenVino support
  This package allows nnstreamer to support OpenVino.
+
+Package: nnstreamer-nnfw
+Architecture: amd64
+Multi-Arch: same
+Depends: nnstreamer, nnfw, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer NNFW (ONE) support
+ This package allows nnstreamer to support NNFW (ONE, On-Device Neural Engine).
 
 Package: nnstreamer-tvm
 Architecture: any

--- a/debian/nnstreamer-nnfw.install
+++ b/debian/nnstreamer-nnfw.install
@@ -1,0 +1,1 @@
+/usr/lib/nnstreamer/filters/libnnstreamer_filter_nnfw.so


### PR DESCRIPTION
Add new pkg for NNFW (ONE) in debian build.

Related issue: https://github.com/Samsung/ONE/issues/7196

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
