### PR TITLE
[Util] fix typo and license

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -1,27 +1,16 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * NNStreamer Common API Header for Plug-Ins
  * Copyright (C) 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
  * Copyright (C) 2019 Wook Song <wook16.song@samsung.com>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation;
- * version 2.1 of the License.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Library General Public License for more details.
- *
  */
 /**
  * @file  nnstreamer_plugin_api.h
  * @date  24 Jan 2019
- * @brief Optional/Addtional NNStreamer APIs for sub-plugin writers. (Need Gst devel)
+ * @brief Optional/Additional NNStreamer APIs for sub-plugin writers. (Need Gst devel)
  * @see https://github.com/nnstreamer/nnstreamer
  * @author  MyungJoo Ham <myungjoo.ham@samsung.com> and Wook Song <wook16.song@samsung.com>
  * @bug No known bugs except for NYI items
- *
  */
 #ifndef __NNS_PLUGIN_API_H__
 #define __NNS_PLUGIN_API_H__
@@ -30,7 +19,7 @@
 #include <gst/gst.h>
 #include <tensor_typedef.h>
 #include <nnstreamer_version.h>
-#include "nnstreamer_plugin_api_util.h"
+#include <nnstreamer_plugin_api_util.h>
 
 G_BEGIN_DECLS
 

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
@@ -6,7 +6,7 @@
 /**
  * @file  nnstreamer_plugin_api_util.h
  * @date  28 Jan 2022
- * @brief Optional/Addtional NNStreamer APIs for sub-plugin writers. (No Gst dep)
+ * @brief Optional/Additional NNStreamer APIs for sub-plugin writers. (No Gst dep)
  * @see https://github.com/nnstreamer/nnstreamer
  * @author Gichan Jang <myungjoo.ham@samsung.com>
  * @bug No known bugs except for NYI items

--- a/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
@@ -1,15 +1,16 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved.
  *
  * @file nnstreamer_plugin_api_util_impl.c
  * @date 28 Jan 2022
- * @brief Tensor common util fucntions for NNStreamer. (No gst dependency)
+ * @brief Tensor common util functions for NNStreamer. (No gst dependency)
  * @see	https://github.com/nnstreamer/nnstreamer
  * @author Gichan Jang <gichan2.jang@samsung.com>
  * @bug No known bugs except for NYI items
  */
 
+#include <string.h>
 #include "nnstreamer_plugin_api_util.h"
 #include "nnstreamer_log.h"
 

--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -183,8 +183,6 @@ gst_tensor_buffer_from_config (GstBuffer * in, GstTensorsConfig * config);
  * @param pad GstPad to get possible caps
  * @param config tensors config structure
  * @return caps for given config. Caller is responsible for unreffing the returned caps.
- * @note This function is included in nnstreamer internal header for native APIs.
- *       When changing the declaration, you should update the internal header (nnstreamer_internal.h).
  */
 extern GstCaps *
 gst_tensor_pad_caps_from_config (GstPad * pad, const GstTensorsConfig * config);
@@ -194,8 +192,6 @@ gst_tensor_pad_caps_from_config (GstPad * pad, const GstTensorsConfig * config);
  * @param pad GstPad to get possible caps
  * @param config tensors config structure
  * @return caps for given config. Caller is responsible for unreffing the returned caps.
- * @note This function is included in nnstreamer internal header for native APIs.
- *       When changing the declaration, you should update the internal header (nnstreamer_internal.h).
  */
 extern GstCaps *
 gst_tensor_pad_possible_caps_from_config (GstPad * pad, const GstTensorsConfig * config);
@@ -204,8 +200,6 @@ gst_tensor_pad_possible_caps_from_config (GstPad * pad, const GstTensorsConfig *
  * @brief Check current pad caps is flexible tensor.
  * @param pad GstPad to check current caps
  * @return TRUE if pad has flexible tensor caps.
- * @note This function is included in nnstreamer internal header for native APIs.
- *       When changing the declaration, you should update the internal header (nnstreamer_internal.h).
  */
 extern gboolean
 gst_tensor_pad_caps_is_flexible (GstPad * pad);


### PR DESCRIPTION
Fix typo and license in util functions and header.
Update internal function description and remove unnecessary param.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
