### PR TITLE
filter/pytorch,caffe2: they have redundant decls. @open sesame 3/17 14:29

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -456,7 +456,7 @@ foreach name, value: project_args
 endforeach
 
 # Add redundant declaration flag when caffe2 and pytorch both are disabled
-if not (pytorch_support_is_available and caffe2_support_is_available)
+if not (pytorch_support_is_available or caffe2_support_is_available)
   redundant_decls_flag = '-Wredundant-decls'
   if cc.has_argument (redundant_decls_flag)
     add_project_arguments([redundant_decls_flag], language: 'c')


### PR DESCRIPTION
Add -Wredundant-decl only when !(pytorch or caffe2), not !(pytorch and caffe2).
Even when only one of the two are included, they have redundant decl warnings.
It appears that we haven't tested cases where only one of pytorch and caffe2 is
enabled.

Fixes #3693

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


