### PR TITLE
[Query] Identify client using id @open sesame 9/2 14:47

### DIFF
--- a/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
+++ b/gst/nnstreamer/tensor_aggregator/tensor_aggregator.c
@@ -521,11 +521,11 @@ static GstAdapter *
 gst_tensor_aggregator_get_adapter (GstTensorAggregator * self, GstBuffer * buf)
 {
   GstMetaQuery *meta;
-  const gchar *key = NULL;
+  guint32 key = 0;
 
   meta = gst_buffer_get_meta_query (buf);
   if (meta)
-    key = meta->host;
+    key = meta->client_id;
 
   return gst_tensor_aggregation_get_adapter (self->adapter_table, key);
 }

--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -209,7 +209,7 @@ gst_tensor_aggregation_init (void);
  * @param key the key to look up (set null to get default adapter)
  */
 extern void
-gst_tensor_aggregation_clear (GHashTable * table, const gchar * key);
+gst_tensor_aggregation_clear (GHashTable * table, const guint32 key);
 
 /**
  * @brief Clears buffers from all adapters in hash table.
@@ -225,7 +225,7 @@ gst_tensor_aggregation_clear_all (GHashTable * table);
  * @return gst-adapter instance. DO NOT release this instance.
  */
 extern GstAdapter *
-gst_tensor_aggregation_get_adapter (GHashTable * table, const gchar * key);
+gst_tensor_aggregation_get_adapter (GHashTable * table, const guint32 key);
 
 /******************************************************
  ************ Commonly used debugging macros **********

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -693,11 +693,11 @@ static GstAdapter *
 gst_tensor_converter_get_adapter (GstTensorConverter * self, GstBuffer * buf)
 {
   GstMetaQuery *meta;
-  const gchar *key = NULL;
+  guint32 key = 0;
 
   meta = gst_buffer_get_meta_query (buf);
   if (meta)
-    key = meta->host;
+    key = meta->client_id;
 
   return gst_tensor_aggregation_get_adapter (self->adapter_table, key);
 }

--- a/gst/nnstreamer/tensor_meta.c
+++ b/gst/nnstreamer/tensor_meta.c
@@ -50,7 +50,7 @@ gst_meta_query_init (GstMeta * meta, gpointer params, GstBuffer * buffer)
   GstMetaQuery *emeta = (GstMetaQuery *) meta;
   UNUSED (params);
   UNUSED (buffer);
-  emeta->host = NULL;
+  emeta->client_id = 0;
   return TRUE;
 }
 
@@ -60,9 +60,8 @@ gst_meta_query_init (GstMeta * meta, gpointer params, GstBuffer * buffer)
 static void
 gst_meta_query_free (GstMeta * meta, GstBuffer * buffer)
 {
-  GstMetaQuery *emeta = (GstMetaQuery *) meta;
+  UNUSED (meta);
   UNUSED (buffer);
-  g_free (emeta->host);
 }
 
 /**
@@ -77,7 +76,7 @@ gst_meta_query_transform (GstBuffer * transbuf, GstMeta * meta,
   UNUSED (buffer);
   UNUSED (type);
   UNUSED (data);
-  dest_meta->host = g_strdup (src_meta->host);
+  dest_meta->client_id = src_meta->client_id;
   return TRUE;
 }
 

--- a/gst/nnstreamer/tensor_meta.h
+++ b/gst/nnstreamer/tensor_meta.h
@@ -25,7 +25,7 @@ typedef struct
 {
   GstMeta meta;
 
-  gchar *host;
+  uint32_t client_id;
 } GstMetaQuery;
 
 /**

--- a/gst/nnstreamer/tensor_query/tensor_query_client.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_client.h
@@ -35,8 +35,6 @@ G_BEGIN_DECLS
 typedef struct _GstTensorQueryClient GstTensorQueryClient;
 typedef struct _GstTensorQueryClientClass GstTensorQueryClientClass;
 
-#define DEFAULT_TIMEOUT_MS 100000
-
 /**
  * @brief GstTensorQueryClient data structure.
  */

