### PR TITLE
Elaborate error messaegs for tensor-filter @open sesame 4/21 11:05

### DIFF
--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -39,6 +39,7 @@ nnstreamer_internal_deps = []
 nnst_single_sources = [
   'hw_accel.c',
   'nnstreamer_conf.c',
+  'nnstreamer_log.c',
   'nnstreamer_subplugin.c',
   'nnstreamer_plugin_api_util_impl.c',
 ]

--- a/gst/nnstreamer/nnstreamer_log.c
+++ b/gst/nnstreamer/nnstreamer_log.c
@@ -1,0 +1,116 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * @file	nnstreamer_log.c
+ * @date	31 Mar 2022
+ * @brief	Internal log and error handling for NNStreamer plugins and core codes.
+ * @see		http://github.com/nnstreamer/nnstreamer
+ * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#ifndef __ANDROID__
+/* Android does not have execinfo.h. It has unwind.h instead. */
+#include <execinfo.h>
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <glib.h>
+
+#include "nnstreamer_log.h"
+
+/**
+ * @brief stack trace as a string for error messages
+ * @return a string of stacktrace result. caller should free it.
+ * @todo The .c file location of this function might be not appropriate.
+ */
+char *
+_backtrace_to_string (void)
+{
+  char *retstr = NULL;
+#ifndef __ANDROID__
+/* Android does not have execinfo.h. It has unwind.h instead. */
+  void *array[20];
+  char **strings;
+  int size, i;
+  int strsize = 0, strcursor = 0;
+
+  size = backtrace (array, 20);
+  strings = backtrace_symbols (array, size);
+  if (strings != NULL) {
+    for (i = 0; i < size; i++)
+      strsize += strlen (strings[i]);
+
+    retstr = malloc (sizeof (char) * (strsize + 1));
+    for (i = 0; i < size; i++) {
+      int len = strlen (strings[i]);
+      memcpy (retstr + strcursor, strings[i], len);
+      strcursor += len;
+    }
+    retstr[strsize] = '\0';
+  }
+
+  free (strings);
+#else
+  retstr = strdup ("Android-nnstreamer does not support backtrace.\n");
+#endif
+
+  return retstr;
+}
+
+#define _NNSTREAMER_ERROR_LENGTH        (4096U)
+static char errmsg[_NNSTREAMER_ERROR_LENGTH] = { 0 };
+
+static int errmsg_reported = 0;
+G_LOCK_DEFINE_STATIC (errlock);
+
+/**
+ * @brief return the last internal error string and clean it.
+ * @return a string of error. Do not free the returned string.
+ */
+const char *
+_nnstreamer_error (void)
+{
+
+  G_LOCK (errlock);
+  if (errmsg_reported || errmsg[0] == '\0') {
+    G_UNLOCK (errlock);
+    return NULL;
+  }
+  G_UNLOCK (errlock);
+
+  errmsg_reported = 1;
+  return errmsg;
+}
+
+/**
+ * @brief overwrites the error message buffer with the new message.
+ */
+void
+_nnstreamer_error_write (const char *fmt, ...)
+{
+  va_list arg_ptr;
+  G_LOCK (errlock);
+
+  va_start (arg_ptr, fmt);
+  vsnprintf (errmsg, _NNSTREAMER_ERROR_LENGTH, fmt, arg_ptr);
+  va_end (arg_ptr);
+
+  errmsg_reported = 0;
+
+  G_UNLOCK (errlock);
+}
+
+/**
+ * @brief cleans up the error message buffer.
+ */
+void
+_nnstreamer_error_clean (void)
+{
+  G_LOCK (errlock);
+
+  errmsg[0] = '\0';
+
+  G_UNLOCK (errlock);
+}

--- a/gst/nnstreamer/nnstreamer_log.c
+++ b/gst/nnstreamer/nnstreamer_log.c
@@ -87,9 +87,12 @@ _nnstreamer_error (void)
 /**
  * @brief overwrites the error message buffer with the new message.
  */
