### PR TITLE
[Common/Adapter] aggregation from multi clients

### DIFF
--- a/gst/nnstreamer/tensor_aggregator/tensor_aggregator.h
+++ b/gst/nnstreamer/tensor_aggregator/tensor_aggregator.h
@@ -29,7 +29,6 @@
 
 #include <gst/gst.h>
 #include <tensor_common.h>
-#include <gst/base/gstadapter.h>
 
 G_BEGIN_DECLS
 
@@ -64,7 +63,7 @@ struct _GstTensorAggregator
   guint frames_flush; /**< number of frames to flush */
   guint frames_dim; /**< index of frames in tensor dimension */
 
-  GstAdapter *adapter; /**< adapt incoming tensor */
+  GHashTable *adapter_table; /**< adapt incoming tensor */
 
   gboolean tensor_configured; /**< True if already successfully configured tensor metadata */
   GstTensorsConfig in_config; /**< input tensor info */

--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -32,6 +32,7 @@
 #include <glib.h>
 #include <stdint.h>
 #include <gst/gst.h>
+#include <gst/base/gstadapter.h>
 #include <gst/base/gstcollectpads.h>
 
 #include "tensor_typedef.h"
@@ -194,6 +195,37 @@ gst_tensor_pad_possible_caps_from_config (GstPad * pad, const GstTensorsConfig *
  */
 extern gboolean
 gst_tensor_pad_caps_is_flexible (GstPad * pad);
+
+/**
+ * @brief Gets new hash table for tensor aggregation.
+ * @return Newly allocated hash table, caller should release this using g_hash_table_destroy().
+ */
+extern GHashTable *
+gst_tensor_aggregation_init (void);
+
+/**
+ * @brief Clears buffers from adapter.
+ * @param table a hash table instance initialized with gst_tensor_aggregation_init()
+ * @param key the key to look up (set null to get default adapter)
+ */
+extern void
+gst_tensor_aggregation_clear (GHashTable * table, const gchar * key);
+
+/**
+ * @brief Clears buffers from all adapters in hash table.
+ * @param table a hash table instance initialized with gst_tensor_aggregation_init()
+ */
+extern void
+gst_tensor_aggregation_clear_all (GHashTable * table);
+
+/**
+ * @brief Gets adapter from hash table.
+ * @param table a hash table instance initialized with gst_tensor_aggregation_init()
+ * @param key the key to look up (set null to get default adapter)
+ * @return gst-adapter instance. DO NOT release this instance.
+ */
+extern GstAdapter *
+gst_tensor_aggregation_get_adapter (GHashTable * table, const gchar * key);
 
 /******************************************************
  ************ Commonly used debugging macros **********

--- a/gst/nnstreamer/tensor_converter/tensor_converter.h
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.h
@@ -35,7 +35,6 @@
 #define __GST_TENSOR_CONVERTER_H__
 
 #include <gst/gst.h>
-#include <gst/base/gstadapter.h>
 #include <tensor_common.h>
 #include "nnstreamer_plugin_api_converter.h"
 #include "tensor_converter_custom.h"
@@ -85,7 +84,7 @@ struct _GstTensorConverter
   guint frames_per_tensor; /**< number of frames in output tensor */
   GstTensorsInfo tensors_info; /**< data structure to get/set tensor info */
 
-  GstAdapter *adapter; /**< adapt incoming media stream */
+  GHashTable *adapter_table; /**< adapt incoming media stream */
 
   media_type in_media_type; /**< incoming media type */
   /** ExternalConverter is used if in_media_type == _NNS_MEDIA_PLUGINS */


### PR DESCRIPTION
Use hashtable to aggregate buffers from multiple clients.
- create gst-adapter for each client id
- for normal case, set default adaptor (no meta in gst-buffer)

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
