### PR TITLE
meson: use version_copmare()

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -275,7 +275,7 @@ if pytorch_support_is_available
   nnstreamer_filter_torch_deps = pytorch_support_deps + [glib_dep, gst_dep, nnstreamer_dep]
 
   # pytorch version
-  if pytorch_support_deps[0].version() >= '1.2.0'
+  if pytorch_support_deps[0].version().version_compare('>=1.2.0')
     nnstreamer_filter_torch_deps += declare_dependency(compile_args: ['-DPYTORCH_VER_ATLEAST_1_2_0=1'])
   endif
 
@@ -633,7 +633,7 @@ if tensorrt_support_is_available
 endif
 
 if lua_support_is_available
-  if lua_support_deps[0].version() >= '5.3'
+  if lua_support_deps[0].version().version_compare('>=5.3')
     message ('tensor-filter::lua does not support Lua >= 5.3, yet. Fix #3531 first.')
     lua_support_is_available = disabler()
   endif


### PR DESCRIPTION
Do not compare version strings with general operators.
Use version_compare() API instead.

Reported by #3591

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