--- a/gst/nnstreamer/tensor_query/tensor_query_common.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.h
@@ -21,6 +21,7 @@ extern "C" {
 
 typedef void * query_connection_handle;
 typedef void * query_server_handle;
+#define DEFAULT_TIMEOUT_MS 100000
 
 /**
  * @brief protocol options for tensor query.
@@ -44,6 +45,7 @@ typedef enum
   _TENSOR_QUERY_CMD_TRANSFER_START = 3,
   _TENSOR_QUERY_CMD_TRANSFER_DATA = 4,
   _TENSOR_QUERY_CMD_TRANSFER_END = 5,
+  _TENSOR_QUERY_CMD_CLIENT_ID = 6,
   _TENSOR_QUERY_CMD_END
 } TensorQueryCommand;
 
@@ -76,6 +78,7 @@ typedef struct
 {
   TensorQueryCommand cmd;
   TensorQueryProtocol protocol;
+  uint32_t client_id;
   union
   {
     TensorQueryDataInfo data_info; /** _TENSOR_QUERY_CMD_TRANSFER_START */
@@ -91,10 +94,10 @@ extern query_connection_handle
 nnstreamer_query_connect (TensorQueryProtocol protocol, const char *ip, uint16_t port, uint32_t timeout_ms);
 
 /**
- * @brief get host from query connection handle
+ * @brief get client id from query connection handle
  */
-char *
-nnstreamer_query_connection_get_host (query_connection_handle connection);
+uint32_t
+nnstreamer_query_connection_get_client_id (query_connection_handle connection);
 
 /**
  * @brief get port from query connection handle
@@ -150,7 +153,7 @@ nnstreamer_query_server_data_free (query_server_handle server_data);
  */
 extern int
 nnstreamer_query_server_init (query_server_handle server_data,
-    TensorQueryProtocol protocol, const char *host, uint16_t port);
+    TensorQueryProtocol protocol, const char *host, uint16_t port, int8_t is_src);
 
 #ifdef __cplusplus
 }

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.h
@@ -47,7 +47,6 @@ struct _GstTensorQueryServerSink
   gchar *host;
   TensorQueryProtocol protocol;
   guint timeout;
-  GAsyncQueue *conn_queue;
   query_server_handle server_data;
 };
 

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
@@ -230,7 +230,7 @@ gst_tensor_query_serversrc_start (GstBaseSrc * bsrc)
   }
 
   if (nnstreamer_query_server_init (src->server_data, src->protocol,
-          src->host, src->port) != 0) {
+          src->host, src->port, TRUE) != 0) {
     nns_loge ("Failed to setup server");
     return FALSE;
   }
@@ -338,8 +338,8 @@ gst_tensor_query_serversrc_create (GstPushSrc * psrc, GstBuffer ** outbuf)
 
         meta_query = gst_buffer_add_meta_query (*outbuf);
         if (meta_query) {
-          meta_query->host =
-              g_strdup (nnstreamer_query_connection_get_host (conn));
+          meta_query->client_id =
+              nnstreamer_query_connection_get_client_id (conn);
         }
         return GST_FLOW_OK;
 

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
@@ -41,7 +41,7 @@ typedef struct _GstTensorQueryServerSrcClass GstTensorQueryServerSrcClass;
  */
 struct _GstTensorQueryServerSrc
 {
-  GstPushSrc element;        /* parent object */
+  GstPushSrc element; /* parent object */
 
   guint16 port;
   gchar *host;
@@ -63,5 +63,4 @@ struct _GstTensorQueryServerSrcClass
 GType gst_tensor_query_serversrc_get_type (void);
 
 G_END_DECLS
-
 #endif /* __GST_TENSOR_QUERY_SERVERSRC_H__ */

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -2496,7 +2496,7 @@ TEST (testTensorAggregator, multiClients)
   memcpy (map.data, data1, data_size);
   gst_memory_unmap (mem, &map);
   meta = gst_buffer_add_meta_query (input1);
-  meta->host = g_strdup ("test-client1");
+  meta->client_id = 0xBADC0FEEU;
 
   input2 = gst_harness_create_buffer (h, data_size);
   mem = gst_buffer_peek_memory (input2, 0);
@@ -2504,7 +2504,7 @@ TEST (testTensorAggregator, multiClients)
   memcpy (map.data, data2, data_size);
   gst_memory_unmap (mem, &map);
   meta = gst_buffer_add_meta_query (input2);
-  meta->host = g_strdup ("test-client2");
+  meta->client_id = 0xBADF00DU;
 
   /* push buffers (1 > 2 > 1) */
   EXPECT_EQ (gst_harness_push (h, gst_buffer_copy_deep (input1)), GST_FLOW_OK);
@@ -2522,7 +2522,7 @@ TEST (testTensorAggregator, multiClients)
   if (received == 1U) {
     output = gst_harness_pull (h);
     meta = gst_buffer_get_meta_query (output);
-    EXPECT_TRUE (meta && g_str_equal (meta->host, "test-client1"));
+    EXPECT_TRUE (meta && (meta->client_id == 0xBADC0FEEU));
 
     mem = gst_buffer_peek_memory (output, 0);
     ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));
@@ -2547,7 +2547,7 @@ TEST (testTensorAggregator, multiClients)
   if (received == 2U) {
     output = gst_harness_pull (h);
     meta = gst_buffer_get_meta_query (output);
-    EXPECT_TRUE (meta && g_str_equal (meta->host, "test-client2"));
+    EXPECT_TRUE (meta && (meta->client_id == 0xBADF00DU));
 
     mem = gst_buffer_peek_memory (output, 0);
     ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));

--- a/tests/nnstreamer_query/unittest_query.cc
+++ b/tests/nnstreamer_query/unittest_query.cc
@@ -259,7 +259,7 @@ TEST (tensorQueryCommon, serverInit0)
   server_data = nnstreamer_query_server_data_new ();
   EXPECT_NE ((void *) NULL, server_data);
 
-  EXPECT_EQ (0, nnstreamer_query_server_init (server_data, _TENSOR_QUERY_PROTOCOL_TCP, "localhost", 3001));
+  EXPECT_EQ (0, nnstreamer_query_server_init (server_data, _TENSOR_QUERY_PROTOCOL_TCP, "localhost", 3001, TRUE));
   nnstreamer_query_server_data_free (server_data);
 }
 
@@ -268,7 +268,7 @@ TEST (tensorQueryCommon, serverInit0)
  */
 TEST (tensorQueryCommon, serverInit1_n)
 {
-  EXPECT_NE (0, nnstreamer_query_server_init (NULL, _TENSOR_QUERY_PROTOCOL_TCP, "localhost", 3001));
+  EXPECT_NE (0, nnstreamer_query_server_init (NULL, _TENSOR_QUERY_PROTOCOL_TCP, "localhost", 3001, TRUE));
 }
 
 /**
@@ -280,7 +280,7 @@ TEST (tensorQueryCommon, serverInit2_n)
   server_data = nnstreamer_query_server_data_new ();
   EXPECT_NE ((void *) NULL, server_data);
 
-  EXPECT_NE (0, nnstreamer_query_server_init (server_data, _TENSOR_QUERY_PROTOCOL_END, "localhost", 3001));
+  EXPECT_NE (0, nnstreamer_query_server_init (server_data, _TENSOR_QUERY_PROTOCOL_END, "localhost", 3001, TRUE));
 
   nnstreamer_query_server_data_free (server_data);
 }


### PR DESCRIPTION
currently, ip address of the client is only used to distinguish client which will receive buffers.
In this case, server cannot distinguish if more than one client with the samp ip is connected.
So instead of ip address, changed it to use the client's unique id.

Test pipeline
server:
```
gst-launch-1.0 tensor_query_serversrc ! other/tensors,num_tensors=1,dimensions=3:300:300:1,types=uint8,framerate=30/1 ! tensor_query_serversink
```
client 1:
```
gst-launch-1.0 v4l2src ! videoconvert ! videoscale !  video/x-raw,width=300,height=300,format=RGB,framerate=30/1 ! tensor_converter ! tensor_query_client ! tensor_decoder mode=direct_video ! videoconvert ! ximagesink
```
client2:
```
gst-launch-1.0 videotestsrc ! videoconvert ! videoscale !  video/x-raw,width=300,height=300,format=RGB,framerate=30/1 ! tensor_converter ! tensor_query_client ! tensor_decoder mode=direct_video ! videoconvert ! ximagesink
```

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
