### PR TITLE
[Query] Update server elements

### DIFF
--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -36,7 +36,8 @@ nnst_common_sources = [
   'tensor_common.c',
   'tensor_common_pipeline.c',
   'tensor_data.c',
-  'tensor_allocator.c'
+  'tensor_allocator.c',
+  'tensor_meta.c'
 ]
 
 foreach s : nnst_common_sources

--- a/gst/nnstreamer/tensor_meta.c
+++ b/gst/nnstreamer/tensor_meta.c
@@ -1,0 +1,101 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Junhwan Kim <jejudo.kim@samsung.com>
+ * 
+ * @file    tensor_meta.c
+ * @date    09 Aug 2021
+ * @brief   Internal tensor meta implementation for nnstreamer
+ * @author  Junhwan Kim <jejudo.kim@samsung.com>
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @bug     No known bugs
+ * 
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "tensor_meta.h"
+
+
+/**
+ * @brief Define meta_query type to register
+ */
+GType
+gst_meta_query_api_get_type (void)
+{
+  static GType type = 0;
+  static const gchar *tags[] = {
+    NULL
+  };
+
+  if (g_once_init_enter (&type)) {
+    GType _type;
+    const GstMetaInfo *meta_info = gst_meta_get_info ("GstMetaQuery");
+    if (meta_info) {
+      _type = meta_info->api;
+    } else {
+      _type = gst_meta_api_type_register ("GstMetaQueryAPI", tags);
+    }
+    g_once_init_leave (&type, _type);
+  }
+  return type;
+}
+
+/**
+ * @brief meta_query init
+ */
+static gboolean
+gst_meta_query_init (GstMeta * meta, gpointer params, GstBuffer * buffer)
+{
+  GstMetaQuery *emeta = (GstMetaQuery *) meta;
+  UNUSED (params);
+  UNUSED (buffer);
+  emeta->host = NULL;
+  return TRUE;
+}
+
+/**
+ * @brief free meta_query
+ */
+static void
+gst_meta_query_free (GstMeta * meta, GstBuffer * buffer)
+{
+  GstMetaQuery *emeta = (GstMetaQuery *) meta;
+  UNUSED (buffer);
+  g_free (emeta->host);
+}
+
+/**
+ * @brief tensor_query meta data transform (source to dest)
+ */
+static gboolean
+gst_meta_query_transform (GstBuffer * transbuf, GstMeta * meta,
+    GstBuffer * buffer, GQuark type, gpointer data)
+{
+  GstMetaQuery *dest_meta = gst_buffer_add_meta_query (transbuf);
+  GstMetaQuery *src_meta = (GstMetaQuery *) meta;
+  UNUSED (buffer);
+  UNUSED (type);
+  UNUSED (data);
+  dest_meta->host = g_strdup (src_meta->host);
+  return TRUE;
+}
+
+/**
+ * @brief Get meta_query info
+ */
+const GstMetaInfo *
+gst_meta_query_get_info (void)
+{
+  static const GstMetaInfo *meta_query_info = NULL;
+
+  if (g_once_init_enter (&meta_query_info)) {
+    const GstMetaInfo *meta = gst_meta_register (GST_META_QUERY_API_TYPE,
+        "GstMetaQuery", sizeof *meta,
+        gst_meta_query_init,
+        gst_meta_query_free,
+        gst_meta_query_transform);
+    g_once_init_leave (&meta_query_info, meta);
+  }
+  return meta_query_info;
+}

--- a/gst/nnstreamer/tensor_meta.h
+++ b/gst/nnstreamer/tensor_meta.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Samsung Electronics Co., Ltd.
+ * 
+ * @file    tensor_meta.h
+ * @date    09 Aug 2021
+ * @brief   Internal tensor meta header for nnstreamer
+ * @author  Junhwan Kim <jejudo.kim@samsung.com>
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @bug     No known bugs
+ * 
+ */
+#ifndef __GST_TENSOR_META_H__
+#define __GST_TENSOR_META_H__
+
+#include <gst/gst.h>
+#include <tensor_typedef.h>
+#include <nnstreamer_util.h>
+
+G_BEGIN_DECLS
+
+/**
+ * @brief GstMetaQuery meta structure
+ */
+typedef struct
+{
+  GstMeta meta;
+
+  gchar *host;
+} GstMetaQuery;
+
+/**
+ * @brief Define meta_query type to register
+ */
+GType gst_meta_query_api_get_type (void);
+#define GST_META_QUERY_API_TYPE (gst_meta_query_api_get_type())
+
+/**
+ * @brief Get meta_query info
+ */
+const GstMetaInfo * gst_meta_query_get_info (void);
+#define GST_META_QUERY_INFO (gst_meta_query_get_info())
+#define gst_buffer_get_meta_query(b) \
+    ((GstMetaQuery *) gst_buffer_get_meta ((b), GST_META_QUERY_API_TYPE))
+#define gst_buffer_add_meta_query(b) \
+    ((GstMetaQuery *) gst_buffer_add_meta ((b), GST_META_QUERY_INFO, NULL))
+
+G_END_DECLS
+
+#endif /* __GST_TENSOR_META_H__ */

