### PR TITLE
[Build] Disable trix engine support for TV releases

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -105,6 +105,7 @@
 %define		mqtt_support 0
 %define		tvm_support 0
 %define		snpe_support 0
+%define		trix_engine_support 0
 %endif
 
 # DA requested to remove unnecessary module builds


### PR DESCRIPTION
This patch disables trix_engine_support for TV releases.

Signed-off-by: yelini-jeong <yelini.jeong@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped