### PR TITLE
[UNITTEST] Add a skip option to the script running test cases

### DIFF
--- a/packaging/run_unittests_binaries.sh
+++ b/packaging/run_unittests_binaries.sh
@@ -7,6 +7,7 @@
 ## @date Dec 20 2019
 ## @brief Runs all the unittests binaries in the specified folder or file
 
+input=""
 skip_tests=""
 this_script="$(basename -- $0)"
 while (( "$#" )); do
@@ -38,6 +39,7 @@ while (( "$#" )); do
   esac
 done
 
+[[ -z "$input" ]] && echo "$this_script: target should be given" && exit 1
 export NNSTREAMER_SOURCE_ROOT_PATH=$(pwd)
 pushd build
 export NNSTREAMER_BUILD_ROOT_PATH=$(pwd)

--- a/packaging/run_unittests_binaries.sh
+++ b/packaging/run_unittests_binaries.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##
 ## SPDX-License-Identifier: LGPL-2.1-only
 ##
-## @file run_unittests.sh
+## @file run_unittests_binaries.sh
 ## @author Parichay Kapoor <pk.kapoor@gmail.com>
 ## @date Dec 20 2019
 ## @brief Runs all the unittests binaries in the specified folder or file


### PR DESCRIPTION
This patch adds an option to skip specific test cases to run_unittests_binaries.sh.

Signed-off-by: Wook Song <wook16.song@samsung.com>

```bash
$ ./packaging/run_unittests_binaries.sh -h
run_unittests_binaries.sh: usage: run_unittests_binaries.sh [options] target
    -k | --skip  BINARY_NAME[,*]
        Skip the test cases whose names are...(valid only if target is a directory)
```

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped