### PR TITLE
[fix/mqttsrc] Set MQTT persistence mode of mqttsrc to None

### DIFF
--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -824,14 +824,14 @@ ret_flow_err:
 static gboolean
 gst_mqtt_src_query (GstBaseSrc * basesrc, GstQuery * query)
 {
-  GstEventType type = GST_QUERY_TYPE (query);
+  GstQueryType type = GST_QUERY_TYPE (query);
   GstMqttSrc *self = GST_MQTT_SRC (basesrc);
   gboolean res = FALSE;
 
   if (self->debug)
     GST_DEBUG_OBJECT (self, "Got %s event", gst_query_type_get_name (type));
 
-  switch (GST_QUERY_TYPE (query)) {
+  switch (type) {
     case GST_QUERY_LATENCY:{
       GstClockTime min_latency = 0;
       GstClockTime max_latency = GST_CLOCK_TIME_NONE;

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -537,7 +537,7 @@ gst_mqtt_src_start (GstBaseSrc * basesrc)
    *                                 mechanism
    */
   ret = MQTTAsync_create (&self->mqtt_client_handle, haddr,
-      self->mqtt_client_id, MQTTCLIENT_PERSISTENCE_DEFAULT, NULL);
+      self->mqtt_client_id, MQTTCLIENT_PERSISTENCE_NONE, NULL);
   g_free (haddr);
   if (ret != MQTTASYNC_SUCCESS)
     return FALSE;


### PR DESCRIPTION
- Fix data type of GstQueryType 
- Default persistence mode have not been tested on various targets. Set it to None mode sync-ing with mqttsink.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
