### PR TITLE
[Query] Change tensor query to accpet ANY caps @open sesame 11/30 17:57

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_client.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_client.h
@@ -46,8 +46,7 @@ struct _GstTensorQueryClient
   GstPad *srcpad; /**< src pad */
 
   gboolean silent; /**< True if logging is minimized */
-  GstTensorsConfig in_config;
-  GstTensorsConfig out_config;
+  gchar *in_caps_str;
 
   TensorQueryProtocol protocol;
 

--- a/gst/nnstreamer/tensor_query/tensor_query_common.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.c
@@ -42,8 +42,8 @@ typedef struct
 {
   TensorQueryProtocol protocol;
   int8_t is_src;
-  GstTensorsConfig src_config;
-  GstTensorsConfig sink_config;
+  char *src_caps_str;
+  char *sink_caps_str;
   GAsyncQueue *msg_queue;
   union
   {
@@ -291,13 +291,19 @@ nnstreamer_query_receive (query_connection_handle connection,
       }
       data->cmd = cmd;
 
-      if (cmd == _TENSOR_QUERY_CMD_TRANSFER_DATA) {
+      if (cmd == _TENSOR_QUERY_CMD_TRANSFER_DATA ||
+          cmd <= _TENSOR_QUERY_CMD_RESPOND_DENY) {
         /* receive size */
         if (query_tcp_receive (conn->socket, (uint8_t *) & data->data.size,
                 sizeof (data->data.size), conn->cancellable, 1) < 0) {
           nns_logd ("Failed to receive size from socket");
           return -EREMOTEIO;
         }
+
+        if (cmd <= _TENSOR_QUERY_CMD_RESPOND_DENY) {
+          data->data.data = (uint8_t *) malloc (data->data.size);
+        }
+
         /* receive data */
         if (query_tcp_receive (conn->socket, (uint8_t *) data->data.data,
                 data->data.size, conn->cancellable, 1) < 0) {
@@ -355,7 +361,8 @@ nnstreamer_query_send (query_connection_handle connection,
         nns_logd ("Failed to send to socket");
         return -EREMOTEIO;
       }
-      if (data->cmd == _TENSOR_QUERY_CMD_TRANSFER_DATA) {
+      if (data->cmd == _TENSOR_QUERY_CMD_TRANSFER_DATA ||
+          data->cmd <= _TENSOR_QUERY_CMD_RESPOND_DENY) {
         /* send size */
         if (!query_tcp_send (conn->socket, (uint8_t *) & data->data.size,
                 sizeof (data->data.size), conn->cancellable)) {
@@ -503,6 +510,8 @@ nnstreamer_query_server_data_free (query_server_handle server_data)
       nns_loge ("Invalid protocol");
       break;
   }
+  g_free (sdata->src_caps_str);
+  g_free (sdata->sink_caps_str);
   g_free (sdata);
 }
 
@@ -697,19 +706,51 @@ _message_handler (void *thread_data)
   }
 
   if (cmd_data.cmd == _TENSOR_QUERY_CMD_REQUEST_INFO) {
-    GstTensorsConfig *config = &cmd_data.data_info.config;
-    if ((gst_tensors_config_is_flexible (config) &&
-            gst_tensors_config_is_flexible (&_sdata->src_config)) ||
-        gst_tensors_info_is_equal (&config->info, &_sdata->src_config.info)) {
-      cmd_data.cmd = _TENSOR_QUERY_CMD_RESPOND_APPROVE;
-      /* respond sink config */
-      gst_tensors_config_copy (config, &_sdata->sink_config);
-    } else {
-      /* respond deny with src config */
-      nns_logw ("tensor info is not equal");
-      cmd_data.cmd = _TENSOR_QUERY_CMD_RESPOND_DENY;
-      gst_tensors_config_copy (config, &_sdata->src_config);
+    GstCaps *sdata_caps, *cmd_caps;
+    GstStructure *structure;
+    gboolean result = FALSE;
+
+    sdata_caps = gst_caps_from_string (_sdata->src_caps_str);
+    cmd_caps = gst_caps_from_string ((char *) cmd_data.data.data);
+    /** Server framerate may vary. Let's skip comparing the framerate. */
+    gst_caps_set_simple (cmd_caps, "framerate", GST_TYPE_FRACTION, 0, 1, NULL);
+    gst_caps_set_simple (sdata_caps, "framerate", GST_TYPE_FRACTION, 0, 1,
+        NULL);
+
+    structure = gst_caps_get_structure (sdata_caps, 0);
+
+    free (cmd_data.data.data);
+
+    if (gst_structure_is_tensor_stream (structure)) {
+      GstTensorsConfig sdata_config, cmd_config;
+      GstStructure *cmd_structure;
+
+      gst_tensors_config_init (&cmd_config);
+      gst_tensors_config_init (&sdata_config);
+      cmd_structure = gst_caps_get_structure (cmd_caps, 0);
+
+      gst_tensors_config_from_structure (&sdata_config, structure);
+      gst_tensors_config_from_structure (&cmd_config, cmd_structure);
+
+      result = gst_tensors_config_is_equal (&sdata_config, &cmd_config);
     }
+
+    if (result || gst_caps_can_intersect (cmd_caps, sdata_caps)) {
+      cmd_data.cmd = _TENSOR_QUERY_CMD_RESPOND_APPROVE;
+      cmd_data.data.data = (uint8_t *) _sdata->sink_caps_str;
+    } else {
+      /* respond deny with src caps string */
+      nns_loge ("Query caps is not acceptable!");
+      nns_loge ("Query client sink caps: %s", (char *) cmd_data.data.data);
+      nns_loge ("Query server src caps: %s", _sdata->src_caps_str);
+      cmd_data.cmd = _TENSOR_QUERY_CMD_RESPOND_DENY;
+      cmd_data.data.data = (uint8_t *) _sdata->src_caps_str;
+    }
+    cmd_data.data.size = (size_t) strlen ((char *) _sdata->src_caps_str);
+
+    gst_caps_unref (sdata_caps);
+    gst_caps_unref (cmd_caps);
+
     if (nnstreamer_query_send (_conn, &cmd_data, DEFAULT_TIMEOUT_MS) != 0) {
       nns_logi ("Failed to send respond");
       goto done;
@@ -884,16 +925,17 @@ error:
 }
 
 /**
- * @brief set server source and sink tensors config.
+ * @brief set server source and sink caps string.
  */
 void
-nnstreamer_query_server_data_set_config (query_server_handle server_data,
-    GstTensorsConfig * src_config, GstTensorsConfig * sink_config)
+nnstreamer_query_server_data_set_caps_str (query_server_handle server_data,
+    const char *src_caps_str, const char *sink_caps_str)
 {
   TensorQueryServerData *sdata = (TensorQueryServerData *) server_data;
-
-  gst_tensors_config_copy (&sdata->src_config, src_config);
-  gst_tensors_config_copy (&sdata->sink_config, sink_config);
+  g_free (sdata->src_caps_str);
+  g_free (sdata->sink_caps_str);
+  sdata->src_caps_str = g_strdup (src_caps_str);
+  sdata->sink_caps_str = g_strdup (sink_caps_str);
 }
 
 /**

--- a/gst/nnstreamer/tensor_query/tensor_query_common.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.h
@@ -57,7 +57,6 @@ typedef enum
  */
 typedef struct
 {
-  GstTensorsConfig config;
   int64_t base_time;
   int64_t sent_time;
   uint64_t duration;
@@ -161,8 +160,8 @@ nnstreamer_query_server_init (query_server_handle server_data,
  * @brief set server source and sink tensors config.
  */
 extern void
-nnstreamer_query_server_data_set_config (query_server_handle server_data,
-    GstTensorsConfig *src_config, GstTensorsConfig *sink_config);
+nnstreamer_query_server_data_set_caps_str (query_server_handle server_data,
+    const char * src_caps_str, const char * sink_caps_str);
 
 /**
  * @brief Get buffer from message queue.

--- a/gst/nnstreamer/tensor_query/tensor_query_server.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.h
@@ -28,13 +28,19 @@ typedef void * query_server_info_handle;
 typedef struct
 {
   gint64 id;
-  GstTensorsConfig sink_config;
+  gchar *sink_caps_str;
   gchar *sink_host;
   guint16 sink_port;
   gboolean configured;
   GMutex lock;
   GCond cond;
 } GstTensorQueryServerInfo;
+
+/**
+ * @brief Get GstTensorQueryServerInfo.
+ */
+query_server_info_handle
+gst_tensor_query_server_get_data (guint id);
 
 /**
  * @brief Add GstTensorQueryServerInfo.
@@ -55,14 +61,15 @@ gboolean
 gst_tensor_query_server_wait_sink (query_server_info_handle server_info_h);
 
 /**
- * @brief set sink config
+ * @brief set sink caps string.
  */
-void gst_tensor_query_server_set_sink_config (query_server_info_handle server_info_h, GstTensorsConfig *config);
+void gst_tensor_query_server_set_sink_caps_str (query_server_info_handle server_info_h, const gchar * caps_str);
 
 /**
- * @brief get sink config
+ * @brief get sink caps string.
  */
-void gst_tensor_query_server_get_sink_config (query_server_info_handle server_info_h, GstTensorsConfig *config);
+gchar *
+gst_tensor_query_server_get_sink_caps_str (query_server_info_handle server_info_h);
 
 /**
  * @brief set sink host address and port

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.h
@@ -43,6 +43,7 @@ typedef struct _GstTensorQueryServerSinkClass GstTensorQueryServerSinkClass;
 struct _GstTensorQueryServerSink
 {
   GstBaseSink element; /**< parent object */
+  GstCaps *caps;
   guint sink_id;
 
   guint16 port;

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
@@ -44,6 +44,7 @@ struct _GstTensorQueryServerSrc
 {
   GstPushSrc element; /* parent object */
   guint src_id;
+  gboolean configured;
 
   guint16 port;
   gchar *host;
@@ -56,7 +57,6 @@ struct _GstTensorQueryServerSrc
   gchar *broker_host;
   guint16 broker_port;
 
-  GstTensorsConfig src_config;
   query_server_handle server_data; /* server data passed to common functions */
   query_server_info_handle server_info_h;
 };

--- a/tests/nnstreamer_query/runTest.sh
+++ b/tests/nnstreamer_query/runTest.sh
@@ -29,8 +29,9 @@ if [[ ! $check_query ]]; then
     exit
 fi
 
-# Run tensor query server as echo server with default adress option.
+# Run tensor query server as echo server with default address option.
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc num-buffers=3 ! other/tensors,num_tensors=1,dimensions=3:300:300:1,types=uint8 ! tensor_query_serversink" 1-1 0 0 $PERFORMANCE $TIMEOUT_SEC &
+sleep 1
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! tee name = t t. ! queue ! multifilesink location= raw1_%1d.log t. ! queue ! tensor_query_client ! multifilesink location=result1_%1d.log" 1-2 0 0 $PERFORMANCE
 callCompareTest raw1_0.log result1_0.log 1-3 "Compare 1-3" 1 0
 callCompareTest raw1_1.log result1_1.log 1-4 "Compare 1-4" 1 0
@@ -41,6 +42,7 @@ sleep 2
 
 # Run tensor query server as echo server with given address option. (multi clients)
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc host=127.0.0.1 port=5001 num-buffers=6 ! other/tensors,num_tensors=1,dimensions=3:300:300:1,types=uint8 ! tensor_query_serversink host=127.0.0.1 port=5002" 2-1 0 0 $PERFORMANCE $TIMEOUT_SEC &
+sleep 1
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! tee name = t t. ! queue ! multifilesink location= raw2_%1d.log t. ! queue ! tensor_query_client src-host=127.0.0.1 src-port=5001 sink-host=127.0.0.1 sink-port=5002 ! multifilesink location=result2_%1d.log" 2-2 0 0 $PERFORMANCE &
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! tee name = t t. ! queue ! multifilesink location= raw2_2_%1d.log t. ! queue ! tensor_query_client src-host=127.0.0.1 src-port=5001 sink-host=127.0.0.1 sink-port=5002 ! multifilesink location=result2_2_%1d.log" 2-3 0 0 $PERFORMANCE
 callCompareTest raw2_0.log result2_0.log 2-4 "Compare 2-4" 1 0
@@ -65,6 +67,7 @@ sleep 2
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
     tensor_query_serversrc id=0 num-buffers=3 ! other/tensors,format=flexible ! tensor_query_serversink id=0 async=false \
     tensor_query_serversrc id=1 port=5000 num-buffers=3 ! other/tensors,format=flexible ! tensor_query_serversink id=1 port=5001  async=false" 5-1 0 0 $PERFORMANCE $TIMEOUT_SEC &
+sleep 1
 # Client pipeline 5-2 is connected to server ID 0.
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
     videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,width=640,height=480,format=RGB ! \
@@ -88,6 +91,7 @@ sleep 2
 
 # Sever src cap: Video, Server sink cap: Viedo test
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc num-buffers=3 ! video/x-raw,width=300,height=300,format=RGB,framerate=0/1 ! tensor_query_serversink" 6-1 0 0 $PERFORMANCE $TIMEOUT_SEC &
+sleep 1
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tee name = t t. ! queue ! multifilesink location= raw6_%1d.log t. ! queue ! tensor_query_client ! multifilesink location=result6_%1d.log" 6-2 0 0 $PERFORMANCE
 callCompareTest raw6_0.log result6_0.log 6-3 "Compare 6-3" 1 0
 callCompareTest raw6_1.log result6_1.log 6-4 "Compare 6-4" 1 0
@@ -97,6 +101,7 @@ sleep 2
 
 # Sever src cap: Video, Server sink cap: Tensor test
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc num-buffers=3 ! video/x-raw,width=300,height=300,format=RGB,framerate=0/1 ! tensor_converter ! tensor_query_serversink" 7-1 0 0 $PERFORMANCE $TIMEOUT_SEC &
+sleep 1
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tee name = t t. ! queue ! multifilesink location= raw7_%1d.log t. ! queue ! tensor_query_client ! multifilesink location=result7_%1d.log" 7-2 0 0 $PERFORMANCE
 callCompareTest raw7_0.log result7_0.log 7-3 "Compare 7-3" 1 0
 callCompareTest raw7_1.log result7_1.log 7-4 "Compare 7-4" 1 0
@@ -106,6 +111,7 @@ sleep 2
 
 # Sever src cap: Tensor, Server sink cap: Video test
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc num-buffers=3 ! other/tensors,num_tensors=1,dimensions=3:300:300:1,types=uint8,format=static,framerate=0/1 ! tensor_decoder mode=direct_video ! videoconvert ! tensor_query_serversink" 8-1 0 0 $PERFORMANCE $TIMEOUT_SEC &
+sleep 1
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! tee name = t t. ! queue ! multifilesink location= raw8_%1d.log t. ! queue ! tensor_query_client ! multifilesink location=result8_%1d.log" 8-2 0 0 $PERFORMANCE
 callCompareTest raw8_0.log result8_0.log 8-3 "Compare 8-3" 1 0
 callCompareTest raw8_1.log result8_1.log 8-4 "Compare 8-4" 1 0
@@ -134,6 +140,7 @@ fi
 # Test Query-hybrid. Get server info from broker.
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc num-buffers=3 operation=passthrough ! other/tensors,format=flexible ! tee name = t t. ! queue ! multifilesink location=server1_%1d.log t. ! queue ! tensor_query_serversink" 4-1 0 0 $PERFORMANCE $TIMEOUT_SEC &
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc num-buffers=3 operation=passthrough port=5000 ! other/tensors,format=flexible ! tee name = t t. ! queue ! multifilesink location=server2_%1d.log t. ! queue ! tensor_query_serversink port=5001" 4-2 0 0 $PERFORMANCE $TIMEOUT_SEC &
+sleep 1
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=7 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! other/tensors,format=flexible ! tee name = t t. ! queue ! multifilesink location= raw4_%1d.log t. ! queue ! tensor_query_client operation=passthrough ! multifilesink location=result4_%1d.log" 4-3 0 0 $PERFORMANCE
 callCompareTest raw4_0.log result4_0.log 4-4 "Compare 4-4" 1 0
 callCompareTest raw4_1.log result4_1.log 4-5 "Compare 4-5" 1 0

--- a/tests/nnstreamer_query/runTest.sh
+++ b/tests/nnstreamer_query/runTest.sh
@@ -85,6 +85,34 @@ callCompareTest raw5_3_1.log result5_3_1.log 5-8 "Compare 5-8" 1 0
 callCompareTest raw5_3_2.log result5_3_2.log 5-9 "Compare 5-9" 1 0
 
 sleep 2
+
+# Sever src cap: Video, Server sink cap: Viedo test
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc num-buffers=3 ! video/x-raw,width=300,height=300,format=RGB,framerate=0/1 ! tensor_query_serversink" 6-1 0 0 $PERFORMANCE $TIMEOUT_SEC &
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tee name = t t. ! queue ! multifilesink location= raw6_%1d.log t. ! queue ! tensor_query_client ! multifilesink location=result6_%1d.log" 6-2 0 0 $PERFORMANCE
+callCompareTest raw6_0.log result6_0.log 6-3 "Compare 6-3" 1 0
+callCompareTest raw6_1.log result6_1.log 6-4 "Compare 6-4" 1 0
+callCompareTest raw6_2.log result6_2.log 6-5 "Compare 6-5" 1 0
+
+sleep 2
+
+# Sever src cap: Video, Server sink cap: Tensor test
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc num-buffers=3 ! video/x-raw,width=300,height=300,format=RGB,framerate=0/1 ! tensor_converter ! tensor_query_serversink" 7-1 0 0 $PERFORMANCE $TIMEOUT_SEC &
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tee name = t t. ! queue ! multifilesink location= raw7_%1d.log t. ! queue ! tensor_query_client ! multifilesink location=result7_%1d.log" 7-2 0 0 $PERFORMANCE
+callCompareTest raw7_0.log result7_0.log 7-3 "Compare 7-3" 1 0
+callCompareTest raw7_1.log result7_1.log 7-4 "Compare 7-4" 1 0
+callCompareTest raw7_2.log result7_2.log 7-5 "Compare 7-5" 1 0
+
+sleep 2
+
+# Sever src cap: Tensor, Server sink cap: Video test
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc num-buffers=3 ! other/tensors,num_tensors=1,dimensions=3:300:300:1,types=uint8,format=static,framerate=0/1 ! tensor_decoder mode=direct_video ! videoconvert ! tensor_query_serversink" 8-1 0 0 $PERFORMANCE $TIMEOUT_SEC &
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! tee name = t t. ! queue ! multifilesink location= raw8_%1d.log t. ! queue ! tensor_query_client ! multifilesink location=result8_%1d.log" 8-2 0 0 $PERFORMANCE
+callCompareTest raw8_0.log result8_0.log 8-3 "Compare 8-3" 1 0
+callCompareTest raw8_1.log result8_1.log 8-4 "Compare 8-4" 1 0
+callCompareTest raw8_2.log result8_2.log 8-5 "Compare 8-5" 1 0
+
+sleep 2
+
 # TODO enable query-hybrid test
 # Now nnsquery library is not available.
 # After publishing the nnsquery pkg, enable below testcases.
@@ -123,6 +151,7 @@ callCompareTest server2_0.log result4_3.log 4-13 "Compare 4-13" 1 0
 callCompareTest server2_1.log result4_4.log 4-14 "Compare 4-14" 1 0
 callCompareTest server2_2.log result4_5.log 4-15 "Compare 4-15" 1 0
 
+sleep 2
 rm *.log
 
 report


### PR DESCRIPTION
Change tensor query to accept ANY caps.
This change makes it possible to offload elements which require large amount of computation, such as tensor transforms, to the server.

Test pipeline.
SERVER
```
gst-launch-1.0 tensor_query_serversrc ! \
    video/x-raw,width=300,height=300,format=RGB ! \
    tensor_query_serversink
```
CLIENT
```
gst-launch-1.0 v4l2src ! videoconvert ! videoscale ! \
   video/x-raw,width=300,height=300,format=RGB,framerate=30/1 ! \
   tensor_query_client ! videoconvert !  ximagesink

```

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>