--- a/gst/nnstreamer/tensor_query/meson.build
+++ b/gst/nnstreamer/tensor_query/meson.build
@@ -3,6 +3,7 @@ tensor_query_sources = [
   'tensor_query_serversrc.c',
   'tensor_query_serversink.c',
   'tensor_query_client.c',
+  'tensor_query_server.c',
 ]
 
 foreach s : tensor_query_sources

--- a/gst/nnstreamer/tensor_query/tensor_query_common.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.h
@@ -91,6 +91,18 @@ extern query_connection_handle
 nnstreamer_query_connect (TensorQueryProtocol protocol, const char *ip, uint32_t port, uint32_t timeout_ms);
 
 /**
+ * @brief get host from query connection handle
+ */
+char *
+nnstreamer_query_connection_get_host (query_connection_handle connection);
+
+/**
+ * @brief get port from query connection handle
+ */
+uint32_t
+nnstreamer_query_connection_get_port (query_connection_handle connection);
+
+/**
  * @brief send command to connected device.
  * @return 0 if OK, negative value if error
  */
@@ -113,33 +125,32 @@ nnstreamer_query_close (query_connection_handle connection);
 
 /* server */
 /**
- * @brief accept client connection
- * @param server_data TensorQueryServerData
- * @return void* casted type of TensorQueryConnection*
+ * @brief accept connection from remote
+ * @return query_connection_handle including connection data
  */
 extern query_connection_handle
 nnstreamer_query_server_accept (query_server_handle server_data);
 
 /**
- * @brief return initialized server_data
- * @param src_info tensors info shared with serversrc element
+ * @brief return initialized server handle
+ * @return query_server_handle, NULL if error
  */
 extern query_server_handle
 nnstreamer_query_server_data_new (void);
 
 /**
- * @brief free server_data
+ * @brief free server handle
  */
 extern void
 nnstreamer_query_server_data_free (query_server_handle server_data);
 
 /**
- * @brief set server_data params and setup server
+ * @brief set server handle params and setup server
  * @return 0 if OK, negative value if error 
  */
 extern int
-nnstreamer_query_server_data_setup (query_server_handle server_data, TensorQueryProtocol protocol, const char * host, uint32_t port);
-
+nnstreamer_query_server_init (query_server_handle server_data,
+    TensorQueryProtocol protocol, const char *host, uint32_t port);
 
 #ifdef __cplusplus
 }

--- a/gst/nnstreamer/tensor_query/tensor_query_server.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.c
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Samsung Electronics Co., Ltd.
+ *
+ * @file    tensor_query_server.c
+ * @date    03 Aug 2021
+ * @brief   GStreamer plugin to handle meta_query for server elements
+ * @author  Junhwan Kim <jejudo.kim@samsung.com>
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @bug     No known bugs
+ *
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "tensor_query_server.h"
+#include <nnstreamer_util.h>
+#include <tensor_typedef.h>
+#include <tensor_common.h>
+
+/**
+ * @brief sink config is shared for src
+ */
+static GstTensorsConfig sink_config;
+
+/**
+ * @brief set sink config 
+ */
+void
+gst_tensor_query_server_set_sink_config (GstTensorsConfig * config)
+{
+  gst_tensors_config_copy (&sink_config, config);
+}
+
+/**
+ * @brief get sink config
+ */
+void
+gst_tensor_query_server_get_sink_config (GstTensorsConfig * config)
+{
+  gst_tensors_config_copy (config, &sink_config);
+}

--- a/gst/nnstreamer/tensor_query/tensor_query_server.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2021 Samsung Electronics Co., Ltd.
+ *
+ * @file    tensor_query_server.h
+ * @date    03 Aug 2021
+ * @brief   GStreamer plugin to handle meta_query for server elements
+ * @author  Junhwan Kim <jejudo.kim@samsung.com>
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @bug     No known bugs
+ *
+ */
+#ifndef __GST_TENSOR_QUERY_SERVER_H__
+#define __GST_TENSOR_QUERY_SERVER_H__
+
+#include <gst/gst.h>
+#include <tensor_common.h>
+
+G_BEGIN_DECLS
+
+/**
+ * @brief set sink config 
+ */
+void gst_tensor_query_server_set_sink_config (GstTensorsConfig *config);
+
+/**
+ * @brief get sink config
+ */
+void gst_tensor_query_server_get_sink_config (GstTensorsConfig *config);
+
+G_END_DECLS
+
+#endif /* __GST_TENSOR_QUERY_CLIENT_H__ */

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.c
@@ -19,13 +19,28 @@
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_query_serversink_debug);
 #define GST_CAT_DEFAULT gst_tensor_query_serversink_debug
 
+#define DEFAULT_HOST "127.0.0.1"
+#define DEFAULT_PORT_SINK 3000
+#define DEFAULT_PROTOCOL _TENSOR_QUERY_PROTOCOL_TCP
+#define DEFAULT_TIMEOUT 10
+
+#define CAPS_STRING GST_TENSORS_CAP_DEFAULT
 /**
- * @brief the capabilities of the inputs and outputs.
+ * @brief the capabilities of the inputs.
  */
-static GstStaticPadTemplate srctemplate = GST_STATIC_PAD_TEMPLATE ("src",
-    GST_PAD_SRC,
+static GstStaticPadTemplate sinktemplate = GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS (GST_TENSORS_FLEX_CAP_DEFAULT));
+    GST_STATIC_CAPS (CAPS_STRING));
+
+enum
+{
+  PROP_0,
+  PROP_HOST,
+  PROP_PORT,
+  PROP_PROTOCOL,
+  PROP_TIMEOUT
+};
 
 #define gst_tensor_query_serversink_parent_class parent_class
 G_DEFINE_TYPE (GstTensorQueryServerSink, gst_tensor_query_serversink,
@@ -36,6 +51,11 @@ static void gst_tensor_query_serversink_set_property (GObject * object,
 static void gst_tensor_query_serversink_get_property (GObject * object,
     guint prop_id, GValue * value, GParamSpec * pspec);
 static void gst_tensor_query_serversink_finalize (GObject * object);
+
+static gboolean gst_tensor_query_serversink_start (GstBaseSink * bsink);
+static gboolean gst_tensor_query_serversink_stop (GstBaseSink * bsink);
+static GstFlowReturn gst_tensor_query_serversink_render (GstBaseSink * bsink,
+    GstBuffer * buf);
 
 /**
  * @brief initialize the class
@@ -55,33 +75,52 @@ gst_tensor_query_serversink_class_init (GstTensorQueryServerSinkClass * klass)
   gobject_class->get_property = gst_tensor_query_serversink_get_property;
   gobject_class->finalize = gst_tensor_query_serversink_finalize;
 
-  /** install property goes here */
+  g_object_class_install_property (gobject_class, PROP_HOST,
+      g_param_spec_string ("host", "Host", "The hostname to listen as",
+          DEFAULT_HOST, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_PORT,
+      g_param_spec_uint ("port", "Port",
+          "The port to listen to (0=random available port)", 0,
+          65535, DEFAULT_PORT_SINK,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_PROTOCOL,
+      g_param_spec_int ("protocol", "Protocol",
+          "The network protocol to establish connection", 0,
+          _TENSOR_QUERY_PROTOCOL_END, DEFAULT_PROTOCOL,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_TIMEOUT,
+      g_param_spec_uint ("timeout", "Timeout",
+          "The timeout as seconds to maintain connection", 0,
+          3600, DEFAULT_TIMEOUT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   gst_element_class_add_pad_template (gstelement_class,
-      gst_static_pad_template_get (&srctemplate));
+      gst_static_pad_template_get (&sinktemplate));
 
   gst_element_class_set_static_metadata (gstelement_class,
       "TensorQueryServerSink", "Sink/Tensor/Query",
       "Send tensor data as a server over the network",
       "Samsung Electronics Co., Ltd.");
 
-  /** method override goes here */
+  gstbasesink_class->start = gst_tensor_query_serversink_start;
+  gstbasesink_class->stop = gst_tensor_query_serversink_stop;
+  gstbasesink_class->render = gst_tensor_query_serversink_render;
 
   GST_DEBUG_CATEGORY_INIT (gst_tensor_query_serversink_debug,
       "tensor_query_serversink", 0, "Tensor Query Server Sink");
 }
 
-/** @todo Remove when the dummy functions are implemented. */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-
 /**
  * @brief initialize the new element
  */
 static void
-gst_tensor_query_serversink_init (GstTensorQueryServerSink * self)
+gst_tensor_query_serversink_init (GstTensorQueryServerSink * sink)
 {
-  return;
+  sink->host = g_strdup (DEFAULT_HOST);
+  sink->port = DEFAULT_PORT_SINK;
+  sink->protocol = DEFAULT_PROTOCOL;
+  sink->timeout = DEFAULT_TIMEOUT;
+  sink->server_data = nnstreamer_query_server_data_new ();
+  sink->conn_queue = g_async_queue_new ();
 }
 
 /**
@@ -90,6 +129,10 @@ gst_tensor_query_serversink_init (GstTensorQueryServerSink * self)
 static void
 gst_tensor_query_serversink_finalize (GObject * object)
 {
+  GstTensorQueryServerSink *sink = GST_TENSOR_QUERY_SERVERSINK (object);
+  g_free (sink->host);
+  nnstreamer_query_server_data_free (sink->server_data);
+  g_async_queue_unref (sink->conn_queue);
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 
@@ -100,7 +143,30 @@ static void
 gst_tensor_query_serversink_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
-  return;
+  GstTensorQueryServerSink *serversink = GST_TENSOR_QUERY_SERVERSINK (object);
+
+  switch (prop_id) {
+    case PROP_HOST:
+      if (!g_value_get_string (value)) {
+        nns_logw ("host property cannot be NULL");
+        break;
+      }
+      g_free (serversink->host);
+      serversink->host = g_value_dup_string (value);
+      break;
+    case PROP_PORT:
+      serversink->port = g_value_get_uint (value);
+      break;
+    case PROP_PROTOCOL:
+      serversink->protocol = g_value_get_int (value);
+      break;
+    case PROP_TIMEOUT:
+      serversink->timeout = g_value_get_uint (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
 }
 
 /**
@@ -110,7 +176,133 @@ static void
 gst_tensor_query_serversink_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec)
 {
-  return;
+  GstTensorQueryServerSink *serversink = GST_TENSOR_QUERY_SERVERSINK (object);
+
+  switch (prop_id) {
+    case PROP_HOST:
+      g_value_set_string (value, serversink->host);
+      break;
+    case PROP_PORT:
+      g_value_set_uint (value, serversink->port);
+      break;
+    case PROP_PROTOCOL:
+      g_value_set_int (value, serversink->protocol);
+      break;
+    case PROP_TIMEOUT:
+      g_value_set_uint (value, serversink->timeout);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
 }
 
-#pragma GCC diagnostic pop
+/**
+ * @brief start rocessing of query_serversrc
+ */
+static gboolean
+gst_tensor_query_serversink_start (GstBaseSink * bsink)
+{
+  GstTensorQueryServerSink *sink = GST_TENSOR_QUERY_SERVERSINK (bsink);
+  GstTensorsConfig config;
+
+  gst_tensors_config_from_peer (bsink->sinkpad, &config, NULL);
+  config.rate_n = 0;
+  config.rate_d = 1;
+  if (!gst_tensors_config_validate (&config)) {
+    nns_loge ("Invalid tensors config from peer");
+    return FALSE;
+  }
+  gst_tensor_query_server_set_sink_config (&config);
+  gst_tensors_config_free (&config);
+
+  if (!sink->server_data) {
+    nns_loge ("Server_data is NULL");
+    return FALSE;
+  }
+
+  if (nnstreamer_query_server_init (sink->server_data, sink->protocol,
+          sink->host, sink->port) != 0) {
+    nns_loge ("Failed to setup server");
+    return FALSE;
+  }
+  return TRUE;
+}
+
+/**
+ * @brief stop processing of query_serversrc
+ */
+static gboolean
+gst_tensor_query_serversink_stop (GstBaseSink * bsink)
+{
+  GstTensorQueryServerSink *sink = GST_TENSOR_QUERY_SERVERSINK (bsink);
+  nnstreamer_query_server_data_free (sink->server_data);
+  return TRUE;
+}
+
+/**
+ * @brief render buffer, send buffer to client 
+ */
+static GstFlowReturn
+gst_tensor_query_serversink_render (GstBaseSink * bsink, GstBuffer * buf)
+{
+  GstTensorQueryServerSink *sink = GST_TENSOR_QUERY_SERVERSINK (bsink);
+  GstMetaQuery *meta_query;
+  TensorQueryCommandData cmd_data;
+  query_connection_handle conn;
+  GstMemory *mem;
+  GstMapInfo map;
+  gchar *host;
+  guint32 i, num_mems;
+
+  meta_query = gst_buffer_get_meta_query (buf);
+  while (TRUE) {
+    conn = nnstreamer_query_server_accept (sink->server_data);
+    host = nnstreamer_query_connection_get_host (conn);
+    if (g_str_equal (host, meta_query->host)) {
+      /* handle buffer */
+      memset (&cmd_data, 0, sizeof (cmd_data));
+      cmd_data.cmd = _TENSOR_QUERY_CMD_TRANSFER_START;
+      num_mems = gst_buffer_n_memory (buf);
+      cmd_data.data_info.num_mems = num_mems;
+      for (i = 0; i < num_mems; i++) {
+        mem = gst_buffer_peek_memory (buf, i);
+        cmd_data.data_info.mem_sizes[i] = mem->size;
+      }
+      if (nnstreamer_query_send (conn, &cmd_data, sink->timeout) != 0) {
+        nns_logi ("Failed to send start command");
+        return GST_FLOW_EOS;
+      }
+
+      for (i = 0; i < num_mems; i++) {
+        mem = gst_buffer_peek_memory (buf, i);
+        if (!gst_memory_map (mem, &map, GST_MAP_READ)) {
+          nns_loge ("Failed to map memory");
+          gst_memory_unref (mem);
+          gst_buffer_unref (buf);
+          return GST_FLOW_ERROR;
+        }
+        cmd_data.cmd = _TENSOR_QUERY_CMD_TRANSFER_DATA;
+        cmd_data.data.size = map.size;
+        cmd_data.data.data = map.data;
+        if (nnstreamer_query_send (conn, &cmd_data, sink->timeout) != 0) {
+          nns_logi ("Failed to send data");
+          return GST_FLOW_EOS;
+        }
+        gst_memory_unmap (mem, &map);
+      }
+
+      cmd_data.cmd = _TENSOR_QUERY_CMD_TRANSFER_END;
+      if (nnstreamer_query_send (conn, &cmd_data, sink->timeout) != 0) {
+        nns_logi ("Failed to send data");
+        return GST_FLOW_EOS;
+      }
+      g_async_queue_push (sink->conn_queue, conn);
+      return GST_FLOW_OK;
+    } else {
+      g_async_queue_push (sink->conn_queue, conn);
+    }
+  }
+
+  return GST_FLOW_ERROR;
+}

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.h
@@ -16,6 +16,9 @@
 #include <gst/gst.h>
 #include <gst/base/gstbasesink.h>
 #include <tensor_common.h>
+#include <tensor_meta.h>
+#include "tensor_query_common.h"
+#include "tensor_query_server.h"
 
 G_BEGIN_DECLS
 
@@ -40,6 +43,12 @@ typedef struct _GstTensorQueryServerSinkClass GstTensorQueryServerSinkClass;
 struct _GstTensorQueryServerSink
 {
   GstBaseSink element; /**< parent object */
+  guint32 port;
+  gchar *host;
+  TensorQueryProtocol protocol;
+  guint timeout;
+  GAsyncQueue *conn_queue;
+  query_server_handle server_data;
 };
 
 /**

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
@@ -14,18 +14,41 @@
 #include <config.h>
 #endif
 
+#include <tensor_typedef.h>
+#include <tensor_common.h>
+#include "tensor_query_common.h"
 #include "tensor_query_serversrc.h"
+#include "tensor_query_server.h"
 
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_query_serversrc_debug);
 #define GST_CAT_DEFAULT gst_tensor_query_serversrc_debug
 
+#define DEFAULT_HOST "127.0.0.1"
+#define DEFAULT_PORT_SRC 3001
+#define DEFAULT_PROTOCOL _TENSOR_QUERY_PROTOCOL_TCP
+#define DEFAULT_TIMEOUT 10
+
+#define CAPS_STRING GST_TENSORS_CAP_DEFAULT
+
 /**
- * @brief the capabilities of the inputs and outputs.
+ * @brief the capabilities of the outputs
  */
-static GstStaticPadTemplate sinktemplate = GST_STATIC_PAD_TEMPLATE ("sink",
-    GST_PAD_SINK,
+static GstStaticPadTemplate srctemplate = GST_STATIC_PAD_TEMPLATE ("src",
+    GST_PAD_SRC,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS (GST_TENSORS_FLEX_CAP_DEFAULT));
+    GST_STATIC_CAPS (CAPS_STRING));
+
+/**
+ * @brief query_serversrc properties
+ */
+enum
+{
+  PROP_0,
+  PROP_HOST,
+  PROP_PORT,
+  PROP_PROTOCOL,
+  PROP_TIMEOUT
+};
 
 #define gst_tensor_query_serversrc_parent_class parent_class
 G_DEFINE_TYPE (GstTensorQueryServerSrc, gst_tensor_query_serversrc,
@@ -37,8 +60,13 @@ static void gst_tensor_query_serversrc_get_property (GObject * object,
     guint prop_id, GValue * value, GParamSpec * pspec);
 static void gst_tensor_query_serversrc_finalize (GObject * object);
 
+static gboolean gst_tensor_query_serversrc_start (GstBaseSrc * bsrc);
+static gboolean gst_tensor_query_serversrc_stop (GstBaseSrc * bsrc);
+static GstFlowReturn gst_tensor_query_serversrc_create (GstPushSrc * psrc,
+    GstBuffer ** buf);
+
 /**
- * @brief initialize the class
+ * @brief initialize the query_serversrc class
  */
 static void
 gst_tensor_query_serversrc_class_init (GstTensorQueryServerSrcClass * klass)
@@ -57,62 +85,264 @@ gst_tensor_query_serversrc_class_init (GstTensorQueryServerSrcClass * klass)
   gobject_class->get_property = gst_tensor_query_serversrc_get_property;
   gobject_class->finalize = gst_tensor_query_serversrc_finalize;
 
-  /** install property goes here */
+  g_object_class_install_property (gobject_class, PROP_HOST,
+      g_param_spec_string ("host", "Host", "The hostname to listen as",
+          DEFAULT_HOST, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_PORT,
+      g_param_spec_int ("port", "Port",
+          "The port to listen to (0=random available port)", 0,
+          65535, DEFAULT_PORT_SRC, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_PROTOCOL,
+      g_param_spec_int ("protocol", "Protocol",
+          "The network protocol to establish connection", 0,
+          _TENSOR_QUERY_PROTOCOL_END, DEFAULT_PROTOCOL,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_TIMEOUT,
+      g_param_spec_int ("timeout", "Timeout",
+          "The timeout as seconds to maintain connection", 0,
+          3600, DEFAULT_TIMEOUT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   gst_element_class_add_pad_template (gstelement_class,
-      gst_static_pad_template_get (&sinktemplate));
+      gst_static_pad_template_get (&srctemplate));
 
   gst_element_class_set_static_metadata (gstelement_class,
       "TensorQueryServerSrc", "Source/Tensor/Query",
       "Receive tensor data as a server over the network",
       "Samsung Electronics Co., Ltd.");
 
-  /** method override goes here */
+  gstbasesrc_class->start = gst_tensor_query_serversrc_start;
+  gstbasesrc_class->stop = gst_tensor_query_serversrc_stop;
+  gstpushsrc_class->create = gst_tensor_query_serversrc_create;
 
   GST_DEBUG_CATEGORY_INIT (gst_tensor_query_serversrc_debug,
       "tensor_query_serversrc", 0, "Tensor Query Server Source");
 }
 
-/** @todo Remove when the dummy functions are implemented. */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-
 /**
- * @brief initialize the new element
+ * @brief initialize the new query_serversrc element
  */
 static void
-gst_tensor_query_serversrc_init (GstTensorQueryServerSrc * self)
+gst_tensor_query_serversrc_init (GstTensorQueryServerSrc * src)
 {
-  return;
+  src->host = g_strdup (DEFAULT_HOST);
+  src->port = DEFAULT_PORT_SRC;
+  src->protocol = DEFAULT_PROTOCOL;
+  src->timeout = DEFAULT_TIMEOUT;
+  gst_tensors_config_init (&src->src_config);
+  src->server_data = nnstreamer_query_server_data_new ();
 }
 
 /**
- * @brief finalize the object
+ * @brief finalize the query_serversrc object
  */
 static void
 gst_tensor_query_serversrc_finalize (GObject * object)
 {
+  GstTensorQueryServerSrc *src = GST_TENSOR_QUERY_SERVERSRC (object);
+
+  g_free (src->host);
+  gst_tensors_config_free (&src->src_config);
+  nnstreamer_query_server_data_free (src->server_data);
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 
 /**
- * @brief set property
+ * @brief set property of query_serversrc
  */
 static void
 gst_tensor_query_serversrc_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
-  return;
+  GstTensorQueryServerSrc *serversrc = GST_TENSOR_QUERY_SERVERSRC (object);
+
+  switch (prop_id) {
+    case PROP_HOST:
+      if (!g_value_get_string (value)) {
+        nns_logw ("host property cannot be NULL");
+        break;
+      }
+      g_free (serversrc->host);
+      serversrc->host = g_value_dup_string (value);
+      break;
+    case PROP_PORT:
+      serversrc->port = g_value_get_uint (value);
+      break;
+    case PROP_PROTOCOL:
+      serversrc->protocol = g_value_get_int (value);
+      break;
+    case PROP_TIMEOUT:
+      serversrc->timeout = g_value_get_int (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
 }
 
 /**
- * @brief get property
+ * @brief get property of query_serversrc
  */
 static void
 gst_tensor_query_serversrc_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec)
 {
-  return;
+  GstTensorQueryServerSrc *serversrc = GST_TENSOR_QUERY_SERVERSRC (object);
+
+  switch (prop_id) {
+    case PROP_HOST:
+      g_value_set_string (value, serversrc->host);
+      break;
+    case PROP_PORT:
+      g_value_set_int (value, serversrc->port);
+      break;
+    case PROP_PROTOCOL:
+      g_value_set_int (value, serversrc->protocol);
+      break;
+    case PROP_TIMEOUT:
+      g_value_set_int (value, serversrc->timeout);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
 }
 
-#pragma GCC diagnostic pop
+/**
+ * @brief start processing of query_serversrc, setting up the server
+ */
+static gboolean
+gst_tensor_query_serversrc_start (GstBaseSrc * bsrc)
+{
+  GstTensorQueryServerSrc *src = GST_TENSOR_QUERY_SERVERSRC (bsrc);
+
+  gst_tensors_config_from_peer (bsrc->srcpad, &src->src_config, NULL);
+  src->src_config.rate_n = 0;
+  src->src_config.rate_d = 1;
+  if (!gst_tensors_config_validate (&src->src_config)) {
+    nns_loge ("Invalid tensors config from peer");
+    return FALSE;
+  }
+
+  if (!src->server_data) {
+    nns_loge ("Server_data is NULL");
+    return FALSE;
+  }
+
+  if (nnstreamer_query_server_init (src->server_data, src->protocol,
+          src->host, src->port) != 0) {
+    nns_loge ("Failed to setup server");
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+ * @brief stop processing of query_serversrc
+ */
+static gboolean
+gst_tensor_query_serversrc_stop (GstBaseSrc * bsrc)
+{
+  GstTensorQueryServerSrc *src = GST_TENSOR_QUERY_SERVERSRC (bsrc);
+  nnstreamer_query_server_data_free (src->server_data);
+  return TRUE;
+}
+
+/**
+ * @brief create query_serversrc, wait on socket and receive data
+ */
+static GstFlowReturn
+gst_tensor_query_serversrc_create (GstPushSrc * psrc, GstBuffer ** outbuf)
+{
+  GstTensorQueryServerSrc *src = GST_TENSOR_QUERY_SERVERSRC (psrc);
+  GstMemory *mem = NULL;
+  GstMapInfo map;
+  GstMetaQuery *meta_query;
+  TensorQueryCommandData cmd_data;
+  TensorQueryDataInfo data_info;
+  query_connection_handle conn;
+  guint i;
+
+  if (!src->server_data) {
+    nns_loge ("Server data is NULL");
+    return GST_FLOW_ERROR;
+  }
+
+  while (TRUE) {
+    conn = nnstreamer_query_server_accept (src->server_data);
+    if (!conn) {
+      nns_loge ("Failed to accept connection");
+      goto error;
+    }
+
+    if (nnstreamer_query_receive (conn, &cmd_data, src->timeout) != 0) {
+      nns_logi ("Failed to receive cmd");
+      continue;
+    }
+
+    switch (cmd_data.cmd) {
+      case _TENSOR_QUERY_CMD_REQUEST_INFO:
+        if (gst_tensors_info_is_equal (&cmd_data.data_info.config.info,
+                &src->src_config.info)) {
+          cmd_data.cmd = _TENSOR_QUERY_CMD_RESPOND_APPROVE;
+          /* respond sink config */
+          gst_tensor_query_server_get_sink_config (&cmd_data.data_info.config);
+        } else {
+          /* respond deny with src config */
+          nns_logw ("tensor info is not equal");
+          cmd_data.cmd = _TENSOR_QUERY_CMD_RESPOND_DENY;
+          gst_tensors_config_copy (&cmd_data.data_info.config,
+              &src->src_config);
+        }
+        if (nnstreamer_query_send (conn, &cmd_data, src->timeout) != 0) {
+          nns_logi ("Failed to send respond");
+          continue;
+        }
+        break;
+
+      case _TENSOR_QUERY_CMD_TRANSFER_START:
+        data_info = cmd_data.data_info;
+        *outbuf = gst_buffer_new ();
+        for (i = 0; i < data_info.num_mems; i++) {
+          mem = gst_allocator_alloc (NULL, data_info.mem_sizes[i], NULL);
+          gst_memory_map (mem, &map, G_PARAM_READWRITE);
+          cmd_data.data.data = map.data;
+          cmd_data.data.size = map.size;
+          if (nnstreamer_query_receive (conn, &cmd_data, src->timeout) != 0) {
+            nns_logi ("Failed to receive data");
+            gst_memory_unmap (mem, &map);
+            gst_memory_unref (mem);
+            goto reset_buffer;
+          }
+
+          gst_memory_unmap (mem, &map);
+          gst_buffer_append_memory (*outbuf, mem);
+        }
+
+        /* receive end */
+        if (nnstreamer_query_receive (conn, &cmd_data, src->timeout) != 0 ||
+            cmd_data.cmd != _TENSOR_QUERY_CMD_TRANSFER_END) {
+          nns_logi ("Failed to receive end command");
+          goto reset_buffer;
+        }
+
+        meta_query = gst_buffer_add_meta_query (*outbuf);
+        if (meta_query) {
+          meta_query->host =
+              g_strdup (nnstreamer_query_connection_get_host (conn));
+        }
+        return GST_FLOW_OK;
+
+      default:
+        nns_loge ("Invalid cmd type %d", cmd_data.cmd);
+        break;
+    }
+    continue;
+  reset_buffer:
+    gst_buffer_unref (*outbuf);
+  }
+
+error:
+  gst_buffer_unref (*outbuf);
+  return GST_FLOW_ERROR;
+}

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
@@ -13,9 +13,11 @@
 #ifndef __GST_TENSOR_QUERY_SERVERSRC_H__
 #define __GST_TENSOR_QUERY_SERVERSRC_H__
 
-#include <gst/gst.h>
+#include <gst/base/gstbasesrc.h>
 #include <gst/base/gstpushsrc.h>
-#include <tensor_common.h>
+#include "tensor_query_common.h"
+#include <nnstreamer_util.h>
+#include <tensor_meta.h>
 
 G_BEGIN_DECLS
 
@@ -39,7 +41,15 @@ typedef struct _GstTensorQueryServerSrcClass GstTensorQueryServerSrcClass;
  */
 struct _GstTensorQueryServerSrc
 {
-  GstPushSrc element; /**< parent object */
+  GstPushSrc element;        /* parent object */
+
+  guint32 port;
+  gchar *host;
+  TensorQueryProtocol protocol;
+  guint timeout;
+
+  GstTensorsConfig src_config;
+  query_server_handle server_data; /* server data passed to common functions */
 };
 
 /**

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -45,6 +45,7 @@ NNSTREAMER_COMMON_SRCS := \
 # nnstreamer plugins. Not used for SINGLE-only build.
 NNSTREAMER_PLUGINS_SRCS := \
     $(NNSTREAMER_GST_HOME)/tensor_data.c \
+    $(NNSTREAMER_GST_HOME)/tensor_meta.c \
     $(NNSTREAMER_GST_HOME)/tensor_common_pipeline.c \
     $(NNSTREAMER_GST_HOME)/registerer/nnstreamer.c \
     $(NNSTREAMER_GST_HOME)/tensor_converter/tensor_converter.c \
@@ -66,7 +67,8 @@ NNSTREAMER_PLUGINS_SRCS := \
     $(NNSTREAMER_GST_HOME)/tensor_query/tensor_query_common.c \
     $(NNSTREAMER_GST_HOME)/tensor_query/tensor_query_client.c \
     $(NNSTREAMER_GST_HOME)/tensor_query/tensor_query_serversink.c \
-    $(NNSTREAMER_GST_HOME)/tensor_query/tensor_query_serversrc.c
+    $(NNSTREAMER_GST_HOME)/tensor_query/tensor_query_serversrc.c \
+    $(NNSTREAMER_GST_HOME)/tensor_query/tensor_query_server.c
 
 # source AMC (Android MediaCodec)
 NNSTREAMER_SOURCE_AMC_SRCS := \


### PR DESCRIPTION
Update query serversrc, serversink & meta-query
Src accepts connection from clients receiving messages such as
- Request Info : send back to client w/ src tensor config
- Start : indicates beginning of data transfer
- Data : contains tensor data
- End : ends transfer

Sink can identify client by meta-query, which contains host address
Sink sends transformed tensor by same policy

Example pipeline
```
gst-launch-1.0 tensor_query_serversrc host=127.0.0.1 ! other/tensors,num_tensors=1,dimensions=3:300:300:1,types=uint8,framerate=30/1 ! tensor_query_serversink host=127.0.0.1

gst-launch-1.0 v4l2src ! videoconvert ! videoscale !  video/x-raw,width=300,height=300,format=RGB,framerate=30/1 ! tensor_converter ! tensor_query_client src-host=127.0.0.1 sink-host=127.0.0.1 ! tensor_decoder mode=direct_video ! videoconvert ! ximagesink
```

Signed-off-by: Junhwan Kim <jejudo.kim@samsung.com>

---

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
