### PR TITLE
[Elements] handle single mem chunk

### DIFF
--- a/gst/nnstreamer/tensor_common_pipeline.c
+++ b/gst/nnstreamer/tensor_common_pipeline.c
@@ -379,6 +379,7 @@ gst_tensor_time_sync_buffer_from_collectpad (GstCollectPads * collect,
     }
 
     if (GST_IS_BUFFER (buf)) {
+      buf = gst_tensor_buffer_from_config (buf, &in_configs);
       n_mem = gst_buffer_n_memory (buf);
 
       /** These are internal logic error. If given inputs are incorrect,

--- a/gst/nnstreamer/tensor_crop/tensor_crop.c
+++ b/gst/nnstreamer/tensor_crop/tensor_crop.c
@@ -708,6 +708,7 @@ gst_tensor_crop_chain (GstTensorCrop * self,
 {
   GstFlowReturn ret;
   GstBuffer *buf_raw, *buf_info, *result;
+  GstTensorCropPadData *cpad;
   tensor_crop_info_s cinfo;
   gboolean drop_raw, drop_info;
 
@@ -722,6 +723,11 @@ gst_tensor_crop_chain (GstTensorCrop * self,
     ret = GST_FLOW_EOS;
     goto done;
   }
+
+  cpad = (GstTensorCropPadData *) data_raw;
+  buf_raw = gst_tensor_buffer_from_config (buf_raw, &cpad->config);
+  cpad = (GstTensorCropPadData *) data_info;
+  buf_info = gst_tensor_buffer_from_config (buf_info, &cpad->config);
 
   /**
    * The case when raw and info have different timestamp.

--- a/gst/nnstreamer/tensor_demux/gsttensordemux.c
+++ b/gst/nnstreamer/tensor_demux/gsttensordemux.c
@@ -475,6 +475,8 @@ gst_tensor_demux_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
   UNUSED (pad);
   tensor_demux = GST_TENSOR_DEMUX (parent);
 
+  buf = gst_tensor_buffer_from_config (buf, &tensor_demux->tensors_config);
+
   if (gst_tensors_config_is_flexible (&tensor_demux->tensors_config)) {
     /* cannot get exact number of tensors from config */
     num_tensors = gst_buffer_n_memory (buf);

--- a/gst/nnstreamer/tensor_sparse/tensor_sparse_dec.h
+++ b/gst/nnstreamer/tensor_sparse/tensor_sparse_dec.h
@@ -43,6 +43,7 @@ struct _GstTensorSparseDec
   GstPad *srcpad; /**< src pad */
 
   /* <private> */
+  GstTensorsConfig in_config; /**< input tensors config */
   GstTensorsConfig out_config; /**< output tensors config */
   gboolean silent; /**< true to print minimized log */
 };

--- a/gst/nnstreamer/tensor_sparse/tensor_sparse_enc.c
+++ b/gst/nnstreamer/tensor_sparse/tensor_sparse_enc.c
@@ -247,6 +247,9 @@ gst_tensor_sparse_enc_parse_caps (GstTensorSparseEnc * self,
   return TRUE;
 }
 
+/**
+ * @brief This function handles sink pad event.
+ */
 static gboolean
 gst_tensor_sparse_enc_sink_event (GstPad * pad, GstObject * parent,
     GstEvent * event)
@@ -378,7 +381,7 @@ gst_tensor_sparse_enc_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
   UNUSED (pad);
 
   info = &self->in_config.info;
-
+  buf = gst_tensor_buffer_from_config (buf, &self->in_config);
   outbuf = gst_buffer_new ();
 
   for (i = 0; i < info->num_tensors; ++i) {

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -1397,6 +1397,7 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
   filter = GST_TENSOR_TRANSFORM_CAST (trans);
 
   g_return_val_if_fail (filter->loaded, GST_FLOW_ERROR);
+  inbuf = gst_tensor_buffer_from_config (inbuf, &filter->in_config);
 
   in_flexible =
       gst_tensor_pad_caps_is_flexible (GST_BASE_TRANSFORM_SINK_PAD (trans));

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -6785,6 +6785,7 @@ typedef struct
   GstClockTime ts_raw;
   tensor_type info_type;
   gpointer info_data;
+  guint info_num;
   gsize info_size;
   GstClockTime ts_info;
 } crop_test_data_s;
@@ -6830,6 +6831,7 @@ _crop_test_init (crop_test_data_s * crop_test)
   crop_test->ts_raw = GST_CLOCK_TIME_NONE;
   crop_test->info_type = _NNS_END;
   crop_test->info_data = NULL;
+  crop_test->info_num = 0;
   crop_test->info_size = 0;
   crop_test->ts_info = GST_CLOCK_TIME_NONE;
 }
@@ -6884,7 +6886,7 @@ _crop_test_free (crop_test_data_s * crop_test)
     gst_tensor_meta_info_init (&meta); \
     meta.type = (ctd)->info_type; \
     meta.dimension[0] = 4U; \
-    meta.dimension[1] = (ctd)->info_size / (4U * gst_tensor_get_element_size ((ctd)->info_type)); \
+    meta.dimension[1] = (ctd)->info_num; \
     meta.format = _NNS_TENSOR_FORMAT_FLEXIBLE; \
     mem = gst_memory_new_wrapped (GST_MEMORY_FLAG_READONLY, \
         (ctd)->info_data, (ctd)->info_size, 0, (ctd)->info_size, NULL, NULL); \
@@ -7083,6 +7085,7 @@ TEST (testTensorCrop, cropTensor)
 
   crop_test.info_type = _NNS_UINT32;
   crop_test.info_size = sizeof (guint) * 8U;
+  crop_test.info_num = 2U;
   crop_test.info_data = g_malloc0 (crop_test.info_size);
   _info = (guint *) crop_test.info_data;
 
@@ -7179,6 +7182,7 @@ TEST (testTensorCrop, rawInvalidSize_n)
 
   crop_test.info_type = _NNS_UINT16;
   crop_test.info_size = gst_tensor_get_element_size (crop_test.info_type) * 8U;
+  crop_test.info_num = 2U;
   crop_test.info_data = g_malloc0 (crop_test.info_size);
 
   /* raw buffer has invalid size */
@@ -7205,6 +7209,7 @@ TEST (testTensorCrop, infoInvalidSize_n)
 
   crop_test.info_type = _NNS_INT8;
   crop_test.info_size = gst_tensor_get_element_size (crop_test.info_type) * 7U;
+  crop_test.info_num = 2U;
   crop_test.info_data = g_malloc0 (crop_test.info_size);
 
   /* info buffer has invalid size */
@@ -7242,6 +7247,7 @@ TEST (testTensorCrop, rawDelayed_n)
 
   crop_test.info_type = _NNS_UINT8;
   crop_test.info_size = gst_tensor_get_element_size (crop_test.info_type) * 8U;
+  crop_test.info_num = 2U;
   crop_test.info_data = g_malloc0 (crop_test.info_size);
   _info = (guint8 *) crop_test.info_data;
 
@@ -7308,6 +7314,7 @@ TEST (testTensorCrop, infoDelayed_n)
 
   crop_test.info_type = _NNS_UINT8;
   crop_test.info_size = gst_tensor_get_element_size (crop_test.info_type) * 8U;
+  crop_test.info_num = 2U;
   crop_test.info_data = g_malloc0 (crop_test.info_size);
   _info = (guint8 *) crop_test.info_data;
 


### PR DESCRIPTION
If incoming buffer has single memory (case with gst-plugins), nnstreamer elements cannot generate output buffer (invalid memory chunks).

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