-void
-_nnstreamer_error_write (const char *fmt, ...)
+__attribute__((__format__ (__printf__, 1, 2)))
+     void _nnstreamer_error_write (const char *fmt, ...)
 {
+  /** The attribute is for clang workaround in macos:
+      https://stackoverflow.com/questions/20167124/vsprintf-and-vsnprintf-wformat-nonliteral-warning-on-clang-5-0
+   */
   va_list arg_ptr;
   G_LOCK (errlock);
 

--- a/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
@@ -175,8 +175,11 @@ gst_tensor_info_validate (const GstTensorInfo * info)
   g_return_val_if_fail (info != NULL, FALSE);
 
   if (info->type == _NNS_END) {
-    nns_logd ("Failed to validate tensor info. type: %s. "
-        "Please specify tensor type. e.g., type=uint8 ",
+    nns_logd
+        ("Failed to validate tensor info. type: %s. Please specify tensor type. e.g., type=uint8 ",
+        _STR_NULL (gst_tensor_get_type_string (info->type)));
+    _nnstreamer_error_write
+        ("Failed to validate tensor info. type: %s. Please specify tensor type. e.g., type=uint8 ",
         _STR_NULL (gst_tensor_get_type_string (info->type)));
     return FALSE;
   }
@@ -374,8 +377,12 @@ gst_tensors_info_validate (const GstTensorsInfo * info)
   g_return_val_if_fail (info != NULL, FALSE);
 
   if (info->num_tensors < 1) {
-    nns_logd ("Failed to validate tensors info. the number of tensors: %d. "
-        "the number of tensors should be greater than 0.", info->num_tensors);
+    nns_logd
+        ("Failed to validate tensors info. the number of tensors: %d. the number of tensors should be greater than 0.",
+        info->num_tensors);
+    _nnstreamer_error_write
+        ("Failed to validate tensors info. the number of tensors: %d. the number of tensors should be greater than 0.",
+        info->num_tensors);
     return FALSE;
   }
 
@@ -737,16 +744,23 @@ gst_tensors_config_validate (const GstTensorsConfig * config)
 
   /* framerate (numerator >= 0 and denominator > 0) */
   if (config->rate_n < 0 || config->rate_d <= 0) {
-    nns_logd ("Failed to validate tensors config. framerate: %d/%d. "
-        "framerate should be numerator >= 0 and denominator > 0.",
+    nns_logd
+        ("Failed to validate tensors config. framerate: %d/%d. framerate should be numerator >= 0 and denominator > 0.",
+        config->rate_n, config->rate_d);
+    _nnstreamer_error_write
+        ("Failed to validate tensors config. framerate: %d/%d. framerate should be numerator >= 0 and denominator > 0.",
         config->rate_n, config->rate_d);
     return FALSE;
   }
 
   /* tensor stream format */
   if (config->format >= _NNS_TENSOR_FORMAT_END) {
-    nns_logd ("Failed to validate tensors config. format: %s. "
-        "format should be one of %s.",
+    nns_logd
+        ("Failed to validate tensors config. format: %s. format should be one of %s.",
+        _STR_NULL (gst_tensor_get_format_string (config->format)),
+        GST_TENSOR_FORMAT_ALL);
+    _nnstreamer_error_write
+        ("Failed to validate tensors config. format: %s. format should be one of %s.",
         _STR_NULL (gst_tensor_get_format_string (config->format)),
         GST_TENSOR_FORMAT_ALL);
     return FALSE;
@@ -844,9 +858,12 @@ gst_tensor_dimension_is_valid (const tensor_dim dim)
   for (i = 0; i < NNS_TENSOR_RANK_LIMIT; ++i) {
     if (dim[i] == 0) {
       gchar *dim_str = gst_tensor_get_dimension_string (dim);
-      nns_logd ("Failed to validate tensor dimension. Given dimension: %s"
-          "The dimension string should be in the form of d1:d2:d3:d4, "
-          "d1:d2:d3, d1:d2, or d1. Here, dN is a positive integer.", dim_str);
+      nns_logd
+          ("Failed to validate tensor dimension. Given dimension: %s. The dimension string should be in the form of d1:d2:d3:d4, d1:d2:d3, d1:d2, or d1. Here, dN is a positive integer.",
+          dim_str);
+      _nnstreamer_error_write
+          ("Failed to validate tensor dimension. Given dimension: %s. The dimension string should be in the form of d1:d2:d3:d4, d1:d2:d3, d1:d2, or d1. Here, dN is a positive integer.",
+          dim_str);
       g_free (dim_str);
       return FALSE;
     }

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -817,19 +817,20 @@ gst_tensor_filter_destroy_notify_util (GstTensorFilterPrivate * priv,
 }
 
 /**
- * @brief Printout the comparison results of two tensors.
+ * @brief Printout the comparison results of two tensors as a string.
  * @param[in] info1 The tensors to be shown on the left hand side
  * @param[in] info2 The tensors to be shown on the right hand side
+ * @return The printout string allocated. Caller should free the value.
  */
-void
-gst_tensor_filter_compare_tensors (const GstTensorsInfo * info1,
+gchar *
+gst_tensorsinfo_compare_to_string (const GstTensorsInfo * info1,
     const GstTensorsInfo * info2)
 {
   gchar *result = NULL;
   gchar *line, *tmp, *left, *right;
   guint i;
 
-  g_return_if_fail (info1 != NULL && info2 != NULL);
+  g_return_val_if_fail (info1 != NULL && info2 != NULL, NULL);
 
   for (i = 0; i < NNS_TENSOR_SIZE_LIMIT; i++) {
     if (info1->num_tensors <= i && info2->num_tensors <= i)
@@ -870,10 +871,22 @@ gst_tensor_filter_compare_tensors (const GstTensorsInfo * info1,
     }
   }
 
-  if (result) {
-    nns_logi ("Tensor info :\n%s", result);
-    g_free (result);
-  }
+  return result;
+}
+
+/**
+ * @brief Printout the comparison results of two tensors.
+ * @param[in] info1 The tensors to be shown on the left hand side
+ * @param[in] info2 The tensors to be shown on the right hand side
+ */
+void
+gst_tensorsinfo_compare_print (const GstTensorsInfo * info1,
+    const GstTensorsInfo * info2)
+{
+  gchar *result = gst_tensorsinfo_compare_to_string (info1, info2);
+  nns_logi ("%s\n", (result == NULL) ?
+      "cannot compare NULL metadata(GstTensorsInfo) with others" : result);
+  g_free (result);
 }
 
 /**
@@ -2345,8 +2358,12 @@ gst_tensor_filter_load_tensor_info (GstTensorFilterPrivate * priv)
     /** if set-property called and already has info, verify it! */
     if (prop->input_meta.num_tensors > 0) {
       if (!gst_tensors_info_is_equal (&in_info, &prop->input_meta)) {
-        g_critical ("The input tensor is not compatible.");
-        gst_tensor_filter_compare_tensors (&in_info, &prop->input_meta);
+        gchar *cmpstr =
+            gst_tensorsinfo_compare_to_string (&in_info, &prop->input_meta);
+        ml_loge
+            ("The input tensor is not compatible with the configuration of the model or tensor-filter property. The two tensor meta (GstTensorsInfo) are not compatible: %s\n",
+            cmpstr);
+        g_free (cmpstr);
         goto done;
       }
     } else {
@@ -2364,8 +2381,12 @@ gst_tensor_filter_load_tensor_info (GstTensorFilterPrivate * priv)
     /** if set-property called and already has info, verify it! */
     if (prop->output_meta.num_tensors > 0) {
       if (!gst_tensors_info_is_equal (&out_info, &prop->output_meta)) {
-        g_critical ("The output tensor is not compatible.");
-        gst_tensor_filter_compare_tensors (&out_info, &prop->output_meta);
+        gchar *cmpstr =
+            gst_tensorsinfo_compare_to_string (&out_info, &prop->output_meta);
+        g_critical
+            ("The output tensor is not compatible with the configuration of the model or tensor-filter property. The two tensor meta (GstTensorsInfo) are not compatible: %s\n",
+            cmpstr);
+        g_free (cmpstr);
         goto done;
       }
     } else {

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -135,13 +135,22 @@ typedef struct _GstTensorFilterPrivate
 } GstTensorFilterPrivate;
 
 /**
+ * @brief Printout the comparison results of two tensors as a string.
+ * @param[in] info1 The tensors to be shown on the left hand side
+ * @param[in] info2 The tensors to be shown on the right hand side
+ * @return The printout string allocated. Caller should free the value.
+ */
+extern gchar *
+gst_tensorsinfo_compare_to_string (const GstTensorsInfo * info,
+    const GstTensorsInfo * info2);
+/**
  * @brief Printout the comparison results of two tensors.
  * @param[in] info1 The tensors to be shown on the left hand side
  * @param[in] info2 The tensors to be shown on the right hand side
  * @todo If this is going to be used by other elements, move this to nnstreamer/tensor_common.
  */
 extern void
-gst_tensor_filter_compare_tensors (const GstTensorsInfo * info1,
+gst_tensorsinfo_compare_print (const GstTensorsInfo * info1,
     const GstTensorsInfo * info2);
 
 /**

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -33,6 +33,7 @@ NNSTREAMER_INCLUDES := \
 NNSTREAMER_COMMON_SRCS := \
     $(NNSTREAMER_GST_HOME)/hw_accel.c \
     $(NNSTREAMER_GST_HOME)/nnstreamer_conf.c \
+    $(NNSTREAMER_GST_HOME)/nnstreamer_log.c \
     $(NNSTREAMER_GST_HOME)/nnstreamer_subplugin.c \
     $(NNSTREAMER_GST_HOME)/nnstreamer_plugin_api_util_impl.c \
     $(NNSTREAMER_GST_HOME)/tensor_filter/tensor_filter_common.c \


### PR DESCRIPTION
commit 6083f63be35bf6ee27a9276be2ee965800d3892e (HEAD -> err/filter/1, github-fork/err/filter/1)
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Wed Mar 30 19:12:59 2022 +0900

    [WIP] filter: elaborate error messages.
    
    Elaborate error and warning messages so that users and developers
    can easily point out and fix issues.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 14f3596df669383db0b8c6d24539e68bb6039d34
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Wed Mar 30 19:12:08 2022 +0900

    common/internal: backtrace function for debugging
    
    For debugging messages, add a backtrace function.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
