### PR TITLE
[Pkg] add filter-single header

### DIFF
--- a/debian/nnstreamer-dev-internal.install
+++ b/debian/nnstreamer-dev-internal.install
@@ -1,2 +1,3 @@
 /usr/include/nnstreamer/nnstreamer_internal.h
+/usr/include/nnstreamer/tensor_filter_single.h
 /usr/lib/*/pkgconfig/nnstreamer-internal.pc


### PR DESCRIPTION
dev-internal pkg should include filter-single header for single-shot API.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
