### PR TITLE
[fix] Fix mem-leak issues in cpp class based filters

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
@@ -272,6 +272,13 @@ edgetpu_subplugin::configure_instance (const GstTensorFilterProperties *prop)
 
   assert (model_path == nullptr);
 
+  if (!g_file_test (prop->model_files[0], G_FILE_TEST_IS_REGULAR)) {
+    const std::string err_msg = "Given file " + (std::string) prop->model_files[0] + " is not valid";
+    std::cerr << err_msg << std::endl;
+    cleanup ();
+    throw std::invalid_argument (err_msg);
+  }
+
   model_path = g_strdup (prop->model_files[0]);
 
   /** Read a model */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
@@ -370,6 +370,13 @@ snpe_subplugin::configure_instance (const GstTensorFilterProperties *prop)
     cleanup ();
   }
 
+  if (!g_file_test (prop->model_files[0], G_FILE_TEST_IS_REGULAR)) {
+    const std::string err_msg = "Given file " + (std::string) prop->model_files[0] + " is not valid";
+    std::cerr << err_msg << std::endl;
+    cleanup ();
+    throw std::invalid_argument (err_msg);
+  }
+
   assert (model_path == nullptr);
 
   model_path = g_strdup (prop->model_files[0]);

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tvm.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tvm.cc
@@ -213,6 +213,13 @@ tvm_subplugin::configure_instance (const GstTensorFilterProperties *prop)
     cleanup ();
   }
 
+  if (!g_file_test (prop->model_files[0], G_FILE_TEST_IS_REGULAR)) {
+    const std::string err_msg = "Given file " + (std::string) prop->model_files[0] + " is not valid";
+    std::cerr << err_msg << std::endl;
+    cleanup ();
+    throw std::invalid_argument (err_msg);
+  }
+
   /* read model */
   model_path = g_strdup (prop->model_files[0]);
   mod_factory = tvm::runtime::Module::LoadFromFile (model_path, "so");

--- a/tests/nnstreamer_filter_lua/unittest_filter_lua.cc
+++ b/tests/nnstreamer_filter_lua/unittest_filter_lua.cc
@@ -347,6 +347,8 @@ TEST (nnstreamerFilterLua, getModelInfo00)
   EXPECT_EQ (out_info.info[0].type, _NNS_UINT8);
 
   sp->close (&prop, &data);
+  gst_tensors_info_free (&in_info);
+  gst_tensors_info_free (&out_info);
   g_free (model_file);
 }
 
@@ -523,7 +525,7 @@ TEST (nnstreamerFilterLua, invoke02_n)
   output.data = g_malloc (output.size);
   ((float *) input.data)[0] = 10.0;
 
-  /* unsucessful invoke with NULL priv_data */
+  /* unsuccessful invoke with NULL priv_data */
   ret = sp->invoke (NULL, NULL, NULL, &input, &output);
   EXPECT_NE (ret, 0);
 
@@ -719,7 +721,7 @@ TEST (nnstreamerFilterLua, reload00)
 
   gchar *model_file2 = g_build_filename (
       root_path, "tests", "test_models", "models", "scaler.lua", NULL);
-  ASSERT_TRUE (g_file_test (model_file, G_FILE_TEST_EXISTS));
+  ASSERT_TRUE (g_file_test (model_file2, G_FILE_TEST_EXISTS));
 
   const gchar *model_files2[] = {
     model_file2,
@@ -790,6 +792,7 @@ TEST (nnstreamerFilterLua, reload00)
 
 
   g_free (model_file);
+  g_free (model_file2);
   g_free (input.data);
   g_free (output.data);
   sp->close (&prop, &data);

--- a/tests/nnstreamer_filter_snpe/unittest_filter_snpe.cc
+++ b/tests/nnstreamer_filter_snpe/unittest_filter_snpe.cc
@@ -93,6 +93,8 @@ TEST (nnstreamerFilterSnpe, getModelInfo00)
   EXPECT_EQ (out_info.info[0].type, _NNS_FLOAT32);
 
   sp->close (&prop, &data);
+  gst_tensors_info_free (&in_info);
+  gst_tensors_info_free (&out_info);
   g_free (model_file);
 }
 

--- a/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
+++ b/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
@@ -14,6 +14,7 @@
 #include <gst/gst.h>
 #include <unittest_util.h>
 
+#include <tensor_common.h>
 #include <nnstreamer_plugin_api_filter.h>
 #include <nnstreamer_util.h>
 
@@ -178,6 +179,8 @@ TEST (nnstreamerFilterTvm, getModelInfo00)
   EXPECT_EQ (out_info.info[0].type, _NNS_FLOAT32);
 
   sp->close (&prop, &data);
+  gst_tensors_info_free (&in_info);
+  gst_tensors_info_free (&out_info);
   g_free (model_file);
 }
 


### PR DESCRIPTION
- Add check for `G_FILE_TEST_IS_REGULAR` in some cpp class based filters
- Free allocated string for lua script
- Fix minor mem-leak in lua, snpe, tvm unittests

Self evaluation:
Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped