### PR TITLE
[TEST] Changed the comparison method of the padded video.

### DIFF
--- a/tests/nnstreamer_decoder/checkResult.py
+++ b/tests/nnstreamer_decoder/checkResult.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Copyright (C) 2022 Samsung Electronics
+#
+# @file checkResult.py
+# @brief Check if the tensor decoder results is correct with the padded video.
+# @author Gichan Jang <gichan2.jang@samsung.com>
+# @date 3 Jan 2022
+# @bug No known bugs
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+from test_utils import compare_video_frame
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 6:
+        print("Wrong # of parameters")
+        exit(-1)
+
+    golden = sys.argv[1]
+    raw = sys.argv[2]
+    colorspace = sys.argv[3]
+    width = int(sys.argv[4])
+    height = int(sys.argv[5])
+
+    # (godlden file, raw file, colorspace, width, height)
+    exit(compare_video_frame(golden, raw, colorspace, width, height))

--- a/tests/nnstreamer_decoder/runTest.sh
+++ b/tests/nnstreamer_decoder/runTest.sh
@@ -38,7 +38,8 @@ function do_test() {
 
     gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=testcase01_${1}_${2}x${3}.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=${1},width=${2},height=${3},framerate=0/1 ! tensor_converter ! tensor_decoder mode=direct_video ! filesink location=\"testcase01_${1}_${2}x${3}.log\" sync=true" ${4} 0 0 $PERFORMANCE
 
-    callCompareTest testcase01_${1}_${2}x${3}.golden.raw testcase01_${1}_${2}x${3}.log ${4} "Golden Test ${4}" 1 0
+    python3 checkResult.py testcase01_${1}_${2}x${3}.golden.raw testcase01_${1}_${2}x${3}.log ${1} ${2} ${3}
+    testResult $? 1 "Golden Test ${4} comparison" 0 1
 }
 
 do_test RGB 640 480 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -74,3 +74,38 @@ def compare_scaled_tensor(d1, d2, innerdim):
             return 5
 
     return 0
+
+
+##
+# @brief Compare raw video frame
+def compare_video_frame(file1, file2, colorspace, width, height):
+    data1 = read_file(file1)
+    data2 = read_file(file2)
+
+    len1 = len(data1)
+    len2 = len(data2)
+
+    if colorspace == "RGB":
+        channel = 3
+    elif colorspace == "BGRx":
+        channel = 4
+    else:
+        print("Please check format. Your format: " + colorspace)
+        return 2
+
+    if len1 != len2:
+        print("Failed to compare file size, file1 len: " + str(len1) + " file2 len:" + str(len2))
+        return 3
+
+    padded = (4 - (channel * width) % 4) % 4
+    ptr = 0
+    for h in range(0, height):
+        for w in range(0, width):
+            for c in range(0, channel):
+                if data1[ptr] != data2[ptr]:
+                    print("Failed to compare data!")
+                    return 4
+                ptr += 1
+        ptr += padded
+
+    return 0


### PR DESCRIPTION
If the test runs with the valgrind, the comparison of the padded video fails.
(Related issue: https://github.com/nnstreamer/nnstreamer/issues/1367)
Zero was padded when running without the valgrind, but trash value was padded when running with the valgrind.
The comparison of the padded data is meaningless, it is modified to compare only the actual data.

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped
