### PR TITLE
Support the SNPE on DA Robot Vacuum cleaner

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -567,6 +567,7 @@ if get_option('enable-mediapipe')
   )
 endif
 
+run_command('sh', '-c', 'touch filter_snpe_list')
 if snpe_support_is_available
   filter_sub_snpe_sources = ['tensor_filter_snpe.cc']
 
@@ -595,6 +596,7 @@ if snpe_support_is_available
     install: true,
     install_dir: nnstreamer_libdir
   )
+  run_command('sh', '-c', 'echo "%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_snpe.so" >> filter_snpe_list')
 endif
 
 if tensorrt_support_is_available

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -115,7 +115,6 @@
 %define		lua_support 0
 %define		mqtt_support 0
 %define		tvm_support 0
-%define		snpe_support 0
 %endif
 
 # Release unit test suite as a subpackage only if check_test is enabled.


### PR DESCRIPTION
To support the SNPE on DA Robot Vacuum cleaner, this patchset should be applied to Tizen 6.5 branch.
All of them are already merged to the main branch.

**Patch items**
* [Spec] Enable SNPE filter on both In-House and public infra
* [Spec] Enable SNPE filter on DA profile 

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
