### PR TITLE
[Coverity] Fix critical and major defects in GstMQTT elements

### DIFF
--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -739,17 +739,17 @@ gst_mqtt_sink_render (GstBaseSink * basesink, GstBuffer * in_buf)
       is_static_sized_buf = TRUE;
     }
 
-    self->mqtt_msg_buf = g_malloc0 (self->mqtt_msg_buf_size);
-    if (!self->mqtt_msg_buf) {
-      self->mqtt_msg_buf_size = 0;
-      ret = GST_FLOW_ERROR;
-      goto ret_with;
-    }
+    self->mqtt_msg_buf = g_try_malloc0 (self->mqtt_msg_buf_size);
+  }
+
+  if (!_mqtt_set_msg_buf_hdr (in_buf, &self->mqtt_msg_hdr)) {
+    ret = GST_FLOW_ERROR;
+    goto ret_with;
   }
 
   msg_pub = self->mqtt_msg_buf;
-
-  if (!_mqtt_set_msg_buf_hdr (in_buf, &self->mqtt_msg_hdr)) {
+  if (!msg_pub) {
+    self->mqtt_msg_buf_size = 0;
     ret = GST_FLOW_ERROR;
     goto ret_with;
   }

--- a/tests/gstreamer_mqtt/GstMqttTestHelper.hh
+++ b/tests/gstreamer_mqtt/GstMqttTestHelper.hh
@@ -164,7 +164,11 @@ private:
   /**
    * @brief Default Constructor
    */
-  GstMqttTestHelper () {};
+  GstMqttTestHelper ():
+      context (nullptr), cl (nullptr), ma (nullptr), dc (nullptr),
+      fail_send (false), fail_disconnect (false), fail_subscribe (false),
+      fail_unsubscribe (false), is_connected (false) {};
+
   GstMqttTestHelper (const GstMqttTestHelper &) = delete;
   GstMqttTestHelper &operator=(const GstMqttTestHelper &) = delete;
 

--- a/tests/gstreamer_mqtt/unittest_mqtt_w_helper.cc
+++ b/tests/gstreamer_mqtt/unittest_mqtt_w_helper.cc
@@ -398,15 +398,24 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch0)
   GstMQTTMessageHdr hdr;
   MQTTAsync_message *msg;
   std::future<int> ma_ret;
+  std::string err_msg;
+  bool err_flag = false;
 
   pipeline = gst_parse_launch (str_pipeline, &err);
-  ASSERT_FALSE (pipeline == NULL);
-  ASSERT_TRUE (err == NULL);
-
+  g_free (str_pipeline);
+  if ((!pipeline) || (err)) {
+    err_flag = true;
+    err_msg = std::string ("Failed to launch the given pipeline");
+    goto free_strs;
+  }
   GstMqttTestHelper::getInstance ().initFailFlags ();
 
   msg = (MQTTAsync_message *) g_try_malloc0 (sizeof(*msg));
-  ASSERT_FALSE (msg == NULL);
+  if (!msg) {
+    err_flag = true;
+    err_msg = std::string ("Failed to allocate a MQTTAsync_message");
+    goto free_strs;
+  }
 
   _set_ts_gst_mqtt_message_hdr (pipeline, &hdr, GST_SECOND, 500 * GST_MSECOND);
   ret = gst_element_set_state (pipeline, GST_STATE_PAUSED);
@@ -424,7 +433,12 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch0)
 
   msg->payloadlen = GST_MQTT_LEN_MSG_HDR + len_buf;
   msg->payload = (MQTTAsync_message *) g_try_malloc0 (msg->payloadlen);
-  ASSERT_FALSE (msg->payload == NULL);
+  if (!msg->payload) {
+    err_flag = true;
+    err_msg = std::string (
+        "Failed to allocate buffer for MQTT message payload");
+    goto free_msg_buf;
+  }
 
   ret = gst_element_set_state (pipeline, GST_STATE_PLAYING);
   EXPECT_NE (ret, GST_STATE_CHANGE_FAILURE);
@@ -447,9 +461,15 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch0)
   EXPECT_EQ (ret, GST_STATE_CHANGE_SUCCESS);
   gst_object_unref (pipeline);
 
-  g_free (topic_name);
-  g_free (str_pipeline);
+  g_free (msg->payload);
+free_msg_buf:
+  g_free (msg);
+free_strs:
   g_free (caps_str);
