### PR TITLE
[Spec] Enable SNPE filter on both In-House and public infra @open sesame 11/11 17:20

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -567,6 +567,7 @@ if get_option('enable-mediapipe')
   )
 endif
 
+run_command('sh', '-c', 'touch filter_snpe_list')
 if snpe_support_is_available
   filter_sub_snpe_sources = ['tensor_filter_snpe.cc']
 
@@ -595,6 +596,7 @@ if snpe_support_is_available
     install: true,
     install_dir: nnstreamer_libdir
   )
+  run_command('sh', '-c', 'echo "%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_snpe.so" >> filter_snpe_list')
 endif
 
 if tensorrt_support_is_available

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -34,7 +34,7 @@
 %define		mqtt_support 1
 %define		lua_support 1
 %define		tvm_support 1
-%define		snpe_support 0
+%define		snpe_support 1
 
 %define		check_test 1
 %define		release_test 1
@@ -102,6 +102,7 @@
 %define		lua_support 0
 %define		mqtt_support 0
 %define		tvm_support 0
+%define		snpe_support 0
 %endif
 
 # DA requested to remove unnecessary module builds
@@ -114,18 +115,17 @@
 %define		lua_support 0
 %define		mqtt_support 0
 %define		tvm_support 0
-%endif
-
-# TODO: The variable `_with_qc_snpe` is temporary. Make proper one.
-%if 0%{?_with_qc_snpe}
-%ifarch aarch64
-%define		snpe_support 1
-%endif
+%define		snpe_support 0
 %endif
 
 # Release unit test suite as a subpackage only if check_test is enabled.
 %if !0%{?check_test}
 %define		release_test 0
+%endif
+
+# Current Tizen Robot profile only supports aarch64.
+%ifnarch aarch64
+%define		snpe_support 0
 %endif
 
 # If it is tizen, we can export Tizen API packages.
@@ -735,13 +735,6 @@ Provides additional gstreamer plugins for nnstreamer pipelines
 %define enable_tvm -Dtvm-support=disabled
 %endif
 
-# Support snpe
-%if 0%{?snpe_support}
-%define enable_snpe -Dsnpe-support=enabled
-%else
-%define enable_snpe -Dsnpe-support=disabled
-%endif
-
 # Framework priority for each file extension
 %define fw_priority_bin ''
 %define fw_priority_nb ''
@@ -785,7 +778,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir
 	%{enable_tizen} %{element_restriction} %{fw_priority} -Denable-env-var=false -Denable-symbolic-link=false \
 	%{enable_tf_lite} %{enable_tf2_lite} %{enable_tf} %{enable_pytorch} %{enable_caffe2} %{enable_python3} \
 	%{enable_nnfw_runtime} %{enable_mvncsdk2} %{enable_openvino} %{enable_armnn} %{enable_edgetpu}  %{enable_vivante} %{enable_flatbuf} \
-	%{enable_tizen_sensor} %{enable_mqtt} %{enable_lua} %{enable_tvm} %{enable_snpe} %{enable_test} %{enable_test_coverage} %{install_test} \
+	%{enable_tizen_sensor} %{enable_mqtt} %{enable_lua} %{enable_tvm} %{enable_test} %{enable_test_coverage} %{install_test} \
 	build
 
 ninja -C build %{?_smp_mflags}
@@ -1002,10 +995,11 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 
 # for snpe
 %if 0%{?snpe_support}
-%files snpe
+# Workaround: Conditionally enable nnstreamer-snpe rpm package
+# when existing actual snpe library (snpe.pc)
+%files snpe -f ext/nnstreamer/tensor_filter/filter_snpe_list
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
-%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_snpe.so
 %endif
 
 %files devel


### PR DESCRIPTION
To support NNStreamer filter for SNPE on both In-House build infra and
those of the public, this patch conditionally enables nnstreamer-snpe
rpm package when existing actual snpe library. (i.e. snpe.pc). In case
of the dummy SNPE package, nnstreamer-snpe rpm contains no files.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**Related Issue**
* https://github.com/nnstreamer/nnstreamer/issues/3442

### Result ###
#### Public Build Infra ####
* `snpe-devel.rpm` contains the `snpe-dummy.pc` so NNStreamer filter for SNPE is not built.
```bash
$ rpm -qlp snpe-devel-0.0.1-1.aarch64.rpm
/usr/lib64/pkgconfig/snpe-dummy.pc

$ rpm -qlp ./nnstreamer-snpe-2.1.0-0.aarch64.rpm
(contains no files)
```

#### In-House Infra ####
* `snpe-devel.rpm` contains the `snpe.pc` file so NNStreamer filter for SNPE is built on In-Hause Infra.
```bash
# Pre-built packages on the build server
$ rpm -qlp snpe-devel-1.53.2-0.aarch64.rpm | grep snpe.pc
/usr/lib64/pkgconfig/snpe.pc

# Build result
$ find . | grep snpe
./nnstreamer-snpe-2.1.0-0.aarch64.rpm
./nnstreamer-snpe-debuginfo-2.1.0-0.aarch64.rpm

$ rpm -qlp ./nnstreamer-snpe-2.1.0-0.aarch64.rpm
/usr/lib/nnstreamer/filters/libnnstreamer_filter_snpe.so
```   


