### PR TITLE
[2.0.y][Build] Add g_memdup2() support for glib >= 2.68

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.cc
@@ -16,6 +16,7 @@
 
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
+#include <nnstreamer_util.h>
 
 #include <thread>
 
@@ -119,7 +120,7 @@ ServiceImplFlatbuf::_get_buffer_from_tensors (Message<Tensors> &msg,
     const Tensor * tensor = tensors->tensor ()->Get (i);
     const void * data = tensor->data ()->data ();
     gsize size = VectorLength (tensor->data ());
-    gpointer new_data = g_memdup (data, size);
+    gpointer new_data = _g_memdup (data, size);
 
     memory = gst_memory_new_wrapped ((GstMemoryFlags) 0, new_data, size,
         0, size, new_data, g_free);

--- a/ext/nnstreamer/extra/nnstreamer_grpc_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_protobuf.cc
@@ -16,6 +16,7 @@
 
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
+#include <nnstreamer_util.h>
 
 #include <thread>
 
@@ -113,7 +114,7 @@ ServiceImplProtobuf::_get_buffer_from_tensors (Tensors &tensors,
     const Tensor * tensor = &tensors.tensor (i);
     const void * data = tensor->data ().c_str ();
     gsize size = tensor->data ().length ();
-    gpointer new_data = g_memdup (data, size);
+    gpointer new_data = _g_memdup (data, size);
 
     memory = gst_memory_new_wrapped ((GstMemoryFlags) 0, new_data, size,
         0, size, new_data, g_free);

--- a/ext/nnstreamer/extra/nnstreamer_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.cc
@@ -125,7 +125,7 @@ gst_tensor_converter_protobuf (GstBuffer *in_buf, GstTensorsConfig *config, void
   GstMemory *in_mem, *out_mem;
   GstMapInfo in_info;
   GstBuffer *out_buf;
-  guint mem_size;
+  gsize mem_size;
   gpointer mem_data;
   UNUSED (priv_data);
 
@@ -160,7 +160,7 @@ gst_tensor_converter_protobuf (GstBuffer *in_buf, GstTensorsConfig *config, void
       config->info.info[i].dimension[j] = tensor->dimension (j);
     }
     mem_size = tensor->data ().length ();
-    mem_data = g_memdup (tensor->data ().c_str (), mem_size);
+    mem_data = _g_memdup (tensor->data ().c_str (), mem_size);
 
     out_mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, mem_data, mem_size,
         0, mem_size, NULL, NULL);

--- a/ext/nnstreamer/tensor_converter/tensor_converter_python3.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_python3.cc
@@ -140,7 +140,8 @@ PYConverterCore::convert (GstBuffer *in_buf, GstTensorsConfig *config)
   GstBuffer *out_buf = NULL;
   PyObject *tensors_info = NULL, *output = NULL, *pyValue = NULL;
   gint rate_n, rate_d;
-  guint i, num, mem_size;
+  guint i, num;
+  gsize mem_size;
   gpointer mem_data;
 
   if (nullptr == in_buf)
@@ -196,7 +197,7 @@ PYConverterCore::convert (GstBuffer *in_buf, GstTensorsConfig *config)
           = (PyArrayObject *)PyList_GetItem (output, (Py_ssize_t)i);
 
       mem_size = PyArray_SIZE (output_array);
-      mem_data = g_memdup ((guint8 *) PyArray_DATA (output_array), mem_size);
+      mem_data = _g_memdup ((guint8 *) PyArray_DATA (output_array), mem_size);
 
       out_mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, mem_data, mem_size,
           0, mem_size, mem_data, g_free);

--- a/gst/nnstreamer/include/nnstreamer_util.h
+++ b/gst/nnstreamer/include/nnstreamer_util.h
@@ -22,4 +22,13 @@
 #define UNUSED(expr) do { (void)(expr); } while (0)
 #endif
 
+/**
+ * @brief g_memdup() function replaced by g_memdup2() in glib version >= 2.68
+ */
+#if GLIB_USE_G_MEMDUP2
+#define _g_memdup(data, size) g_memdup2 (data, size)
+#else
+#define _g_memdup(data, size) g_memdup (data, size)
+#endif
+
 #endif /* __NNSTREAMER_UTIL_H__ */

--- a/meson.build
+++ b/meson.build
@@ -126,6 +126,9 @@ add_project_arguments('-DNNSTREAMER_CONF_FILE="' + join_paths(nnstreamer_inidir,
 
 # Dependencies
 glib_dep = dependency('glib-2.0')
+if glib_dep.version().version_compare('>= 2.68.0')
+  add_project_arguments('-DGLIB_USE_G_MEMDUP2', language: ['c', 'cpp'])
+endif
 gobject_dep = dependency('gobject-2.0')
 gmodule_dep = dependency('gmodule-2.0')
 gio_dep = dependency('gio-2.0')

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -12,6 +12,7 @@
 #include <glib/gstdio.h>
 #include <gst/app/gstappsrc.h>
 #include <gst/gst.h>
+#include <nnstreamer_util.h>
 #include <unittest_util.h>
 
 static int data_received;
@@ -92,10 +93,10 @@ TEST (join, normal0)
 
   g_signal_connect (sink_handle, "new-data", (GCallback)new_data_cb, (gpointer)&idx);
 
-  buf_0 = gst_buffer_new_wrapped (g_memdup (test_frames[0], 192), 192);
+  buf_0 = gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192);
   buf_3 = gst_buffer_copy (buf_0);
 
-  buf_1 = gst_buffer_new_wrapped (g_memdup (test_frames[1], 192), 192);
+  buf_1 = gst_buffer_new_wrapped (_g_memdup (test_frames[1], 192), 192);
   buf_4 = gst_buffer_copy (buf_1);
 
   data_received = 0;

--- a/tests/nnstreamer_converter/unittest_converter.cc
+++ b/tests/nnstreamer_converter/unittest_converter.cc
@@ -16,6 +16,8 @@
 #include <flatbuffers/flexbuffers.h>
 #include <gst/app/gstappsrc.h>
 #include <nnstreamer_plugin_api_converter.h>
+#include <nnstreamer_util.h>
+
 
 #define TEST_TIMEOUT_MS (10000U)
 
@@ -66,7 +68,7 @@ tensor_converter_custom_cb (GstBuffer *in_buf,
     }
     flexbuffers::Blob tensor_data = tensor[3].AsBlob ();
     mem_size = tensor_data.size ();
-    mem_data = g_memdup (tensor_data.data (), mem_size);
+    mem_data = _g_memdup (tensor_data.data (), mem_size);
 
     out_mem = gst_memory_new_wrapped ((GstMemoryFlags) 0, mem_data, mem_size,
         0, mem_size, mem_data, g_free);
@@ -395,8 +397,8 @@ TEST (tensorConverterPython, dynamicDimension)
   data_received = (guint *) g_malloc0 (sizeof (guint));
   g_signal_connect (sink_handle, "new-data", (GCallback)new_data_cb, data_received);
 
-  buf_0 = gst_buffer_new_wrapped (g_memdup (_test_frames1, 96), 96);
-  buf_1 = gst_buffer_new_wrapped (g_memdup (_test_frames2, 192), 192);
+  buf_0 = gst_buffer_new_wrapped (_g_memdup (_test_frames1, 96), 96);
+  buf_1 = gst_buffer_new_wrapped (_g_memdup (_test_frames2, 192), 192);
   buf_2 = gst_buffer_copy (buf_0);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, TEST_TIMEOUT_MS), 0);


### PR DESCRIPTION
Update to fix build with glib version 2.68 and later

Legacy function:
  gpointer g_memdup ( gconstpointer mem, guint byte_size )
is deprecated since version 2.68 and replaced by:
  gpointer g_memdup2 ( gconstpointer mem, gsize byte_size )

Difference is byte_size argument type changed from guint to gsize.

Signed-off-by: Julien Vuillaumier <julien.vuillaumier@nxp.com>
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

This is a hotfix cherry-picking from main --> 2.0.y for https://github.com/nnstreamer/nnstreamer/issues/3218#issuecomment-977885118 (@ggardet )