### PR TITLE
[test/ssat] Disable proto flat flex buf SSAT tests when there are no supports

### DIFF
--- a/tests/nnstreamer_flatbuf/runTest.sh
+++ b/tests/nnstreamer_flatbuf/runTest.sh
@@ -32,6 +32,24 @@ convertBMP2PNG
 
 PATH_TO_PLUGIN="../../build"
 
+if [[ -d $PATH_TO_PLUGIN ]]; then
+    ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_converter"
+    if [[ -d ${ini_path} ]]; then
+        check=$(ls ${ini_path} | grep flatbuf.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find flatbuf shared lib"
+            report
+            exit
+        fi
+    else
+        echo "Cannot find ${ini_path}"
+    fi
+else
+    echo "No build directory"
+    report
+    exit
+fi
+
 ##
 ## @brief Execute gstreamer pipeline and compare the output of the pipeline
 ## @param $1 Colorspace

--- a/tests/nnstreamer_flexbuf/runTest.sh
+++ b/tests/nnstreamer_flexbuf/runTest.sh
@@ -32,6 +32,24 @@ convertBMP2PNG
 
 PATH_TO_PLUGIN="../../build"
 
+if [[ -d $PATH_TO_PLUGIN ]]; then
+    ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_converter"
+    if [[ -d ${ini_path} ]]; then
+        check=$(ls ${ini_path} | grep flexbuf.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find flexbuf shared lib"
+            report
+            exit
+        fi
+    else
+        echo "Cannot find ${ini_path}"
+    fi
+else
+    echo "No build directory"
+    report
+    exit
+fi
+
 ##
 ## @brief Execute gstreamer pipeline and compare the output of the pipeline
 ## @param $1 Colorspace

--- a/tests/nnstreamer_protobuf/runTest.sh
+++ b/tests/nnstreamer_protobuf/runTest.sh
@@ -32,6 +32,24 @@ convertBMP2PNG
 
 PATH_TO_PLUGIN="../../build"
 
+if [[ -d $PATH_TO_PLUGIN ]]; then
+    ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/extra"
+    if [[ -d ${ini_path} ]]; then
+        check=$(ls ${ini_path} | grep protobuf.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find protobuf shared lib"
+            report
+            exit
+        fi
+    else
+        echo "Cannot find ${ini_path}"
+    fi
+else
+    echo "No build directory"
+    report
+    exit
+fi
+
 ##
 ## @brief Execute gstreamer pipeline and compare the output of the pipeline
 ## @param $1 Colorspace


### PR DESCRIPTION
- Disable protobuf, flatbuf, flexbuf SSAT tests when related libs did not built

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [✔]Passed [ ]Failed [ ]Skipped
2. Run test: [✔]Passed [ ]Failed [ ]Skipped
