### PR TITLE
test: ppa/armhf timeout

### DIFF
--- a/tests/nnstreamer_converter/unittest_converter.cc
+++ b/tests/nnstreamer_converter/unittest_converter.cc
@@ -19,7 +19,7 @@
 #include <nnstreamer_util.h>
 
 
-#define TEST_TIMEOUT_MS (10000U)
+#define TEST_TIMEOUT_MS (30000U)
 
 /**
  * @brief custom callback function

--- a/tests/nnstreamer_decoder/unittest_decoder.cc
+++ b/tests/nnstreamer_decoder/unittest_decoder.cc
@@ -17,7 +17,7 @@
 #include <unittest_util.h>
 #include <tensor_decoder_custom.h>
 
-#define TEST_TIMEOUT_MS (1000U)
+#define TEST_TIMEOUT_MS (5000U)
 
 static int data_received;
 

--- a/tests/nnstreamer_if/unittest_if.cc
+++ b/tests/nnstreamer_if/unittest_if.cc
@@ -16,7 +16,7 @@
 #include <unittest_util.h>
 #include "../gst/nnstreamer/tensor_if/gsttensorif.h"
 
-#define TEST_TIMEOUT_MS (5000U)
+#define TEST_TIMEOUT_MS (20000U)
 
 static int data_received;
 


### PR DESCRIPTION
We have the following error at PPA for armhf build:
```
../tests/nnstreamer_converter/unittest_converter.cc:409: Failure
Value of: wait_pipeline_process_buffers (data_received, 1, TEST_TIMEOUT_MS)
  Actual: false
Expected: true
../tests/nnstreamer_converter/unittest_converter.cc:414: Failure
Expected: (caps) != (nullptr), actual: NULL vs 4-byte object <00-00 00-00>

(unittest_converter:16055): GStreamer-CRITICAL **: 06:06:01.349: gst_caps_get_structure: assertion 'GST_IS_CAPS (caps)' failed
../tests/nnstreamer_converter/unittest_converter.cc:416: Failure
Expected: (structure) != (nullptr), actual: NULL vs 4-byte object <00-00 00-00>

** (unittest_converter:16055): CRITICAL **: 06:06:01.351: gst_tensors_config_from_structure: assertion 'structure != NULL' failed
../tests/nnstreamer_converter/unittest_converter.cc:418: Failure
      Expected: 1U
      Which is: 1
To be equal to: config.info.num_tensors
      Which is: 0
```

Refer: https://launchpad.net/~nnstreamer/+archive/ubuntu/ppa/+build/23511173

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

