### PR TITLE
[Test] Fix build issue with GCC 11 [-Werror=maybe-uninitialized]

### DIFF
--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -948,7 +948,7 @@ TEST (commonTensorsConfig, validateInvalidParam2_n)
  */
 TEST (commonTensorsConfig, fromStructreInvalidParam0_n)
 {
-  GstStructure structure;
+  GstStructure structure = { 0 };
 
   EXPECT_FALSE (gst_tensors_config_from_structure (NULL, &structure));
 }


### PR DESCRIPTION
Correction for build issue showing up with GCC 11

unittest_common.cc:953:51:
error: 'structure' may be used uninitialized [-Werror=maybe-uninitialized]

Signed-off-by: Julien Vuillaumier <julien.vuillaumier@nxp.com>

Self evaluation:
SSAT unit tests: passed
