### PR TITLE
[Filter/Sub] Add alias option for backward compatibility.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -118,6 +118,9 @@ nnstreamer_conf.set('FRAMEWORK_PRIORITY_TFLITE', get_option('framework-priority-
 nnstreamer_conf.set('FRAMEWORK_PRIORITY_NB', get_option('framework-priority-nb'))
 nnstreamer_conf.set('FRAMEWORK_PRIORITY_BIN', get_option('framework-priority-bin'))
 
+# Set the alias for backward compatibility
+nnstreamer_conf.set('TRIX_ENGINE_ALIAS', get_option('trix-engine-alias'))
+
 # Define default conf file
 add_project_arguments('-DNNSTREAMER_CONF_FILE="' + join_paths(nnstreamer_inidir, 'nnstreamer.ini') + '"', language: 'c')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -44,6 +44,7 @@ option('framework-priority-tflite', type: 'string', value: 'tensorflow-lite,nnfw
 option('framework-priority-nb', type: 'string', value: '', description: 'A comma separated prioritized list of neural network frameworks to open a .nb file')
 option('framework-priority-bin', type: 'string', value: '', description: 'A comma separated prioritized list of neural network frameworks to open a .bin file')
 option('skip-tflite-flatbuf-check', type: 'boolean', value: false, description: 'Do not check the availability of flatbuf for tensorflow-lite build. In some systems, flatbuffers\' dependency cannot be found with meson.')
+option('trix-engine-alias', type: 'string', value: 'srnpu', description: 'The alias name list of trix-engine sub-plugin. This option provides backward compatibility of the previous framework name.')
 
 # Utilities
 option('enable-nnstreamer-check', type: 'boolean', value: true)

--- a/nnstreamer.ini.in
+++ b/nnstreamer.ini.in
@@ -27,4 +27,7 @@ enable_use_gpu=@TORCH_USE_GPU@
 [tensorflow-lite]
 subplugin_priority=@TFLITE_SUBPLUGIN_PRIORITY@
 
+[filter-aliases]
+trix-engine = @TRIX_ENGINE_ALIAS@
+
 @ELEMENT_RESTRICTION_CONFIG@


### PR DESCRIPTION
This patch newly adds the `filter-aliases` section for searching the sub-plugin. If the alias name is provided from ini file, then it could be used as sub-plugin.

* Searching sequence: exact match -> priority option ->  `filter-aliases` section

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

### Submit v2
* Add `filter-aliases` section in ini file
* Add default `trix-engine` value for backward compatibility of SRNPU.

#### ini file
```
[filter-aliases]
trix-engine = srnpu
```





