### PR TITLE
[transform] Fix transform_caps in direction GST_PAD_SRC 

### DIFF
--- a/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
@@ -614,7 +614,10 @@ gst_tensors_info_get_types_string (const GstTensorsInfo * info)
     GString *types = g_string_new (NULL);
 
     for (i = 0; i < info->num_tensors; i++) {
-      g_string_append (types, gst_tensor_get_type_string (info->info[i].type));
+      if (info->info[i].type != _NNS_END) {
+        g_string_append (types,
+            gst_tensor_get_type_string (info->info[i].type));
+      }
 
       if (i < info->num_tensors - 1) {
         g_string_append (types, ",");

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -1001,7 +1001,7 @@ gst_tensor_filter_transform_caps (GstBaseTransform * trans,
           &in_config.info, &out_info);
     }
 
-    /* If output combibation option is given, reconfigure tensor info */
+    /* If output combination option is given, reconfigure tensor info */
     if (configured)
       configured = gst_tensor_filter_common_get_combined_out_info (priv,
           &in_config.info, &out_info, &out_config.info);
@@ -1034,7 +1034,7 @@ gst_tensor_filter_transform_caps (GstBaseTransform * trans,
      */
 
     intersection =
-        gst_caps_intersect_full (filter, result, GST_CAPS_INTERSECT_FIRST);
+        gst_caps_intersect_full (result, filter, GST_CAPS_INTERSECT_FIRST);
 
     gst_caps_unref (result);
     result = intersection;

--- a/tests/nnstreamer_filter_pytorch/runTest.sh
+++ b/tests/nnstreamer_filter_pytorch/runTest.sh
@@ -125,6 +125,9 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=2 ! videos
 ## correct input/output info
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=2 ! videoscale ! videoconvert ! video/x-raw,width=3,height=4,format=GRAY8,framerate=0/1 ! tensor_converter ! tensor_transform mode=transpose option=2:1:0:3 ! other/tensors,num_tensors=1,dimensions=4:3:1:1,types=uint8,format=static,framerate=0/1 ! tensor_transform mode=typecast option=float32 ! tee name=t t. ! queue ! mux.sink_0 t. ! queue ! mux.sink_1  tensor_mux name=mux sync_mode=nosync ! queue ! tensor_filter framework=pytorch model=${PATH_TO_MODEL} input=4:3:1:1.4:3:1:1 inputtype=float32.float32 output=4:3:1:1.4:3:1:1 outputtype=float32.float32 ! filesink location=tensorfilter.out.log" 8 0 0 $PERFORMANCE
 
+## transform after filter specifying format as static
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=2 ! videoscale ! videoconvert ! video/x-raw,width=3,height=4,format=GRAY8,framerate=0/1 ! tensor_converter ! tensor_transform mode=transpose option=2:1:0:3 ! other/tensors,num_tensors=1,dimensions=4:3:1:1,types=uint8,format=static,framerate=0/1 ! tensor_transform mode=typecast option=float32 ! tee name=t t. ! queue ! mux.sink_0 t. ! queue ! mux.sink_1  tensor_mux name=mux sync_mode=nosync ! queue ! tensor_filter framework=pytorch model=${PATH_TO_MODEL} input=4:3:1:1.4:3:1:1 inputtype=float32.float32 output=4:3:1:1.4:3:1:1 outputtype=float32.float32 ! other/tensors,format=static ! tensor_transform mode=typecast option=uint8 ! filesink location=tensorfilter.out.log" 9 0 0 $PERFORMANCE
+
 # Cleanup
 rm info *.log *.golden
 


### PR DESCRIPTION
- Check null before call g_string_append to remove logs `g_string_insert_len: assertion 'len == 0 || val != NULL' failed`
- Since tensor_transform cannot specify the sinkpad's type caps in some modes, let the `transform_caps` remove the field in that case
- Add a test to check whether tensor_filter - tensor_transform pipeline can be negotiated with static format, not flexible format.
- Modify the order of `caps_intersect_full` in tensor_filter

This resolves #3636

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped