### PR TITLE
[README] Fix daily build log link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ neural network developers to manage neural network pipelines and their filters e
 |     | [Tizen](http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/) | [Ubuntu](https://launchpad.net/~nnstreamer/+archive/ubuntu/ppa) | Android | Yocto | macOS |
 | :-- | :--: | :--: | :--: | :--: | :--: |
 |     | 5.5M2 and later | 16.04/18.04/20.04 | 9/P | Zeus and later |   |
-| arm | [![armv7l badge](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/badge/armv7l_result_badge.svg)](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/) | Available  | Available| Ready | N/A |
-| arm64 |  [![aarch64 badge](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/badge/aarch64_result_badge.svg)](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/) | Available  | [![android badge](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/badge/android_result_badge.svg)](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/) | Planned | N/A |
-| x64 | [![x64 badge](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/badge/x86_64_result_badge.svg)](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/)  | [![ubuntu badge](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/badge/ubuntu_result_badge.svg)](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/latest/android/)  | Ready  | Ready | Available |
-| x86 | [![x86 badge](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/badge/i586_result_badge.svg)](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/)  | N/A  | N/A  | N/A | N/A |
+| arm | [![armv7l badge](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/badge/armv7l_result_badge.svg)](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/latest/log/) | Available  | Available| Ready | N/A |
+| arm64 |  [![aarch64 badge](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/badge/aarch64_result_badge.svg)](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/latest/log/) | Available  | [![android badge](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/badge/android_result_badge.svg)](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/latest/log/) | Planned | N/A |
+| x64 | [![x64 badge](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/badge/x86_64_result_badge.svg)](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/latest/log/)  | [![ubuntu badge](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/badge/ubuntu_result_badge.svg)](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/latest/log/)  | Ready  | Ready | Available |
+| x86 | [![x86 badge](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/badge/i586_result_badge.svg)](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/latest/log/)  | N/A  | N/A  | N/A | N/A |
 | Publish | [Tizen Repo](http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/) | [PPA](https://launchpad.net/~nnstreamer/+archive/ubuntu/ppa) | [Daily build](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/latest/android/) |   | [Brew Tap](Documentation/getting-started-macos.md) |
 | API | C/C# (Official) | C | Java | C  | C  |
 
 - Ready: CI system ensures build-ability and unit-testing. Users may easily build and execute. However, we do not have automated release & deployment system for this instance.
 - Available: binary packages are released and deployed automatically and periodically along with CI tests.
-- [Daily Release](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/)
+- [Daily Release](http://nnstreamer.mooo.com/nnstreamer/ci/daily-build/build_result/latest/)
 - SDK Support: Tizen Studio (5.5 M2+) / Android Studio (JCenter, "nnstreamer")
 - [Enabled features of official releases](Documentation/features-per-distro.md)
 


### PR DESCRIPTION
 - Fix invalid log link of the ubuntu daily build.
 - Change link of the badges to daily log path.

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
