### PR TITLE
[fix/query] Fix the order of calling `g_socket_listener_set_backlog`

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_common.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.c
@@ -534,13 +534,15 @@ nnstreamer_query_server_init (query_server_handle server_data,
       }
 
       sdata->socket_listener = g_socket_listener_new ();
+      g_socket_listener_set_backlog (sdata->socket_listener, N_BACKLOG);
+
       if (!g_socket_listener_add_address (sdata->socket_listener, saddr,
               G_SOCKET_TYPE_STREAM, G_SOCKET_PROTOCOL_TCP, NULL, NULL, &err)) {
         nns_loge ("Failed to add address: %s", err->message);
         g_clear_error (&err);
         return -EADDRNOTAVAIL;
       }
-      g_socket_listener_set_backlog (sdata->socket_listener, N_BACKLOG);
+
       sdata->conn_queue = g_async_queue_new ();
       if (sdata->is_src)
         sdata->msg_queue = g_async_queue_new ();


### PR DESCRIPTION
- backlog should be set before adding address or socket to listener.
REF:
https://people.gnome.org/~ebassi/docs/_build/Gio/method.SocketListener.set_backlog.html#description

- This commit should remove the following error logs:
```
...
GLib-GIO-CRITICAL **: 15:20:18.773: g_socket_set_listen_backlog: assertion '!socket->priv->listening' failed
...
```

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
