### PR TITLE
[Test] Fix python custom converter test fail

### DIFF
--- a/tests/test_models/models/custom_converter_json.py
+++ b/tests/test_models/models/custom_converter_json.py
@@ -32,7 +32,7 @@ class CustomConverter(object):
     # tensor 1 : {"name":"John", "age":30}
     def convert(self, input_array):
         json_data = json.loads(input_array[0].tobytes())
-        json_string = json_data["json_string"].encode()
+        json_string = (json_data["json_string"] + '\0').encode()
         json_object = json.dumps(json_data["json_object"]).encode()
 
         output_array1 = np.frombuffer(json_string, dtype=np.uint8)


### PR DESCRIPTION
Getting result from python json parser, result string doesn't contain
null char, the test fails.
Add null char to the string from python json parser.

Daily build failure: http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/latest/log/build_log_tizen_armv7l_output_2022-01-11.txt
```
...
[  357s] [ RUN      ] tensorConverterPython.jsonParser
[  357s] ../tests/nnstreamer_converter/unittest_converter.cc:490: Failure
[  357s] Expected equality of these values:
[  357s]   "string_example"
[  357s]   output
[  357s]     Which is: "string_exampleh\xE1\x18"
[  357s] [  FAILED  ] tensorConverterPython.jsonParser (282 ms)
...
```

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped



