### PR TITLE
[INI] Add extra configuration file for product support

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -96,6 +96,7 @@ typedef struct
   gboolean enable_symlink;    /**< TRUE to allow symbolic link file */
 
   gchar *conffile;            /**< Location of conf file. */
+  gchar *extra_conffile;      /**< Location of extra configuration file. */
 
   subplugin_conf conf[NNSCONF_PATH_END];
 } confdata;
@@ -330,6 +331,8 @@ nnsconf_loadconf (gboolean force_reload)
     /* Do Clean Up */
     g_free (conf.conffile);
     conf.conffile = NULL;
+    g_free (conf.extra_conffile);
+    conf.extra_conffile = NULL;
 
     for (t = 0; t < NNSCONF_PATH_END; t++) {
 
@@ -399,6 +402,8 @@ nnsconf_loadconf (gboolean force_reload)
       conf.enable_symlink = _parse_bool_string (value, FALSE);
       g_free (value);
 
+      conf.extra_conffile =
+          g_key_file_get_string (key_file, "common", "extra_config_path", NULL);
       conf.conf[NNSCONF_PATH_FILTERS].path[CONF_SOURCE_INI] =
           g_key_file_get_string (key_file, "filter", "filters", NULL);
       conf.conf[NNSCONF_PATH_DECODERS].path[CONF_SOURCE_INI] =

--- a/meson.build
+++ b/meson.build
@@ -536,6 +536,13 @@ endif
 nnstreamer_install_conf.set('ELEMENT_RESTRICTION_CONFIG', restriction_config)
 nnstreamer_install_conf.set('TEST_TEMPLATE_DIR', unittest_base_dir) # TEST_TEMPLATE_DIR will be empty if `install-test` is false
 
+# Extra configuration
+extra_config_path = ''
+if get_option('extra_config_path') != ''
+  extra_config_path = 'extra_config_path=' + get_option('extra_config_path')
+endif
+nnstreamer_install_conf.set('EXTRA_CONFIG_PATH', extra_config_path)
+
 # Install .ini
 configure_file(input: 'nnstreamer.ini.in', output: 'nnstreamer.ini',
   install_dir: nnstreamer_inidir,
@@ -583,6 +590,7 @@ if get_option('enable-test')
   nnstreamer_test_conf.set('ENABLE_ENV_VAR', true)
   nnstreamer_test_conf.set('ENABLE_SYMBOLIC_LINK', false)
   nnstreamer_test_conf.set('TORCH_USE_GPU', false)
+  nnstreamer_test_conf.set('EXTRA_CONFIG_PATH', '')
   nnstreamer_test_conf.set('ELEMENT_RESTRICTION_CONFIG', '')
 
   configure_file(input: 'nnstreamer.ini.in', output: 'nnstreamer-test.ini',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -55,3 +55,6 @@ option('enable-pbtxt-converter', type: 'boolean', value: true)
 
 # Install Paths
 option('subplugindir', type: 'string', value: '')
+
+# Extra configuration
+option('extra_config_path', type: 'string', value: '')

--- a/nnstreamer.ini.in
+++ b/nnstreamer.ini.in
@@ -3,6 +3,7 @@
 [common]
 enable_envvar=@ENABLE_ENV_VAR@
 enable_symlink=@ENABLE_SYMBOLIC_LINK@
+@EXTRA_CONFIG_PATH@
 
 [filter]
 filters=@SUBPLUGIN_INSTALL_PREFIX@/filters/

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -1665,6 +1665,39 @@ TEST (confCustom, envStr01)
 }
 
 /**
+ * @brief Test for extra configuration path
+ */
+TEST (confCustom, checkExtraConfPath_p)
+{
+  gchar *fullpath = g_build_path ("/", g_get_tmp_dir (), "nns-tizen-XXXXXX", NULL);
+  gchar *dir = g_mkdtemp (fullpath);
+  gchar *filename = g_build_path ("/", dir, "nnstreamer.ini", NULL);
+  const gchar *extra_conf = "/opt/usr/vd/product.ini";
+  gchar *confenv = g_strdup (g_getenv ("NNSTREAMER_CONF"));;
+
+  FILE *fp = g_fopen (filename, "w");
+  ASSERT_TRUE (fp != NULL);
+  g_fprintf (fp, "[common]\n");
+  g_fprintf (fp, "extra_config_path=%s\n", extra_conf);
+  fclose (fp);
+
+  EXPECT_TRUE (g_setenv ("NNSTREAMER_CONF", filename, TRUE));
+  EXPECT_TRUE (nnsconf_loadconf (TRUE));
+
+  EXPECT_TRUE (check_custom_conf ("common", "extra_config_path", extra_conf));
+  g_remove (filename);
+  g_free (fullpath);
+  g_free (filename);
+
+  if (confenv) {
+    EXPECT_TRUE (g_setenv ("NNSTREAMER_CONF", confenv, TRUE));
+    g_free (confenv);
+  } else {
+    g_unsetenv ("NNSTREAMER_CONF");
+  }
+}
+
+/**
  * @brief Test nnstreamer conf util (name prefix with invalid param).
  */
 TEST (confCustom, subpluginPrefix_n)


### PR DESCRIPTION
The product team wants to update the nnstreamer configuration (i.e.
/etc/nnstreamer.ini). However, the partition is Read-Only so it is not
updatable. Because of this reason, they want another nnstreamer
configuration file to meet their request such as product-specific
restricted elements. This patch newly adds the nnstreamer extension ini
file for product support.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

### New element in nnstreamer.ini  ###
```ini
[common]
extra_config_path=/tmp/nns-api-X6XDF1/nns-product.ini	 # Location of product-specific configuration file.
```

### Related issue
* https://github.com/nnstreamer/nnstreamer/issues/3629