### PR TITLE
[Flatbuf] support flexible tensors

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.cc
@@ -28,6 +28,7 @@
 #include <gst/base/gstdataqueue.h>
 
 using nnstreamer::flatbuf::Tensor_type;
+using nnstreamer::flatbuf::Tensor_format;
 using nnstreamer::flatbuf::frame_rate;
 
 using flatbuffers::grpc::MessageBuilder;
@@ -141,7 +142,7 @@ ServiceImplFlatbuf::_get_tensors_from_buffer (GstBuffer *buffer,
   flatbuffers::Offset<Tensors> tensors;
   std::vector<flatbuffers::Offset<Tensor>> tensor_vector;
   Tensor_type tensor_type;
-
+  Tensor_format format = (Tensor_format) config_->format;
   unsigned int num_tensors = config_->info.num_tensors;
   frame_rate fr = frame_rate (config_->rate_n, config_->rate_d);
 
@@ -173,7 +174,7 @@ ServiceImplFlatbuf::_get_tensors_from_buffer (GstBuffer *buffer,
     tensor_vector.push_back (tensor);
   }
 
-  tensors = CreateTensors (builder, num_tensors, &fr, builder.CreateVector (tensor_vector));
+  tensors = CreateTensors (builder, num_tensors, &fr, builder.CreateVector (tensor_vector), format);
 
   builder.Finish (tensors);
   msg = builder.ReleaseMessage<Tensors>();

--- a/ext/nnstreamer/include/nnstreamer.fbs
+++ b/ext/nnstreamer/include/nnstreamer.fbs
@@ -24,6 +24,14 @@ enum Tensor_type : int {
   NNS_END
   }
 
+enum Tensor_format : int {
+  NNS_TENSOR_FORAMT_STATIC = 0,
+  NNS_TENSOR_FORMAT_FLEXIBLE,
+  NNS_TENSOR_FORMAT_SPARSE,
+
+  NNS_TENSOR_FORMAT_END
+  }
+
 struct frame_rate {
   rate_n : int;
   rate_d : int;
@@ -40,6 +48,7 @@ table Tensors {
   num_tensor : int;
   fr : frame_rate;
   tensor : [Tensor]; // tensor size is limited to 16
+  format : Tensor_format = NNS_TENSOR_FORAMT_STATIC;
 }
 
 root_type Tensors;

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
@@ -90,6 +90,8 @@ fbc_convert (GstBuffer *in_buf, GstTensorsConfig *config, void *priv_data)
   g_assert (tensors);
 
   config->info.num_tensors = tensors->num_tensor ();
+  config->format = (tensor_format) tensors->format ();
+
   if (tensors->num_tensor () > NNS_TENSOR_SIZE_LIMIT) {
     nns_loge ("The number of tensors is limited to %d", NNS_TENSOR_SIZE_LIMIT);
     goto done;

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -358,7 +358,7 @@ gst_tensor_converter_init (GstTensorConverter * self)
   self->mode_option = NULL;
   self->custom.func = NULL;
   self->custom.data = NULL;
-
+  self->do_not_append_header = FALSE;
   gst_tensors_info_init (&self->tensors_info);
   gst_tensors_config_init (&self->tensors_config);
   self->tensors_configured = FALSE;
@@ -918,7 +918,8 @@ _gst_tensor_converter_chain_push (GstTensorConverter * self, GstBuffer * buf)
   }
 
   /* if output is flexible, add header. */
-  if (gst_tensor_pad_caps_is_flexible (self->srcpad)) {
+  if (!self->do_not_append_header
+      && gst_tensor_pad_caps_is_flexible (self->srcpad)) {
     buffer = _gst_tensor_converter_chain_flex_tensor (self, buffer);
   }
 
@@ -1192,6 +1193,8 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
             self->in_media_type);
         goto error;
       }
+      self->do_not_append_header =
+          (new_config.format == _NNS_TENSOR_FORMAT_FLEXIBLE);
 
       if (inbuf == NULL) {
         nns_loge ("Failed to convert media to tensors.");

--- a/gst/nnstreamer/tensor_converter/tensor_converter.h
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.h
@@ -104,6 +104,7 @@ struct _GstTensorConverter
   gchar *mode_option; /**< tensor converter mode option */
   gchar *ext_fw; /**< tensor converter custom mode framework */
   converter_custom_cb_s custom;
+  gboolean do_not_append_header;
 
   void *priv_data; /**< plugin's private data */
 };

--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -85,7 +85,7 @@ enum
 /**
  * @brief Support multi-tensor along with single-tensor as the input
  */
-#define CAPS_STRING GST_TENSOR_CAP_DEFAULT "; " GST_TENSORS_CAP_DEFAULT
+#define CAPS_STRING GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_DEFAULT ";" GST_TENSORS_FLEX_CAP_DEFAULT
 
 /**
  * @brief The capabilities of the inputs
@@ -681,6 +681,9 @@ gst_tensordec_transform (GstBaseTransform * trans,
     GstTensorMemory input[NNS_TENSOR_SIZE_LIMIT];
     guint i, num_tensors;
 
+    if (gst_tensors_config_is_flexible (&self->tensor_config)) {
+      self->tensor_config.info.num_tensors = gst_buffer_n_memory (inbuf);
+    }
     num_tensors = self->tensor_config.info.num_tensors;
     /** Internal logic error. Negotation process should prevent this! */
     g_assert (gst_buffer_n_memory (inbuf) == num_tensors);


### PR DESCRIPTION
Support flexible tensors for flatbuffers.

Test pipeline
Server:
```
gst-launch-1.0 \
    videotestsrc pattern=13 ! video/x-raw,format=RGB,width=640,height=480,framerate=5/1 ! tensor_converter ! mux.sink_0 \
    videotestsrc pattern=18 ! video/x-raw,format=RGB,width=640,height=480,framerate=5/1 ! tensor_converter ! other/tensors,format=flexible ! mux.sink_1 \
    tensor_mux name=mux ! tensor_decoder mode=flatbuf ! gdppay ! tcpserversink
```
Client
```
gst-launch-1.0 \
    tcpclientsrc ! gdpdepay ! other/flatbuf-tensor ! tensor_converter ! other/tensors,format=flexible ! tensor_sink
```