### PR TITLE
[armnn] compilation error - unused parameter

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -227,6 +227,9 @@ int
 ArmNNCore::makeCaffeNetwork (std::map<std::string, armnn::TensorShape> &input_map,
     std::vector<std::string> &output_vec)
 {
+  UNUSED (input_map);
+  UNUSED (output_vec);
+
   g_printerr ("ARMNN-CAFFE was not enabled at build-time. tensor-filter::armnn cannot handle caffe networks.");
   return -EPERM;
 }


### PR DESCRIPTION
correction for occurences of compilation error below, when compilation
switch ENABLE_ARMNN_CAFFE is disabled :
error: unused parameter '[parameter name]' [-Werror=unused-parameter]

**Self evaluation:**
SSAT: passed
Gtest armnn: passed
