### PR TITLE
meson.build: Fix subplugin install

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -97,7 +97,7 @@ nnstreamer_inidir = join_paths(nnstreamer_prefix, get_option('sysconfdir'))
 plugins_install_dir = join_paths(nnstreamer_libdir, 'gstreamer-' + gst_api_verision)
 
 # nnstreamer sub-plugins path
-subplugin_install_prefix = join_paths(nnstreamer_prefix, 'lib', 'nnstreamer')
+subplugin_install_prefix = join_paths(nnstreamer_prefix, get_option('libdir'), 'nnstreamer')
 filter_subplugin_install_dir = join_paths(subplugin_install_prefix, 'filters')
 decoder_subplugin_install_dir = join_paths(subplugin_install_prefix, 'decoders')
 customfilter_install_dir = join_paths(subplugin_install_prefix, 'customfilters')


### PR DESCRIPTION
Use 'libdir' for library path to cover a multilib envoironment.

These checks are usually done before release, for example in the scenario
where images are created for a 64-bit target (imx8 * boards) but which also
supports running 32-bit applications.

This is the error in a linux/yocto build:

| ERROR: nnstreamer-2.0.0-r0 do_package: QA Issue: nnstreamer: Files/directories were installed but not shipped in any package:
|   /usr/lib/nnstreamer/customfilters/libnnstreamer_customfilter_passthrough_variable.so
|   /usr/lib/nnstreamer/customfilters/libdummyLSTM.so
|   /usr/lib/nnstreamer/customfilters/libnnstreamer_customfilter_scaler.so
|   /usr/lib/nnstreamer/customfilters/libnnstreamer_customfilter_average.so
|   /usr/lib/nnstreamer/customfilters/libnnstreamer_customfilter_scaler_allocator.so
|   /usr/lib/nnstreamer/customfilters/libnnscustom_drop_buffer.so
|   /usr/lib/nnstreamer/customfilters/libnnscustom_framecounter.so
|   /usr/lib/nnstreamer/customfilters/libdummyRNN.so
|   /usr/lib/nnstreamer/customfilters/libnnstreamer_customfilter_passthrough.so
|   /usr/lib/nnstreamer/converters/libnnstreamer_converter_protobuf.so
|   /usr/lib/nnstreamer/converters/libnnstreamer_converter_python3.so
|   /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_bounding_boxes.so
|   /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_direct_video.so
|   /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_pose_estimation.so
|   /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_image_labeling.so
|   /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_image_segment.so
|   /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_python3.so
|   /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_protobuf.so
|   /usr/lib/nnstreamer/filters/libnnstreamer_filter_cpp.so
|   /usr/lib/nnstreamer/filters/libnnstreamer_filter_armnn.so
|   /usr/lib/nnstreamer/filters/libnnstreamer_filter_python3.so
|   /usr/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow2-lite.so
|   /usr/lib/nnstreamer/extra/nnstreamer_python3.so
| Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
| nnstreamer: 23 installed and not shipped files. [installed-vs-shipped]

Signed-off-by: Cristinel Panfir <cristinel.panfir@nxp.com>


---


