### PR TITLE
[tensor_query] Fix double free in tensor_query_server @open sesame 08/19 10:24

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_common.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.h
@@ -146,7 +146,7 @@ nnstreamer_query_server_data_free (query_server_handle server_data);
 
 /**
  * @brief set server handle params and setup server
- * @return 0 if OK, negative value if error 
+ * @return 0 if OK, negative value if error
  */
 extern int
 nnstreamer_query_server_init (query_server_handle server_data,

--- a/gst/nnstreamer/tensor_query/tensor_query_server.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.h
@@ -19,7 +19,7 @@
 G_BEGIN_DECLS
 
 /**
- * @brief set sink config 
+ * @brief set sink config
  */
 void gst_tensor_query_server_set_sink_config (GstTensorsConfig *config);
 

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.c
@@ -133,6 +133,7 @@ gst_tensor_query_serversink_finalize (GObject * object)
   GstTensorQueryServerSink *sink = GST_TENSOR_QUERY_SERVERSINK (object);
   g_free (sink->host);
   nnstreamer_query_server_data_free (sink->server_data);
+  sink->server_data = NULL;
   g_async_queue_unref (sink->conn_queue);
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
@@ -238,6 +239,7 @@ gst_tensor_query_serversink_stop (GstBaseSink * bsink)
 {
   GstTensorQueryServerSink *sink = GST_TENSOR_QUERY_SERVERSINK (bsink);
   nnstreamer_query_server_data_free (sink->server_data);
+  sink->server_data = NULL;
   return TRUE;
 }
 

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
@@ -143,6 +143,7 @@ gst_tensor_query_serversrc_finalize (GObject * object)
   g_free (src->host);
   gst_tensors_config_free (&src->src_config);
   nnstreamer_query_server_data_free (src->server_data);
+  src->server_data = NULL;
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 
@@ -245,6 +246,7 @@ gst_tensor_query_serversrc_stop (GstBaseSrc * bsrc)
 {
   GstTensorQueryServerSrc *src = GST_TENSOR_QUERY_SERVERSRC (bsrc);
   nnstreamer_query_server_data_free (src->server_data);
+  src->server_data = NULL;
   return TRUE;
 }
 


### PR DESCRIPTION
- Assign NULL value after call `query_server_data_free` to  prevent double free
- Remove some trailing spaces

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
