### PR TITLE
[LICENSE] Add SPDX reference in LICENSE file.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -501,4 +501,11 @@ necessary.  Here is a sample; alter the names:
 
 That's all there is to it!
 
+-------------------------------------------------------------------------------
+Note:
+Individual files contain the following tag instead of the full license text.
 
+              SPDX-License-Identifier: LGPL-2.1-only
+
+This enables machine processing of license information based on the SPDX
+License Identifiers that are here available: http://spdx.org/licenses/


### PR DESCRIPTION
Add SPDX license identifier reference in LICENSE file.

See: https://github.com/nnstreamer/TAOS-CI/pull/733#discussion_r685098782

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
