### PR TITLE
[tensor_sparse] Add elements tensor_sparse_enc and tensor_sparse_dec

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -288,6 +288,11 @@ gst_tensors_config_copy (GstTensorsConfig * dest, const GstTensorsConfig * src);
 #define gst_tensors_config_is_flexible(c) ((c)->format == _NNS_TENSOR_FORMAT_FLEXIBLE)
 
 /**
+ * @brief Macro to check stream format (sparse tensors for caps negotiation)
+ */
+#define gst_tensors_config_is_sparse(c) ((c)->format == _NNS_TENSOR_FORMAT_SPARSE)
+
+/**
  * @brief Get tensor caps from tensors config (for other/tensor)
  * @param config tensors config info
  * @return caps for given config

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -118,6 +118,14 @@
     GST_TENSORS_CAP_MAKE ("flexible")
 
 /**
+ * @brief Caps string for the caps template of sparse tensors.
+ * This mimetype handles non-static, sparse tensor stream without specifying the data type and shape of the tensor.
+ * The maximum number of tensors in a buffer is 16 (NNS_TENSOR_SIZE_LIMIT).
+ */
+#define GST_TENSORS_SPARSE_CAP_DEFAULT \
+    GST_TENSORS_CAP_MAKE ("sparse")
+
+/**
  * @brief Default static capability for Protocol Buffers
  * protobuf converter will convert this capability to other/tensor(s)
  */

--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -55,6 +55,7 @@ nnst_plugins = [
   'tensor_mux',
   'tensor_sink',
   'tensor_source',
+  'tensor_sparse',
   'tensor_split',
   'tensor_transform',
   'tensor_filter',

--- a/gst/nnstreamer/registerer/nnstreamer.c
+++ b/gst/nnstreamer/registerer/nnstreamer.c
@@ -61,6 +61,8 @@
 #if defined(__gnu_linux__) && !defined(__ANDROID__)
 #include <tensor_source/tensor_src_iio.h>
 #endif /* __gnu_linux__ && !__ANDROID__ */
+#include <tensor_sparse/tensor_sparse_enc.h>
+#include <tensor_sparse/tensor_sparse_dec.h>
 #include <tensor_split/gsttensorsplit.h>
 #include <tensor_transform/tensor_transform.h>
 #include <tensor_if/gsttensorif.h>
@@ -94,6 +96,8 @@ gst_nnstreamer_init (GstPlugin * plugin)
   NNSTREAMER_INIT (plugin, reposink, REPOSINK);
   NNSTREAMER_INIT (plugin, reposrc, REPOSRC);
   NNSTREAMER_INIT (plugin, sink, SINK);
+  NNSTREAMER_INIT (plugin, sparse_enc, SPARSE_ENC);
+  NNSTREAMER_INIT (plugin, sparse_dec, SPARSE_DEC);
   NNSTREAMER_INIT (plugin, split, SPLIT);
   NNSTREAMER_INIT (plugin, transform, TRANSFORM);
   NNSTREAMER_INIT (plugin, if, IF);

--- a/gst/nnstreamer/tensor_sink/tensor_sink.c
+++ b/gst/nnstreamer/tensor_sink/tensor_sink.c
@@ -237,7 +237,7 @@ gst_tensor_sink_class_init (GstTensorSinkClass * klass)
 
   /** pad template */
   pad_caps = gst_caps_from_string (GST_TENSOR_CAP_DEFAULT ";"
-      GST_TENSORS_CAP_MAKE ("{ static, flexible }"));
+      GST_TENSORS_CAP_MAKE ("{ static, flexible, sparse }"));
   pad_template = gst_pad_template_new ("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
       pad_caps);
   gst_element_class_add_pad_template (element_class, pad_template);

--- a/gst/nnstreamer/tensor_sparse/meson.build
+++ b/gst/nnstreamer/tensor_sparse/meson.build
@@ -1,0 +1,9 @@
+tensor_sparse_sources = [
+  'tensor_sparse_util.c',
+  'tensor_sparse_enc.c',
+  'tensor_sparse_dec.c'
+]
+
+foreach s : tensor_sparse_sources
+  nnstreamer_sources += join_paths(meson.current_source_dir(), s)
+endforeach

