### PR TITLE
[filter] Bug fix for pytorch filter with gpu

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -382,7 +382,7 @@ TorchCore::processIValue (torch::jit::IValue value, GstTensorMemory *output, uns
 
   /** bring from gpu to cpu */
   if (use_gpu) {
-    output_tensor.to (at::kCPU);
+    output_tensor = output_tensor.to (at::kCPU);
   }
   /** make the memory contiguous for direct access */
   output_tensor = output_tensor.contiguous ();
@@ -436,7 +436,7 @@ TorchCore::invoke (const GstTensorMemory *input, GstTensorMemory *output)
     tensor = torch::from_blob (input[i].data, input_shape, options);
 
     if (use_gpu) {
-      tensor.to (at::kCUDA);
+      tensor = tensor.to (at::kCUDA);
     }
 
     input_feeds.emplace_back (tensor);


### PR DESCRIPTION
ptyorch filter when working with gpu backend had bugs when converting
between the devices. The tensors returned by the conversion were not
captured. This patch provides the corresponding fix.

See also: #3620

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>