### PR TITLE
[Common] Fix config from structure function @open sesame 9/16 9:13

### DIFF
--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -905,7 +905,7 @@ gst_tensors_config_from_structure (GstTensorsConfig * config,
       }
     }
 
-    if (format == _NNS_TENSOR_FORMAT_STATIC) {
+    if (config->format == _NNS_TENSOR_FORMAT_STATIC) {
       gst_structure_get_int (structure, "num_tensors",
           (gint *) (&config->info.num_tensors));
 


### PR DESCRIPTION
Wrong format variable is used at L908.
If format is not given, gst_tensor_get_format (L898) returns `_NNS_TENSOR_FORMAT_END`
If tensors format is not given, default format (_NNS_TENSOR_FORMAT_STATIC) should be used.

Signed-off-by: gichan <gichan2.jang@samsung.com>
**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
