### PR TITLE
converter: elaborate error messages @open sesame 3/28 19:04

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
@@ -198,6 +198,14 @@ extern void
 gst_tensors_info_copy (GstTensorsInfo * dest, const GstTensorsInfo * src);
 
 /**
+ * @brief GstTensorsInfo represented as a string. Caller should free it.
+ * @param info GstTensorsInfo structure
+ * @return The newly allocated string representing the tensorsinfo. Free after use.
+ */
+extern gchar *
+gst_tensors_info_to_string (const GstTensorsInfo * info);
+
+/**
  * @brief Initialize the tensors config info structure (for other/tensors)
  * @param config tensors config structure to be initialized
  */
@@ -232,6 +240,14 @@ gst_tensors_config_is_equal (const GstTensorsConfig * c1,
  */
 extern void
 gst_tensors_config_copy (GstTensorsConfig * dest, const GstTensorsConfig * src);
+
+/**
+ * @brief Tensor config represented as a string. Caller should free it.
+ * @param config tensor config structure
+ * @return The newly allocated string representing the config. Free after use.
+ */
+extern gchar *
+gst_tensors_config_to_string (const GstTensorsConfig * config);
 
 /**
  * @brief Macro to check stream format (static tensors for caps negotiation)


### PR DESCRIPTION
When there is a pipeline error, especially at the construct phase,
users need elaborated error messages that provide useful infomation
to correct pipeline descriptions.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

