### PR TITLE
[Conf] Update the name of 'restricted-elements'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -530,7 +530,7 @@ restriction_config = ''
 if get_option('enable-element-restriction')
   restriction_config = '''[element-restriction]
 enable_element_restriction=True
-restricted_elements=''' + get_option('restricted-elements')
+allowed_elements=''' + get_option('allowed-elements')
 endif
 
 nnstreamer_install_conf.set('ELEMENT_RESTRICTION_CONFIG', restriction_config)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -36,7 +36,7 @@ option('enable-symbolic-link', type: 'boolean', value: true)
 option('enable-tizen', type: 'boolean', value: false)
 option('tizen-version-major', type: 'integer', min : 4, max : 9999, value: 9999) # 9999 means "not Tizen"
 option('enable-element-restriction', type: 'boolean', value: false) # true to restrict gst-elements in api
-option('restricted-elements', type: 'string', value: '')
+option('allowed-elements', type: 'string', value: '')
 option('enable-cppfilter', type: 'boolean', value: true) # Allows C++ custom filters
 option('enable-filter-cpp-class', type: 'boolean', value: true) # Allows to accept C++ classes as filter subplugin implementation.
 option('enable-tizen-sensor', type: 'boolean', value: false)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -639,17 +639,17 @@ Provides additional gstreamer plugins for nnstreamer pipelines
 
 %if %{with tizen}
 %define enable_tizen -Denable-tizen=true -Dtizen-version-major=0%{tizen_version_major}
-# Element restriction in Tizen
-%define restricted_element_base     'capsfilter input-selector output-selector queue tee valve appsink appsrc audioconvert audiorate audioresample audiomixer videoconvert videocrop videorate videoscale videoflip videomixer compositor fakesrc fakesink filesrc filesink audiotestsrc videotestsrc jpegparse jpegenc jpegdec pngenc pngdec tcpclientsink tcpclientsrc tcpserversink tcpserversrc xvimagesink ximagesink evasimagesink evaspixmapsink glimagesink theoraenc lame vorbisenc wavenc volume oggmux avimux matroskamux v4l2src avsysvideosrc camerasrc tvcamerasrc pulsesrc fimcconvert tizenwlsink gdppay gdpdepay join '
-%define restricted_element_edgeai   'rtpdec rtspsrc rtspclientsink zmqsrc zmqsink mqttsrc mqttsink udpsrc udpsink multiudpsink '
-%define restricted_element_audio    'audioamplify audiochebband audiocheblimit audiodynamic audioecho audiofirfilter audioiirfilter audioinvert audiokaraoke audiopanorama audiowsincband audiowsinclimit scaletempo stereo '
+# Element allowance in Tizen
+%define allowed_element_base     'capsfilter input-selector output-selector queue tee valve appsink appsrc audioconvert audiorate audioresample audiomixer videoconvert videocrop videorate videoscale videoflip videomixer compositor fakesrc fakesink filesrc filesink audiotestsrc videotestsrc jpegparse jpegenc jpegdec pngenc pngdec tcpclientsink tcpclientsrc tcpserversink tcpserversrc xvimagesink ximagesink evasimagesink evaspixmapsink glimagesink theoraenc lame vorbisenc wavenc volume oggmux avimux matroskamux v4l2src avsysvideosrc camerasrc tvcamerasrc pulsesrc fimcconvert tizenwlsink gdppay gdpdepay join '
+%define allowed_element_edgeai   'rtpdec rtspsrc rtspclientsink zmqsrc zmqsink mqttsrc mqttsink udpsrc udpsink multiudpsink '
+%define allowed_element_audio    'audioamplify audiochebband audiocheblimit audiodynamic audioecho audiofirfilter audioiirfilter audioinvert audiokaraoke audiopanorama audiowsincband audiowsinclimit scaletempo stereo '
 %if "%{?profile}" == "tv"
-%define restricted_element_vd       'tvdpbsrc '
-%define restricted_element          %{restricted_element_base}%{restricted_element_audio}%{restricted_element_edgeai}%{restricted_element_vd}
+%define allowed_element_vd       'tvdpbsrc '
+%define allowed_element          %{allowed_element_base}%{allowed_element_audio}%{allowed_element_edgeai}%{allowed_element_vd}
 %else
-%define restricted_element          %{restricted_element_base}%{restricted_element_audio}%{restricted_element_edgeai}
+%define allowed_element          %{allowed_element_base}%{allowed_element_audio}%{allowed_element_edgeai}
 %endif
-%define element_restriction -Denable-element-restriction=true -Drestricted-elements=%{restricted_element}
+%define element_restriction -Denable-element-restriction=true -Dallowed-elements=%{allowed_element}
 %endif #if tizen
 
 # Support tensorflow


### PR DESCRIPTION
The name 'restricted-elements' of nnstreamer configuration is not
matched as its real operation. This patch renames it to
'allowed_elements'.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

### Related PR
* https://github.com/nnstreamer/api/pull/128
