### PR TITLE
tensor_filter TFLite subplugin - XNNPACK delegate @open sesame 11/29 12:40

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -238,6 +238,10 @@ if tflite2_support_is_available
     tflite2_compile_args += '-DTFLITE_EXTERNAL_DELEGATE_SUPPORTED'
   endif
 
+  if get_option('tflite2-xnnpack-delegate-support')
+    tflite2_compile_args += '-DTFLITE_XNNPACK_DELEGATE_SUPPORTED'
+  endif
+
   tflite2_extra_dep = declare_dependency(
     compile_args : tflite2_compile_args
   )

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -333,20 +333,28 @@ TFLiteInterpreter::invoke (const GstTensorMemory *input, GstTensorMemory *output
   start_time = g_get_monotonic_time ();
 
   /**
-   * When XNNPACK Delegate is used, we should not assign other buffer as ptr of output tensor data.
-   * The output data should be memcpy-ed from interpreter's output tensors.
+   * XNNPACK Delegate uses fixed buffer address for input/output tensors.
+   * Therefore tensor data is to be manually copied from/to input/output GStreamer
+   * buffers memory whose address changes at every round.
    */
-  if (!is_xnnpack_delegated) {
+  if (is_xnnpack_delegated) {
+    for (unsigned int i = 0; i < inputTensorMeta.num_tensors; ++i) {
+      tensor_ptr = inputTensorPtr[i];
+      g_assert(tensor_ptr->bytes == input[i].size);
+      memcpy (tensor_ptr->data.raw, input[i].data, input[i].size);
+    }
+  } else {
+    for (unsigned int i = 0; i < inputTensorMeta.num_tensors; ++i) {
+      tensor_ptr = inputTensorPtr[i];
+      tensor_ptr->data.raw = (char *) input[i].data;
+    }
+
     for (unsigned int i = 0; i < outputTensorMeta.num_tensors; ++i) {
       tensor_ptr = outputTensorPtr[i];
       tensor_ptr->data.raw = (char *) output[i].data;
     }
   }
 
-  for (unsigned int i = 0; i < inputTensorMeta.num_tensors; ++i) {
-    tensor_ptr = inputTensorPtr[i];
-    tensor_ptr->data.raw = (char *) input[i].data;
-  }
   stop_time = g_get_monotonic_time ();
 
   tflite_internal_stats.total_overhead_latency += stop_time - start_time;
@@ -356,7 +364,9 @@ TFLiteInterpreter::invoke (const GstTensorMemory *input, GstTensorMemory *output
 
   if (is_xnnpack_delegated) {
     for (unsigned int i = 0; i < outputTensorMeta.num_tensors; ++i) {
-      memcpy (output[i].data, outputTensorPtr[i]->data.raw, output[i].size);
+      tensor_ptr = outputTensorPtr[i];
+      g_assert(tensor_ptr->bytes == output[i].size);
+      memcpy (output[i].data, tensor_ptr->data.raw, output[i].size);
     }
   }
 
@@ -448,8 +458,8 @@ TFLiteInterpreter::loadModel (int num_threads, tflite_delegate_e delegate)
       xnnpack_delegate.reset (TfLiteXNNPackDelegateCreate (&xnnpack_options));
       setDelegate (xnnpack_delegate.get ());
       is_xnnpack_delegated = true;
-      ml_logw ("Output tensors should be memcpy-ed rather than explictly assigning its ptr when XNNPACK Delegate is used.");
-      ml_logw ("This could cause performance degradation if sizes of output tensors are large");
+      ml_logw ("Input/output tensors should be memcpy-ed rather than explictly assigning its ptr when XNNPACK Delegate is used.");
+      ml_logw ("This could cause performance degradation if sizes of input/output tensors are large");
 #else
       ml_logw ("XNNPACK delegate support is available only in Android with tflite v2.3.0 or higher and XNNPACK support should be enabled for tf-lite subplugin build.");
 #endif

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -90,6 +90,14 @@
 #endif
 
 /**
+ * @brief prevent usage by TFLite of default delegates that may not be supported
+ */
+#if TFLITE_VERSION_MAJOR >= 2 && TFLITE_VERSION_MINOR >= 4
+#define TFLITE_RESOLVER_WITHOUT_DEFAULT_DELEGATES
+#endif
+
+
+/**
  * @brief Macro for debug mode.
  */
 #ifndef DBG
@@ -408,7 +416,11 @@ TFLiteInterpreter::loadModel (int num_threads, tflite_delegate_e delegate)
 
   interpreter = nullptr;
 
+#ifdef TFLITE_RESOLVER_WITHOUT_DEFAULT_DELEGATES
+  tflite::ops::builtin::BuiltinOpResolverWithoutDefaultDelegates resolver;
+#else
   tflite::ops::builtin::BuiltinOpResolver resolver;
+#endif
   tflite::InterpreterBuilder (*model, resolver) (&interpreter);
   if (!interpreter) {
     ml_loge ("Failed to construct interpreter\n");

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -29,6 +29,7 @@ option('enable-pytorch-use-gpu', type: 'boolean', value: false) # default value,
 option('tflite2-gpu-delegate-support', type: 'boolean', value: 'false')
 option('tflite2-nnapi-delegate-support', type: 'boolean', value: 'false')
 option('tflite2-external-delegate-support', type: 'boolean', value: 'false')
+option('tflite2-xnnpack-delegate-support', type: 'boolean', value: 'false')
 option('enable-mediapipe', type: 'boolean', value: false)
 option('enable-env-var', type: 'boolean', value: true)
 option('enable-symbolic-link', type: 'boolean', value: true)


### PR DESCRIPTION
---
**Changes proposed in this PR:**

2 items related to XNNPACK delegate usage with TfLite framework (tested on TfLite 2.6):

1) Peculiarity of TfLite XNNPACK delegate usage in TfLite is that both input and output tensors buffer addresses are cached within XNNPACK runtime during first invoke(). NNStreamer tensor_filter input/output buffer memory addresses change from an inference to an other, therefore i/o buffer data has to be copied between Gst memory and TfLite allocated memory for tensors. Failure to do so typically leads to system crash as TfLite interpreter tries to access during subsequent invoke() to the GStreamer buffers populated during 1st invoke that have chances to have been deallocated and unmapped.
Currently only output tensors data copy is provisioned for XNNPACK case.

2) When TfLite library is built with XNNPACK delegate support, XNNPACK delegate is used as a default delegate for the graph, even though not explicitly applied via ModifyGraphWithDelegate().
Issue is that XNNPACK usage requires tensor data copies so for NNStreamer case, XNNPACK should only be used when explicitly selected by the user (custom=Delegate:XNNPACK) so that TfLite subplugin is aware about XNNPACK usage and handle input/output tensors accordingly.
API for OpResolver has been introduced in TfLite 2.4 for this:
tflite::ops::builtin::BuiltinOpResolverWithoutDefaultDelegates resolver;
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/kernels/register.h#L36

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [*]Passed [ ]Failed []Skipped
SSAT test suite passed

**How to evaluate:**
1. need TFLite library built with XNNPACK support 
2. enable NNStreamer meson build option -Dtflite2-xnnpack-delegate-support=true
3. use tensor_filter property custom=Delegate:XNNPACK

