### PR TITLE
TFLite: Allow to skip flatbuf dep check

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -131,7 +131,7 @@ if tflite_support_is_available
   )
   message('TensorFlow-lite version: ' + tflite_ver)
 
-  if not flatbuf_support_is_available
+  if not get_option('skip-tflite-flatbuf-check') and not flatbuf_support_is_available
     flatbuf_dep = dependency('flatbuffers', required : true, \
         not_found_message : 'flatbuf devel package should be install to build the tensorflow lite subplugin.')
   endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -43,6 +43,7 @@ option('enable-vivante', type: 'boolean', value: false)
 option('framework-priority-tflite', type: 'string', value: 'tensorflow-lite,nnfw,armnn,edgetpu', description: 'A comma separated prioritized list of neural network frameworks to open a .tflite file')
 option('framework-priority-nb', type: 'string', value: '', description: 'A comma separated prioritized list of neural network frameworks to open a .nb file')
 option('framework-priority-bin', type: 'string', value: '', description: 'A comma separated prioritized list of neural network frameworks to open a .bin file')
+option('skip-tflite-flatbuf-check', type: 'boolean', value: false, description: 'Do not check the availability of flatbuf for tensorflow-lite build. In some systems, flatbuffers\' dependency cannot be found with meson.')
 
 # Utilities
 option('enable-nnstreamer-check', type: 'boolean', value: true)


### PR DESCRIPTION
In Yocto build, it appears that flatbuf dep check
is not available:
https://github.com/nnstreamer/meta-neural-network/blob/master/recipes-nnstreamer/nnstreamer/files/0001-Disable-flatbuf-check-for-tf-lite-for-yocto-build.patch

@anyj0527 : Let's remove all *.patch files from
meta-neural-network by updating related nnstreamer/*.git
*.patch files in meta-neural-network are obvious
hazards.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
