### PR TITLE
[transform] Add per-channel feature for arithmetic op

### DIFF
--- a/gst/nnstreamer/tensor_transform/README.md
+++ b/gst/nnstreamer/tensor_transform/README.md
@@ -51,7 +51,7 @@ title: tensor_transform
 
     - (2): arithmetic
       - A mode for arithmetic operations with tensor
-      - An option should be provided as option=[typecast:TYPE,]add|mul|div:NUMBER..., ...
+      - An option should be provided as option=[typecast:TYPE,][per-channel:(false|true@DIM),]add|mul|div:NUMBER[@CH_IDX]..., ...
       - Example 1: Element-wise add 25 and multiply 4
 
         ```bash
@@ -62,6 +62,13 @@ title: tensor_transform
 
         ```bash
         ... ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:-25 ! ...
+        ```
+
+      - For "per-channel", DIM means the dimension which should be viewed as channel and CH_IDX means the idx of channel the given operation should be applied to. When CH_IDX is not given, the operation is applied to all channels.
+      - Example 3: Add 255 only for 1-th channel when 0-th dim is channel (for RGB image, add 255 for G channel)
+
+        ```bash
+        ... ! video/x-raw,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=per-channel:true@0,add:255@1 ! ...
         ```
 
     - (3): transpose

--- a/gst/nnstreamer/tensor_transform/tensor_transform.h
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.h
@@ -104,6 +104,7 @@ typedef struct _tensor_transform_typecast {
 typedef struct
 {
   tensor_transform_operator op;
+  int applying_ch;
   tensor_data_s value;
 } tensor_transform_operator_s;
 
@@ -112,6 +113,8 @@ typedef struct
  */
 typedef struct _tensor_transform_arithmetic {
   tensor_type out_type;
+  gboolean per_channel_arith;
+  guint ch_dim;
 } tensor_transform_arithmetic;
 
 /**

--- a/tests/transform_arithmetic/runTest.sh
+++ b/tests/transform_arithmetic/runTest.sh
@@ -133,6 +133,15 @@ testResult $? 7-8 "Golden test comparison" 0 1
 # Fail Test for the option string is wrong
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=casttype:uint64,mul:65535 acceleration=false ! fakesink sync=true " 8F_n 0 1 $PERFORMANCE
 
+# Test for per-channel (black (videotestsrc pattern=2) RGB image with tensor_transform vs. red (pattern=4) RGB image)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc pattern=2 num-buffers=1 ! videoscale ! \
+videoconvert ! video/x-raw,format=RGB,width=8,height=4 ! tensor_converter ! \
+tensor_transform mode=arithmetic option=per-channel:true@0,add:255@0 ! filesink location=\"red.log\" buffer-mode=unbuffered sync=true \
+videotestsrc pattern=4 num-buffers=1 ! videoscale ! videoconvert ! \
+video/x-raw,format=RGB,width=8,height=4 ! filesink location=\"black_channel_op.log\" buffer-mode=unbuffered sync=true
+" 9 0 0 $PERFORMANCE
+callCompareTest black_channel_op.log red.log 9-1 "Compare red RGB value" 1 0
+
 rm *.log *.bmp *.png *.golden *.raw *.dat
 
 report


### PR DESCRIPTION
- Add "per-channel" arithmetic op (this resolves #3711)
- The syntax:
```
tensor_transform mode=arithmetic
option=typecast:float32,per-channel:true@DIM,add:A@CH_IDX,div:D@CH_IDX
```
- DIM means the dimension which is viewed as channel
ex) For 3:4:4:1 incoming tensor, per-channel:true@0 means 0-th DIM (value is 3) is the channel
- CH means the idx of channel that given operation is applied. If @CH_IDX is missing, the operation is applied to all channels.
ex) add:255@0 means add 255 to the 0-th channel (which is R among the RGB)

- Usage examples:
```
$ gst-launch-1.0 videotestsrc pattern=2 num-buffers=1 ! videoscale !
videoconvert ! video/x-raw,format=RGB,width=2,height=2 !
tensor_converter ! tensor_transform mode=arithmetic
option=typecast:float32,per-channel:true@0,add:1.5@0,add:2.5@1 ! filesink
location=out.log

$ od -f out.log
0000000             1.5             2.5               0             1.5
0000020             2.5               0             1.5             2.5
0000040               0             1.5             2.5               0
0000060
```

```
$ gst-launch-1.0 videotestsrc pattern=2 num-buffers=1 ! videoscale !
videoconvert ! video/x-raw,format=RGBA,width=4,height=2 ! 
tensor_converter ! 
tensor_transform mode=arithmetic option=typecast:float32,per-channel:true@0,add:1.5@0,add:2.5@1,add:4@2,add:-127.5@3,div:2@2,div:127.5@3 ! 
filesink location=out.log && od -vf out.log

0000000             1.5             2.5               2               1
0000020             1.5             2.5               2               1
0000040             1.5             2.5               2               1
0000060             1.5             2.5               2               1
0000100             1.5             2.5               2               1
0000120             1.5             2.5               2               1
0000140             1.5             2.5               2               1
0000160             1.5             2.5               2               1
0000200
```
```
$ gst-launch-1.0 videotestsrc pattern=2 num-buffers=1 ! videoscale ! videoconvert !
video/x-raw,format=RGBA,width=4,height=2 ! tensor_converter !
tensor_transform mode=arithmetic option=typecast:float32,per-channel:true@1,add:1.5@1 !
filesink location=out.log && od -vf out.log

0000000               0               0               0             255
0000020             1.5             1.5             1.5           256.5
0000040               0               0               0             255
0000060               0               0               0             255
0000100               0               0               0             255
0000120             1.5             1.5             1.5           256.5
0000140               0               0               0             255
0000160               0               0               0             255
```

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
