### PR TITLE
[Spec] Add restricted_element_vd for VD element

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -643,7 +643,12 @@ Provides additional gstreamer plugins for nnstreamer pipelines
 %define restricted_element_base     'capsfilter input-selector output-selector queue tee valve appsink appsrc audioconvert audiorate audioresample audiomixer videoconvert videocrop videorate videoscale videoflip videomixer compositor fakesrc fakesink filesrc filesink audiotestsrc videotestsrc jpegparse jpegenc jpegdec pngenc pngdec tcpclientsink tcpclientsrc tcpserversink tcpserversrc xvimagesink ximagesink evasimagesink evaspixmapsink glimagesink theoraenc lame vorbisenc wavenc volume oggmux avimux matroskamux v4l2src avsysvideosrc camerasrc tvcamerasrc pulsesrc fimcconvert tizenwlsink gdppay gdpdepay join '
 %define restricted_element_edgeai   'rtpdec rtspsrc rtspclientsink zmqsrc zmqsink mqttsrc mqttsink udpsrc udpsink multiudpsink queryclient queryserversrc queryserversink '
 %define restricted_element_audio    'audioamplify audiochebband audiocheblimit audiodynamic audioecho audiofirfilter audioiirfilter audioinvert audiokaraoke audiopanorama audiowsincband audiowsinclimit scaletempo stereo '
+%if "%{?profile}" == "tv"
+%define restricted_element_vd       'tvdpbsrc '
+%define restricted_element          %{restricted_element_base}%{restricted_element_audio}%{restricted_element_edgeai}%{restricted_element_vd}
+%else
 %define restricted_element          %{restricted_element_base}%{restricted_element_audio}%{restricted_element_edgeai}
+%endif
 %define element_restriction -Denable-element-restriction=true -Drestricted-elements=%{restricted_element}
 %endif #if tizen
 


### PR DESCRIPTION
This patch newly adds the restricted_element_vd for VD specialized
elements.

It is cherry-picking from main branch.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

