### PR TITLE
[armnn] compilation error - missing initializer

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -669,7 +669,7 @@ armnn_open (const GstTensorFilterProperties *prop, void **private_data)
   if (prop->model_files[0] == NULL)
     return -EINVAL;
 
-  hw = parse_accl_hw (prop->accl_str, armnn_accl_support);
+  hw = parse_accl_hw (prop->accl_str, armnn_accl_support, NULL, NULL);
   try {
     core = new ArmNNCore (prop->model_files[0], hw);
   } catch (const std::bad_alloc &ex) {


### PR DESCRIPTION

warning correction -- breaks build with -Werror :
parse_accl_args struct has 4 members - some compilers and/or options require explicit definition of the 4 members.
Added explicit definition of NULL arguments for missing initalizers .
Same approach is used in existing code base for pytorch tensor filter.

Tests: 
ssat suite: passed
armnn GTest suite: passed


correction for compilation error:

tensor_filter_armnn.cc: In function 'int armnn_open(const GstTensorFilterProperties*, void**)':
nnstreamer_plugin_api_filter.h:568:76: error: missing initializer for member 'parse_accl_args::auto_accl' [-Werror=missing-field-initializers]
    #define parse_accl_hw(...) parse_accl_hw_fill((parse_accl_args){__VA_ARGS__})
                                                                               ^
tensor_filter_armnn.cc:672:8: note: in expansion of macro 'parse_accl_hw'
    hw = parse_accl_hw (prop->accl_str, armnn_accl_support);
         ^~~~~~~~~~~~~

Signed-off-by: Julien Vuillaumier <julien.vuillaumier@nxp.com>