### PR TITLE
[Spec] Enable SNPE filter on DA profile

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -115,7 +115,6 @@
 %define		lua_support 0
 %define		mqtt_support 0
 %define		tvm_support 0
-%define		snpe_support 0
 %endif
 
 # Release unit test suite as a subpackage only if check_test is enabled.


### PR DESCRIPTION
Tizen Robot Vacuum cleaner needs the SNPE filter. This patch enables it
on the DA profile.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
