### PR TITLE
[TEST] Adjust state change timeout.

### DIFF
--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 #define _print_log(...) if (DBG) g_message (__VA_ARGS__)
 
-#define UNITTEST_STATECHANGE_TIMEOUT (1000U)
+#define UNITTEST_STATECHANGE_TIMEOUT (2000U)
 #define TEST_DEFAULT_SLEEP_TIME (10000U)
 #define TEST_TIMEOUT_LIMIT (10000000U) /* 10 secs */
 


### PR DESCRIPTION
Releated issue: https://github.com/nnstreamer/nnstreamer/issues/3275
cppFilterObj.base03 test fail intermittenly on armv7l during state change to GST_STATE_PLAYING.
(http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/latest/log/build_log_tizen_armv7l_output_2021-09-16.txt)

When measuring the state change time, it took around 600~800 ms on armv7l.
The current timeout is 1,000 ms, which is close to the boundary.
The test failure did not occur when repeated 1,000 times with 2,000 ms timeout.

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

