### PR TITLE
[PKG] Add omitted header to internal dev package

### DIFF
--- a/debian/nnstreamer-dev-internal.install
+++ b/debian/nnstreamer-dev-internal.install
@@ -1,4 +1,5 @@
 /usr/include/nnstreamer/nnstreamer_internal.h
 /usr/include/nnstreamer/nnstreamer_log.h
 /usr/include/nnstreamer/tensor_filter_single.h
+/usr/include/nnstreamer/nnstreamer_conf.h
 /usr/lib/*/pkgconfig/nnstreamer-internal.pc

--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -82,6 +82,7 @@ subdir('include')
 # Private header for sub-plugins and native APIs
 nnstreamer_headers += join_paths(meson.current_source_dir(), 'nnstreamer_internal.h')
 nnstreamer_headers += join_paths(meson.current_source_dir(), 'nnstreamer_log.h')
+nnstreamer_headers += join_paths(meson.current_source_dir(), 'nnstreamer_conf.h')
 
 # Build libraries ("both_libraries" are supported from 0.46.)
 nnstreamer_shared = shared_library('nnstreamer',

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -1030,6 +1030,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{_includedir}/nnstreamer/nnstreamer_internal.h
 %{_includedir}/nnstreamer/nnstreamer_log.h
 %{_includedir}/nnstreamer/tensor_filter_single.h
+%{_includedir}/nnstreamer/nnstreamer_conf.h
 %{_libdir}/pkgconfig/nnstreamer-internal.pc
 
 %files devel-static


### PR DESCRIPTION
nnstreamer_conf.h file is not included in any dev package. To make
some test cases for product-specific ini file, some function in this header
is necessary. This patch adds nnstreamer_conf.h file to
nnstreamer-devel-internal package.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped


