### PR TITLE
[build/tflite] Check each delegate symbol in build time

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -223,9 +223,40 @@ if tflite2_support_is_available
     tflite2_compile_args += '-DUSE_TENSORFLOW2_HEADER_PATH=1'
   endif
 
-  # TODO: tflite v2.8.0+ supports build option for external delegate
-  # remove below option after that.
-  if get_option('tflite2-external-delegate-support')
+  # Check each delegate linking with given tflite library
+  ## xnnpack delegate
+  if cxx.links('''
+        #include "tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h"
+        TfLiteXNNPackDelegateOptions xnnpack_options = TfLiteXNNPackDelegateOptionsDefault ();
+        int main() {return 0;}
+      ''', dependencies : [tflite2_support_deps, thread_dep], name : 'xnnpack delegate')
+    tflite2_compile_args += '-DTFLITE_XNNPACK_DELEGATE_SUPPORTED'
+  endif
+
+  ## gpu delegate
+  if cxx.links('''
+        #include "tensorflow/lite/delegates/gpu/delegate.h"
+        TfLiteGpuDelegateOptionsV2 gpu_options = TfLiteGpuDelegateOptionsV2Default ();
+        int main() {return 0;}
+      ''', dependencies : [tflite2_support_deps, libdl_dep], name : 'gpu delegate')
+    tflite2_compile_args += '-DTFLITE_GPU_DELEGATE_SUPPORTED'
+  endif
+
+  ## nnapi delegate
+  if cxx.links('''
+        #include "tensorflow/lite/delegates/nnapi/nnapi_delegate.h"
+        tflite::StatefulNnApiDelegate::StatefulNnApiDelegate ();
+        int main() {return 0;}
+      ''', dependencies : [tflite2_support_deps], name : 'nnapi delegate')
+    tflite2_compile_args += '-DTFLITE_NNAPI_DELEGATE_SUPPORTED'
+  endif
+
+  ## external delegate
+  if cxx.links('''
+      #include "tensorflow/lite/delegates/external/external_delegate.h"
+      TfLiteExternalDelegateOptions external_options = TfLiteExternalDelegateOptionsDefault ("");
+      int main() {return 0;}
+    ''', dependencies : [tflite2_support_deps, libdl_dep], name : 'external delegate')
     tflite2_compile_args += '-DTFLITE_EXTERNAL_DELEGATE_SUPPORTED'
   endif
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -52,14 +52,27 @@
 #  include <tensorflow/contrib/lite/model.h>
 #endif
 
-#if TFLITE_VERSION_MAJOR >= 2
+/** control delegate headers */
+#ifdef TFLITE_XNNPACK_DELEGATE_SUPPORTED
 #  if USE_TENSORFLOW2_HEADER_PATH
 #    include <tensorflow2/lite/delegates/xnnpack/xnnpack_delegate.h>
-#    include <tensorflow2/lite/delegates/gpu/delegate.h>
-#    include <tensorflow2/lite/delegates/nnapi/nnapi_delegate.h>
 #  else
 #    include <tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h>
+#  endif
+#endif
+
+#ifdef TFLITE_GPU_DELEGATE_SUPPORTED
+#  if USE_TENSORFLOW2_HEADER_PATH
+#    include <tensorflow2/lite/delegates/gpu/delegate.h>
+#  else
 #    include <tensorflow/lite/delegates/gpu/delegate.h>
+#  endif
+#endif
+
+#ifdef TFLITE_NNAPI_DELEGATE_SUPPORTED
+#  if USE_TENSORFLOW2_HEADER_PATH
+#    include <tensorflow2/lite/delegates/nnapi/nnapi_delegate.h>
+#  else
 #    include <tensorflow/lite/delegates/nnapi/nnapi_delegate.h>
 #  endif
 #endif
@@ -428,7 +441,7 @@ TFLiteInterpreter::loadModel (int num_threads, tflite_delegate_e delegate_e)
   switch (delegate_e) {
     case TFLITE_DELEGATE_XNNPACK:
     {
-#if TFLITE_VERSION_MAJOR >= 2
+#if TFLITE_XNNPACK_DELEGATE_SUPPORTED
       /* set xnnpack delegate */
       TfLiteXNNPackDelegateOptions xnnpack_options =
           TfLiteXNNPackDelegateOptionsDefault();
@@ -452,7 +465,7 @@ TFLiteInterpreter::loadModel (int num_threads, tflite_delegate_e delegate_e)
     }
     case TFLITE_DELEGATE_GPU:
     {
-#if TFLITE_VERSION_MAJOR >= 2
+#if TFLITE_GPU_DELEGATE_SUPPORTED
       /* set gpu delegate when accelerator set to GPU */
       TfLiteGpuDelegateOptionsV2 options = TfLiteGpuDelegateOptionsV2Default ();
       options.experimental_flags = TFLITE_GPU_EXPERIMENTAL_FLAGS_NONE;
@@ -482,7 +495,7 @@ TFLiteInterpreter::loadModel (int num_threads, tflite_delegate_e delegate_e)
     }
     case TFLITE_DELEGATE_NNAPI:
     {
-#if TFLITE_VERSION_MAJOR >= 2
+#if TFLITE_NNAPI_DELEGATE_SUPPORTED
       /* set nnapi delegate when accelerator set to auto (cpu.neon in Android) or NPU */
       delegate = new tflite::StatefulNnApiDelegate ();
       void (* deleter) (TfLiteDelegate *) =

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -27,7 +27,6 @@ option('trix-engine-support', type: 'feature', value: 'auto')
 option('enable-test', type: 'boolean', value: true)
 option('install-test', type: 'boolean', value: false)
 option('enable-pytorch-use-gpu', type: 'boolean', value: false) # default value, can be specified at run time
-option('tflite2-external-delegate-support', type: 'boolean', value: 'false')
 option('enable-mediapipe', type: 'boolean', value: false)
 option('enable-env-var', type: 'boolean', value: true)
 option('enable-symbolic-link', type: 'boolean', value: true)


### PR DESCRIPTION
- Check each tflite delegate symbol by linking with tflite dep in build time

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed []Skipped
2. Run test: [X]Passed [ ]Failed []Skipped

This resolves #3674 