### PR TITLE
[MQTT] Wait until connection is established.

### DIFF
--- a/gst/mqtt/mqttcommon.h
+++ b/gst/mqtt/mqttcommon.h
@@ -37,6 +37,8 @@
 
 #define GST_US_TO_NS_MULTIPLIER 1000
 
+#define DEFAULT_MQTT_CONN_TIMEOUT_SEC 5
+
 /**
  * @brief Defined a custom data type, GstMQTTMessageHdr
  *

--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -214,6 +214,7 @@ gst_mqtt_sink_init (GstMqttSink * self)
   self->mqtt_ntp_ports = NULL;
   self->mqtt_ntp_num_srvs = 0;
   self->get_epoch_func = default_mqtt_get_unix_epoch;
+  self->is_connected = FALSE;
 
   /** init basesink properties */
   gst_base_sink_set_qos_enabled (basesink, DEFAULT_QOS);
@@ -554,6 +555,7 @@ gst_mqtt_sink_start (GstBaseSink * basesink)
   gchar *haddr = g_strdup_printf ("%s:%s", self->mqtt_host_address,
       self->mqtt_host_port);
   int ret;
+  gint64 end_time;
 
   if (!g_strcmp0 (DEFAULT_MQTT_CLIENT_ID, self->mqtt_client_id)) {
     g_free (self->mqtt_client_id);
@@ -586,10 +588,29 @@ gst_mqtt_sink_start (GstBaseSink * basesink)
 
   ret = MQTTAsync_connect (self->mqtt_client_handle, &self->mqtt_conn_opts);
   if (ret != MQTTASYNC_SUCCESS) {
-    return FALSE;
+    goto error;
   }
 
+  /* Waiting for the connection */
+  end_time = g_get_monotonic_time () +
+      DEFAULT_MQTT_CONN_TIMEOUT_SEC * G_TIME_SPAN_SECOND;
+  g_mutex_lock (&self->mqtt_sink_mutex);
+  while (!self->is_connected) {
+    if (!g_cond_wait_until (&self->mqtt_sink_gcond, &self->mqtt_sink_mutex,
+            end_time)) {
+      g_mutex_unlock (&self->mqtt_sink_mutex);
+      g_critical ("Failed to connect to MQTT broker from mqttsink."
+          "Please check broker is running status or broker host address.");
+      goto error;
+    }
+  }
+  g_mutex_unlock (&self->mqtt_sink_mutex);
+
   return TRUE;
+
+error:
+  MQTTAsync_destroy (&self->mqtt_client_handle);
+  return FALSE;
 }
 
 /**
@@ -614,6 +635,7 @@ gst_mqtt_sink_stop (GstBaseSink * basesink)
 
     MQTTAsync_disconnect (self->mqtt_client_handle, &disconn_opts);
     g_mutex_lock (&self->mqtt_sink_mutex);
+    self->is_connected = FALSE;
     g_cond_wait_until (&self->mqtt_sink_gcond, &self->mqtt_sink_mutex,
         end_time);
     g_mutex_unlock (&self->mqtt_sink_mutex);
@@ -1235,6 +1257,7 @@ cb_mqtt_on_connect (void *context, MQTTAsync_successData * response)
 
   g_atomic_int_set (&self->mqtt_sink_state, MQTT_CONNECTED);
   g_mutex_lock (&self->mqtt_sink_mutex);
+  self->is_connected = TRUE;
   g_cond_broadcast (&self->mqtt_sink_gcond);
   g_mutex_unlock (&self->mqtt_sink_mutex);
 }
@@ -1252,6 +1275,7 @@ cb_mqtt_on_connect_failure (void *context, MQTTAsync_failureData * response)
 
   g_atomic_int_set (&self->mqtt_sink_state, MQTT_CONNECT_FAILURE);
   g_mutex_lock (&self->mqtt_sink_mutex);
+  self->is_connected = FALSE;
   g_cond_broadcast (&self->mqtt_sink_gcond);
   g_mutex_unlock (&self->mqtt_sink_mutex);
 }
@@ -1317,6 +1341,7 @@ cb_mqtt_on_connection_lost (void *context, char *cause)
 
   g_atomic_int_set (&self->mqtt_sink_state, MQTT_CONNECTION_LOST);
   g_mutex_lock (&self->mqtt_sink_mutex);
+  self->is_connected = FALSE;
   g_cond_broadcast (&self->mqtt_sink_gcond);
   g_mutex_unlock (&self->mqtt_sink_mutex);
 }

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -80,6 +80,7 @@ struct _GstMqttSink {
   gchar *mqtt_ntp_srvs;
   gchar **mqtt_ntp_hnames;
   guint16 *mqtt_ntp_ports;
+  gboolean is_connected;
 
   mqtt_get_unix_epoch get_epoch_func;
 

--- a/tests/gstreamer_mqtt/unittest_mqtt.cc
+++ b/tests/gstreamer_mqtt/unittest_mqtt.cc
@@ -12,25 +12,26 @@
 #include <gst/check/gstharness.h>
 #include <gst/gst.h>
 #include <gtest/gtest.h>
+#include <unittest_util.h>
 
 /**
  * @brief Test for mqttsink with wrong URL
  */
 TEST (testMqttSink, sinkPushWrongurl_n)
 {
-  const static gsize data_size = 1024;
-  GstHarness *h = gst_harness_new_parse ("mqttsink host=invalid_host");
-  GstBuffer *in_buf;
-  GstFlowReturn ret;
+  gchar *pipeline;
+  GstElement *gstpipe;
 
-  ASSERT_TRUE (h != NULL);
+  /* Create a nnstreamer pipeline */
+  pipeline = g_strdup_printf (
+      "videotestsrc is-live=true ! video/x-raw,format=RGB,width=640,height=480,framerate=5/1 ! mqttsink host=invalid_host pub-topic=test/videotestsrc");
+  gstpipe = gst_parse_launch (pipeline, NULL);
+  EXPECT_NE (pipeline, nullptr);
 
-  in_buf = gst_harness_create_buffer (h, data_size);
-  ret = gst_harness_push (h, in_buf);
+  EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
-  EXPECT_EQ (ret, GST_FLOW_ERROR);
-
-  gst_harness_teardown (h);
+  gst_object_unref (gstpipe);
+  g_free (pipeline);
 }
 
 /**
@@ -38,19 +39,19 @@ TEST (testMqttSink, sinkPushWrongurl_n)
  */
 TEST (testMqttSink, sinkPushWrongPort_n)
 {
-  const static gsize data_size = 1024;
-  GstHarness *h = gst_harness_new_parse ("mqttsink port=-1");
-  GstBuffer *in_buf;
-  GstFlowReturn ret;
+  gchar *pipeline;
+  GstElement *gstpipe;
 
-  ASSERT_TRUE (h != NULL);
+  /* Create a nnstreamer pipeline */
+  pipeline = g_strdup_printf (
+      "videotestsrc is-live=true ! video/x-raw,format=RGB,width=640,height=480,framerate=5/1 ! mqttsink port=-1 pub-topic=test/videotestsrc");
+  gstpipe = gst_parse_launch (pipeline, NULL);
+  EXPECT_NE (pipeline, nullptr);
 
-  in_buf = gst_harness_create_buffer (h, data_size);
-  ret = gst_harness_push (h, in_buf);
+  EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
-  EXPECT_EQ (ret, GST_FLOW_ERROR);
-
-  gst_harness_teardown (h);
+  gst_object_unref (gstpipe);
+  g_free (pipeline);
 }
 
 /**


### PR DESCRIPTION
Change to wait until the connection is successfully finished within the timeout limit.

This patch fixes the error:
ERROR: MQTTSrc: cb_mqtt_on_connect_failure: failed to connect to the broker: TCP/TLS connect failure.

Test pipeline:
Publisher
```bash
$ gst-launch-1.0 videotestsrc is-live=true ! video/x-raw,format=RGB,width=640,height=480,framerate=5/1 ! mqttsink pub-topic=test/videotestsrc
```
Subscriber
```bash
$ gst-launch-1.0 mqttsrc sub-topic=test/videotestsrc ! video/x-raw,format=RGB,width=640,height=480,framerate=5/1 ! videoconvert ! ximagesink
```

Signed-off-by: gichan <gichan2.jang@samsung.com>


**Self evaluation:**
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped

