### PR TITLE
[build/snpe] Build snpe subplugin when the platform supports the lib

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -568,38 +568,22 @@ if get_option('enable-mediapipe')
 endif
 
 if snpe_support_is_available
-  snpe_env_exist = run_command('[', '-z', snpe_support_SNPE_ROOT, ']').returncode()
-  snpe_dir_not_exist = run_command('[', '-d', snpe_support_SNPE_ROOT, ']').returncode()
-
-  if snpe_env_exist != 1 or snpe_dir_not_exist != 0
-    error('Cannot find $SNPE_ROOT')
-  endif
-
-  snpe_incdir = include_directories(join_paths(snpe_support_SNPE_ROOT, 'include/zdl'))
-
-  snpe_dep = cxx.find_library('libSNPE',
-    dirs: join_paths(snpe_support_SNPE_ROOT, 'lib/x86_64-linux-clang'),
-    required: true
-  )
+  filter_sub_snpe_sources = ['tensor_filter_snpe.cc']
 
   snpe_cpp_args = []
   snpe_cpp_args += '-Wno-terminate'
-
-  filter_sub_snpe_sources = ['tensor_filter_snpe.cc']
 
   nnstreamer_filter_snpe_sources = []
   foreach s : filter_sub_snpe_sources
     nnstreamer_filter_snpe_sources += join_paths(meson.current_source_dir(), s)
   endforeach
 
-  nnstreamer_filter_snpe_deps = snpe_support_deps + [glib_dep, gst_dep, nnstreamer_dep, snpe_dep]
+  nnstreamer_filter_snpe_deps = [glib_dep, gst_dep, nnstreamer_dep, snpe_support_deps]
 
-  nnstreamer_filter_snpe_so_lib = shared_library(
-    'nnstreamer_filter_snpe',
+  shared_library('nnstreamer_filter_snpe',
     nnstreamer_filter_snpe_sources,
     cpp_args: snpe_cpp_args,
     dependencies: nnstreamer_filter_snpe_deps,
-    include_directories: snpe_incdir,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
@@ -608,14 +592,8 @@ if snpe_support_is_available
     nnstreamer_filter_snpe_sources,
     cpp_args: snpe_cpp_args,
     dependencies: nnstreamer_filter_snpe_deps,
-    include_directories: snpe_incdir,
     install: true,
     install_dir: nnstreamer_libdir
-  )
-
-  nnstreamer_filter_snpe_dep = declare_dependency(
-    link_with: nnstreamer_filter_snpe_so_lib,
-    include_directories: snpe_incdir
   )
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -174,13 +174,32 @@ endif
 
 # snpe
 snpe_dep = dependency('', required: false)
-SNPE_ROOT = ''
 if not get_option('snpe-support').disabled()
-  # Check $SNPE_ROOT (where SNPE SDK is located)
-  cmd = run_command('sh', '-c', 'echo $SNPE_ROOT')
-  SNPE_ROOT = cmd.stdout().strip()
-  if SNPE_ROOT != ''
-    snpe_dep = declare_dependency()
+  # Check whether the platform supports snpe
+  snpe_dep = dependency('snpe', required: false)
+  if (not snpe_dep.found())
+    # Check whether $SNPE_ROOT (where SNPE SDK is located) is set.
+    cmd = run_command('sh', '-c', 'echo $SNPE_ROOT')
+    SNPE_ROOT = cmd.stdout().strip()
+    if SNPE_ROOT != ''
+      message('Got $SNPE_ROOT: @0@'.format(SNPE_ROOT))
+      snpe_dir_not_exist = run_command('[', '-d', SNPE_ROOT, ']').returncode()
+      if snpe_dir_not_exist != 0
+        error('@0@ does not exists'.format(SNPE_ROOT))
+      endif
+
+      snpe_lib = cxx.find_library('libSNPE',
+        dirs: join_paths(SNPE_ROOT, 'lib/x86_64-linux-clang'),
+        required: true
+      )
+
+      snpe_incdir = include_directories(join_paths(SNPE_ROOT, 'include/zdl'))
+
+      snpe_dep = declare_dependency(
+        dependencies: snpe_lib,
+        include_directories: snpe_incdir
+      )
+    endif
   endif
 endif
 
@@ -317,7 +336,6 @@ features = {
   'snpe-support': {
     'extra_deps': [ snpe_dep ],
     'project_args': { 'ENABLE_SNPE' : 1 },
-    'extra_args': { 'SNPE_ROOT': SNPE_ROOT }
   },
   'flatbuf-support': {
     'extra_deps': [ flatc, flatbuf_dep, flatbuf_version_check_dep ],

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -34,6 +34,7 @@
 %define		mqtt_support 1
 %define		lua_support 1
 %define		tvm_support 1
+%define		snpe_support 0
 
 %define		check_test 1
 %define		release_test 1
@@ -113,6 +114,13 @@
 %define		lua_support 0
 %define		mqtt_support 0
 %define		tvm_support 0
+%endif
+
+# TODO: The variable `_with_qc_snpe` is temporary. Make proper one.
+%if 0%{?_with_qc_snpe}
+%ifarch aarch64
+%define		snpe_support 1
+%endif
 %endif
 
 # Release unit test suite as a subpackage only if check_test is enabled.
@@ -272,6 +280,10 @@ BuildRequires:	lua-devel
 
 %if 0%{?tvm_support}
 BuildRequires:	tvm-runtime-devel
+%endif
+
+%if 0%{?snpe_support}
+BuildRequires:	snpe-devel
 %endif
 
 # Unit Testing Uses SSAT (hhtps://github.com/myungjoo/SSAT.git)
@@ -438,6 +450,16 @@ Requires:	nnstreamer = %{version}-%{release}
 Requires:	tvm
 %description tvm
 NNStreamer's tensor_filter subplugin of tvm
+%endif
+
+# for snpe
+%if 0%{?snpe_support}
+%package snpe
+Summary:	NNStreamer snpe Support
+Requires:	nnstreamer = %{version}-%{release}
+Requires:	snpe
+%description snpe
+NNStreamer's tensor_fliter subplugin of snpe
 %endif
 
 %package devel
@@ -713,6 +735,13 @@ Provides additional gstreamer plugins for nnstreamer pipelines
 %define enable_tvm -Dtvm-support=disabled
 %endif
 
+# Support snpe
+%if 0%{?snpe_support}
+%define enable_snpe -Dsnpe-support=enabled
+%else
+%define enable_snpe -Dsnpe-support=disabled
+%endif
+
 # Framework priority for each file extension
 %define fw_priority_bin ''
 %define fw_priority_nb ''
@@ -756,7 +785,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir
 	%{enable_tizen} %{element_restriction} %{fw_priority} -Denable-env-var=false -Denable-symbolic-link=false \
 	%{enable_tf_lite} %{enable_tf2_lite} %{enable_tf} %{enable_pytorch} %{enable_caffe2} %{enable_python3} \
 	%{enable_nnfw_runtime} %{enable_mvncsdk2} %{enable_openvino} %{enable_armnn} %{enable_edgetpu}  %{enable_vivante} %{enable_flatbuf} \
-	%{enable_tizen_sensor} %{enable_mqtt} %{enable_lua} %{enable_tvm} %{enable_test} %{enable_test_coverage} %{install_test} \
+	%{enable_tizen_sensor} %{enable_mqtt} %{enable_lua} %{enable_tvm} %{enable_snpe} %{enable_test} %{enable_test_coverage} %{install_test} \
 	build
 
 ninja -C build %{?_smp_mflags}
@@ -969,6 +998,14 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_tvm.so
+%endif
+
+# for snpe
+%if 0%{?snpe_support}
+%files snpe
+%manifest nnstreamer.manifest
+%defattr(-,root,root,-)
+%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_snpe.so
 %endif
 
 %files devel


### PR DESCRIPTION
- If the build platform supports snpe lib, use it to build snpe subplugin
- Add snpe related packages in spec

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

