### PR TITLE
Test: enhancing log behaviors for unittest

### DIFF
--- a/gst/nnstreamer/nnstreamer_log.h
+++ b/gst/nnstreamer/nnstreamer_log.h
@@ -29,7 +29,14 @@
 #define TAG_NAME "nnstreamer"
 
 #if defined(__TIZEN__)
+
+/** Check if unittest_util.h's fake dlog is enabled */
+#ifndef FAKEDLOG
 #include <dlog.h>
+#else
+/** A unit test code is referring me. */
+#include "../../tests/unittest_util.h"
+#endif
 
 #define ml_logi(...) \
     dlog_print (DLOG_INFO, TAG_NAME, __VA_ARGS__)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -36,17 +36,6 @@ gtest_dep = dependency('gtest', required: false)
 if gtest_dep.found()
   lesser_code_quality_accepted_for_unittest_code = declare_dependency(compile_args: ['-Wno-unused-parameter', '-Wno-missing-field-initializers'])
 
-  nnstreamer_unittest_deps = [
-    nnstreamer_dep,
-    nnstreamer_internal_deps,
-    glib_dep,
-    gst_dep,
-    gst_app_dep,
-    gst_check_dep,
-    gtest_dep,
-    lesser_code_quality_accepted_for_unittest_code
-  ]
-
   # Shared library of internal APIs for nnstreamer-gtest
   unittest_util_shared = shared_library('nnstreamer_unittest_util',
     join_paths(meson.current_source_dir(), 'unittest_util.c'),
@@ -57,13 +46,26 @@ if gtest_dep.found()
   )
   unittest_util_dep = declare_dependency(link_with: unittest_util_shared,
     dependencies: nnstreamer_base_deps,
+    compile_args: ['-DFAKEDLOG=1'],
     include_directories: include_directories('.')
   )
+
+  nnstreamer_unittest_deps = [
+    unittest_util_dep,
+    nnstreamer_dep,
+    nnstreamer_internal_deps,
+    glib_dep,
+    gst_dep,
+    gst_app_dep,
+    gst_check_dep,
+    gtest_dep,
+    lesser_code_quality_accepted_for_unittest_code
+  ]
 
   # Run unittest_common
   unittest_common = executable('unittest_common',
     join_paths('common', 'unittest_common.cc'),
-    dependencies: [nnstreamer_unittest_deps, unittest_util_dep],
+    dependencies: [nnstreamer_unittest_deps],
     install: get_option('install-test'),
     install_dir: unittest_install_dir
   )
@@ -75,7 +77,7 @@ if gtest_dep.found()
   if gst18_dep.found()
     unittest_sink = executable('unittest_sink',
       join_paths('nnstreamer_sink', 'unittest_sink.cc'),
-      dependencies: [nnstreamer_unittest_deps, unittest_util_dep],
+      dependencies: [nnstreamer_unittest_deps],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )
@@ -95,7 +97,7 @@ if gtest_dep.found()
     # Run unittest_if
     unittest_if = executable('unittest_if',
       join_paths('nnstreamer_if', 'unittest_if.cc'),
-      dependencies: [nnstreamer_unittest_deps, unittest_util_dep],
+      dependencies: [nnstreamer_unittest_deps],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )
@@ -105,7 +107,7 @@ if gtest_dep.found()
     # Run unittest_rate
     unittest_rate = executable('unittest_rate',
       join_paths('nnstreamer_rate', 'unittest_rate.cc'),
-      dependencies: [nnstreamer_unittest_deps, unittest_util_dep],
+      dependencies: [nnstreamer_unittest_deps],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )
@@ -115,7 +117,7 @@ if gtest_dep.found()
     # Run unittest_filter_single
     unittest_filter_single = executable('unittest_filter_single',
       join_paths('nnstreamer_filter_single', 'unittest_filter_single.cc'),
-      dependencies: [nnstreamer_unittest_deps, unittest_util_dep],
+      dependencies: [nnstreamer_unittest_deps],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )
@@ -125,7 +127,7 @@ if gtest_dep.found()
     # Run unittest_join
     unittest_join = executable('unittest_join',
       join_paths('gstreamer_join', 'unittest_join.cc'),
-      dependencies: [nnstreamer_unittest_deps, unittest_util_dep, join_dep],
+      dependencies: [nnstreamer_unittest_deps, join_dep],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )
@@ -135,7 +137,7 @@ if gtest_dep.found()
     # Run unittest_query
     unittest_query = executable('unittest_query',
       join_paths('nnstreamer_query', 'unittest_query.cc'),
-      dependencies: [nnstreamer_unittest_deps, unittest_util_dep],
+      dependencies: [nnstreamer_unittest_deps],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )
@@ -146,7 +148,7 @@ if gtest_dep.found()
     if mqtt_support_is_available
       unittest_mqtt_w_helper = executable('unittest_mqtt_w_helper',
           join_paths('gstreamer_mqtt', 'unittest_mqtt_w_helper.cc'),
-          dependencies: [gstmqtt_mocking_dep, nnstreamer_unittest_deps, unittest_util_dep],
+          dependencies: [gstmqtt_mocking_dep, nnstreamer_unittest_deps],
           install: get_option('install-test'),
           install_dir: unittest_install_dir)
 
@@ -154,7 +156,7 @@ if gtest_dep.found()
 
       unittest_mqtt = executable('unittest_mqtt',
           join_paths('gstreamer_mqtt', 'unittest_mqtt.cc'),
-          dependencies: [nnstreamer_unittest_deps, unittest_util_dep],
+          dependencies: [nnstreamer_unittest_deps],
           install: get_option('install-test'),
           install_dir: unittest_install_dir)
 
@@ -165,7 +167,7 @@ if gtest_dep.found()
     if build_platform != 'macos'
       unittest_src_iio = executable('unittest_src_iio',
         join_paths('nnstreamer_source', 'unittest_src_iio.cc'),
-        dependencies: [nnstreamer_unittest_deps, unittest_util_dep],
+        dependencies: [nnstreamer_unittest_deps],
         install: get_option('install-test'),
         install_dir: unittest_install_dir
       )
@@ -177,7 +179,7 @@ if gtest_dep.found()
     if flatbuf_support_is_available
       unittest_converter = executable('unittest_converter',
         join_paths('nnstreamer_converter', 'unittest_converter.cc'),
-        dependencies: [nnstreamer_unittest_deps, unittest_util_dep, flatbuf_dep, nnstreamer_python3_helper_dep],
+        dependencies: [nnstreamer_unittest_deps, flatbuf_dep, nnstreamer_python3_helper_dep],
         install: get_option('install-test'),
         install_dir: unittest_install_dir
       )
@@ -190,7 +192,7 @@ if gtest_dep.found()
   if armnn_support_is_available
     unittest_filter_armnn = executable('unittest_filter_armnn',
       join_paths('nnstreamer_filter_armnn', 'unittest_filter_armnn.cc'),
-      dependencies: [glib_dep, gst_dep, nnstreamer_dep, gtest_dep, armnn_plugin_dep],
+      dependencies: [nnstreamer_unittest_deps, armnn_plugin_dep],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )
@@ -202,7 +204,7 @@ if gtest_dep.found()
   if lua_support_is_available
     unittest_filter_lua = executable('unittest_filter_lua',
       join_paths('nnstreamer_filter_lua', 'unittest_filter_lua.cc'),
-      dependencies: [unittest_util_dep, glib_dep, gst_dep, nnstreamer_dep, gtest_dep],
+      dependencies: [nnstreamer_unittest_deps],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )
@@ -214,7 +216,7 @@ if gtest_dep.found()
   if snpe_support_is_available
     unittest_filter_snpe = executable('unittest_filter_snpe',
       join_paths('nnstreamer_filter_snpe', 'unittest_filter_snpe.cc'),
-      dependencies: [unittest_util_dep, glib_dep, gst_dep, nnstreamer_dep, gtest_dep],
+      dependencies: [nnstreamer_unittest_deps],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )
@@ -226,7 +228,7 @@ if gtest_dep.found()
   if tflite2_support_is_available
     unittest_filter_tensorflow2_lite = executable('unittest_filter_tensorflow2_lite',
       join_paths('nnstreamer_filter_tensorflow2_lite', 'unittest_filter_tensorflow2_lite.cc'),
-      dependencies: [unittest_util_dep, glib_dep, gst_dep, nnstreamer_dep, gtest_dep],
+      dependencies: [nnstreamer_unittest_deps],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )
@@ -238,7 +240,7 @@ if gtest_dep.found()
   if flatbuf_support_is_available
     unittest_decoder = executable('unittest_decoder',
       join_paths('nnstreamer_decoder', 'unittest_decoder.cc'),
-      dependencies: [nnstreamer_unittest_deps, unittest_util_dep, flatbuf_dep],
+      dependencies: [nnstreamer_unittest_deps, flatbuf_dep],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )

--- a/tests/nnstreamer_filter_edgetpu/meson.build
+++ b/tests/nnstreamer_filter_edgetpu/meson.build
@@ -1,10 +1,7 @@
 if get_option('enable-edgetpu')
   unittest_edgetpu_deps = [
-    gtest_dep,
-    glib_dep,
-    gst_dep,
+    nnstreamer_unittest_deps,
     gst_base_dep,
-    nnstreamer_dep, # need to modify this to get the dummy loaded
   ]
   unittest_edgetpu = executable('unittest_edgetpu',
     ['unittest_edgetpu.cc'],

--- a/tests/nnstreamer_filter_edgetpu/unittest_edgetpu.cc
+++ b/tests/nnstreamer_filter_edgetpu/unittest_edgetpu.cc
@@ -147,6 +147,9 @@ main (int argc, char **argv)
 
   gst_init (&argc, &argv);
 
+  /* Force the binary to use dlog_print of untitest-util by calling it directly */
+  ml_logd ("Edge TPU test starts w/ dummy backend.");
+
   try {
     result = RUN_ALL_TESTS ();
   } catch (...) {

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -3,6 +3,7 @@ if not gtest_dep.found()
 endif
 
 tizen_apptest_deps = [
+  unittest_util_dep,
   gtest_dep,
   glib_dep
 ]

--- a/tests/nnstreamer_filter_mvncsdk2/meson.build
+++ b/tests/nnstreamer_filter_mvncsdk2/meson.build
@@ -10,11 +10,8 @@ unittest_mvncsdk_helper_dep = declare_dependency(
 )
 
 unittest_mvncsdk_deps = [
-  gtest_dep,
-  glib_dep,
-  gst_dep,
+  nnstreamer_unittest_deps,
   gst_base_dep,
-  nnstreamer_dep, # need to modify this to get the dummy loaded
   unittest_mvncsdk_helper_dep,
 ]
 

--- a/tests/nnstreamer_filter_openvino/meson.build
+++ b/tests/nnstreamer_filter_openvino/meson.build
@@ -1,8 +1,7 @@
 if get_option('enable-openvino')
   unittest_openvino_deps = [
-    nnstreamer_dep,
+    nnstreamer_unittest_deps,
     nnstreamer_filter_openvino_dep,
-    gtest_dep,
     openvino_deps,
   ]
 

--- a/tests/nnstreamer_filter_tvm/meson.build
+++ b/tests/nnstreamer_filter_tvm/meson.build
@@ -1,6 +1,6 @@
 unittest_filter_tvm = executable('unittest_filter_tvm',
   ['unittest_filter_tvm.cc'],
-  dependencies: [unittest_util_dep, glib_dep, gst_dep, nnstreamer_dep, gtest_dep],
+  dependencies: [nnstreamer_unittest_deps],
   install: get_option('install-test'),
   install_dir: unittest_install_dir
 )

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -22,6 +22,7 @@
 #include <tensor_meta.h>
 #include <unistd.h>
 
+#include "../unittest_util.h"
 #include "../gst/nnstreamer/tensor_sparse/tensor_sparse_util.h"
 #include "../gst/nnstreamer/tensor_transform/tensor_transform.h"
 
@@ -32,13 +33,6 @@
 #endif
 
 /**
- * @brief Macro for debug mode.
- */
-#ifndef DBG
-#define DBG FALSE
-#endif
-
-/**
  * @brief Macro for default value of the transform's 'acceleration' property
  */
 #ifdef HAVE_ORC
@@ -46,15 +40,6 @@
 #else
 #define DEFAULT_VAL_PROP_ACCELERATION FALSE
 #endif
-
-/**
- * @brief Macro for debug message.
- */
-#define _print_log(...)        \
-  do {                         \
-    if (DBG)                   \
-      g_message (__VA_ARGS__); \
-  } while (0)
 
 #define str(s) #s
 #define TEST_TRANSFORM_TYPECAST(                                               \

--- a/tests/tizen_nnfw_runtime/meson.build
+++ b/tests/tizen_nnfw_runtime/meson.build
@@ -1,4 +1,4 @@
-test_nnfw_deps = [glib_dep, gst_dep, nnstreamer_dep, gtest_dep, nnfw_plugin_dep, unittest_util_dep]
+test_nnfw_deps = [nnstreamer_unittest_deps, nnfw_plugin_dep]
 
 unittest_nnfw_runtime_raw = executable('unittest_nnfw_runtime_raw',
   'unittest_tizen_nnfw_runtime_raw.cc',

--- a/tests/tizen_sensor/meson.build
+++ b/tests/tizen_sensor/meson.build
@@ -7,18 +7,9 @@ unittest_sensor_helper_dep = declare_dependency(
   link_with: unittest_sensor_helper,
 )
 
-tizen_sensor_apptest_deps = [
-  gtest_dep,
-  glib_dep,
-  gst_dep,
-  nnstreamer_dep,
-  unittest_sensor_helper_dep,
-  unittest_util_dep
-]
-
 unittest_tizen_sensor = executable('unittest_tizen_sensor',
   ['unittest_tizen_sensor.cc'],
-  dependencies: tizen_sensor_apptest_deps,
+  dependencies: [nnstreamer_unittest_deps, unittest_sensor_helper_dep],
   install: get_option('install-test'),
   install_dir: unittest_install_dir
 )

--- a/tests/unittest_util.c
+++ b/tests/unittest_util.c
@@ -10,6 +10,7 @@
  */
 #include <gst/gst.h>
 #include <glib/gstdio.h>
+#include <nnstreamer_log.h>
 #include "unittest_util.h"
 
 /**
@@ -92,3 +93,41 @@ wait_pipeline_process_buffers (const guint * data_received,
   }
   return TRUE;
 }
+
+#ifdef FAKEDLOG
+/**
+ * @brief Hijack dlog Tizen infra for unit testing to force printing out.
+ * @bug The original dlog_print returns the number of bytes printed.
+ *      This returns 0.
+ */
+int
+dlog_print (log_priority prio, const char *tag, const char *fmt, ...)
+{
+  va_list arg_ptr;
+  GLogLevelFlags level;
+  switch (prio) {
+    case DLOG_FATAL:
+      level = G_LOG_LEVEL_ERROR;
+      break;
+    case DLOG_ERROR:
+      level = G_LOG_LEVEL_CRITICAL;
+      break;
+    case DLOG_WARN:
+      level = G_LOG_LEVEL_WARNING;
+      break;
+    case DLOG_INFO:
+      level = G_LOG_LEVEL_INFO;
+      break;
+    case DLOG_DEBUG:
+      level = G_LOG_LEVEL_DEBUG;
+      break;
+    default:
+      level = G_LOG_LEVEL_DEBUG;
+  }
+  va_start (arg_ptr, fmt);
+  g_logv (tag, level, fmt, arg_ptr);
+  va_end (arg_ptr);
+
+  return 0;
+}
+#endif

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -22,7 +22,7 @@ extern "C" {
 #ifndef DBG
 #define DBG FALSE
 #endif
-#define _print_log(...) if (DBG) g_message (__VA_ARGS__)
+#define _print_log(...) do { if (DBG) g_message (__VA_ARGS__); } while (0)
 
 #define UNITTEST_STATECHANGE_TIMEOUT (2000U)
 #define TEST_DEFAULT_SLEEP_TIME (10000U)
@@ -70,6 +70,34 @@ extern gboolean wait_pipeline_process_buffers (const guint * data_received, guin
       }                                                                    \
     } while (len < exp_len);                                               \
   } while (0)
+
+
+#ifdef FAKEDLOG
+/**
+ * @brief enum definition copied from Tizen dlog (MIT License)
+ * @detail If real dlog is included, this will generate errors.
+ *         Do not include real dlog.
+ */
+typedef enum {
+        DLOG_UNKNOWN = 0, /**< Keep this always at the start */
+        DLOG_DEFAULT, /**< Default */
+        DLOG_VERBOSE, /**< Verbose */
+        DLOG_DEBUG, /**< Debug */
+        DLOG_INFO, /**< Info */
+        DLOG_WARN, /**< Warning */
+        DLOG_ERROR, /**< Error */
+        DLOG_FATAL, /**< Fatal */
+        DLOG_SILENT, /**< Silent */
+        DLOG_PRIO_MAX /**< Keep this always at the end. */
+} log_priority;
+
+/**
+ * @brief Hijack dlog Tizen infra for unit testing to force printing out.
+ * @bug The original dlog_print returns the number of bytes printed.
+ *      This returns 0.
+ */
+extern int dlog_print (log_priority prio, const char *tag, const char *fmt, ...);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
    
    
    1. Add a dlog_print hijacker that makes dlog calls independent
    from dlog daemon and drivers. As a result, developers can now
    read the dlog log messages of unittests in gbs environment.
    
    2. Clean up a bit of meson.build dependency declaration of
    unit tests.
    
    3. A unit test without direct dlog call is updated to call
    it directly so that the hijacker is linked (edgetpu).

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

