### PR TITLE
[Query] Support flexible tensors format

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.c
@@ -25,7 +25,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_tensor_query_serversink_debug);
 #define DEFAULT_PROTOCOL _TENSOR_QUERY_PROTOCOL_TCP
 #define DEFAULT_TIMEOUT 10
 
-#define CAPS_STRING GST_TENSORS_CAP_DEFAULT
+#define CAPS_STRING GST_TENSORS_CAP_DEFAULT ";" GST_TENSORS_FLEX_CAP_DEFAULT
 /**
  * @brief the capabilities of the inputs.
  */


### PR DESCRIPTION
Support flexible tensors format for tensor query.

Test pipeline
server:
 gst-launch-1.0 tensor_query_serversrc host=127.0.0.1 ! other/tensors,format=flexible ! tensor_query_serversink host=127.0.0.1
client:
 gst-launch-1.0 v4l2src ! videoconvert ! videoscale !  video/x-raw,width=320,height=240,format=RGB,framerate=30/1 ! tensor_converter ! other/tensors,format=flexible ! tensor_query_client src-host=127.0.0.1 sink-host=127.0.0.1 ! tensor_converter input-dim=3:320:240 input-type=uint8 ! tensor_decoder mode=direct_video ! videoconvert ! ximagesink

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

