### PR TITLE
[query] Handle different framerate of clients

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_client.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_client.c
@@ -353,7 +353,7 @@ gst_tensor_query_client_sink_event (GstPad * pad,
         }
 
         /** Receive client ID from server src */
-        if (0 != nnstreamer_query_receive (self->src_conn, &cmd_buf, -1)) {
+        if (0 != nnstreamer_query_receive (self->src_conn, &cmd_buf, 1)) {
           nns_loge ("Failed to receive client ID.");
           goto done;
         }
@@ -368,8 +368,7 @@ gst_tensor_query_client_sink_event (GstPad * pad,
           goto done;
         }
 
-        if (0 != nnstreamer_query_receive (self->src_conn, &cmd_buf,
-                DEFAULT_TIMEOUT_MS)) {
+        if (0 != nnstreamer_query_receive (self->src_conn, &cmd_buf, 1)) {
           nns_loge ("Failed to receive response from the query server.");
           goto done;
         }
@@ -561,8 +560,7 @@ gst_tensor_query_client_chain (GstPad * pad,
     return GST_FLOW_ERROR;
   }
   /** Receive start command buffer */
-  if (0 != nnstreamer_query_receive (self->sink_conn, &cmd_buf,
-          DEFAULT_TIMEOUT_MS)) {
+  if (0 != nnstreamer_query_receive (self->sink_conn, &cmd_buf, 1)) {
     nns_loge ("Failed to receive start command buffer");
     return GST_FLOW_ERROR;
   }
@@ -599,8 +597,7 @@ gst_tensor_query_client_chain (GstPad * pad,
     }
     cmd_buf.data.data = out_info.data;
 
-    ecode = nnstreamer_query_receive (self->sink_conn, &cmd_buf,
-        DEFAULT_TIMEOUT_MS);
+    ecode = nnstreamer_query_receive (self->sink_conn, &cmd_buf, 1);
     gst_memory_unmap (out_mem, &out_info);
 
     if (ecode != 0) {
@@ -610,8 +607,7 @@ gst_tensor_query_client_chain (GstPad * pad,
   }
 
   /** Receive end command buffer */
-  if (0 != nnstreamer_query_receive (self->sink_conn, &cmd_buf,
-          DEFAULT_TIMEOUT_MS)) {
+  if (0 != nnstreamer_query_receive (self->sink_conn, &cmd_buf, 1)) {
     nns_loge ("Failed to receive end command buffer");
     goto error;
   }

--- a/gst/nnstreamer/tensor_query/tensor_query_common.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.c
@@ -85,9 +85,9 @@ typedef struct
   };
 } TensorQueryConnection;
 
-static gboolean
+static int
 query_tcp_receive (GSocket * socket, uint8_t * data, size_t size,
-    GCancellable * cancellable);
+    GCancellable * cancellable, int8_t blocking);
 static gboolean query_tcp_send (GSocket * socket, uint8_t * data, size_t size,
     GCancellable * cancellable);
 static void
@@ -236,13 +236,16 @@ nnstreamer_query_connect (TensorQueryProtocol protocol, const char *ip,
 /**
  * @brief receive command from connected device.
  * @return 0 if OK, negative value if error
+ * @param blocking Socket operation mode. 0 for non-blocking mode, other for blocking mode.
+ * @note The socket operates in two modes: blocking and non-blocking.
+ *       In non-blocking mode, if there is no data available, it is immediately returned.
  */
 int
 nnstreamer_query_receive (query_connection_handle connection,
-    TensorQueryCommandData * data, uint32_t timeout_ms)
+    TensorQueryCommandData * data, int8_t blocking)
 {
   TensorQueryConnection *conn = (TensorQueryConnection *) connection;
-  UNUSED (timeout_ms);
+
   if (!conn) {
     nns_loge ("Invalid connection data");
     return -EINVAL;
@@ -253,8 +256,8 @@ nnstreamer_query_receive (query_connection_handle connection,
     {
       TensorQueryCommand cmd;
 
-      if (!query_tcp_receive (conn->socket, (uint8_t *) & cmd, sizeof (cmd),
-              conn->cancellable)) {
+      if (query_tcp_receive (conn->socket, (uint8_t *) & cmd, sizeof (cmd),
+              conn->cancellable, blocking) < 0) {
         nns_logd ("Failed to receive from socket");
         return -EREMOTEIO;
       }
@@ -262,29 +265,29 @@ nnstreamer_query_receive (query_connection_handle connection,
 
       if (cmd == _TENSOR_QUERY_CMD_TRANSFER_DATA) {
         /* receive size */
-        if (!query_tcp_receive (conn->socket, (uint8_t *) & data->data.size,
-                sizeof (data->data.size), conn->cancellable)) {
+        if (query_tcp_receive (conn->socket, (uint8_t *) & data->data.size,
+                sizeof (data->data.size), conn->cancellable, 1) < 0) {
           nns_logd ("Failed to receive size from socket");
           return -EREMOTEIO;
         }
         /* receive data */
-        if (!query_tcp_receive (conn->socket, (uint8_t *) data->data.data,
-                data->data.size, conn->cancellable)) {
+        if (query_tcp_receive (conn->socket, (uint8_t *) data->data.data,
+                data->data.size, conn->cancellable, 1) < 0) {
           nns_logd ("Failed to receive data from socket");
           return -EREMOTEIO;
         }
         return 0;
       } else if (data->cmd == _TENSOR_QUERY_CMD_CLIENT_ID) {
         /* receive client id */
-        if (!query_tcp_receive (conn->socket, (uint8_t *) & data->client_id,
-                CLIENT_ID_LEN, conn->cancellable)) {
+        if (query_tcp_receive (conn->socket, (uint8_t *) & data->client_id,
+                CLIENT_ID_LEN, conn->cancellable, 1) < 0) {
           nns_logd ("Failed to receive client id from socket");
           return -EREMOTEIO;
         }
       } else {
         /* receive data_info */
-        if (!query_tcp_receive (conn->socket, (uint8_t *) & data->data_info,
-                sizeof (TensorQueryDataInfo), conn->cancellable)) {
+        if (query_tcp_receive (conn->socket, (uint8_t *) & data->data_info,
+                sizeof (TensorQueryDataInfo), conn->cancellable, 1) < 0) {
           nns_logd ("Failed to receive data info from socket");
           return -EREMOTEIO;
         }
@@ -537,29 +540,34 @@ nnstreamer_query_server_accept (query_server_handle server_data)
 
 /**
  * @brief [TCP] receive data for tcp server
+ * @return 0 if OK, negative value if error
  */
-static gboolean
+static int
 query_tcp_receive (GSocket * socket, uint8_t * data, size_t size,
-    GCancellable * cancellable)
+    GCancellable * cancellable, int8_t blocking)
 {
   size_t bytes_received = 0;
   ssize_t rret;
   GError *err = NULL;
+
   while (bytes_received < size) {
-    rret = g_socket_receive (socket, (char *) data + bytes_received,
-        size - bytes_received, cancellable, &err);
+    rret =
+        g_socket_receive_with_blocking (socket, (char *) data + bytes_received,
+        size - bytes_received, blocking, cancellable, &err);
+
     if (rret == 0) {
       nns_logi ("Connection closed");
-      return FALSE;
+      return -EREMOTEIO;
     }
+
     if (rret < 0) {
-      nns_loge ("Failed to read from socket: %s", err->message);
+      nns_logi ("Failed to read from socket: %s", err->message);
       g_clear_error (&err);
-      return FALSE;
+      return -EREMOTEIO;
     }
     bytes_received += rret;
   }
-  return TRUE;
+  return 0;
 }
 
 /**
@@ -670,7 +678,7 @@ accept_socket_async_cb (GObject * source, GAsyncResult * result,
     }
     conn->client_id = cmd_data.client_id;
   } else {
-    if (0 != nnstreamer_query_receive (conn, &cmd_data, -1)) {
+    if (0 != nnstreamer_query_receive (conn, &cmd_data, 1)) {
       nns_loge ("Failed to receive command.");
       nnstreamer_query_close (conn);
       return;

--- a/gst/nnstreamer/tensor_query/tensor_query_common.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.h
@@ -117,7 +117,7 @@ nnstreamer_query_send (query_connection_handle connection, TensorQueryCommandDat
  * @return 0 if OK, negative value if error
  */
 extern int
-nnstreamer_query_receive (query_connection_handle connection, TensorQueryCommandData *data, uint32_t timeout_ms);
+nnstreamer_query_receive (query_connection_handle connection, TensorQueryCommandData *data, int8_t blocking);
 
 /**
  * @brief close connection with corresponding id.


### PR DESCRIPTION
Problem:  Query server shouldn't follow framerates of clients.
Temporary solution: If data is not available in the socket, check the next socket.
Todo: Create threads for each client. (NNS 2.0 later)

Test pipeline:
server
```
gst-launch-1.0 tensor_query_serversrc  ! other/tensors,num_tensors=1,dimensions=3:320:240:1,types=uint8 ! tensor_query_serversink
```
client 1, framerate: 30/1
```
gst-launch-1.0 v4l2src ! videoconvert ! videoscale ! video/x-raw,width=320,height=240,format=RGB,framerate=30/1 ! tensor_converter !  tensor_query_client ! tensor_decoder mode=direct_video ! videoconvert ! ximagesink
```
client 2, framerate: 1/1
```
gst-launch-1.0 videotestsrc ! videoconvert ! videoscale ! video/x-raw,width=320,height=240,format=RGB,framerate=1/1 ! tensor_converter !  tensor_query_client ! tensor_decoder mode=direct_video ! videoconvert ! ximagesink
```
Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>
