### PR TITLE
[Log] exporting logger

### DIFF
--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -92,7 +92,6 @@ endif
 subdir('include')
 
 # Private header for sub-plugins and native APIs
-nnstreamer_headers += join_paths(meson.current_source_dir(), 'nnstreamer_log.h')
 nnstreamer_headers += join_paths(meson.current_source_dir(), 'nnstreamer_internal.h')
 
 nnstreamer_single_shared = shared_library('nnstreamer-single',

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -1076,7 +1076,6 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 
 %files devel-internal
 %{_includedir}/nnstreamer/nnstreamer_internal.h
-%{_includedir}/nnstreamer/nnstreamer_log.h
 %{_includedir}/nnstreamer/tensor_filter_single.h
 %{_libdir}/pkgconfig/nnstreamer-internal.pc
 

--- a/tests/unittest_util.c
+++ b/tests/unittest_util.c
@@ -10,7 +10,6 @@
  */
 #include <gst/gst.h>
 #include <glib/gstdio.h>
-#include <nnstreamer_log.h>
 #include <string.h>
 #include "unittest_util.h"
 


### PR DESCRIPTION
Log util is available only in nnstreamer repo.
Remove exporting the header for logging.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
