### PR TITLE
[Filter] Rename srnpu to trixengine

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -1215,7 +1215,7 @@ gst_tensor_filter_detect_framework (const gchar * const *model_files,
     else if (g_str_equal (ext[0], ".bin") || g_str_equal (ext[0], ".xml"))
       detected_fw = g_strdup ("openvino");
     else if (g_str_equal (ext[0], ".tvn"))
-      detected_fw = g_strdup ("srnpu");
+      detected_fw = g_strdup ("trix-engine");
   } else if (num_models == 2) {
     if (g_str_equal (ext[0], ".pb") && g_str_equal (ext[1], ".pb") &&
         !g_str_equal (model_files[0], model_files[1]))


### PR DESCRIPTION
The patch update the name 'srnpu' to 'trixengine'.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