+  g_free (topic_name);
+
+  if (err_flag)
+    FAIL () << err_msg;
 }
 
 /**
@@ -472,15 +492,23 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch1)
   GstMQTTMessageHdr hdr;
   MQTTAsync_message *msg;
   std::future<int> ma_ret;
+  std::string err_msg;
+  bool err_flag = false;
 
   pipeline = gst_parse_launch (str_pipeline, &err);
-  ASSERT_FALSE (pipeline == NULL);
-  ASSERT_TRUE (err == NULL);
-
+  g_free (str_pipeline);
+  if ((!pipeline) || (err)) {
+    err_flag = true;
+    err_msg = std::string ("Failed to launch the given pipeline");
+    goto free_strs;
+  }
   GstMqttTestHelper::getInstance ().initFailFlags ();
 
   msg = (MQTTAsync_message *) g_try_malloc0 (sizeof(*msg));
-  ASSERT_FALSE (msg == NULL);
+  if (!msg) {
+    err_msg = std::string ("Failed to allocate a MQTTAsync_message");
+    goto free_strs;
+  }
 
   _set_ts_gst_mqtt_message_hdr (pipeline, &hdr, GST_SECOND, 500 * GST_MSECOND);
   ret = gst_element_set_state (pipeline, GST_STATE_PAUSED);
@@ -498,7 +526,12 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch1)
 
   msg->payloadlen = GST_MQTT_LEN_MSG_HDR + len_buf;
   msg->payload = g_try_malloc0 (msg->payloadlen);
-  ASSERT_FALSE (msg->payload == NULL);
+  if (!msg->payload) {
+    err_msg = std::string (
+        "Failed to allocate buffer for MQTT message payload");
+    err_flag = true;
+    goto free_msg_buf;
+  }
 
   ret = gst_element_set_state (pipeline, GST_STATE_PLAYING);
   EXPECT_NE (ret, GST_STATE_CHANGE_FAILURE);
@@ -513,8 +546,6 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch1)
   ret = gst_element_get_state (pipeline, &cur_state, NULL, GST_CLOCK_TIME_NONE);
   EXPECT_EQ (ret, GST_STATE_CHANGE_SUCCESS);
   EXPECT_EQ (cur_state, GST_STATE_PLAYING);
-
-  g_free (caps_str);
 
   /** Changing caps while the pipeline is in the GST_STATE_PLAYING state */
   caps_str = g_strdup ("video/x-raw,width=320,height=160,format=YUY2");
@@ -535,9 +566,15 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch1)
   EXPECT_EQ (ret, GST_STATE_CHANGE_SUCCESS);
   gst_object_unref (pipeline);
 
-  g_free (topic_name);
-  g_free (str_pipeline);
+  g_free (msg->payload);
+free_msg_buf:
+  g_free (msg);
+free_strs:
   g_free (caps_str);
