### PR TITLE
[Query] Add address resolver for server

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_common.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.h
@@ -88,7 +88,7 @@ typedef struct
  * @return 0 if OK, negative value if error
  */
 extern query_connection_handle
-nnstreamer_query_connect (TensorQueryProtocol protocol, const char *ip, uint32_t port, uint32_t timeout_ms);
+nnstreamer_query_connect (TensorQueryProtocol protocol, const char *ip, uint16_t port, uint32_t timeout_ms);
 
 /**
  * @brief get host from query connection handle
@@ -150,7 +150,7 @@ nnstreamer_query_server_data_free (query_server_handle server_data);
  */
 extern int
 nnstreamer_query_server_init (query_server_handle server_data,
-    TensorQueryProtocol protocol, const char *host, uint32_t port);
+    TensorQueryProtocol protocol, const char *host, uint16_t port);
 
 #ifdef __cplusplus
 }

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.c
@@ -20,7 +20,7 @@
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_query_serversink_debug);
 #define GST_CAT_DEFAULT gst_tensor_query_serversink_debug
 
-#define DEFAULT_HOST "127.0.0.1"
+#define DEFAULT_HOST "localhost"
 #define DEFAULT_PORT_SINK 3000
 #define DEFAULT_PROTOCOL _TENSOR_QUERY_PROTOCOL_TCP
 #define DEFAULT_TIMEOUT 10

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.h
@@ -43,7 +43,7 @@ typedef struct _GstTensorQueryServerSinkClass GstTensorQueryServerSinkClass;
 struct _GstTensorQueryServerSink
 {
   GstBaseSink element; /**< parent object */
-  guint32 port;
+  guint16 port;
   gchar *host;
   TensorQueryProtocol protocol;
   guint timeout;

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
@@ -23,7 +23,7 @@
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_query_serversrc_debug);
 #define GST_CAT_DEFAULT gst_tensor_query_serversrc_debug
 
-#define DEFAULT_HOST "127.0.0.1"
+#define DEFAULT_HOST "localhost"
 #define DEFAULT_PORT_SRC 3001
 #define DEFAULT_PROTOCOL _TENSOR_QUERY_PROTOCOL_TCP
 #define DEFAULT_TIMEOUT 10

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
@@ -43,7 +43,7 @@ struct _GstTensorQueryServerSrc
 {
   GstPushSrc element;        /* parent object */
 
-  guint32 port;
+  guint16 port;
   gchar *host;
   TensorQueryProtocol protocol;
   guint timeout;


### PR DESCRIPTION
Add address resolver for server.

Signed-off-by: gichan <gichan2.jang@samsung.com>

Todo:
 common properties are adjusted by .ini and envvar.

Test pieline
Server:
```
gst-launch-1.0 tensor_query_serversrc ! other/tensors,num_tensors=1,dimensions=3:300:300:1,types=uint8,framerate=30/1 ! tensor_query_serversink
```

Client:
```
gst-launch-1.0 v4l2src ! videoconvert ! videoscale !  video/x-raw,width=300,height=300,format=RGB,framerate=30/1 ! tensor_converter ! tensor_query_client ! tensor_decoder mode=direct_video ! videoconvert ! ximagesink
```

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

