### PR TITLE
[TEST] Wait for the server to start and fix comment.

### DIFF
--- a/tests/nnstreamer_query/runTest.sh
+++ b/tests/nnstreamer_query/runTest.sh
@@ -56,6 +56,7 @@ sleep 2
 
 # Test flexible tensors
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc num-buffers=3 ! other/tensors,format=flexible ! tensor_query_serversink" 3-1 0 0 $PERFORMANCE $TIMEOUT_SEC &
+sleep 1
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! other/tensors,format=flexible ! tee name = t t. ! queue ! multifilesink location= raw3_%1d.log t. ! queue ! tensor_query_client ! multifilesink location=result3_%1d.log" 3-2 0 0 $PERFORMANCE
 callCompareTest raw3_0.log result3_0.log 3-3 "Compare 3-3" 1 0
 callCompareTest raw3_1.log result3_1.log 3-4 "Compare 3-4" 1 0
@@ -74,7 +75,7 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
     tensor_converter ! other/tensors,format=flexible ! tee name=t \
         t. ! queue ! multifilesink location= raw5_2_%1d.log \
         t. ! queue ! tensor_query_client ! multifilesink location=result5_2_%1d.log" 5-2 0 0 $PERFORMANCE &
-# Client pipeline 5-2 is connected to server ID 1.
+# Client pipeline 5-3 is connected to server ID 1.
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
     videotestsrc pattern=13 num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! \
     tensor_converter ! other/tensors,format=flexible ! tee name=t \


### PR DESCRIPTION
 - Wait for the server to start.
    If client attempts to connect to the server when the server is not ready, it may  fails.
    Previous PR, sleep time was omitted only in Test 7.
 - Fix invalid comment.

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped
