### PR TITLE
[Query] Change error message when GstMeta is invalid.

### DIFF
--- a/gst/nnstreamer/tensor_query/README.md
+++ b/gst/nnstreamer/tensor_query/README.md
@@ -119,3 +119,9 @@ $ cd nnstreamer/tests/nnstreamer_query
 $ ssat # or $ bash runTest.sh
 ```
  * For more detailed installation methods, see [here](/Documentation/how-to-run-examples.md).
+
+
+## Appendix
+### Available elements on query server.
+Multiple `tensor_query_client` can connect to the query server. The `query_serversrc` add a unique client ID (given by the query server) to the meta of the GstBuffer to distinguish clients. If there is an element that does not copy meta information, the `tensor_query_serversink` cannot send it to the client because it does not know which client receive the buffer.  
+Please check list [here](https://github.com/nnstreamer/nnstreamer/wiki/Available-elements-on-query-server)

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.h
@@ -51,6 +51,8 @@ struct _GstTensorQueryServerSink
   guint timeout;
   query_server_handle server_data;
   query_server_info_handle server_info_h;
+  gint metaless_frame_limit;
+  gint metaless_frame_count;
 };
 
 /**


### PR DESCRIPTION
Some GStreamer element don't copy GstMeta. So tensor query cannot handle buffer.
Change error message when GstMeta is invalid and stop pipeline.
The available elements table is not completed yet and will change frequently, so I will write it on the wiki page first.

*note: query server src does not set format (GST_FORMAT_TIME) currently, compositor also is not availabe.  This will also be changed soon.

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