--- a/gst/nnstreamer/tensor_sparse/tensor_sparse_dec.c
+++ b/gst/nnstreamer/tensor_sparse/tensor_sparse_dec.c
@@ -1,0 +1,420 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Samsung Electronics Co., Ltd.
+ *
+ * @file	tensor_sparse_dec.c
+ * @date	27 Jul 2021
+ * @brief	GStreamer element to decode sparse tensors into dense tensors
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+/**
+ * SECTION:element-tensor_sparse_dec
+ *
+ * tensor_sparse_dec is a GStreamer element to decode incoming sparse tensor into static (dense) format.
+ *
+ * The input is always in the format of other/tensors,format=sparse.
+ * The output is always in the format of ohter/tensors,format=static.
+ *
+ * Please see also tensor_sparse_enc.
+ *
+ * <refsect2>
+ * <title>Example launch line</title>
+ * |[
+ * gst-launch-1.0 ... ! other/tensors,format=static ! \
+ *    tensor_sparse_enc ! other/tensors,format=sparse ! \
+ *    tensor_sparse_dec ! tensor_sink
+ * ]|
+ * </refsect2>
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <string.h>
+#include <nnstreamer_util.h>
+#include "tensor_sparse_dec.h"
+
+/**
+ * @brief Macro for debug mode.
+ */
+#ifndef DBG
+#define DBG (!self->silent)
+#endif
+
+GST_DEBUG_CATEGORY_STATIC (gst_tensor_sparse_dec_debug);
+#define GST_CAT_DEFAULT gst_tensor_sparse_dec_debug
+
+/**
+ * @brief tensor_sparse_dec properties
+ */
+enum
+{
+  PROP_0,
+  PROP_SILENT
+};
+
+/**
+ * @brief Flag to print minimized log.
+ */
+#define DEFAULT_SILENT TRUE
+
+/**
+ * @brief Template for sink pad.
+ */
+static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS (GST_TENSORS_SPARSE_CAP_DEFAULT));
+
+/**
+ * @brief Template for src pad.
+ */
+static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",
+    GST_PAD_SRC,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS (GST_TENSORS_CAP_DEFAULT));
+
+#define gst_tensor_sparse_dec_parent_class parent_class
+G_DEFINE_TYPE (GstTensorSparseDec, gst_tensor_sparse_dec, GST_TYPE_ELEMENT);
+
+static void gst_tensor_sparse_dec_finalize (GObject * object);
+static void gst_tensor_sparse_dec_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec);
+static void gst_tensor_sparse_dec_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec);
+static GstFlowReturn
+gst_tensor_sparse_dec_chain (GstPad * pad, GstObject * parent, GstBuffer * buf);
+static gboolean
+gst_tensor_sparse_dec_sink_event (GstPad * pad, GstObject * parent,
+    GstEvent * event);
+static gboolean gst_tensor_sparse_dec_sink_query (GstPad * pad,
+    GstObject * parent, GstQuery * query);
+
+/**
+ * @brief Initialize the tensor_sparse's class.
+ */
+static void
+gst_tensor_sparse_dec_class_init (GstTensorSparseDecClass * klass)
+{
+  GObjectClass *object_class;
+  GstElementClass *element_class;
+
+  GST_DEBUG_CATEGORY_INIT (gst_tensor_sparse_dec_debug, "tensor_sparse_dec", 0,
+      "Element to decode sparse tensors");
+
+  object_class = (GObjectClass *) klass;
+  element_class = (GstElementClass *) klass;
+
+  object_class->set_property = gst_tensor_sparse_dec_set_property;
+  object_class->get_property = gst_tensor_sparse_dec_get_property;
+  object_class->finalize = gst_tensor_sparse_dec_finalize;
+
+  /**
+   * GstTensorSparseDec::silent:
+   *
+   * The flag to enable/disable debugging messages.
+   */
+  g_object_class_install_property (object_class, PROP_SILENT,
+      g_param_spec_boolean ("silent", "Silent", "Produce verbose output",
+          DEFAULT_SILENT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  gst_element_class_add_pad_template (element_class,
+      gst_static_pad_template_get (&src_template));
+  gst_element_class_add_pad_template (element_class,
+      gst_static_pad_template_get (&sink_template));
+
+  gst_element_class_set_static_metadata (element_class,
+      "TensorSparseDec",
+      "Filter/Tensor",
+      "Element to decode dense tensors into sparse tensors",
+      "Samsung Electronics Co., Ltd.");
+}
+
+/**
+ * @brief Initialize tensor_sparse_dec element.
+ */
+static void
+gst_tensor_sparse_dec_init (GstTensorSparseDec * self)
+{
+  /* setup sink pad */
+  self->sinkpad = gst_pad_new_from_static_template (&sink_template, "sink");
+  gst_element_add_pad (GST_ELEMENT (self), self->sinkpad);
+
+  /* setup src pad */
+  self->srcpad = gst_pad_new_from_static_template (&src_template, "src");
+  gst_element_add_pad (GST_ELEMENT (self), self->srcpad);
+
+  /* setup chain function */
+  gst_pad_set_chain_function (self->sinkpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_sparse_dec_chain));
+
+  /* setup event function */
+  gst_pad_set_event_function (self->sinkpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_sparse_dec_sink_event));
+
+  gst_pad_set_query_function (self->sinkpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_sparse_dec_sink_query));
+
+  /* init properties */
+  self->silent = DEFAULT_SILENT;
+  gst_tensors_config_init (&self->out_config);
+}
+
+/**
+ * @brief Function to finalize instance.
+ */
+static void
+gst_tensor_sparse_dec_finalize (GObject * object)
+{
+  GstTensorSparseDec *self;
+  self = GST_TENSOR_SPARSE_DEC (object);
+
+  gst_tensors_config_free (&self->out_config);
+
+  G_OBJECT_CLASS (parent_class)->finalize (object);
+}
+
+/**
+ * @brief Setter for tensor_sparse_dec properties.
+ */
+static void
+gst_tensor_sparse_dec_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  GstTensorSparseDec *self;
+
+  self = GST_TENSOR_SPARSE_DEC (object);
+
+  switch (prop_id) {
+    case PROP_SILENT:
+      self->silent = g_value_get_boolean (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief Getter for tensor_sparse_dec properties.
+ */
+static void
+gst_tensor_sparse_dec_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  GstTensorSparseDec *self;
+
+  self = GST_TENSOR_SPARSE_DEC (object);
+
+  switch (prop_id) {
+    case PROP_SILENT:
+      g_value_set_boolean (value, self->silent);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief Get pad caps for caps negotiation.
+ */
+static GstCaps *
+gst_tensor_sparse_dec_query_caps (GstTensorSparseDec * self, GstPad * pad,
+    GstCaps * filter)
+{
+  GstCaps *caps;
+
+  caps = gst_pad_get_current_caps (pad);
+  if (!caps) {
+    /** pad don't have current caps. use the template caps */
+    caps = gst_pad_get_pad_template_caps (pad);
+  }
+
+  silent_debug_caps (self, caps, "caps");
+  silent_debug_caps (self, filter, "filter");
+
+  if (filter) {
+    GstCaps *intersection;
+    intersection =
+        gst_caps_intersect_full (filter, caps, GST_CAPS_INTERSECT_FIRST);
+
+    gst_caps_unref (caps);
+    caps = intersection;
+  }
+
+  silent_debug_caps (self, caps, "result");
+  return caps;
+}
+
+/**
+ * @brief This function handles sink pad query.
+ */
+static gboolean
+gst_tensor_sparse_dec_sink_query (GstPad * pad, GstObject * parent,
+    GstQuery * query)
+{
+  GstTensorSparseDec *self;
+  self = GST_TENSOR_SPARSE_DEC (parent);
+
+  GST_DEBUG_OBJECT (self, "Received %s query: %" GST_PTR_FORMAT,
+      GST_QUERY_TYPE_NAME (query), query);
+
+  switch (GST_QUERY_TYPE (query)) {
+    case GST_QUERY_CAPS:
+    {
+      GstCaps *caps;
+      GstCaps *filter;
+
+      gst_query_parse_caps (query, &filter);
+      caps = gst_tensor_sparse_dec_query_caps (self, pad, filter);
+      silent_debug_caps (self, filter, "filter");
+      silent_debug_caps (self, caps, "caps");
+      gst_query_set_caps_result (query, caps);
+      gst_caps_unref (caps);
+      return TRUE;
+    }
+    case GST_QUERY_ACCEPT_CAPS:
+    {
+      GstCaps *caps;
+      GstCaps *template_caps;
+      gboolean res = FALSE;
+
+      gst_query_parse_accept_caps (query, &caps);
+      silent_debug_caps (self, caps, "caps");
+
+      if (gst_caps_is_fixed (caps)) {
+        template_caps = gst_pad_get_pad_template_caps (pad);
+
+        res = gst_caps_can_intersect (template_caps, caps);
+        gst_caps_unref (template_caps);
+      }
+
+      gst_query_set_accept_caps_result (query, res);
+      return TRUE;
+    }
+    default:
+      break;
+  }
+
+  return gst_pad_query_default (pad, parent, query);
+}
+
+static gboolean
+gst_tensor_sparse_dec_sink_event (GstPad * pad, GstObject * parent,
+    GstEvent * event)
+{
+  GstTensorSparseDec *self;
+  self = GST_TENSOR_SPARSE_DEC (parent);
+  g_return_val_if_fail (event != NULL, FALSE);
+
+  switch (GST_EVENT_TYPE (event)) {
+    case GST_EVENT_CAPS:
+    {
+      GstCaps *caps, *out_caps;
+      GstStructure *structure;
+
+      gst_event_parse_caps (event, &caps);
+      silent_debug_caps (self, caps, "caps");
+
+      /* set out_config as srcpad's peer */
+      gst_tensors_config_from_peer (self->srcpad, &self->out_config, NULL);
+
+      /* set framerate */
+      structure = gst_caps_get_structure (caps, 0);
+      if (gst_structure_has_field (structure, "framerate")) {
+        gst_structure_get_fraction (structure, "framerate",
+            &self->out_config.rate_n, &self->out_config.rate_d);
+      } else {
+        /* cannot get the framerate */
+        self->out_config.rate_n = 0;
+        self->out_config.rate_d = 1;
+      }
+
+      out_caps = gst_tensor_pad_caps_from_config (self->srcpad,
+          &self->out_config);
+
+      silent_debug_caps (self, out_caps, "out_caps");
+      gst_pad_set_caps (self->srcpad, out_caps);
+
+      gst_event_unref (event);
+      return TRUE;
+    }
+    default:
+      break;
+  }
+
+  return gst_pad_event_default (pad, parent, event);
+}
+
+/**
+ * @brief Internal function to transform the input buffer.
+ */
+static GstFlowReturn
+gst_tensor_sparse_dec_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
+{
+  GstFlowReturn ret = GST_FLOW_ERROR;
+  GstTensorSparseDec *self = GST_TENSOR_SPARSE_DEC (parent);
+  GstTensorMetaInfo meta;
+  GstMemory *mem, *out_mem;
+  GstMapInfo map;
+  GstBuffer *outbuf;
+  GstTensorsInfo info;
+  guint i;
+
+  UNUSED (pad);
+  outbuf = gst_buffer_new ();
+
+  gst_tensors_info_init (&info);
+  info.num_tensors = gst_buffer_n_memory (buf);
+
+  for (i = 0; i < info.num_tensors; ++i) {
+    mem = gst_buffer_peek_memory (buf, i);
+
+    if (!gst_memory_map (mem, &map, GST_MAP_READ)) {
+      nns_loge ("failed to map given buffer");
+      goto done;
+    }
+
+    if (!gst_tensor_meta_info_parse_header (&meta, map.data)) {
+      nns_loge ("failed to parse meta info from given buffer");
+      gst_memory_unmap (mem, &map);
+      goto done;
+    }
+
+    out_mem = gst_tensor_sparse_to_dense (&meta, map.data);
+    gst_memory_unmap (mem, &map);
+
+    if (!out_mem) {
+      nns_loge ("failed to convert to dense tensor");
+      goto done;
+    }
+
+    gst_buffer_append_memory (outbuf, out_mem);
+    gst_tensor_meta_info_convert (&meta, &info.info[i]);
+  }
+
+  /* check the decoded tensor with negotiated config when it's valid */
+  if (gst_tensors_config_validate (&self->out_config)) {
+    if (!gst_tensors_info_is_equal (&self->out_config.info, &info)) {
+      /* if it's not compatible with downstream, do not send the buffer */
+      /** @todo consider more error handling */
+      gst_buffer_unref (outbuf);
+      ret = GST_FLOW_OK;
+      goto done;
+    }
+  }
+
+  ret = gst_pad_push (self->srcpad, outbuf);
+
+done:
+  gst_buffer_unref (buf);
+  if (ret != GST_FLOW_OK)
+    gst_buffer_unref (outbuf);
+
+  return ret;
+}

--- a/gst/nnstreamer/tensor_sparse/tensor_sparse_dec.h
+++ b/gst/nnstreamer/tensor_sparse/tensor_sparse_dec.h
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Samsung Electronics Co., Ltd.
+ *
+ * @file	tensor_sparse_dec.h
+ * @date	27 Jul 2021
+ * @brief	GStreamer element to decode sparse tensors into dense tensors
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#ifndef __GST_TENSOR_SPARSE_DEC_H__
+#define __GST_TENSOR_SPARSE_DEC_H__
+
+#include <gst/gst.h>
+#include <tensor_common.h>
+#include "tensor_sparse_util.h"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_TENSOR_SPARSE_DEC \
+  (gst_tensor_sparse_dec_get_type())
+#define GST_TENSOR_SPARSE_DEC(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_TENSOR_SPARSE_DEC,GstTensorSparseDec))
+#define GST_TENSOR_SPARSE_DEC_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_TENSOR_SPARSE_DEC,GstTensorSparseDecClass))
+#define GST_IS_TENSOR_SPARSE_DEC(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_TENSOR_SPARSE_DEC))
+#define GST_IS_TENSOR_SPARSE_DEC_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_SPARSE_DEC))
+
+typedef struct _GstTensorSparseDec GstTensorSparseDec;
+typedef struct _GstTensorSparseDecClass GstTensorSparseDecClass;
+
+/**
+ * @brief GstTensorSparseDec data structure.
+ */
+struct _GstTensorSparseDec
+{
+  GstElement element; /**< parent object */
+  GstPad *sinkpad; /**< sink pad */
+  GstPad *srcpad; /**< src pad */
+
+  /* <private> */
+  GstTensorsConfig out_config; /**< output tensors config */
+  gboolean silent; /**< true to print minimized log */
+};
+
+/**
+ * @brief GstTensorSparseClass data structure.
+ */
+struct _GstTensorSparseDecClass
+{
+  GstElementClass parent_class; /**< parent class */
+};
+
+/**
+ * @brief Function to get type of tensor_sparse.
+ */
+GType gst_tensor_sparse_dec_get_type (void);
+
+G_END_DECLS
+
+#endif /* __GST_TENSOR_SPARSE_DEC_H__ */

--- a/gst/nnstreamer/tensor_sparse/tensor_sparse_enc.c
+++ b/gst/nnstreamer/tensor_sparse/tensor_sparse_enc.c
@@ -1,0 +1,420 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Samsung Electronics Co., Ltd.
+ *
+ * @file	tensor_sparse_enc.c
+ * @date	27 Jul 2021
+ * @brief	GStreamer element to encode dense tensors into sparse tensors
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+/**
+ * SECTION:element-tensor_sparse_enc
+ *
+ * tensor_sparse_enc is a GStreamer element to encode incoming tensor into sparse format.
+ *
+ * The input is always in the format of other/tensors,format=static.
+ * The output is always in the format of ohter/tensors,format=sparse.
+ *
+ * Please see also tensor_sparse_dec.
+ *
+ * <refsect2>
+ * <title>Example launch line</title>
+ * |[
+ * gst-launch-1.0 ... ! other/tensors,format=static ! \
+ *    tensor_sparse_enc ! tensor_sink
+ * ]|
+ * </refsect2>
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <string.h>
+#include <nnstreamer_util.h>
+#include "tensor_sparse_enc.h"
+
+/**
+ * @brief Macro for debug mode.
+ */
+#ifndef DBG
+#define DBG (!self->silent)
+#endif
+
+GST_DEBUG_CATEGORY_STATIC (gst_tensor_sparse_enc_debug);
+#define GST_CAT_DEFAULT gst_tensor_sparse_enc_debug
+
+/**
+ * @brief tensor_sparse_enc properties
+ */
+enum
+{
+  PROP_0,
+  PROP_SILENT
+};
+
+/**
+ * @brief Flag to print minimized log.
+ */
+#define DEFAULT_SILENT TRUE
+
+/**
+ * @brief Template for sink pad.
+ */
+static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS (GST_TENSORS_CAP_DEFAULT));
+
+/**
+ * @brief Template for src pad.
+ */
+static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",
+    GST_PAD_SRC,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS (GST_TENSORS_SPARSE_CAP_DEFAULT));
+
+#define gst_tensor_sparse_enc_parent_class parent_class
+G_DEFINE_TYPE (GstTensorSparseEnc, gst_tensor_sparse_enc, GST_TYPE_ELEMENT);
+
+static void gst_tensor_sparse_enc_finalize (GObject * object);
+static void gst_tensor_sparse_enc_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec);
+static void gst_tensor_sparse_enc_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec);
+static GstFlowReturn
+gst_tensor_sparse_enc_chain (GstPad * pad, GstObject * parent, GstBuffer * buf);
+static GstCaps *gst_tensor_sparse_enc_query_caps (GstTensorSparseEnc * self,
+    GstPad * pad, GstCaps * filter);
+static gboolean gst_tensor_sparse_enc_sink_event (GstPad * pad,
+    GstObject * parent, GstEvent * event);
+static gboolean gst_tensor_sparse_enc_sink_query (GstPad * pad,
+    GstObject * parent, GstQuery * query);
+
+/**
+ * @brief Initialize the tensor_sparse's class.
+ */
+static void
+gst_tensor_sparse_enc_class_init (GstTensorSparseEncClass * klass)
+{
+  GObjectClass *object_class;
+  GstElementClass *element_class;
+
+  GST_DEBUG_CATEGORY_INIT (gst_tensor_sparse_enc_debug, "tensor_sparse_enc", 0,
+      "Element to encode sparse tensors");
+
+  object_class = (GObjectClass *) klass;
+  element_class = (GstElementClass *) klass;
+
+  object_class->set_property = gst_tensor_sparse_enc_set_property;
+  object_class->get_property = gst_tensor_sparse_enc_get_property;
+  object_class->finalize = gst_tensor_sparse_enc_finalize;
+
+  /**
+   * GstTensorSparseEnc::silent:
+   *
+   * The flag to enable/disable debugging messages.
+   */
+  g_object_class_install_property (object_class, PROP_SILENT,
+      g_param_spec_boolean ("silent", "Silent", "Produce verbose output",
+          DEFAULT_SILENT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  gst_element_class_add_pad_template (element_class,
+      gst_static_pad_template_get (&src_template));
+
+  gst_element_class_add_pad_template (element_class,
+      gst_static_pad_template_get (&sink_template));
+
+  gst_element_class_set_static_metadata (element_class,
+      "TensorSparseEnc",
+      "Filter/Tensor",
+      "Element to encode dense tensors into sparse tensors",
+      "Samsung Electronics Co., Ltd.");
+}
+
+/**
+ * @brief Initialize tensor_sparse_enc element.
+ */
+static void
+gst_tensor_sparse_enc_init (GstTensorSparseEnc * self)
+{
+  /* setup sink pad */
+  self->sinkpad = gst_pad_new_from_static_template (&sink_template, "sink");
+  gst_element_add_pad (GST_ELEMENT (self), self->sinkpad);
+
+  /* setup src pad */
+  self->srcpad = gst_pad_new_from_static_template (&src_template, "src");
+  gst_element_add_pad (GST_ELEMENT (self), self->srcpad);
+
+  /* setup chain function */
+  gst_pad_set_chain_function (self->sinkpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_sparse_enc_chain));
+
+  /* setup event function */
+  gst_pad_set_event_function (self->sinkpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_sparse_enc_sink_event));
+
+  gst_pad_set_query_function (self->sinkpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_sparse_enc_sink_query));
+
+  /* init properties */
+  self->silent = DEFAULT_SILENT;
+  gst_tensors_config_init (&self->in_config);
+}
+
+/**
+ * @brief Function to finalize instance.
+ */
+static void
+gst_tensor_sparse_enc_finalize (GObject * object)
+{
+  GstTensorSparseEnc *self;
+  self = GST_TENSOR_SPARSE_ENC (object);
+
+  gst_tensors_config_free (&self->in_config);
+
+  G_OBJECT_CLASS (parent_class)->finalize (object);
+}
+
+/**
+ * @brief Setter for tensor_sparse_enc properties.
+ */
+static void
+gst_tensor_sparse_enc_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  GstTensorSparseEnc *self;
+
+  self = GST_TENSOR_SPARSE_ENC (object);
+
+  switch (prop_id) {
+    case PROP_SILENT:
+      self->silent = g_value_get_boolean (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief Getter for tensor_sparse_enc properties.
+ */
+static void
+gst_tensor_sparse_enc_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  GstTensorSparseEnc *self;
+
+  self = GST_TENSOR_SPARSE_ENC (object);
+
+  switch (prop_id) {
+    case PROP_SILENT:
+      g_value_set_boolean (value, self->silent);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief Parse caps and set tensors config
+ */
+static gboolean
+gst_tensor_sparse_enc_parse_caps (GstTensorSparseEnc * self,
+    const GstCaps * caps)
+{
+  GstStructure *structure;
+  GstTensorsConfig config;
+
+  g_return_val_if_fail (caps != NULL, FALSE);
+  g_return_val_if_fail (gst_caps_is_fixed (caps), FALSE);
+
+  structure = gst_caps_get_structure (caps, 0);
+
+  if (!gst_tensors_config_from_structure (&config, structure) ||
+      !gst_tensors_config_validate (&config)) {
+    /** not fully configured */
+    GST_ERROR_OBJECT (self, "Failed to configure tensors config.\n");
+    return FALSE;
+  }
+
+  self->in_config = config;
+  return TRUE;
+}
+
+static gboolean
+gst_tensor_sparse_enc_sink_event (GstPad * pad, GstObject * parent,
+    GstEvent * event)
+{
+  GstTensorSparseEnc *self;
+  self = GST_TENSOR_SPARSE_ENC (parent);
+
+  g_return_val_if_fail (event != NULL, FALSE);
+
+  switch (GST_EVENT_TYPE (event)) {
+    case GST_EVENT_CAPS:
+    {
+      GstCaps *caps;
+      gboolean ret;
+
+      gst_event_parse_caps (event, &caps);
+      silent_debug_caps (self, caps, "caps");
+
+      ret = gst_tensor_sparse_enc_parse_caps (self, caps);
+      gst_event_unref (event);
+      return ret;
+    }
+    default:
+      break;
+  }
+
+  return gst_pad_event_default (pad, parent, event);
+}
+
+/**
+ * @brief Get pad caps for caps negotiation.
+ */
+static GstCaps *
+gst_tensor_sparse_enc_query_caps (GstTensorSparseEnc * self, GstPad * pad,
+    GstCaps * filter)
+{
+  GstCaps *caps;
+
+  caps = gst_pad_get_current_caps (pad);
+  if (!caps) {
+    /** pad don't have current caps. use the template caps */
+    caps = gst_pad_get_pad_template_caps (pad);
+  }
+
+  silent_debug_caps (self, caps, "caps");
+  silent_debug_caps (self, filter, "filter");
+
+  if (filter) {
+    GstCaps *intersection;
+    intersection =
+        gst_caps_intersect_full (filter, caps, GST_CAPS_INTERSECT_FIRST);
+
+    gst_caps_unref (caps);
+    caps = intersection;
+  }
+
+  silent_debug_caps (self, caps, "result");
+  return caps;
+}
+
+/**
+ * @brief This function handles sink pad query.
+ */
+static gboolean
+gst_tensor_sparse_enc_sink_query (GstPad * pad, GstObject * parent,
+    GstQuery * query)
+{
+  GstTensorSparseEnc *self;
+
+  self = GST_TENSOR_SPARSE_ENC (parent);
+
+  GST_DEBUG_OBJECT (self, "Received %s query: %" GST_PTR_FORMAT,
+      GST_QUERY_TYPE_NAME (query), query);
+
+  switch (GST_QUERY_TYPE (query)) {
+    case GST_QUERY_CAPS:
+    {
+      GstCaps *caps;
+      GstCaps *filter;
+
+      gst_query_parse_caps (query, &filter);
+      caps = gst_tensor_sparse_enc_query_caps (self, pad, filter);
+      silent_debug_caps (self, filter, "filter");
+      silent_debug_caps (self, caps, "caps");
+      gst_query_set_caps_result (query, caps);
+      gst_caps_unref (caps);
+      return TRUE;
+    }
+    case GST_QUERY_ACCEPT_CAPS:
+    {
+      GstCaps *caps;
+      GstCaps *template_caps;
+      gboolean res = FALSE;
+
+      gst_query_parse_accept_caps (query, &caps);
+      silent_debug_caps (self, caps, "caps");
+
+      if (gst_caps_is_fixed (caps)) {
+        template_caps = gst_pad_get_pad_template_caps (pad);
+
+        res = gst_caps_can_intersect (template_caps, caps);
+        gst_caps_unref (template_caps);
+      }
+
+      gst_query_set_accept_caps_result (query, res);
+      return TRUE;
+    }
+    default:
+      break;
+  }
+
+  return gst_pad_query_default (pad, parent, query);
+}
+
+
+/**
+ * @brief Internal function to transform the input buffer.
+ */
+static GstFlowReturn
+gst_tensor_sparse_enc_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
+{
+  GstFlowReturn ret = GST_FLOW_OK;
+  GstTensorSparseEnc *self = GST_TENSOR_SPARSE_ENC (parent);
+  GstMemory *mem, *out_mem;
+  GstMapInfo map;
+  GstBuffer *outbuf;
+  GstTensorsInfo *info;
+  guint i;
+
+  UNUSED (pad);
+
+  info = &self->in_config.info;
+
+  outbuf = gst_buffer_new ();
+
+  for (i = 0; i < info->num_tensors; ++i) {
+    GstTensorMetaInfo meta;
+    gst_tensor_info_convert_to_meta (&info->info[i], &meta);
+
+    meta.format = _NNS_TENSOR_FORMAT_SPARSE;
+    meta.media_type = _NNS_TENSOR;
+
+    /* do real encoding here */
+    mem = gst_buffer_peek_memory (buf, i);
+    if (!gst_memory_map (mem, &map, GST_MAP_READ)) {
+      ml_loge ("Cannot map input buffer to gst-buffer at sparse_enc.");
+      ret = GST_FLOW_ERROR;
+      goto done;
+    }
+
+    out_mem = gst_tensor_sparse_from_dense (&meta, map.data);
+    gst_memory_unmap (mem, &map);
+
+    if (!out_mem) {
+      nns_loge ("failed to convert to sparse tensor");
+      ret = GST_FLOW_ERROR;
+      goto done;
+    }
+
+    gst_buffer_append_memory (outbuf, out_mem);
+  }
+
+  ret = gst_pad_push (self->srcpad, outbuf);
+
+done:
+  gst_buffer_unref (buf);
+  if (ret != GST_FLOW_OK)
+    gst_buffer_unref (outbuf);
+
+  return ret;
+}

--- a/gst/nnstreamer/tensor_sparse/tensor_sparse_enc.h
+++ b/gst/nnstreamer/tensor_sparse/tensor_sparse_enc.h
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Samsung Electronics Co., Ltd.
+ *
+ * @file	tensor_sparse_enc.h
+ * @date	27 Jul 2021
+ * @brief	GStreamer element to encode sparse tensors into dense tensors
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#ifndef __GST_TENSOR_SPARSE_ENC_H__
+#define __GST_TENSOR_SPARSE_ENC_H__
+
+#include <gst/gst.h>
+#include <tensor_common.h>
+#include "tensor_sparse_util.h"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_TENSOR_SPARSE_ENC \
+  (gst_tensor_sparse_enc_get_type())
+#define GST_TENSOR_SPARSE_ENC(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_TENSOR_SPARSE_ENC,GstTensorSparseEnc))
+#define GST_TENSOR_SPARSE_ENC_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_TENSOR_SPARSE_ENC,GstTensorSparseEncClass))
+#define GST_IS_TENSOR_SPARSE_ENC(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_TENSOR_SPARSE_ENC))
+#define GST_IS_TENSOR_SPARSE_ENC_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_SPARSE_ENC))
+
+typedef struct _GstTensorSparseEnc GstTensorSparseEnc;
+typedef struct _GstTensorSparseEncClass GstTensorSparseEncClass;
+
+/**
+ * @brief GstTensorSparseEnc data structure.
+ */
+struct _GstTensorSparseEnc
+{
+  GstElement element; /**< parent object */
+  GstPad *sinkpad; /**< sink pad */
+  GstPad *srcpad; /**< src pad */
+
+  /* <private> */
+  GstTensorsConfig in_config; /**< input tensors config */
+  gboolean silent; /**< true to print minimized log */
+};
+
+/**
+ * @brief GstTensorSparseClass data structure.
+ */
+struct _GstTensorSparseEncClass
+{
+  GstElementClass parent_class; /**< parent class */
+};
+
+/**
+ * @brief Function to get type of tensor_sparse.
+ */
+GType gst_tensor_sparse_enc_get_type (void);
+
+G_END_DECLS
+
+#endif /* __GST_TENSOR_SPARSE_ENC_H__ */

--- a/gst/nnstreamer/tensor_sparse/tensor_sparse_util.c
+++ b/gst/nnstreamer/tensor_sparse/tensor_sparse_util.c
@@ -1,0 +1,226 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer / NNStreamer Sparse Tensor support
+ * Copyright (C) 2021 Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ */
+/**
+ * @file	tensor_sparse_util.c
+ * @date	27 Jul 2021
+ * @brief	Util functions for tensor_sparse encoder and decoder.
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#include <tensor_common.h>
+#include <tensor_data.h>
+#include "tensor_sparse_util.h"
+
+/**
+ * @brief Make dense tensor with input sparse tensor.
+ * @param[in,out] meta tensor meta structure to be updated
+ * @param[in] in pointer of input sparse tensor data
+ * @return pointer of GstMemory with dense tensor data or NULL on error. Caller should handle this newly allocated memory.
+ */
+GstMemory *
+gst_tensor_sparse_to_dense (GstTensorMetaInfo * meta, gpointer in)
+{
+  guint i, nnz;
+  guint8 *output, *input;
+  guint *indices;
+  gsize output_size, element_size;
+
+  meta->format = _NNS_TENSOR_FORMAT_STATIC;
+
+  element_size = gst_tensor_get_element_size (meta->type);
+  output_size = gst_tensor_meta_info_get_data_size (meta);
+
+  if (element_size == 0 || output_size == 0) {
+    nns_loge ("Got invalid meta info");
+    return NULL;
+  }
+
+  output = (guint8 *) g_malloc0 (output_size);
+
+  nnz = meta->sparse_info.nnz;
+  input = (guint8 *) in + gst_tensor_meta_info_get_header_size (meta);
+  indices = ((guint *) ((guint8 *) input + element_size * nnz));
+
+  for (i = 0; i < nnz; ++i) {
+    switch (meta->type) {
+      case _NNS_INT32:
+        ((int32_t *) output)[indices[i]] = ((int32_t *) input)[i];
+        break;
+      case _NNS_UINT32:
+        ((uint32_t *) output)[indices[i]] = ((uint32_t *) input)[i];
+        break;
+      case _NNS_INT16:
+        ((int16_t *) output)[indices[i]] = ((int16_t *) input)[i];
+        break;
+      case _NNS_UINT16:
+        ((uint16_t *) output)[indices[i]] = ((uint16_t *) input)[i];
+        break;
+      case _NNS_INT8:
+        ((int8_t *) output)[indices[i]] = ((int8_t *) input)[i];
+        break;
+      case _NNS_UINT8:
+        ((uint8_t *) output)[indices[i]] = ((uint8_t *) input)[i];
+        break;
+      case _NNS_FLOAT64:
+        ((double *) output)[indices[i]] = ((double *) input)[i];
+        break;
+      case _NNS_FLOAT32:
+        ((float *) output)[indices[i]] = ((float *) input)[i];
+        break;
+      case _NNS_INT64:
+        ((int64_t *) output)[indices[i]] = ((int64_t *) input)[i];
+        break;
+      case _NNS_UINT64:
+        ((uint64_t *) output)[indices[i]] = ((uint64_t *) input)[i];
+        break;
+      default:
+        nns_loge ("Error occured during get tensor value");
+        g_free (output);
+
+        return NULL;
+    }
+  }
+
+  return gst_memory_new_wrapped (0, output, output_size, 0,
+      output_size, output, g_free);
+}
+
+/**
+ * @brief Make sparse tensor with input dense tensor.
+ * @param[in,out] meta tensor meta structure to be updated
+ * @param[in] in pointer of input dense tensor data
+ * @return pointer of GstMemory with sparse tensor data or NULL on error. Caller should handle this newly allocated memory.
+ */
+GstMemory *
+gst_tensor_sparse_from_dense (GstTensorMetaInfo * meta, gpointer in)
+{
+  guint i, nnz = 0;
+  guint8 *output;
+  tensor_type data_type;
+  void *values;
+  guint *indices;
+  gsize output_size;
+  gsize header_size = gst_tensor_meta_info_get_header_size (meta);
+  gsize element_size = gst_tensor_get_element_size (meta->type);
+  gulong element_count = gst_tensor_get_element_count (meta->dimension);
+
+  if (element_size == 0 || element_count == 0) {
+    nns_loge ("Got invalid meta info");
+    return NULL;
+  }
+
+  /** alloc maximum possible size of memory */
+  values = g_malloc0 (element_size * element_count);
+  indices = g_malloc0 (sizeof (guint) * element_count);
+
+  data_type = meta->type;
+
+  /** Consider using macro to reduce loc and readability */
+  for (i = 0; i < element_count; ++i) {
+    switch (data_type) {
+      case _NNS_INT32:
+        if (((int32_t *) in)[i] != 0) {
+          ((int32_t *) values)[nnz] = ((int32_t *) in)[i];
+          indices[nnz] = i;
+          nnz += 1;
+        }
+        break;
+      case _NNS_UINT32:
+        if (((uint32_t *) in)[i] != 0) {
+          ((uint32_t *) values)[nnz] = ((uint32_t *) in)[i];
+          indices[nnz] = i;
+          nnz += 1;
+        }
+        break;
+      case _NNS_INT16:
+        if (((int16_t *) in)[i] != 0) {
+          ((int16_t *) values)[nnz] = ((int16_t *) in)[i];
+          indices[nnz] = i;
+          nnz += 1;
+        }
+        break;
+      case _NNS_UINT16:
+        if (((uint16_t *) in)[i] != 0) {
+          ((uint16_t *) values)[nnz] = ((uint16_t *) in)[i];
+          indices[nnz] = i;
+          nnz += 1;
+        }
+        break;
+      case _NNS_INT8:
+        if (((int8_t *) in)[i] != 0) {
+          ((int8_t *) values)[nnz] = ((int8_t *) in)[i];
+          indices[nnz] = i;
+          nnz += 1;
+        }
+        break;
+      case _NNS_UINT8:
+        if (((uint8_t *) in)[i] != 0) {
+          ((uint8_t *) values)[nnz] = ((uint8_t *) in)[i];
+          indices[nnz] = i;
+          nnz += 1;
+        }
+        break;
+      case _NNS_FLOAT64:
+        if (((double *) in)[i] != 0) {
+          ((double *) values)[nnz] = ((double *) in)[i];
+          indices[nnz] = i;
+          nnz += 1;
+        }
+        break;
+      case _NNS_FLOAT32:
+        if (((float *) in)[i] != 0) {
+          ((float *) values)[nnz] = ((float *) in)[i];
+          indices[nnz] = i;
+          nnz += 1;
+        }
+        break;
+      case _NNS_INT64:
+        if (((int64_t *) in)[i] != 0) {
+          ((int64_t *) values)[nnz] = ((int64_t *) in)[i];
+          indices[nnz] = i;
+          nnz += 1;
+        }
+        break;
+      case _NNS_UINT64:
+        if (((uint64_t *) in)[i] != 0) {
+          ((uint64_t *) values)[nnz] = ((uint64_t *) in)[i];
+          indices[nnz] = i;
+          nnz += 1;
+        }
+        break;
+      default:
+        nns_loge ("Error occured during get tensor value");
+        g_free (values);
+        g_free (indices);
+
+        return NULL;
+    }
+  }
+
+  /** update meta nnz info */
+  meta->sparse_info.nnz = nnz;
+
+  /** write to output buffer */
+  output_size = element_size * nnz + sizeof (guint) * nnz;
+
+  /** add meta info header */
+  output_size += header_size;
+  output = g_malloc0 (output_size);
+
+  gst_tensor_meta_info_update_header (meta, output);
+
+  memcpy (output + header_size, values, element_size * nnz);
+  memcpy (output + header_size + (element_size * nnz),
+      indices, sizeof (guint) * nnz);
+
+  g_free (values);
+  g_free (indices);
+
+  return gst_memory_new_wrapped (0, output, output_size, 0,
+      output_size, output, g_free);
+}

--- a/gst/nnstreamer/tensor_sparse/tensor_sparse_util.h
+++ b/gst/nnstreamer/tensor_sparse/tensor_sparse_util.h
@@ -16,26 +16,24 @@
 #define __GST_TENSOR_SPARSE_UTIL_H__
 
 #include <gst/gst.h>
-#include <tensor_common.h>
+#include <tensor_typedef.h>
 
 /**
- * @brief NYI. Make dense tensor with input sparse tensor.
+ * @brief Make dense tensor with input sparse tensor.
  * @param[in,out] meta tensor meta structure to be updated
  * @param[in] in pointer of input sparse tensor data
- * @param[out] out pointer of output dense tensor data. Assume that it's already allocated.
- * @return TRUE if no error
+ * @return pointer of GstMemory with dense tensor data or NULL on error. Caller should handle this newly allocated memory.
  */
-extern gboolean
-gst_tensor_sparse_to_dense (GstTensorMetaInfo * meta, gpointer in, gpointer out);
+extern GstMemory *
+gst_tensor_sparse_to_dense (GstTensorMetaInfo * meta, gpointer in);
 
 /**
- * @brief NYI. Make sparse tensor with input dense tensor.
+ * @brief Make sparse tensor with input dense tensor.
  * @param[in,out] meta tensor meta structure to be updated
  * @param[in] in pointer of input dense tensor data
- * @param[out] out pointer of output sparse tensor data. Assume that it's already allocated.
- * @param TRUE if no error
+ * @return pointer of GstMemory with sparse tensor data or NULL on error. Caller should handle this newly allocated memory.
  */
-extern gboolean
-gst_tensor_sparse_from_dense (GstTensorMetaInfo * meta, gpointer in, gpointer out);
+extern GstMemory *
+gst_tensor_sparse_from_dense (GstTensorMetaInfo * meta, gpointer in);
 
 #endif /* __GST_TENSOR_SPARSE_UTIL_H__ */

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -60,6 +60,9 @@ NNSTREAMER_PLUGINS_SRCS := \
     $(NNSTREAMER_GST_HOME)/tensor_repo/tensor_reposink.c \
     $(NNSTREAMER_GST_HOME)/tensor_repo/tensor_reposrc.c \
     $(NNSTREAMER_GST_HOME)/tensor_sink/tensor_sink.c \
+    $(NNSTREAMER_GST_HOME)/tensor_sparse/tensor_sparse_util.c \
+    $(NNSTREAMER_GST_HOME)/tensor_sparse/tensor_sparse_enc.c \
+    $(NNSTREAMER_GST_HOME)/tensor_sparse/tensor_sparse_dec.c \
     $(NNSTREAMER_GST_HOME)/tensor_split/gsttensorsplit.c \
     $(NNSTREAMER_GST_HOME)/tensor_transform/tensor_transform.c \
     $(NNSTREAMER_GST_HOME)/tensor_if/gsttensorif.c \

--- a/tests/nnstreamer_sparse/runTest.sh
+++ b/tests/nnstreamer_sparse/runTest.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
+## @file runTest.sh
+## @author Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+## @date 27 Jul 2021
+## @brief SSAT Test Cases for NNStreamer tensor_sparse_enc and tensor_sparse_dec
+##
+
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
+"
+fi
+
+# This is compatible with SSAT (https://github.com/myungjoo/SSAT)
+testInit $1
+
+PATH_TO_PLUGIN="../../build"
+# Check lua libraries are built. This test utilizes it for making "sparse" dense tensors.
+if [[ -d $PATH_TO_PLUGIN ]]; then
+    ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
+    if [[ -d ${ini_path} ]]; then
+        check=$(ls ${ini_path} | grep lua.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find lua shared lib"
+            report
+            exit
+        fi
+    else
+        echo "Cannot find ${ini_path}"
+        report exit
+    fi
+else
+    echo "No build directory"
+    report
+    exit
+fi
+
+# Make sample dense tensor (two random positions are non-zero values)
+MAKE_SAMPLE_TENSORS_SCRIPT="
+inputTensorsInfo = { num = 1, dim = {{3, 10, 10, 1},}, type = {'uint8',} }
+outputTensorsInfo = { num = 1, dim = {{1, 3, 4, 1},}, type = {'uint8',} }
+
+
+function nnstreamer_invoke()
+  math.randomseed(os.time())
+  oC = outputTensorsInfo['dim'][1][1]
+  oW = outputTensorsInfo['dim'][1][2]
+  oH = outputTensorsInfo['dim'][1][3]
+  oN = outputTensorsInfo['dim'][1][4]
+
+  output = output_tensor(1)
+
+  ww = math.random(oW)
+  hh = math.random(oH)
+  outIndex = 0
+  outIndex = outIndex + (hh - 1)*oW*oC
+  outIndex = outIndex + (ww - 1)*oC
+  outIndex = outIndex + 1
+  output[outIndex] = math.random(127)
+
+  ww = math.random(oW)
+  hh = math.random(oH)
+  outIndex = 0
+  outIndex = outIndex + (hh - 1)*oW*oC
+  outIndex = outIndex + (ww - 1)*oC
+  outIndex = outIndex + 1
+  output[outIndex] = math.random(127)
+
+end
+"
+
+# Make sample dense tensors (2 tensors, two random positions of each tensor are non-zero values)
+MAKE_SAMPLE_2TENSORS_SCRIPT="
+inputTensorsInfo = { num = 1, dim = {{3, 10, 10, 1},}, type = {'uint8',} }
+outputTensorsInfo = { num = 2, dim = {{1, 3, 4, 1}, {1, 5, 5, 1}}, type = {'uint8', 'float32'} }
+
+
+function nnstreamer_invoke()
+  oC = outputTensorsInfo['dim'][1][1]
+  oW = outputTensorsInfo['dim'][1][2]
+  oH = outputTensorsInfo['dim'][1][3]
+  oN = outputTensorsInfo['dim'][1][4]
+  output = output_tensor(1)
+
+  ww = math.random(oW)
+  hh = math.random(oH)
+  outIndex = 0
+  outIndex = outIndex + (hh - 1)*oW*oC
+  outIndex = outIndex + (ww - 1)*oC
+  outIndex = outIndex + 1
+  output[outIndex] = math.random(127)
+
+  ww = math.random(oW)
+  hh = math.random(oH)
+  outIndex = 0
+  outIndex = outIndex + (hh - 1)*oW*oC
+  outIndex = outIndex + (ww - 1)*oC
+  outIndex = outIndex + 1
+  output[outIndex] = math.random(127)
+
+  oC = outputTensorsInfo['dim'][2][1]
+  oW = outputTensorsInfo['dim'][2][2]
+  oH = outputTensorsInfo['dim'][2][3]
+  oN = outputTensorsInfo['dim'][2][4]
+  output = output_tensor(2)
+
+  ww = math.random(oW)
+  hh = math.random(oH)
+  outIndex = 0
+  outIndex = outIndex + (hh - 1)*oW*oC
+  outIndex = outIndex + (ww - 1)*oC
+  outIndex = outIndex + 1
+  output[outIndex] = math.random(127)
+
+  ww = math.random(oW)
+  hh = math.random(oH)
+  outIndex = 0
+  outIndex = outIndex + (hh - 1)*oW*oC
+  outIndex = outIndex + (ww - 1)*oC
+  outIndex = outIndex + 1
+  output[outIndex] = math.random(127)
+
+end
+"
+
+# Test encoding and decoding
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+videotestsrc num-buffers=1 ! \
+    video/x-raw,format=RGB,width=10,height=10,framerate=0/1 ! videoconvert ! \
+    tensor_converter ! tensor_filter framework=lua \
+    model=\"${MAKE_SAMPLE_TENSORS_SCRIPT}\" ! tee name=t \
+        t. ! queue ! filesink location=sample1.dense sync=true \
+        t. ! queue ! tensor_sparse_enc ! \
+            other/tensors,format=sparse,framerate=0/1 ! \
+            tensor_sparse_dec ! \
+            filesink location=dec1.result sync=true
+" 1 0 0 $PERFORMANCE
+callCompareTest sample1.dense dec1.result 1-1 "Compare 1" 0 0
+
+# Should set types and framerate in capsfilter
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+    filesrc location=sample1.dense ! \
+    other/tensors,num_tensors=1,dimensions=1:3:4:1 ! \
+    tensor_sparse_enc ! \
+    tensor_sink" 1_n 0 1 $PERFORMANCE
+
+# Test encoding and decoding with `num_tensors=2`
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+videotestsrc num-buffers=1 ! \
+    video/x-raw,format=RGB,width=10,height=10,framerate=0/1 ! videoconvert ! \
+    tensor_converter ! tensor_filter framework=lua \
+    model=\"${MAKE_SAMPLE_2TENSORS_SCRIPT}\" ! tee name=t \
+    t. ! queue ! filesink location=sample2.dense sync=true \
+    t. ! queue ! tensor_sparse_enc ! \
+    other/tensors,format=sparse,framerate=0/1 ! \
+    tensor_sparse_dec ! \
+    filesink location=dec2.result sync=true
+" 2 0 0 $PERFORMANCE
+callCompareTest sample2.dense dec2.result 2-1 "Compare 2" 0 0
+
+# Test with tensor_converter
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+filesrc location=sample1.dense ! \
+    application/octet-stream ! \
+    tensor_converter input-dim=1:3:4:1 input-type=uint8 ! \
+    tensor_sparse_enc ! tensor_sink" 3 0 0 $PERFORMANCE
+
+# Sparse tensor filesrc/sink test (for `num_tensors=1`)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+videotestsrc num-buffers=1 ! \
+    video/x-raw,format=RGB,width=10,height=10,framerate=0/1 ! videoconvert ! \
+    tensor_converter ! tensor_filter framework=lua \
+    model=\"${MAKE_SAMPLE_TENSORS_SCRIPT}\" ! tensor_sparse_enc ! filesink location=./sample1.sparse" 4 0 0 $PERFORMANCE
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+filesrc location=sample1.sparse ! \
+    other/tensors,format=sparse,framerate=0/1 ! \
+    tensor_sparse_dec ! \
+    other/tensors,num_tensors=1,framerate=0/1,dimensions=1:3:4:1,types=uint8 ! \
+    tensor_sparse_enc ! \
+    filesink location=enc1.result sync=true" 5 0 0 $PERFORMANCE
+callCompareTest sample1.sparse enc1.result 5-1 "Compare 5" 0 0
+
+DEC_RESULT_TEST_SCRIPT="
+inputTensorsInfo = {
+    num = 1,
+    dim = {{1, 3, 4, 1},},
+    type = {'uint8',}
+}
+
+outputTensorsInfo = {
+    num = 1,
+    dim = {{1, 3, 4, 1},},
+    type = {'uint8',}
+}
+
+function nnstreamer_invoke()
+    input = input_tensor(1)
+    output = output_tensor(1)
+    for i=1,1*4*3*1 do
+        output[i] = input[i] --[[ copy input into output --]]
+    end
+end
+"
+
+# Test with tensor_transform and tensor_filter
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+filesrc location=sample1.sparse ! \
+    other/tensors,format=sparse,framerate=0/1 ! \
+    tensor_sparse_dec ! \
+    tensor_transform mode=arithmetic option=add:1,div:1 ! \
+    tensor_filter framework=lua model=\"${DEC_RESULT_TEST_SCRIPT}\" ! \
+    tensor_sink" 6 0 0 $PERFORMANCE
+
+rm *.dense *.result *.sparse
+
+report


### PR DESCRIPTION
- tensor_sparse_enc: encoding static tensors into sparse tensors
- tensor_sparse_dec: decoding sparse tensors into stsatic tensors
- Add SSAT test for sparse tensors


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

