### PR TITLE
[MqttSrc/Sink] release mqtt handle

### DIFF
--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -175,6 +175,7 @@ gst_mqtt_sink_init (GstMqttSink * self)
   MQTTAsync_responseOptions respn_opts = MQTTAsync_responseOptions_initializer;
 
   /** init MQTT related variables */
+  self->mqtt_client_handle = NULL;
   self->mqtt_conn_opts = conn_opts;
   self->mqtt_conn_opts.onSuccess = cb_mqtt_on_connect;
   self->mqtt_conn_opts.onFailure = cb_mqtt_on_connect_failure;
@@ -458,8 +459,10 @@ gst_mqtt_sink_class_finalize (GObject * object)
   self->mqtt_host_address = NULL;
   g_free (self->mqtt_host_port);
   self->mqtt_host_port = NULL;
-  g_free (self->mqtt_client_handle);
-  self->mqtt_client_handle = NULL;
+  if (self->mqtt_client_handle) {
+    MQTTAsync_destroy (&self->mqtt_client_handle);
+    self->mqtt_client_handle = NULL;
+  }
   g_free (self->mqtt_client_id);
   self->mqtt_client_id = NULL;
   g_free (self->mqtt_msg_buf);
@@ -610,6 +613,7 @@ gst_mqtt_sink_start (GstBaseSink * basesink)
 
 error:
   MQTTAsync_destroy (&self->mqtt_client_handle);
+  self->mqtt_client_handle = NULL;
   return FALSE;
 }
 
@@ -647,7 +651,7 @@ gst_mqtt_sink_stop (GstBaseSink * basesink)
       break;
   }
   MQTTAsync_destroy (&self->mqtt_client_handle);
-
+  self->mqtt_client_handle = NULL;
   return TRUE;
 }
 

--- a/gst/mqtt/mqttsrc.c
+++ b/gst/mqtt/mqttsrc.c
@@ -178,6 +178,7 @@ gst_mqtt_src_init (GstMqttSrc * self)
   gst_base_src_set_async (basesrc, FALSE);
 
   /** init mqttsrc properties */
+  self->mqtt_client_handle = NULL;
   self->debug = DEFAULT_DEBUG;
   self->is_live = DEFAULT_IS_LIVE;
   self->mqtt_client_id = g_strdup (DEFAULT_MQTT_CLIENT_ID);
@@ -409,7 +410,11 @@ gst_mqtt_src_class_finalize (GObject * object)
   GstMqttSrc *self = GST_MQTT_SRC (object);
   GstBuffer *remained;
 
-  g_free (self->mqtt_client_handle);
+  if (self->mqtt_client_handle) {
+    MQTTAsync_destroy (&self->mqtt_client_handle);
+    self->mqtt_client_handle = NULL;
+  }
+
   g_free (self->mqtt_client_id);
   g_free (self->mqtt_host_address);
   g_free (self->mqtt_host_port);
@@ -567,6 +572,7 @@ gst_mqtt_src_start (GstBaseSrc * basesrc)
 
 error:
   MQTTAsync_destroy (&self->mqtt_client_handle);
+  self->mqtt_client_handle = NULL;
   return FALSE;
 }
 
@@ -584,7 +590,7 @@ gst_mqtt_src_stop (GstBaseSrc * basesrc)
   self->is_connected = FALSE;
   g_mutex_unlock (&self->mqtt_src_mutex);
   MQTTAsync_destroy (&self->mqtt_client_handle);
-
+  self->mqtt_client_handle = NULL;
   return TRUE;
 }
 


### PR DESCRIPTION
Destroy mqtt-async handle when the element instance is finalized.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