+  g_free (topic_name);
+
+  if (err_flag)
+    FAIL () << err_msg;
 }
 
 /**
@@ -560,16 +597,25 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch0_n)
   GstMQTTMessageHdr hdr;
   MQTTAsync_message *msg;
   std::future<int> ma_ret;
+  std::string err_msg;
+  bool err_flag = false;
 
   pipeline = gst_parse_launch (str_pipeline, &err);
-  ASSERT_FALSE (pipeline == NULL);
-  ASSERT_TRUE (err == NULL);
+  g_free (str_pipeline);
+  if ((!pipeline) || (err)) {
+    err_flag = true;
+    err_msg = std::string ("Failed to launch the given pipeline");
+    goto free_strs;
+  }
 
   GstMqttTestHelper::getInstance ().initFailFlags ();
   GstMqttTestHelper::getInstance ().setFailSubscribe (TRUE);
 
   msg = (MQTTAsync_message *) g_try_malloc0 (sizeof(*msg));
-  ASSERT_FALSE (msg == NULL);
+  if (!msg) {
+    err_msg = std::string ("Failed to allocate a MQTTAsync_message");
+    goto free_strs;
+  }
 
   _set_ts_gst_mqtt_message_hdr (pipeline, &hdr, GST_SECOND, 500 * GST_MSECOND);
   ret = gst_element_set_state (pipeline, GST_STATE_PAUSED);
@@ -587,7 +633,12 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch0_n)
 
   msg->payloadlen = GST_MQTT_LEN_MSG_HDR + len_buf;
   msg->payload = (MQTTAsync_message *) g_try_malloc0 (msg->payloadlen);
-  ASSERT_FALSE (msg->payload == NULL);
+  if (!msg->payload) {
+    err_msg = std::string (
+        "Failed to allocate buffer for MQTT message payload");
+    err_flag = true;
+    goto free_msg_buf;
+  }
 
   ret = gst_element_set_state (pipeline, GST_STATE_PLAYING);
   EXPECT_NE (ret, GST_STATE_CHANGE_FAILURE);
@@ -611,9 +662,15 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch0_n)
   GstMqttTestHelper::getInstance ().setFailSubscribe (FALSE);
   gst_object_unref (pipeline);
 
-  g_free (topic_name);
-  g_free (str_pipeline);
+  g_free (msg->payload);
+free_msg_buf:
+  g_free (msg);
+free_strs:
   g_free (caps_str);
+  g_free (topic_name);
+
+  if (err_flag)
+    FAIL () << err_msg;
 }
 
 /**
@@ -636,16 +693,25 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch1_n)
   GstMQTTMessageHdr hdr;
   MQTTAsync_message *msg;
   std::future<int> ma_ret;
+  std::string err_msg;
+  bool err_flag = false;
 
   pipeline = gst_parse_launch (str_pipeline, &err);
-  ASSERT_FALSE (pipeline == NULL);
-  ASSERT_TRUE (err == NULL);
+  g_free (str_pipeline);
+  if ((!pipeline) || (err)) {
+    err_flag = true;
+    err_msg = std::string ("Failed to launch the given pipeline");
+    goto free_strs;
+  }
 
   GstMqttTestHelper::getInstance ().initFailFlags ();
   GstMqttTestHelper::getInstance ().setFailDisconnect (TRUE);
 
   msg = (MQTTAsync_message *) g_try_malloc0 (sizeof(*msg));
-  ASSERT_FALSE (msg == NULL);
+  if (!msg) {
+    err_msg = std::string ("Failed to allocate a MQTTAsync_message");
+    goto free_strs;
+  }
 
   _set_ts_gst_mqtt_message_hdr (pipeline, &hdr, GST_SECOND, 500 * GST_MSECOND);
   ret = gst_element_set_state (pipeline, GST_STATE_PAUSED);
@@ -663,7 +729,12 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch1_n)
 
   msg->payloadlen = GST_MQTT_LEN_MSG_HDR + len_buf;
   msg->payload = (MQTTAsync_message *) g_try_malloc0 (msg->payloadlen);
-  ASSERT_FALSE (msg->payload == NULL);
+  if (!msg->payload) {
+    err_msg = std::string (
+        "Failed to allocate buffer for MQTT message payload");
+    err_flag = true;
+    goto free_msg_buf;
+  }
 
   ret = gst_element_set_state (pipeline, GST_STATE_PLAYING);
   EXPECT_NE (ret, GST_STATE_CHANGE_FAILURE);
@@ -688,9 +759,15 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch1_n)
   EXPECT_EQ (ret, GST_STATE_CHANGE_SUCCESS);
   gst_object_unref (pipeline);
 
-  g_free (topic_name);
-  g_free (str_pipeline);
+  g_free (msg->payload);
+free_msg_buf:
+  g_free (msg);
+free_strs:
   g_free (caps_str);
+  g_free (topic_name);
+
+  if (err_flag)
+    FAIL () << err_msg;
 }
 
 /**
@@ -713,16 +790,25 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch2)
   GstMQTTMessageHdr hdr;
   MQTTAsync_message *msg;
   std::future<int> ma_ret;
+  std::string err_msg;
+  bool err_flag = false;
 
   pipeline = gst_parse_launch (str_pipeline, &err);
-  ASSERT_FALSE (pipeline == NULL);
-  ASSERT_TRUE (err == NULL);
+  g_free (str_pipeline);
+  if ((!pipeline) || (err)) {
+    err_flag = true;
+    err_msg = std::string ("Failed to launch the given pipeline");
+    goto free_strs;
+  }
 
   GstMqttTestHelper::getInstance ().initFailFlags ();
   GstMqttTestHelper::getInstance ().setFailUnsubscribe (TRUE);
 
   msg = (MQTTAsync_message *) g_try_malloc0 (sizeof(*msg));
-  ASSERT_FALSE (msg == NULL);
+  if (!msg) {
+    err_msg = std::string ("Failed to allocate a MQTTAsync_message");
+    goto free_strs;
+  }
 
   _set_ts_gst_mqtt_message_hdr (pipeline, &hdr, GST_SECOND, 500 * GST_MSECOND);
   ret = gst_element_set_state (pipeline, GST_STATE_PAUSED);
@@ -740,7 +826,12 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch2)
 
   msg->payloadlen = GST_MQTT_LEN_MSG_HDR + len_buf;
   msg->payload = (MQTTAsync_message *) g_try_malloc0 (msg->payloadlen);
-  ASSERT_FALSE (msg->payload == NULL);
+  if (!msg->payload) {
+    err_msg = std::string (
+        "Failed to allocate buffer for MQTT message payload");
+    err_flag = true;
+    goto free_msg_buf;
+  }
 
   ret = gst_element_set_state (pipeline, GST_STATE_PLAYING);
   EXPECT_NE (ret, GST_STATE_CHANGE_FAILURE);
@@ -765,9 +856,15 @@ TEST (testMqttSrcWithHelper, srcNormalLaunch2)
   EXPECT_EQ (ret, GST_STATE_CHANGE_SUCCESS);
   gst_object_unref (pipeline);
 
-  g_free (topic_name);
-  g_free (str_pipeline);
+  g_free (msg->payload);
+free_msg_buf:
+  g_free (msg);
+free_strs:
   g_free (caps_str);
+  g_free (topic_name);
+
+  if (err_flag)
+    FAIL () << err_msg;
 }
 
 /**


### PR DESCRIPTION
This PR fixes the following critical and major Coverity defects in GstMQTTSink, GstMQTTSrc, and the unit test cases.
- WGID 1238814, which is a critical defect, in mqttsink.c
- Three major defects (WGID 1238821, 1238825, and 1238826) in mqttsrc.c
- Five critical defects (WGID 1238819, 1238820, 1238824, 1238830, and 1238831) in unittest_mqtt_w_helper.cc
- WGID 1238828, which is a critical defect, in GstMqttTestHelper.hh

Signed-off-by: Wook Song <wook16.song@samsung.com>