### PR TITLE
[subplugin] g_module_open with LOCAL flag (instead of GLOBAL)

### DIFF
--- a/gst/nnstreamer/nnstreamer_subplugin.c
+++ b/gst/nnstreamer/nnstreamer_subplugin.c
@@ -112,7 +112,7 @@ _search_subplugin (subpluginType type, const gchar * name, const gchar * path)
   g_return_val_if_fail (name != NULL, NULL);
   g_return_val_if_fail (path != NULL, NULL);
 
-  module = g_module_open (path, 0);
+  module = g_module_open (path, G_MODULE_BIND_LOCAL);
   /* If this is a correct subplugin, it will register itself */
   if (module == NULL) {
     ml_loge ("Cannot open %s(%s) with error %s.", name, path,


### PR DESCRIPTION
- When tf1-lite and tf2-lite both are present, the later called
  subplugin is not initalized. It's because the constructor functions
  are same as "init_filter_tflite".
  e.g.) `g_module_open (...tf1lite.so, 0)` will call "init_filter_tflite" of
  tf2lite.so.
- This resolves #3709

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
