### PR TITLE
[converter/python3] Temporarily remove Py_Finalize

### DIFF
--- a/ext/nnstreamer/tensor_converter/tensor_converter_python3.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_python3.cc
@@ -10,7 +10,7 @@
 *         which converts to tensors using python.
  * @see		https://github.com/nnstreamer/nnstreamer
  * @author	Gichan Jang <gichan2.jang@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @bug		python converter with Python3.9.10 is stucked during Py_Finalize().
  */
 
 #include <nnstreamer_plugin_api_converter.h>
@@ -372,16 +372,16 @@ void
 fini_converter_py (void)
 {
   unregisterExternalConverter (Python.name);
+/**
+ * @todo Remove below lines after this issue is addressed.
+ * Tizen issues: After python version has been upgraded from 3.9.1 to 3.9.10, python converter is stopped at Py_Finalize.
+ * Since Py_Initialize is not called twice from this object, Py_Finalize is temporarily removed.
+ */
+#if 0
   /** Python should be initialized and finalized only once */
-  if (Py_IsInitialized()) {
-    /**
-     * @todo: There is a crash problem between Python C-API and numpy.
-     *        If this problem is solved, let's remove the sleep time.
-     * related issue: https://github.com/numpy/numpy/issues/8097
-     */
-    g_usleep (100000);
+  if (Py_IsInitialized())
     Py_Finalize ();
-  }
+#endif
 }
 #ifdef __cplusplus
 }

--- a/tests/nnstreamer_converter/unittest_converter.cc
+++ b/tests/nnstreamer_converter/unittest_converter.cc
@@ -365,7 +365,7 @@ new_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
 /**
  * @brief Test for dynamic dimension of the custom converter
  */
-TEST (tensorConverterPython, DISABLED_dynamicDimension)
+TEST (tensorConverterPython, dynamicDimension)
 {
   GstBuffer *buf_0, *buf_1, *buf_2;
   GstElement *appsrc_handle, *sink_handle;
@@ -495,7 +495,7 @@ new_data_cb_json (GstElement *element, GstBuffer *buffer, gpointer user_data)
 /**
  * @brief Test for python json parser of the custom converter
  */
-TEST (tensorConverterPython, DISABLED_jsonParser)
+TEST (tensorConverterPython, jsonParser)
 {
   GstElement *sink_handle;
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
@@ -540,7 +540,7 @@ TEST (tensorConverterPython, DISABLED_jsonParser)
 /**
  * @brief Test for python custom converter with invalid param
  */
-TEST (tensorConverterPython, DISABLED_openTwice)
+TEST (tensorConverterPython, openTwice)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const NNStreamerExternalConverter *ex;
@@ -573,7 +573,7 @@ TEST (tensorConverterPython, DISABLED_openTwice)
 /**
  * @brief Test for python custom converter with invalid param
  */
-TEST (tensorConverterPython, DISABLED_invalidParam_n)
+TEST (tensorConverterPython, invalidParam_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   gchar *test_model, *data_file;
@@ -607,7 +607,7 @@ TEST (tensorConverterPython, DISABLED_invalidParam_n)
 /**
  * @brief Test for python custom converter with invalid param
  */
-TEST (tensorConverterPython, DISABLED_invalidParam2_n)
+TEST (tensorConverterPython, invalidParam2_n)
 {
   const NNStreamerExternalConverter *ex;
   GstTensorsConfig config;
@@ -622,7 +622,7 @@ TEST (tensorConverterPython, DISABLED_invalidParam2_n)
 /**
  * @brief Test for python custom converter with invalid param
  */
-TEST (tensorConverterPython, DISABLED_invalidParam3_n)
+TEST (tensorConverterPython, invalidParam3_n)
 {
   const NNStreamerExternalConverter *ex;
   GstCaps *caps;
@@ -639,7 +639,7 @@ TEST (tensorConverterPython, DISABLED_invalidParam3_n)
 /**
  * @brief Test for python custom converter with invalid param
  */
-TEST (tensorConverterPython, DISABLED_invalidParam4_n)
+TEST (tensorConverterPython, invalidParam4_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const NNStreamerExternalConverter *ex;
@@ -668,7 +668,7 @@ TEST (tensorConverterPython, DISABLED_invalidParam4_n)
 /**
  * @brief Test for python custom converter with invalid param
  */
-TEST (tensorConverterPython, DISABLED_invalidParam5_n)
+TEST (tensorConverterPython, invalidParam5_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const NNStreamerExternalConverter *ex;
@@ -697,7 +697,7 @@ TEST (tensorConverterPython, DISABLED_invalidParam5_n)
 /**
  * @brief Test for python custom converter with invalid param
  */
-TEST (tensorConverterPython, DISABLED_invalidParam6_n)
+TEST (tensorConverterPython, invalidParam6_n)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
   const NNStreamerExternalConverter *ex;

--- a/tests/nnstreamer_converter_python3/runTest.sh
+++ b/tests/nnstreamer_converter_python3/runTest.sh
@@ -8,10 +8,6 @@
 ## @brief SSAT Test Cases for NNStreamer
 ##
 
-# Temporarily dedisable tests until the problem is resolved.
-report
-exit
-
 if [[ "$SSATAPILOADED" != "1" ]]; then
     SILENT=0
     INDEPENDENT=1


### PR DESCRIPTION
Tizen issues: After python version has been upgraded from 3.9.1 to 3.9.10, python converter is stopped at Py_Finalize.
Since Py_Initialize is not called twice from this object, Py_Finalize is temporarily removed.

Related issue: #3684 

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped
