### PR TITLE
[TEST/util] Change getTempFilename function

### DIFF
--- a/tests/cpp_methods/unittest_cpp_methods.cc
+++ b/tests/cpp_methods/unittest_cpp_methods.cc
@@ -106,6 +106,8 @@ TEST (cppFilterOnDemand, pipeline01)
   }
   g_free (str_pipeline);
 
+  g_remove (tmp1);
+  g_remove (tmp2);
   g_free (tmp1);
   g_free (tmp2);
   EXPECT_EQ (basic._unregister (), 0);
@@ -183,6 +185,9 @@ TEST (cppFilterObj, base01_n)
   }
   g_free (str_pipeline);
 
+  g_remove (tmp1);
+  g_remove (tmp2);
+  g_remove (tmp3);
   g_free (tmp1);
   g_free (tmp2);
   g_free (tmp3);
@@ -226,6 +231,9 @@ TEST (cppFilterObj, base02_n)
   }
   g_free (str_pipeline);
 
+  g_remove (tmp1);
+  g_remove (tmp2);
+  g_remove (tmp3);
   g_free (tmp1);
   g_free (tmp2);
   g_free (tmp3);
@@ -286,6 +294,11 @@ TEST (cppFilterObj, base03)
   }
   g_free (str_pipeline);
 
+  g_remove (tmp1);
+  g_remove (tmp2);
+  g_remove (tmp3);
+  g_remove (tmp4);
+  g_remove (tmp5);
   g_free (tmp1);
   g_free (tmp2);
   g_free (tmp3);

--- a/tests/nnstreamer_converter/unittest_converter.cc
+++ b/tests/nnstreamer_converter/unittest_converter.cc
@@ -152,6 +152,9 @@ TEST (tensorConverterCustom, normal0)
 
   gst_object_unref (pipeline);
   g_free (str_pipeline);
+  g_remove (tmp_tensor_raw);
+  g_remove (tmp_flex_raw);
+  g_remove (tmp_flex_to_tensor);
   g_free (tmp_tensor_raw);
   g_free (tmp_flex_raw);
   g_free (tmp_flex_to_tensor);

--- a/tests/nnstreamer_decoder/unittest_decoder.cc
+++ b/tests/nnstreamer_decoder/unittest_decoder.cc
@@ -141,6 +141,8 @@ TEST (tensorDecoderCustom, normal0)
 
   gst_object_unref (pipeline);
   g_free (str_pipeline);
+  g_remove (tmp_flex_default);
+  g_remove (tmp_flex_custom);
   g_free (tmp_flex_default);
   g_free (tmp_flex_custom);
 }

--- a/tests/nnstreamer_if/unittest_if.cc
+++ b/tests/nnstreamer_if/unittest_if.cc
@@ -347,7 +347,7 @@ TEST_F (tensor_if_run, action_0)
   gst_object_unref (pipeline);
 
   g_free (str_pipeline);
-
+  g_remove (tmp);
   g_free (tmp);
 }
 
@@ -409,6 +409,8 @@ TEST_F (tensor_if_run, action_1)
 
   g_free (str_pipeline);
 
+  g_remove (tmp_true);
+  g_remove (tmp_false);
   g_free (tmp_true);
   g_free (tmp_false);
 }
@@ -475,6 +477,8 @@ TEST_F (tensor_if_run, action_2)
   gst_object_unref (pipeline);
   g_free (str_pipeline);
 
+  g_remove (tmp1);
+  g_remove (tmp2);
   g_free (tmp1);
   g_free (tmp2);
 }

--- a/tests/unittest_util.c
+++ b/tests/unittest_util.c
@@ -42,7 +42,7 @@ setPipelineStateSync (GstElement * pipeline, GstState state,
 
 /**
  * @brief Get temp file name.
- * @return file name (should free string with g_free)
+ * @return file name (should finalize it with g_remove() and g_free() after use)
  */
 gchar *
 getTempFilename (void)
@@ -66,9 +66,6 @@ getTempFilename (void)
   }
 
   g_close (fd, NULL);
-  if (g_remove (tmp_fn) != 0) {
-    _print_log ("failed to remove temp file %s", tmp_fn);
-  }
 
   return tmp_fn;
 }

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -14,6 +14,7 @@
 #include <glib.h>
 #include <stdint.h>
 #include <errno.h>
+#include <glib/gstdio.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
When creating a temp file name, it is intended to create a unique name, but duplicated temp names may occasionally generated because we remove generated file and get the temp name only.
So sometimes duplicated temp file names are generated when creating temp filenames multiple times.

Change the file to delete after it is used.
Previously, if 1,000 tests were performed, it failed about 15 times on my local PC.
There was no failure when I repeated 2,000 times with this change.


Related issue: #3275 

For example, generate tmp filename 5 times, tmp2 and tmp3 is duplicated.


[  200s] ** (unittest_cppfilter:132252): CRITICAL **: 05:07:52.416: tmp1: /tmp/nnstreamer_unittest_temp_UJOPE1
[  200s] ** (unittest_cppfilter:132252): CRITICAL **: 05:07:52.416: tmp2: /tmp/**nnstreamer_unittest_temp_VIOPE1**
[  200s] ** (unittest_cppfilter:132252): CRITICAL **: 05:07:52.416: tmp3: /tmp/**nnstreamer_unittest_temp_VIOPE1**
[  200s] ** (unittest_cppfilter:132252): CRITICAL **: 05:07:52.416: tmp4: /tmp/nnstreamer_unittest_temp_AJOPE1
[  200s] ** (unittest_cppfilter:132252): CRITICAL **: 05:07:52.416: tmp5: /tmp/nnstreamer_unittest_temp_ILOPE1
 
Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped