### PR TITLE
[TEST] Disable MQTT Test when broker is not available.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -545,6 +545,12 @@ configure_file(input: 'nnstreamer-internal.pc.in', output: 'nnstreamer-internal.
   configuration: nnstreamer_install_conf
 )
 
+# Check whether mqtt broker is running or not.
+check_mosquitto = run_command ('bash', './tests/check_broker.sh').stdout()
+if check_mosquitto != ''
+  add_project_arguments('-D__MQTT_BROKER_ENABLED__=1', language: ['c', 'cpp'])
+endif
+
 # Build nnstreamer (common, plugins)
 subdir('gst')
 

--- a/tests/check_broker.sh
+++ b/tests/check_broker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+mosquitto_pub -r -t check/broker/running -m "mosquitto_broker_is_running"
+check=`mosquitto_sub  -t check/broker/running --remove-retained -W 1 | grep mosquitto_broker_is_running`
+
+if [ "$check" = "mosquitto_broker_is_running" ]; then
+    echo 1
+fi

--- a/tests/gstreamer_mqtt/unittest_mqtt.cc
+++ b/tests/gstreamer_mqtt/unittest_mqtt.cc
@@ -54,6 +54,7 @@ TEST (testMqttSink, sinkPushWrongPort_n)
   g_free (pipeline);
 }
 
+#ifdef __MQTT_BROKER_ENABLED__
 /**
  * @brief Test pushing EOS event to mqttsink
  */
@@ -284,6 +285,8 @@ TEST (testMqttSrc, srcGetSetProperties_n)
 
   gst_harness_teardown (h);
 }
+
+#endif /* #ifdef __MQTT_BROKER_ENABLED__ */
 
 /**
  * @brief Main GTest


### PR DESCRIPTION
If the broker is not available, the mqtt element cannot be changed to the playing state.
However, harnesses are used in the mqtt test, and errors occur if harnesses cannot be changed to the playing state.
So, if there's no broker on the test environment, the test fails.

For example, the build on the lunch pad failed.
https://launchpadlibrarian.net/566158157/buildlog_ubuntu-bionic-amd64.nnstreamer_2.1.0.0-0~202110290743~ubuntu18.04.1_BUILDING.txt.gz

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed [ ]Skipped
2. Run test: [* ]Passed [ ]Failed [ ]Skipped
