### PR TITLE
[Filter/MXNet] Add a sub-plugin filter for MXNet @open sesame 5/2 13:33

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -731,3 +731,33 @@ if trix_engine_support_is_available
     install_dir: nnstreamer_libdir
   )
 endif
+
+if mxnet_support_is_available
+  if not get_option('enable-filter-cpp-class')
+    error ('enable-filter-cpp-class should be set as \'true\' to build the tensor filter for MXNet.')
+  endif
+
+  filter_sub_mxnet_sources = [
+    'tensor_filter_mxnet.cc'
+  ]
+
+  nnstreamer_filter_mxnet_sources = []
+  foreach s : filter_sub_mxnet_sources
+    nnstreamer_filter_mxnet_sources += join_paths(meson.current_source_dir(), s)
+  endforeach
+
+  nnstreamer_filter_mxnet_deps = mxnet_support_deps + [glib_dep, gst_dep, nnstreamer_dep, libdl_dep]
+
+  nnstreamer_filter_mxnet_so_lib = shared_library('nnstreamer_filter_mxnet',
+    nnstreamer_filter_mxnet_sources,
+    dependencies: nnstreamer_filter_mxnet_deps,
+    install: true,
+    install_dir: filter_subplugin_install_dir,
+    cpp_args: ['-Wno-non-virtual-dtor']
+  )
+
+  nnstreamer_filter_mxnet_dep = declare_dependency(
+    link_with: nnstreamer_filter_mxnet_so_lib,
+    include_directories: include_directories('.')
+  )
+endif

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -173,10 +173,10 @@ const GstTensorFilterFrameworkInfo TensorFilterMXNet::info_ = { .name = "mxnet",
   .allocate_in_invoke = FALSE,
   .run_without_model = FALSE,
   .verify_model_path = TRUE,
-  .hw_list = (const accl_hw[]){ ACCL_CPU },
-  .num_hw = 1,
-  .accl_auto = static_cast<accl_hw>(-1),
-  .accl_default = static_cast<accl_hw>(-1),
+  .hw_list = (const accl_hw[]){ ACCL_CPU, ACCL_GPU },
+  .num_hw = 2,
+  .accl_auto = ACCL_CPU,
+  .accl_default = ACCL_CPU,
   .statistics = nullptr };
 
 TensorFilterMXNet::TensorFilterMXNet ()
@@ -201,6 +201,11 @@ TensorFilterMXNet::configure_instance (const GstTensorFilterProperties *prop)
 {
   if (prop->num_models != 1) {
     throw std::invalid_argument ("Multiple models is not supported.");
+  }
+
+  if (std::find (prop->hw_list, prop->hw_list + prop->num_hw, ACCL_GPU)
+      != (prop->hw_list + prop->num_hw)) {
+    ctx_ = Context::gpu ();
   }
 
   try {

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -1,0 +1,480 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer Tensor_Filter, MXNet Module
+ * Copyright (C) 2020 Bumsik Kim <k.bumsik@gmail.com>
+ */
+/**
+ * @file	tensor_filter_mxnet.cc
+ * @date	5 Oct 2020
+ * @brief	MXNet module for tensor_filter gstreamer plugin
+ * @see		http://github.com/nnstreamer/nnstreamer
+ * @author	Bumsik Kim <k.bumsik@gmail.com>
+ * @bug		No known bugs except for NYI items
+ *
+ * This is the MXNet plugin for tensor_filter.
+ *
+ * @details Usage examples
+ *
+ *          Case 1: simple ImageNet example found in test case:
+ *                  https://github.com/nnstreamer/nnstreamer/tree/main/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
+ *            gst-launch-1.0 \
+ *               appsrc ! application/octet-stream \
+ *               ! tensor_converter input-dim=1:3:224:224 input-type=float32 \
+ *               ! tensor_filter \
+ *                   framework=mxnet \
+ *                   model=model/Inception-BN.json \
+ *                   input=1:3:224:224 \
+ *                   inputtype=float32 \
+ *                   inputname=data \
+ *                   output=1 \
+ *                   outputtype=float32 \
+ *                   outputname=argmax_channel \
+ *                   custom=input_rank=4 \
+ *                   accelerator=true:cpu,!npu,!gpu \
+ *               ! appsink",
+ *
+ * @note Special considerations on props:
+ *
+ *   outputname:
+ *     The output name should not be the name of output layer, but the name of
+ *     MXNet NDArray operator passed to the output. For example, the most common
+ *     name is "argmax_channel" for typical classification model. It also can be
+ *     "sigmoid" or etc.
+ *     If it is not meant to do any operations, "_copyto" operator may be used.
+ *     The output will be passed as-is.
+ *     The current limitation is that it only takes a unary operator, meaning it
+ *     does not take additional parameters.
+ *     The candidates of operators can be found here:
+ *      - https://github.com/apache/incubator-mxnet/blob/1.7.0/benchmark/opperf/nd_operations/unary_operators.py#L24-L28
+ *      - https://mxnet.apache.org/versions/1.7/api/python/docs/api/ndarray/op/index.html?highlight=argmax_channel#mxnet.ndarray.op.argmax_channel
+ *
+ *     If this prop is not configured appropriately, the application may get
+ *     unexpected output values, or even segfaults without warning messages.
+ *
+ *   custom:
+ *     Each entries are separated by ','
+ *     Each entries have property_key=value format.
+ *     There must be no speces.
+ *
+ *     Supported props:
+ *       input_rank: (mandatory)
+ *            Rank of each input tensors.
+ *            Each ranks are separeted by ':'.
+ *            The number of ranks must be the same as the number of input
+ *            tensors.
+ *
+ *     Examples:
+ *       tensor_filter framework=mxnet model=model/Inception-BN.json
+ *                input=1:3:224:224
+ *                inputname=data
+ *                ...
+ *                custom=input_rank=4
+ *
+ *        tensor_filter framework=mxnet model=model/Inception-BN.json
+ *                input=1:3:224:224,1
+ *                inputname=data1,data2
+ *                ...
+ *                custom=input_rank=4:1
+ */
+#include <nnstreamer_cppplugin_api_filter.hh>
+#include <stdexcept>
+#include <tensor_common.h>
+
+#include <fcntl.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <mxnet-cpp/MxNetCpp.h>
+
+using nnstreamer::tensor_filter_subplugin;
+using namespace mxnet::cpp;
+
+namespace nnstreamer
+{
+namespace tensorfilter_mxnet
+{
+
+const static std::string kFileLocation = "/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc";
+const static std::string kFileUrl = "https://github.com/nnstreamer/nnstreamer/tree/main" + kFileLocation;
+
+void init_filter_mxnet (void) __attribute__ ((constructor)); /**< Dynamic library contstructor */
+void fini_filter_mxnet (void) __attribute__ ((destructor)); /**< Dynamic library desctructor */
+
+class TensorFilterMXNet final : public tensor_filter_subplugin
+{
+  public:
+  static void init_filter (); /**< Dynamic library contstructor helper */
+  static void fini_filter (); /**< Dynamic library desctructor helper */
+
+  TensorFilterMXNet ();
+  ~TensorFilterMXNet ();
+
+  /**< Implementations of tensor_filter_subplugin */
+  tensor_filter_subplugin &getEmptyInstance ();
+  void configure_instance (const GstTensorFilterProperties *prop);
+  void invoke (const GstTensorMemory *input, GstTensorMemory *output);
+  void getFrameworkInfo (GstTensorFilterFrameworkInfo &info);
+  int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info);
+  int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data);
+
+  static const std::string ext_symbol; /**< extension of model symbol (.json) */
+  static const std::string ext_params; /**< extension of model parameters (.params) */
+
+  /**< Data type for MXNet NDArray from <mshadow/base.h> which causes errors when included */
+  enum TypeFlag : int {
+    kFloat32 = 0,
+    kFloat64 = 1,
+    kFloat16 = 2,
+    kUint8 = 3,
+    kInt32 = 4,
+    kInt8 = 5,
+    kInt64 = 6,
+    kBool = 7,
+    kInt16 = 8,
+    kUint16 = 9,
+    kUint32 = 10,
+    kUint64 = 11,
+    kBfloat16 = 12
+  };
+
+  private:
+  Shape tensorInfoToShape (GstTensorInfo &tensorinfo, int rank);
+  TypeFlag tensorTypeToMXNet (tensor_type type);
+  void parseCustomProperties (const GstTensorFilterProperties *prop);
+
+  bool empty_model_; /**< Empty (not initialized) model flag */
+  static const GstTensorFilterFrameworkInfo info_; /**< Framework info */
+  GstTensorsInfo inputs_info_; /**< Input tensors metadata */
+  GstTensorsInfo outputs_info_; /**< Output tensors metadata */
+
+  // GstTensorInfo does not contain rank info, so extra fields needed */
+  int input_ranks_[NNS_TENSOR_RANK_LIMIT]; /**< Rank info of input tensor */
+  int output_ranks_[NNS_TENSOR_RANK_LIMIT]; /**< Rank info of output tensor */
+
+  std::string model_symbol_path_; /**< The model symbol .json file */
+  std::string model_params_path_; /**< The model paremeters .params file */
+
+  Symbol net_; /**< Model symbol */
+  std::unique_ptr<Executor> executor_; /**< Model executor */
+  std::map<std::string, NDArray> args_map_; /**< arguments information of model, used internally by MXNet */
+  std::map<std::string, NDArray> aux_map_; /**< auxiliary information of model, used internally by MXNet */
+  Context ctx_; /**< Device type (CPU or GPU) */
+
+  static TensorFilterMXNet *registeredRepresentation;
+};
+
+const std::string TensorFilterMXNet::ext_symbol = ".json";
+const std::string TensorFilterMXNet::ext_params = ".params";
+
+const GstTensorFilterFrameworkInfo TensorFilterMXNet::info_ = { .name = "mxnet",
+  .allow_in_place = FALSE,
+  .allocate_in_invoke = FALSE,
+  .run_without_model = FALSE,
+  .verify_model_path = TRUE,
+  .hw_list = (const accl_hw[]){ ACCL_CPU },
+  .num_hw = 1,
+  .accl_auto = static_cast<accl_hw>(-1),
+  .accl_default = static_cast<accl_hw>(-1),
+  .statistics = nullptr };
+
+TensorFilterMXNet::TensorFilterMXNet ()
+    : tensor_filter_subplugin (), empty_model_ (true), ctx_ (Context::cpu ())
+{
+  /** Nothing to do. Just let it have an empty instance */
+}
+
+TensorFilterMXNet::~TensorFilterMXNet ()
+{
+  executor_.reset ();
+}
+
+tensor_filter_subplugin &
+TensorFilterMXNet::getEmptyInstance ()
+{
+  return *(new TensorFilterMXNet ());
+}
+
+void
+TensorFilterMXNet::configure_instance (const GstTensorFilterProperties *prop)
+{
+  if (prop->num_models != 1) {
+    throw std::invalid_argument ("Multiple models is not supported.");
+  }
+
+  try {
+    parseCustomProperties (prop);
+  } catch (const std::invalid_argument &e) {
+    throw std::invalid_argument ("Failed to parse \"custom\" prop:"
+                                 + std::string (e.what ()) + "\n\tReference: " + kFileUrl);
+  }
+
+  // Validate model file paths and then assign
+  std::tie (model_symbol_path_, model_params_path_) = [&] {
+    const std::vector<std::string> extensions{ TensorFilterMXNet::ext_symbol,
+      TensorFilterMXNet::ext_params };
+
+    // trim extension like .json
+    const std::string model_path = [&] {
+      std::string path (prop->model_files[0]);
+      for (const std::string &ext : extensions) {
+        if (g_str_has_suffix (path.c_str (), ext.c_str ())) {
+          return path.substr (0, path.length () - ext.length ());
+        }
+      }
+      return path;
+    }();
+
+    // validate paths
+    for (const std::string &ext : extensions) {
+      std::string path (model_path + ext);
+      if (g_access (path.c_str (), R_OK) != 0) {
+        throw std::invalid_argument ("Failed to open the " + ext + " file, " + path);
+      }
+    }
+
+    return std::make_tuple (model_path + TensorFilterMXNet::ext_symbol,
+        model_path + TensorFilterMXNet::ext_params);
+  }();
+
+  // Read a model
+  net_ = Symbol::Load (model_symbol_path_);
+
+  // Load parameters into temporary array maps
+  // The following loop split loaded param map into arg parm
+  // and aux param with target context
+  std::map<std::string, NDArray> parameters;
+  NDArray::Load (model_params_path_, nullptr, &parameters);
+  for (const auto &pair : parameters) {
+    std::string type = pair.first.substr (0, 4);
+    std::string name = pair.first.substr (4);
+    if (type == "arg:") {
+      args_map_[name] = pair.second.Copy (ctx_);
+    } else if (type == "aux:") {
+      aux_map_[name] = pair.second.Copy (ctx_);
+    }
+  }
+
+  // WaitAll is need when we copy data between GPU and the main memory
+  NDArray::WaitAll ();
+
+  gst_tensors_info_copy (&inputs_info_, &prop->input_meta);
+  gst_tensors_info_copy (&outputs_info_, &prop->output_meta);
+
+  // Set ndarrays for the input layers
+  for (unsigned int i = 0; i < inputs_info_.num_tensors; i++) {
+    auto &input_tensor = inputs_info_.info[i];
+    args_map_[input_tensor.name]
+        = NDArray (tensorInfoToShape (input_tensor, input_ranks_[i]), ctx_,
+            false, tensorTypeToMXNet (input_tensor.type));
+  }
+
+  // These are ndarrays where the execution engine runs
+  std::vector<NDArray> arg_arrays;
+  std::vector<NDArray> grad_arrays;
+  std::vector<OpReqType> grad_reqs;
+  std::vector<NDArray> aux_arrays;
+
+  try {
+    // infer and create ndarrays according to the given array maps.
+    net_.InferExecutorArrays (ctx_, &arg_arrays, &grad_arrays, &grad_reqs,
+        &aux_arrays, args_map_, std::map<std::string, NDArray> (),
+        std::map<std::string, OpReqType> (), aux_map_);
+    for (auto& i : grad_reqs) i = OpReqType::kNullOp;
+
+    // Create a symbolic execution engine after binding the model to input parameters.
+    executor_ = std::make_unique<Executor> (
+        net_, ctx_, arg_arrays, grad_arrays, grad_reqs, aux_arrays);
+  } catch (const std::exception &e) {
+    throw std::system_error (ENODEV, std::system_category (),
+        std::string (e.what ()) + "\nFailed to bind parameters to the model. This is mostly caused by wrong \"input\" and \"inputname\" information.");
+  }
+  empty_model_ = false;
+}
+
+void
+TensorFilterMXNet::invoke (const GstTensorMemory *input, GstTensorMemory *output)
+{
+  assert (!empty_model_);
+  assert (executor_);
+
+  // Copy input
+  for (unsigned int i = 0; i < inputs_info_.num_tensors; i++) {
+    auto &input_info = inputs_info_.info[i];
+    auto &input_ndarray = args_map_[input_info.name];
+
+    assert ((input_ndarray.Size () * sizeof (mx_float)) == input[i].size);
+    input_ndarray.SyncCopyFromCPU (
+        (const mx_float *)input[i].data, input_ndarray.Size ());
+    NDArray::WaitAll ();
+  }
+
+  // Run forward pass
+  executor_->Forward (false);
+  NDArray::WaitAll ();
+
+  // Copy output
+  for (unsigned int i = 0; i < outputs_info_.num_tensors; i++) {
+    auto &output_info = outputs_info_.info[i];
+    NDArray result;
+
+    // Warning: It will cause segfault if the operator name (output name) is different from expected.
+    //          The user should know the name of the operator name.
+    Operator (output_info.name) (executor_->outputs[0]).Invoke (result);
+    NDArray::WaitAll ();
+
+    assert ((result.Size () * sizeof (mx_float)) == output[i].size);
+    result.SyncCopyToCPU ((mx_float *)output[i].data, result.Size ());
+    NDArray::WaitAll ();
+  }
+}
+
+void
+TensorFilterMXNet::getFrameworkInfo (GstTensorFilterFrameworkInfo &info)
+{
+  info = info_;
+}
+
+int
+TensorFilterMXNet::getModelInfo (
+    model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info)
+{
+  switch (ops) {
+  case GET_IN_OUT_INFO:
+    gst_tensors_info_copy (std::addressof (in_info), std::addressof (inputs_info_));
+    gst_tensors_info_copy (std::addressof (out_info), std::addressof (outputs_info_));
+    break;
+  case SET_INPUT_INFO:
+  default:
+    return -ENOENT;
+  }
+  return 0;
+}
+
+int
+TensorFilterMXNet::eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data)
+{
+  return -ENOENT;
+}
+
+/**
+ * @brief Convert GstTensorInfo to MXNet Shape
+ */
+Shape
+TensorFilterMXNet::tensorInfoToShape (GstTensorInfo &tensorinfo, int rank)
+{
+  return Shape (std::vector<index_t> (tensorinfo.dimension, tensorinfo.dimension + rank));
+}
+
+/**
+ * @brief Convert tensor_type to MXNet TypeFlag
+ */
+TensorFilterMXNet::TypeFlag
+TensorFilterMXNet::tensorTypeToMXNet (tensor_type type)
+{
+  switch (type) {
+  case _NNS_INT32:
+    return kInt32;
+  case _NNS_UINT32:
+    return kUint32;
+  case _NNS_INT16:
+    return kInt16;
+  case _NNS_UINT16:
+    return kUint16;
+  case _NNS_INT8:
+    return kInt8;
+  case _NNS_UINT8:
+    return kUint8;
+  case _NNS_FLOAT64:
+    return kFloat64;
+  case _NNS_FLOAT32:
+    return kFloat32;
+  case _NNS_INT64:
+    return kInt64;
+  case _NNS_UINT64:
+    return kUint64;
+  default:
+    throw std::invalid_argument ("Unsupported data type.");
+  }
+}
+
+/**
+ * @brief Parse custom prop and set instance options accordingly.
+ */
+void
+TensorFilterMXNet::parseCustomProperties (const GstTensorFilterProperties *prop)
+{
+  using unique_g_strv = std::unique_ptr<gchar *, std::function<void (gchar **)>>;
+  bool is_input_rank_parsed = false;
+
+  if (prop->custom_properties) {
+    unique_g_strv options (g_strsplit (prop->custom_properties, ",", -1), g_strfreev);
+    guint len = g_strv_length (options.get ());
+
+    for (guint i = 0; i < len; i++) {
+      unique_g_strv option (g_strsplit (options.get ()[i], "=", -1), g_strfreev);
+
+      if (g_strv_length (option.get ()) > 1) {
+        g_strstrip (option.get ()[0]);
+        g_strstrip (option.get ()[1]);
+
+        if (g_ascii_strcasecmp (option.get ()[0], "input_rank") == 0) {
+          unique_g_strv ranks (g_strsplit (option.get ()[1], ":", -1), g_strfreev);
+          guint num_outputs = g_strv_length (ranks.get ());
+
+          if (num_outputs != prop->input_meta.num_tensors) {
+            throw std::invalid_argument (
+                "The number of ranks does not match the number of input tensors.");
+          }
+
+          for (guint i = 0; i < num_outputs; i++) {
+            input_ranks_[i] = g_ascii_strtoull (ranks.get ()[i], nullptr, 10);
+          }
+          is_input_rank_parsed = true;
+        } else {
+          throw std::invalid_argument (
+              "Unsupported custom property: " + std::string (option.get ()[0]) + ".");
+        }
+      }
+    }
+  }
+
+  if (!is_input_rank_parsed) {
+    throw std::invalid_argument ("\"input_rank\" must be set. e.g. custom=input_rank=4:1");
+  }
+  return;
+}
+
+TensorFilterMXNet *TensorFilterMXNet::registeredRepresentation = nullptr;
+
+/** @brief Initialize this object for tensor_filter subplugin runtime register */
+void
+TensorFilterMXNet::init_filter (void)
+{
+  registeredRepresentation
+      = tensor_filter_subplugin::register_subplugin<TensorFilterMXNet> ();
+}
+
+void
+init_filter_mxnet ()
+{
+  TensorFilterMXNet::init_filter ();
+}
+
+/** @brief Destruct the subplugin */
+void
+TensorFilterMXNet::fini_filter (void)
+{
+  assert (registeredRepresentation != nullptr);
+  tensor_filter_subplugin::unregister_subplugin (registeredRepresentation);
+}
+
+void
+fini_filter_mxnet ()
+{
+  TensorFilterMXNet::fini_filter ();
+}
+
+} // namespace tensorfilter_mxnet
+} /* namespace nnstreamer */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -103,10 +103,6 @@ namespace nnstreamer
 {
 namespace tensorfilter_mxnet
 {
-
-const static std::string kFileLocation
-    = "<nnstreamer_repo_home>/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc";
-
 extern "C" {
 void init_filter_mxnet (void)
     __attribute__ ((constructor)); /**< Dynamic library contstructor */
@@ -212,9 +208,8 @@ TensorFilterMXNet::configure_instance (const GstTensorFilterProperties *prop)
   try {
     parseCustomProperties (prop);
   } catch (const std::invalid_argument &e) {
-    throw std::invalid_argument (
-        "Failed to parse \"custom\" prop:" + std::string (e.what ())
-        + "\n\tReference: " + kFileLocation);
+    throw std::invalid_argument ("Failed to parse \"custom\" prop:"
+                                 + std::string (e.what ()) + "\n\tReference: " + __FILE__);
   }
 
   // Validate model file paths and then assign

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -93,9 +93,11 @@
 #include <sys/types.h>
 
 #include <mxnet-cpp/MxNetCpp.h>
+#include <mxnet/lib_api.h>
 
 using nnstreamer::tensor_filter_subplugin;
 using namespace mxnet::cpp;
+using namespace mxnet::ext;
 
 namespace nnstreamer
 {
@@ -131,26 +133,9 @@ class TensorFilterMXNet final : public tensor_filter_subplugin
   static const std::string ext_symbol; /**< extension of model symbol (.json) */
   static const std::string ext_params; /**< extension of model parameters (.params) */
 
-  /**< Data type for MXNet NDArray from <mshadow/base.h> which causes errors when included */
-  enum TypeFlag : int {
-    kFloat32 = 0,
-    kFloat64 = 1,
-    kFloat16 = 2,
-    kUint8 = 3,
-    kInt32 = 4,
-    kInt8 = 5,
-    kInt64 = 6,
-    kBool = 7,
-    kInt16 = 8,
-    kUint16 = 9,
-    kUint32 = 10,
-    kUint64 = 11,
-    kBfloat16 = 12
-  };
-
   private:
   Shape tensorInfoToShape (GstTensorInfo &tensorinfo, int rank);
-  TypeFlag tensorTypeToMXNet (tensor_type type);
+  MXDType tensorTypeToMXNet (tensor_type type);
   void parseCustomProperties (const GstTensorFilterProperties *prop);
   void splitParamMap (const std::map<std::string, NDArray> &paramMap,
       std::map<std::string, NDArray> *argParamInTargetContext,
@@ -398,18 +383,12 @@ TensorFilterMXNet::tensorInfoToShape (GstTensorInfo &tensorinfo, int rank)
 /**
  * @brief Convert tensor_type to MXNet TypeFlag
  */
-TensorFilterMXNet::TypeFlag
+mxnet::ext::MXDType
 TensorFilterMXNet::tensorTypeToMXNet (tensor_type type)
 {
   switch (type) {
     case _NNS_INT32:
       return kInt32;
-    case _NNS_UINT32:
-      return kUint32;
-    case _NNS_INT16:
-      return kInt16;
-    case _NNS_UINT16:
-      return kUint16;
     case _NNS_INT8:
       return kInt8;
     case _NNS_UINT8:
@@ -420,8 +399,6 @@ TensorFilterMXNet::tensorTypeToMXNet (tensor_type type)
       return kFloat32;
     case _NNS_INT64:
       return kInt64;
-    case _NNS_UINT64:
-      return kUint64;
     default:
       throw std::invalid_argument ("Unsupported data type.");
   }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -101,9 +101,11 @@ namespace tensorfilter_mxnet
 {
 
 const static std::string kFileLocation = "/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc";
-const static std::string kFileUrl = "https://github.com/nnstreamer/nnstreamer/tree/main" + kFileLocation;
+const static std::string kFileUrl
+    = "https://github.com/nnstreamer/nnstreamer/tree/main" + kFileLocation;
 
-void init_filter_mxnet (void) __attribute__ ((constructor)); /**< Dynamic library contstructor */
+void init_filter_mxnet (void)
+    __attribute__ ((constructor)); /**< Dynamic library contstructor */
 void fini_filter_mxnet (void) __attribute__ ((destructor)); /**< Dynamic library desctructor */
 
 class TensorFilterMXNet final : public tensor_filter_subplugin
@@ -190,7 +192,8 @@ const GstTensorFilterFrameworkInfo TensorFilterMXNet::info_ = { .name = "mxnet",
   .statistics = nullptr };
 
 TensorFilterMXNet::TensorFilterMXNet ()
-    : tensor_filter_subplugin (), empty_model_ (true), ctx_ (Context::cpu ()), enable_tensorrt_ (false)
+    : tensor_filter_subplugin (), empty_model_ (true), ctx_ (Context::cpu ()),
+      enable_tensorrt_ (false)
 {
   /** Nothing to do. Just let it have an empty instance */
 }
@@ -299,7 +302,8 @@ TensorFilterMXNet::configure_instance (const GstTensorFilterProperties *prop)
     net_.InferExecutorArrays (ctx_, &arg_arrays, &grad_arrays, &grad_reqs,
         &aux_arrays, args_map_, std::map<std::string, NDArray> (),
         std::map<std::string, OpReqType> (), aux_map_);
-    for (auto& i : grad_reqs) i = OpReqType::kNullOp;
+    for (auto &i : grad_reqs)
+      i = OpReqType::kNullOp;
 
     // Create a symbolic execution engine after binding the model to input parameters.
     executor_ = std::make_unique<Executor> (
@@ -324,7 +328,7 @@ TensorFilterMXNet::invoke (const GstTensorMemory *input, GstTensorMemory *output
 
     assert ((input_ndarray.Size () * sizeof (mx_float)) == input[i].size);
     input_ndarray.SyncCopyFromCPU (
-        (const mx_float *)input[i].data, input_ndarray.Size ());
+        (const mx_float *) input[i].data, input_ndarray.Size ());
     NDArray::WaitAll ();
   }
 
@@ -343,7 +347,7 @@ TensorFilterMXNet::invoke (const GstTensorMemory *input, GstTensorMemory *output
     NDArray::WaitAll ();
 
     assert ((result.Size () * sizeof (mx_float)) == output[i].size);
-    result.SyncCopyToCPU ((mx_float *)output[i].data, result.Size ());
+    result.SyncCopyToCPU ((mx_float *) output[i].data, result.Size ());
     NDArray::WaitAll ();
   }
 }
@@ -359,13 +363,13 @@ TensorFilterMXNet::getModelInfo (
     model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info)
 {
   switch (ops) {
-  case GET_IN_OUT_INFO:
-    gst_tensors_info_copy (std::addressof (in_info), std::addressof (inputs_info_));
-    gst_tensors_info_copy (std::addressof (out_info), std::addressof (outputs_info_));
-    break;
-  case SET_INPUT_INFO:
-  default:
-    return -ENOENT;
+    case GET_IN_OUT_INFO:
+      gst_tensors_info_copy (std::addressof (in_info), std::addressof (inputs_info_));
+      gst_tensors_info_copy (std::addressof (out_info), std::addressof (outputs_info_));
+      break;
+    case SET_INPUT_INFO:
+    default:
+      return -ENOENT;
   }
   return 0;
 }
@@ -392,28 +396,28 @@ TensorFilterMXNet::TypeFlag
 TensorFilterMXNet::tensorTypeToMXNet (tensor_type type)
 {
   switch (type) {
-  case _NNS_INT32:
-    return kInt32;
-  case _NNS_UINT32:
-    return kUint32;
-  case _NNS_INT16:
-    return kInt16;
-  case _NNS_UINT16:
-    return kUint16;
-  case _NNS_INT8:
-    return kInt8;
-  case _NNS_UINT8:
-    return kUint8;
-  case _NNS_FLOAT64:
-    return kFloat64;
-  case _NNS_FLOAT32:
-    return kFloat32;
-  case _NNS_INT64:
-    return kInt64;
-  case _NNS_UINT64:
-    return kUint64;
-  default:
-    throw std::invalid_argument ("Unsupported data type.");
+    case _NNS_INT32:
+      return kInt32;
+    case _NNS_UINT32:
+      return kUint32;
+    case _NNS_INT16:
+      return kInt16;
+    case _NNS_UINT16:
+      return kUint16;
+    case _NNS_INT8:
+      return kInt8;
+    case _NNS_UINT8:
+      return kUint8;
+    case _NNS_FLOAT64:
+      return kFloat64;
+    case _NNS_FLOAT32:
+      return kFloat32;
+    case _NNS_INT64:
+      return kInt64;
+    case _NNS_UINT64:
+      return kUint64;
+    default:
+      throw std::invalid_argument ("Unsupported data type.");
   }
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -84,6 +84,7 @@
 #include <nnstreamer_util.h>
 #include <stdexcept>
 #include <tensor_common.h>
+#include <unistd.h>
 
 #include <fcntl.h>
 #include <glib.h>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -102,9 +102,8 @@ namespace nnstreamer
 namespace tensorfilter_mxnet
 {
 
-const static std::string kFileLocation = "/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc";
-const static std::string kFileUrl
-    = "https://github.com/nnstreamer/nnstreamer/tree/main" + kFileLocation;
+const static std::string kFileLocation
+    = "<nnstreamer_repo_home>/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc";
 
 extern "C" {
 void init_filter_mxnet (void) __attribute__ ((constructor)); /**< Dynamic library contstructor */
@@ -227,8 +226,9 @@ TensorFilterMXNet::configure_instance (const GstTensorFilterProperties *prop)
   try {
     parseCustomProperties (prop);
   } catch (const std::invalid_argument &e) {
-    throw std::invalid_argument ("Failed to parse \"custom\" prop:"
-                                 + std::string (e.what ()) + "\n\tReference: " + kFileUrl);
+    throw std::invalid_argument (
+        "Failed to parse \"custom\" prop:" + std::string (e.what ())
+        + "\n\tReference: " + kFileLocation);
   }
 
   // Validate model file paths and then assign

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -54,7 +54,7 @@
  *   custom:
  *     Each entries are separated by ','
  *     Each entries have property_key=value format.
- *     There must be no speces.
+ *     There must be no spaces.
  *
  *     Supported props:
  *       input_rank: (mandatory)

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -105,9 +105,10 @@ const static std::string kFileLocation = "/ext/nnstreamer/tensor_filter/tensor_f
 const static std::string kFileUrl
     = "https://github.com/nnstreamer/nnstreamer/tree/main" + kFileLocation;
 
-void init_filter_mxnet (void)
-    __attribute__ ((constructor)); /**< Dynamic library contstructor */
+extern "C" {
+void init_filter_mxnet (void) __attribute__ ((constructor)); /**< Dynamic library contstructor */
 void fini_filter_mxnet (void) __attribute__ ((destructor)); /**< Dynamic library desctructor */
+}
 
 class TensorFilterMXNet final : public tensor_filter_subplugin
 {

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -106,7 +106,8 @@ const static std::string kFileLocation
     = "<nnstreamer_repo_home>/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc";
 
 extern "C" {
-void init_filter_mxnet (void) __attribute__ ((constructor)); /**< Dynamic library contstructor */
+void init_filter_mxnet (void)
+    __attribute__ ((constructor)); /**< Dynamic library contstructor */
 void fini_filter_mxnet (void) __attribute__ ((destructor)); /**< Dynamic library desctructor */
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -81,6 +81,7 @@
  *                custom=input_rank=4:1
  */
 #include <nnstreamer_cppplugin_api_filter.hh>
+#include <nnstreamer_util.h>
 #include <stdexcept>
 #include <tensor_common.h>
 
@@ -377,6 +378,8 @@ TensorFilterMXNet::getModelInfo (
 int
 TensorFilterMXNet::eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data)
 {
+  UNUSED (ops);
+  UNUSED (data);
   return -ENOENT;
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -81,9 +81,9 @@
  *                custom=input_rank=4:1
  */
 #include <nnstreamer_cppplugin_api_filter.hh>
+#include <nnstreamer_plugin_api.h>
 #include <nnstreamer_util.h>
 #include <stdexcept>
-#include <tensor_common.h>
 #include <unistd.h>
 
 #include <fcntl.h>

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -108,6 +108,10 @@ NNSTREAMER_FILTER_SNPE_SRCS := \
 NNSTREAMER_FILTER_SNAP_SRCS := \
     $(NNSTREAMER_EXT_HOME)/tensor_filter/tensor_filter_snap.cc
 
+# filter mxnet
+NNSTREAMER_FILTER_MXNET_SRCS := \
+    $(NNSTREAMER_EXT_HOME)/tensor_filter/tensor_filter_mxnet.cc
+
 # converter flatbuffers
 NNSTREAMER_CONVERTER_FLATBUF_SRCS := \
     $(NNSTREAMER_EXT_HOME)/tensor_converter/tensor_converter_util.c \

--- a/meson.build
+++ b/meson.build
@@ -294,6 +294,16 @@ if not get_option('armnn-support').disabled()
   endif
 endif
 
+# mxnet
+if not get_option('mxnet-support').disabled()
+  mxnet_dep = cxx.find_library('mxnet', required: false)
+  if not mxnet_dep.found()
+    if cxx.check_header('mxnet-cpp/MxNetCpp.h', required: get_option('mxnet-support'))
+      mxnet_dep = declare_dependency(link_args: ['-lmxnet'])
+    endif
+  endif
+endif
+
 # features registration to be controlled
 #
 # register feature as follows
@@ -391,6 +401,9 @@ features = {
   'aitt-support': {
     'target': 'aitt',
     'project_args': { 'ENABLE_AITT' : 1 }
+  },
+  'mxnet-support': {
+    'extra_deps': [ mxnet_dep ]
   }
 }
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -23,6 +23,7 @@ option('tvm-support', type: 'feature', value: 'auto')
 option('query-hybrid-support', type: 'feature', value: 'auto')
 option('trix-engine-support', type: 'feature', value: 'auto')
 option('aitt-support', type: 'feature', value: 'auto')
+option('mxnet-support', type: 'feature', value: 'auto')
 
 # booleans & other options
 option('enable-test', type: 'boolean', value: true)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -366,7 +366,7 @@ if get_option('install-test')
     install_subdir('nnstreamer_protobuf', install_dir: unittest_install_dir)
   endif
   if mxnet_support_is_available
-    install_subdir('unittest_filter_mxnet', install_dir: unittest_tests_install_dir)
+    install_subdir('unittest_filter_mxnet', install_dir: unittest_install_dir)
   endif
   install_subdir('nnstreamer_mux', install_dir: unittest_install_dir)
   install_subdir('nnstreamer_rate', install_dir: unittest_install_dir)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -303,6 +303,10 @@ if gtest_dep.found()
   if get_option('enable-openvino')
     subdir('nnstreamer_filter_openvino')
   endif
+
+  if mxnet_support_is_available
+    subdir('nnstreamer_filter_mxnet')
+  endif
 endif # gtest_dep.found()
 
 tensor_filter_ext_enabled = tflite_support_is_available or \
@@ -311,7 +315,8 @@ tensor_filter_ext_enabled = tflite_support_is_available or \
     have_python3 or \
     pytorch_support_is_available or caffe2_support_is_available or \
     nnfw_runtime_support_is_available or get_option('enable-edgetpu') or \
-    mvncsdk2_support_is_available or get_option('enable-openvino')
+    mvncsdk2_support_is_available or get_option('enable-openvino') or \
+    mxnet_support_is_available
 if get_option('install-test') and tensor_filter_ext_enabled
   install_subdir('test_models', install_dir: unittest_install_dir)
 endif
@@ -359,6 +364,9 @@ if get_option('install-test')
   endif
   if protobuf_support_is_available
     install_subdir('nnstreamer_protobuf', install_dir: unittest_install_dir)
+  endif
+  if mxnet_support_is_available
+    install_subdir('unittest_filter_mxnet', install_dir: unittest_tests_install_dir)
   endif
   install_subdir('nnstreamer_mux', install_dir: unittest_install_dir)
   install_subdir('nnstreamer_rate', install_dir: unittest_install_dir)

--- a/tests/nnstreamer_filter_mxnet/Predictor.hh
+++ b/tests/nnstreamer_filter_mxnet/Predictor.hh
@@ -1,0 +1,400 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * This example demonstrates image classification workflow with pre-trained models using MXNet C++ API.
+ * The example performs following tasks.
+ * 1. Load the pre-trained model.
+ * 2. Load the parameters of pre-trained model.
+ * 3. Load the inference dataset and create a new ImageRecordIter.
+ * 4. Run the forward pass and obtain throughput & accuracy.
+ */
+#include <stdexcept>
+#ifndef _WIN32
+#include <sys/time.h>
+#endif
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <chrono>
+#include <string>
+#include <vector>
+#include <random>
+#include <type_traits>
+#include <opencv2/opencv.hpp>
+#include "mxnet/c_api.h"
+#include "mxnet/tuple.h"
+#include "mxnet-cpp/MxNetCpp.h"
+#include "mxnet-cpp/initializer.h"
+
+using namespace mxnet::cpp;
+
+double ms_now() {
+  double ret;
+#ifdef _WIN32
+  auto timePoint = std::chrono::high_resolution_clock::now().time_since_epoch();
+  ret = std::chrono::duration<double, std::milli>(timePoint).count();
+#else
+  struct timeval time;
+  gettimeofday(&time, nullptr);
+  ret = 1e+3 * time.tv_sec + 1e-3 * time.tv_usec;
+#endif
+  return ret;
+}
+
+inline bool file_exists (const std::string &name)
+{
+  std::ifstream fhandle(name.c_str());
+  return fhandle.good();
+}
+
+// define the data type for NDArray, aliged with the definition in mshadow/base.h
+enum TypeFlag {
+  kFloat32 = 0,
+  kFloat64 = 1,
+  kFloat16 = 2,
+  kUint8 = 3,
+  kInt32 = 4,
+  kInt8  = 5,
+  kInt64 = 6,
+};
+
+/*
+ * class Predictor
+ *
+ * This class encapsulates the functionality to load the model, prepare dataset and run the forward pass.
+ */
+
+class Predictor {
+ public:
+    Predictor() {}
+    Predictor(const std::string& model_json_file,
+              const std::string& model_params_file,
+              const Shape& input_shape,
+              const std::string& data_layer_type,
+              bool use_gpu,
+              bool enable_tensorrt,
+              MXDataIter * val_iter);
+    ~Predictor();
+
+    static MXDataIter *CreateImageRecordIter(
+              const std::string& dataset,
+              const Shape& input_shape,
+              const std::string& data_layer_type,
+              const std::vector<float>& rgb_mean,
+              const std::vector<float>& rgb_std,
+              int shuffle_chunk_seed,
+              int seed,
+              const int data_nthreads,
+              bool use_gpu);
+    void LogInferenceResult(std::vector<mx_float> &log_vector, int num_inference_batches);
+ private:
+    bool AdvanceDataIter(int skipped_batches);
+    void LoadModel(const std::string& model_json_file);
+    void LoadParameters(const std::string& model_parameters_file);
+    void SplitParamMap(const std::map<std::string, NDArray> &paramMap,
+        std::map<std::string, NDArray> *argParamInTargetContext,
+        std::map<std::string, NDArray> *auxParamInTargetContext,
+        Context targetContext);
+    void ConvertParamMapToTargetContext(const std::map<std::string, NDArray> &paramMap,
+        std::map<std::string, NDArray> *paramMapInTargetContext,
+        Context targetContext);
+
+    int GetDataLayerType();
+
+    MXDataIter * val_iter_;
+    std::map<std::string, NDArray> args_map_;
+    std::map<std::string, NDArray> aux_map_;
+    Symbol net_;
+    Shape input_shape_;
+    Executor *executor_;
+    Context global_ctx_ = Context::cpu();
+
+    bool use_gpu_;
+    bool enable_tensorrt_;
+    std::string data_layer_type_;
+};
+
+
+/*
+ * The constructor takes following parameters as input:
+ *  1. model_json_file:  The model in json formatted file.
+ *  2. model_params_file: File containing model parameters
+ *  3. input_shape: Shape of input data to the model. Since this class will be running one inference at a time,
+ *                  the input shape is required to be in format Shape(1, number_of_channels, height, width)
+ *                  The input image will be resized to (height x width) size before running the inference.
+ *  4. data_layer_type: data type for data layer
+ *  5. use_gpu: determine if run inference on GPU
+ *  6. enable_tensorrt: determine if enable TensorRT
+ *  7. val_iter: validation dataset iterator
+ *
+ * The constructor will:
+ *  1. Load the model and parameter files.
+ *  2. Infer and construct NDArrays according to the input argument and create an executor.
+ */
+Predictor::Predictor(const std::string& model_json_file,
+              const std::string& model_params_file,
+              const Shape& input_shape,
+              const std::string& data_layer_type,
+              bool use_gpu,
+              bool enable_tensorrt,
+              MXDataIter * val_iter)
+    : val_iter_(val_iter),
+      input_shape_(input_shape),
+      use_gpu_(use_gpu),
+      enable_tensorrt_(enable_tensorrt),
+      data_layer_type_(data_layer_type){
+  if (use_gpu) {
+    global_ctx_ = Context::gpu();
+  }
+  // Load the model
+  LoadModel(model_json_file);
+  // Initilize the parameters
+  LoadParameters(model_params_file);
+
+  int dtype = GetDataLayerType();
+  if (dtype == -1) {
+    throw std::runtime_error("Unsupported data layer type...");
+  }
+  args_map_["data"] = NDArray(input_shape_, global_ctx_, false, dtype);
+  Shape label_shape(input_shape_[0]);
+
+  std::vector<NDArray> arg_arrays;
+  std::vector<NDArray> grad_arrays;
+  std::vector<OpReqType> grad_reqs;
+  std::vector<NDArray> aux_arrays;
+
+  // infer and create ndarrays according to the given input ndarrays.
+  net_.InferExecutorArrays(global_ctx_, &arg_arrays, &grad_arrays, &grad_reqs,
+                           &aux_arrays, args_map_, std::map<std::string, NDArray>(),
+                           std::map<std::string, OpReqType>(), aux_map_);
+
+  // Create an executor after binding the model to input parameters.
+  executor_ = new Executor(net_, global_ctx_, arg_arrays, grad_arrays, grad_reqs, aux_arrays);
+}
+
+/*
+ * The following function is used to get the data layer type for input data
+ */
+int Predictor::GetDataLayerType() {
+  int ret_type = -1;
+  if (data_layer_type_ == "float32") {
+    ret_type = kFloat32;
+  } else if (data_layer_type_ == "int8") {
+    ret_type = kInt8;
+  } else if (data_layer_type_ == "uint8") {
+    ret_type = kUint8;
+  } else {
+    LG << "Unsupported data layer type " << data_layer_type_ << "..."
+       << "Please use one of {float32, int8, uint8}";
+  }
+  return ret_type;
+}
+
+/*
+ * create a new ImageRecordIter according to the given parameters:
+ *  1. dataset: data file (.rec) to be used for inference
+ *  2. input_shape: Shape of input data to the model. Since this class will be running one inference at a time,
+ *                  the input shape is required to be in format Shape(1, number_of_channels, height, width)
+ *                  The input image will be resized to (height x width) size before running the inference.
+ *  3. data_layer_type: data type for data layer
+ *  4. rgb_mean: mean value to be subtracted on R/G/B channel
+ *  5. rgb_std: standard deviation on R/G/B channel
+ *  6. shuffle_chunk_seed: shuffling chunk seed
+ *  7. seed: shuffling seed
+ *  8. data_nthreads: number of threads for data loading
+ *  9. use_gpu: determine if run inference on GPU
+ */
+MXDataIter * Predictor::CreateImageRecordIter(
+              const std::string& dataset,
+              const Shape& input_shape,
+              const std::string& data_layer_type,
+              const std::vector<float>& rgb_mean,
+              const std::vector<float>& rgb_std,
+              int shuffle_chunk_seed,
+              int seed,
+              const int data_nthreads,
+              bool use_gpu) {
+  MXDataIter * val_iter = new MXDataIter("ImageRecordIter");
+  if (!file_exists (dataset)) {
+    throw std::runtime_error("Error: " + dataset + " must be provided");
+  }
+
+  std::vector<index_t> shape_vec;
+  for (index_t i = 1; i < input_shape.ndim(); i++)
+    shape_vec.push_back(input_shape[i]);
+  mxnet::TShape data_shape(shape_vec.begin(), shape_vec.end());
+
+  // set image record parser parameters
+  val_iter->SetParam("path_imgrec", dataset);
+  val_iter->SetParam("label_width", 1);
+  val_iter->SetParam("data_shape", data_shape);
+  val_iter->SetParam("preprocess_threads", data_nthreads);
+  val_iter->SetParam("shuffle_chunk_seed", shuffle_chunk_seed);
+
+  // set Batch parameters
+  val_iter->SetParam("batch_size", input_shape[0]);
+
+  // image record parameters
+  val_iter->SetParam("shuffle", true);
+  val_iter->SetParam("seed", seed);
+
+  // set normalize parameters
+  val_iter->SetParam("mean_r", rgb_mean[0]);
+  val_iter->SetParam("mean_g", rgb_mean[1]);
+  val_iter->SetParam("mean_b", rgb_mean[2]);
+  val_iter->SetParam("std_r", rgb_std[0]);
+  val_iter->SetParam("std_g", rgb_std[1]);
+  val_iter->SetParam("std_b", rgb_std[2]);
+
+  // set prefetcher parameters
+  if (use_gpu) {
+    val_iter->SetParam("ctx", "gpu");
+  } else {
+    val_iter->SetParam("ctx", "cpu");
+  }
+  val_iter->SetParam("dtype", data_layer_type);
+
+  val_iter->CreateDataIter();
+  return val_iter;
+}
+
+/*
+ * The following function loads the model from json file.
+ */
+void Predictor::LoadModel(const std::string& model_json_file) {
+  if (!file_exists (model_json_file)) {
+    LG << "Model file " << model_json_file << " does not exist";
+    throw std::runtime_error("Model file does not exist");
+  }
+  LG << "Loading the model from " << model_json_file << std::endl;
+  net_ = Symbol::Load(model_json_file);
+  if (enable_tensorrt_) {
+    net_ = net_.GetBackendSymbol("TensorRT");
+  }
+}
+
+/*
+ * The following function loads the model parameters.
+ */
+void Predictor::LoadParameters(const std::string& model_parameters_file) {
+  if (!file_exists (model_parameters_file)) {
+    LG << "Parameter file " << model_parameters_file << " does not exist";
+    throw std::runtime_error("Model parameters does not exist");
+  }
+  LG << "Loading the model parameters from " << model_parameters_file << std::endl;
+  std::map<std::string, NDArray> parameters;
+  NDArray::Load(model_parameters_file, 0, &parameters);
+  if (enable_tensorrt_) {
+    std::map<std::string, NDArray> intermediate_args_map;
+    std::map<std::string, NDArray> intermediate_aux_map;
+    SplitParamMap(parameters, &intermediate_args_map, &intermediate_aux_map, Context::cpu());
+    contrib::InitTensorRTParams(net_, &intermediate_args_map, &intermediate_aux_map);
+    ConvertParamMapToTargetContext(intermediate_args_map, &args_map_, global_ctx_);
+    ConvertParamMapToTargetContext(intermediate_aux_map, &aux_map_, global_ctx_);
+  } else {
+    SplitParamMap(parameters, &args_map_, &aux_map_, global_ctx_);
+  }
+  /*WaitAll is need when we copy data between GPU and the main memory*/
+  NDArray::WaitAll();
+}
+
+/*
+ * The following function split loaded param map into arg parm
+ *   and aux param with target context
+ */
+void Predictor::SplitParamMap(const std::map<std::string, NDArray> &paramMap,
+    std::map<std::string, NDArray> *argParamInTargetContext,
+    std::map<std::string, NDArray> *auxParamInTargetContext,
+    Context targetContext) {
+  for (const auto& pair : paramMap) {
+    std::string type = pair.first.substr(0, 4);
+    std::string name = pair.first.substr(4);
+    if (type == "arg:") {
+      (*argParamInTargetContext)[name] = pair.second.Copy(targetContext);
+    } else if (type == "aux:") {
+      (*auxParamInTargetContext)[name] = pair.second.Copy(targetContext);
+    }
+  }
+}
+
+/*
+ * The following function copy the param map into the target context
+ */
+void Predictor::ConvertParamMapToTargetContext(const std::map<std::string, NDArray> &paramMap,
+    std::map<std::string, NDArray> *paramMapInTargetContext,
+    Context targetContext) {
+  for (const auto& pair : paramMap) {
+    (*paramMapInTargetContext)[pair.first] = pair.second.Copy(targetContext);
+  }
+}
+
+/*
+ * The following function runs the forward pass on the model
+ * and use real data for testing accuracy and performance.
+ */
+void Predictor::LogInferenceResult(std::vector<mx_float> &log_vector, int num_inference_batches) {
+  log_vector.reserve(num_inference_batches);
+  // Create metrics
+  Accuracy val_acc;
+
+  val_iter_->Reset();
+  val_acc.Reset();
+  int nBatch = 0;
+
+  double ms = ms_now();
+  while (val_iter_->Next()) {
+    auto data_batch = val_iter_->GetDataBatch();
+    data_batch.data.CopyTo(&args_map_["data"]);
+    NDArray::WaitAll();
+
+    // running on forward pass
+    executor_->Forward(false);
+    NDArray::WaitAll();
+    NDArray result;
+    Operator("argmax_channel")(executor_->outputs[0]).Invoke(result);
+
+    // Write to the log file
+    mx_uint len = result.GetShape()[0];
+    std::vector<mx_float> data_vector(len);
+    result.SyncCopyToCPU(&data_vector, len);
+    log_vector.push_back(data_vector[0]);
+
+    // Update score
+    val_acc.Update(data_batch.label, executor_->outputs[0]);
+    if (++nBatch >= num_inference_batches) {
+      break;
+    }
+  }
+
+  ms = ms_now() - ms;
+  auto args_name = net_.ListArguments();
+  LG << "INFO:" << "Finished inference with: " << nBatch * input_shape_[0]
+     << " images ";
+  LG << "INFO:" << "Batch size = " << input_shape_[0] << " for inference";
+  LG << "INFO:" << "Accuracy: " << val_acc.Get();
+  LG << "INFO:" << "Throughput: " << (1000.0 * nBatch * input_shape_[0] / ms)
+     << " images per second";
+}
+
+Predictor::~Predictor() {
+  if (executor_) {
+    delete executor_;
+  }
+}

--- a/tests/nnstreamer_filter_mxnet/Predictor.hh
+++ b/tests/nnstreamer_filter_mxnet/Predictor.hh
@@ -18,8 +18,8 @@
  */
 
 /*
- * This example demonstrates image classification workflow with pre-trained models using MXNet C++ API.
- * The example performs following tasks.
+ * This example demonstrates image classification workflow with pre-trained
+ * models using MXNet C++ API. The example performs following tasks.
  * 1. Load the pre-trained model.
  * 2. Load the parameters of pre-trained model.
  * 3. Load the inference dataset and create a new ImageRecordIter.
@@ -29,39 +29,43 @@
 #ifndef _WIN32
 #include <sys/time.h>
 #endif
+#include <chrono>
 #include <fstream>
 #include <iostream>
 #include <map>
-#include <chrono>
-#include <string>
-#include <vector>
-#include <random>
-#include <type_traits>
 #include <opencv2/opencv.hpp>
-#include "mxnet/c_api.h"
-#include "mxnet/tuple.h"
+#include <random>
+#include <string>
+#include <type_traits>
+#include <vector>
+
 #include "mxnet-cpp/MxNetCpp.h"
 #include "mxnet-cpp/initializer.h"
+#include "mxnet/c_api.h"
+#include "mxnet/tuple.h"
 
 using namespace mxnet::cpp;
 
-double ms_now() {
+double
+ms_now ()
+{
   double ret;
 #ifdef _WIN32
-  auto timePoint = std::chrono::high_resolution_clock::now().time_since_epoch();
-  ret = std::chrono::duration<double, std::milli>(timePoint).count();
+  auto timePoint = std::chrono::high_resolution_clock::now ().time_since_epoch ();
+  ret = std::chrono::duration<double, std::milli> (timePoint).count ();
 #else
   struct timeval time;
-  gettimeofday(&time, nullptr);
+  gettimeofday (&time, nullptr);
   ret = 1e+3 * time.tv_sec + 1e-3 * time.tv_usec;
 #endif
   return ret;
 }
 
-inline bool file_exists (const std::string &name)
+inline bool
+file_exists (const std::string &name)
 {
-  std::ifstream fhandle(name.c_str());
-  return fhandle.good();
+  std::ifstream fhandle (name.c_str ());
+  return fhandle.good ();
 }
 
 // define the data type for NDArray, aliged with the definition in mshadow/base.h
@@ -71,7 +75,7 @@ enum TypeFlag {
   kFloat16 = 2,
   kUint8 = 3,
   kInt32 = 4,
-  kInt8  = 5,
+  kInt8 = 5,
   kInt64 = 6,
 };
 
@@ -81,64 +85,56 @@ enum TypeFlag {
  * This class encapsulates the functionality to load the model, prepare dataset and run the forward pass.
  */
 
-class Predictor {
- public:
-    Predictor() {}
-    Predictor(const std::string& model_json_file,
-              const std::string& model_params_file,
-              const Shape& input_shape,
-              const std::string& data_layer_type,
-              bool use_gpu,
-              bool enable_tensorrt,
-              MXDataIter * val_iter);
-    ~Predictor();
+class Predictor
+{
+  public:
+  Predictor ()
+  {
+  }
+  Predictor (const std::string &model_json_file, const std::string &model_params_file,
+      const Shape &input_shape, const std::string &data_layer_type,
+      bool use_gpu, bool enable_tensorrt, MXDataIter *val_iter);
+  ~Predictor ();
 
-    static MXDataIter *CreateImageRecordIter(
-              const std::string& dataset,
-              const Shape& input_shape,
-              const std::string& data_layer_type,
-              const std::vector<float>& rgb_mean,
-              const std::vector<float>& rgb_std,
-              int shuffle_chunk_seed,
-              int seed,
-              const int data_nthreads,
-              bool use_gpu);
-    void LogInferenceResult(std::vector<mx_float> &log_vector, int num_inference_batches);
- private:
-    bool AdvanceDataIter(int skipped_batches);
-    void LoadModel(const std::string& model_json_file);
-    void LoadParameters(const std::string& model_parameters_file);
-    void SplitParamMap(const std::map<std::string, NDArray> &paramMap,
-        std::map<std::string, NDArray> *argParamInTargetContext,
-        std::map<std::string, NDArray> *auxParamInTargetContext,
-        Context targetContext);
-    void ConvertParamMapToTargetContext(const std::map<std::string, NDArray> &paramMap,
-        std::map<std::string, NDArray> *paramMapInTargetContext,
-        Context targetContext);
+  static MXDataIter *CreateImageRecordIter (const std::string &dataset,
+      const Shape &input_shape, const std::string &data_layer_type,
+      const std::vector<float> &rgb_mean, const std::vector<float> &rgb_std,
+      int shuffle_chunk_seed, int seed, const int data_nthreads, bool use_gpu);
+  void LogInferenceResult (std::vector<mx_float> &log_vector, int num_inference_batches);
 
-    int GetDataLayerType();
+  private:
+  bool AdvanceDataIter (int skipped_batches);
+  void LoadModel (const std::string &model_json_file);
+  void LoadParameters (const std::string &model_parameters_file);
+  void SplitParamMap (const std::map<std::string, NDArray> &paramMap,
+      std::map<std::string, NDArray> *argParamInTargetContext,
+      std::map<std::string, NDArray> *auxParamInTargetContext, Context targetContext);
+  void ConvertParamMapToTargetContext (const std::map<std::string, NDArray> &paramMap,
+      std::map<std::string, NDArray> *paramMapInTargetContext, Context targetContext);
 
-    MXDataIter * val_iter_;
-    std::map<std::string, NDArray> args_map_;
-    std::map<std::string, NDArray> aux_map_;
-    Symbol net_;
-    Shape input_shape_;
-    Executor *executor_;
-    Context global_ctx_ = Context::cpu();
+  int GetDataLayerType ();
 
-    bool use_gpu_;
-    bool enable_tensorrt_;
-    std::string data_layer_type_;
+  MXDataIter *val_iter_;
+  std::map<std::string, NDArray> args_map_;
+  std::map<std::string, NDArray> aux_map_;
+  Symbol net_;
+  Shape input_shape_;
+  Executor *executor_;
+  Context global_ctx_ = Context::cpu ();
+
+  bool use_gpu_;
+  bool enable_tensorrt_;
+  std::string data_layer_type_;
 };
-
 
 /*
  * The constructor takes following parameters as input:
  *  1. model_json_file:  The model in json formatted file.
  *  2. model_params_file: File containing model parameters
- *  3. input_shape: Shape of input data to the model. Since this class will be running one inference at a time,
- *                  the input shape is required to be in format Shape(1, number_of_channels, height, width)
- *                  The input image will be resized to (height x width) size before running the inference.
+ *  3. input_shape: Shape of input data to the model. Since this class will be
+ * running one inference at a time, the input shape is required to be in format
+ * Shape(1, number_of_channels, height, width) The input image will be resized
+ * to (height x width) size before running the inference.
  *  4. data_layer_type: data type for data layer
  *  5. use_gpu: determine if run inference on GPU
  *  6. enable_tensorrt: determine if enable TensorRT
@@ -146,34 +142,29 @@ class Predictor {
  *
  * The constructor will:
  *  1. Load the model and parameter files.
- *  2. Infer and construct NDArrays according to the input argument and create an executor.
+ *  2. Infer and construct NDArrays according to the input argument and create
+ * an executor.
  */
-Predictor::Predictor(const std::string& model_json_file,
-              const std::string& model_params_file,
-              const Shape& input_shape,
-              const std::string& data_layer_type,
-              bool use_gpu,
-              bool enable_tensorrt,
-              MXDataIter * val_iter)
-    : val_iter_(val_iter),
-      input_shape_(input_shape),
-      use_gpu_(use_gpu),
-      enable_tensorrt_(enable_tensorrt),
-      data_layer_type_(data_layer_type){
+Predictor::Predictor (const std::string &model_json_file, const std::string &model_params_file,
+    const Shape &input_shape, const std::string &data_layer_type, bool use_gpu,
+    bool enable_tensorrt, MXDataIter *val_iter)
+    : val_iter_ (val_iter), input_shape_ (input_shape), use_gpu_ (use_gpu),
+      enable_tensorrt_ (enable_tensorrt), data_layer_type_ (data_layer_type)
+{
   if (use_gpu) {
-    global_ctx_ = Context::gpu();
+    global_ctx_ = Context::gpu ();
   }
   // Load the model
-  LoadModel(model_json_file);
+  LoadModel (model_json_file);
   // Initilize the parameters
-  LoadParameters(model_params_file);
+  LoadParameters (model_params_file);
 
-  int dtype = GetDataLayerType();
+  int dtype = GetDataLayerType ();
   if (dtype == -1) {
-    throw std::runtime_error("Unsupported data layer type...");
+    throw std::runtime_error ("Unsupported data layer type...");
   }
-  args_map_["data"] = NDArray(input_shape_, global_ctx_, false, dtype);
-  Shape label_shape(input_shape_[0]);
+  args_map_["data"] = NDArray (input_shape_, global_ctx_, false, dtype);
+  Shape label_shape (input_shape_[0]);
 
   std::vector<NDArray> arg_arrays;
   std::vector<NDArray> grad_arrays;
@@ -181,18 +172,20 @@ Predictor::Predictor(const std::string& model_json_file,
   std::vector<NDArray> aux_arrays;
 
   // infer and create ndarrays according to the given input ndarrays.
-  net_.InferExecutorArrays(global_ctx_, &arg_arrays, &grad_arrays, &grad_reqs,
-                           &aux_arrays, args_map_, std::map<std::string, NDArray>(),
-                           std::map<std::string, OpReqType>(), aux_map_);
+  net_.InferExecutorArrays (global_ctx_, &arg_arrays, &grad_arrays, &grad_reqs,
+      &aux_arrays, args_map_, std::map<std::string, NDArray> (),
+      std::map<std::string, OpReqType> (), aux_map_);
 
   // Create an executor after binding the model to input parameters.
-  executor_ = new Executor(net_, global_ctx_, arg_arrays, grad_arrays, grad_reqs, aux_arrays);
+  executor_ = new Executor (net_, global_ctx_, arg_arrays, grad_arrays, grad_reqs, aux_arrays);
 }
 
 /*
  * The following function is used to get the data layer type for input data
  */
-int Predictor::GetDataLayerType() {
+int
+Predictor::GetDataLayerType ()
+{
   int ret_type = -1;
   if (data_layer_type_ == "float32") {
     ret_type = kFloat32;
@@ -210,9 +203,10 @@ int Predictor::GetDataLayerType() {
 /*
  * create a new ImageRecordIter according to the given parameters:
  *  1. dataset: data file (.rec) to be used for inference
- *  2. input_shape: Shape of input data to the model. Since this class will be running one inference at a time,
- *                  the input shape is required to be in format Shape(1, number_of_channels, height, width)
- *                  The input image will be resized to (height x width) size before running the inference.
+ *  2. input_shape: Shape of input data to the model. Since this class will be
+ * running one inference at a time, the input shape is required to be in format
+ * Shape(1, number_of_channels, height, width) The input image will be resized
+ * to (height x width) size before running the inference.
  *  3. data_layer_type: data type for data layer
  *  4. rgb_mean: mean value to be subtracted on R/G/B channel
  *  5. rgb_std: standard deviation on R/G/B channel
@@ -221,115 +215,117 @@ int Predictor::GetDataLayerType() {
  *  8. data_nthreads: number of threads for data loading
  *  9. use_gpu: determine if run inference on GPU
  */
-MXDataIter * Predictor::CreateImageRecordIter(
-              const std::string& dataset,
-              const Shape& input_shape,
-              const std::string& data_layer_type,
-              const std::vector<float>& rgb_mean,
-              const std::vector<float>& rgb_std,
-              int shuffle_chunk_seed,
-              int seed,
-              const int data_nthreads,
-              bool use_gpu) {
-  MXDataIter * val_iter = new MXDataIter("ImageRecordIter");
+MXDataIter *
+Predictor::CreateImageRecordIter (const std::string &dataset,
+    const Shape &input_shape, const std::string &data_layer_type,
+    const std::vector<float> &rgb_mean, const std::vector<float> &rgb_std,
+    int shuffle_chunk_seed, int seed, const int data_nthreads, bool use_gpu)
+{
+  MXDataIter *val_iter = new MXDataIter ("ImageRecordIter");
   if (!file_exists (dataset)) {
-    throw std::runtime_error("Error: " + dataset + " must be provided");
+    throw std::runtime_error ("Error: " + dataset + " must be provided");
   }
 
   std::vector<index_t> shape_vec;
-  for (index_t i = 1; i < input_shape.ndim(); i++)
-    shape_vec.push_back(input_shape[i]);
-  mxnet::TShape data_shape(shape_vec.begin(), shape_vec.end());
+  for (index_t i = 1; i < input_shape.ndim (); i++)
+    shape_vec.push_back (input_shape[i]);
+  mxnet::TShape data_shape (shape_vec.begin (), shape_vec.end ());
 
   // set image record parser parameters
-  val_iter->SetParam("path_imgrec", dataset);
-  val_iter->SetParam("label_width", 1);
-  val_iter->SetParam("data_shape", data_shape);
-  val_iter->SetParam("preprocess_threads", data_nthreads);
-  val_iter->SetParam("shuffle_chunk_seed", shuffle_chunk_seed);
+  val_iter->SetParam ("path_imgrec", dataset);
+  val_iter->SetParam ("label_width", 1);
+  val_iter->SetParam ("data_shape", data_shape);
+  val_iter->SetParam ("preprocess_threads", data_nthreads);
+  val_iter->SetParam ("shuffle_chunk_seed", shuffle_chunk_seed);
 
   // set Batch parameters
-  val_iter->SetParam("batch_size", input_shape[0]);
+  val_iter->SetParam ("batch_size", input_shape[0]);
 
   // image record parameters
-  val_iter->SetParam("shuffle", true);
-  val_iter->SetParam("seed", seed);
+  val_iter->SetParam ("shuffle", true);
+  val_iter->SetParam ("seed", seed);
 
   // set normalize parameters
-  val_iter->SetParam("mean_r", rgb_mean[0]);
-  val_iter->SetParam("mean_g", rgb_mean[1]);
-  val_iter->SetParam("mean_b", rgb_mean[2]);
-  val_iter->SetParam("std_r", rgb_std[0]);
-  val_iter->SetParam("std_g", rgb_std[1]);
-  val_iter->SetParam("std_b", rgb_std[2]);
+  val_iter->SetParam ("mean_r", rgb_mean[0]);
+  val_iter->SetParam ("mean_g", rgb_mean[1]);
+  val_iter->SetParam ("mean_b", rgb_mean[2]);
+  val_iter->SetParam ("std_r", rgb_std[0]);
+  val_iter->SetParam ("std_g", rgb_std[1]);
+  val_iter->SetParam ("std_b", rgb_std[2]);
 
   // set prefetcher parameters
   if (use_gpu) {
-    val_iter->SetParam("ctx", "gpu");
+    val_iter->SetParam ("ctx", "gpu");
   } else {
-    val_iter->SetParam("ctx", "cpu");
+    val_iter->SetParam ("ctx", "cpu");
   }
-  val_iter->SetParam("dtype", data_layer_type);
+  val_iter->SetParam ("dtype", data_layer_type);
 
-  val_iter->CreateDataIter();
+  val_iter->CreateDataIter ();
   return val_iter;
 }
 
 /*
  * The following function loads the model from json file.
  */
-void Predictor::LoadModel(const std::string& model_json_file) {
+void
+Predictor::LoadModel (const std::string &model_json_file)
+{
   if (!file_exists (model_json_file)) {
     LG << "Model file " << model_json_file << " does not exist";
-    throw std::runtime_error("Model file does not exist");
+    throw std::runtime_error ("Model file does not exist");
   }
   LG << "Loading the model from " << model_json_file << std::endl;
-  net_ = Symbol::Load(model_json_file);
+  net_ = Symbol::Load (model_json_file);
   if (enable_tensorrt_) {
-    net_ = net_.GetBackendSymbol("TensorRT");
+    net_ = net_.GetBackendSymbol ("TensorRT");
   }
 }
 
 /*
  * The following function loads the model parameters.
  */
-void Predictor::LoadParameters(const std::string& model_parameters_file) {
+void
+Predictor::LoadParameters (const std::string &model_parameters_file)
+{
   if (!file_exists (model_parameters_file)) {
     LG << "Parameter file " << model_parameters_file << " does not exist";
-    throw std::runtime_error("Model parameters does not exist");
+    throw std::runtime_error ("Model parameters does not exist");
   }
   LG << "Loading the model parameters from " << model_parameters_file << std::endl;
   std::map<std::string, NDArray> parameters;
-  NDArray::Load(model_parameters_file, 0, &parameters);
+  NDArray::Load (model_parameters_file, 0, &parameters);
   if (enable_tensorrt_) {
     std::map<std::string, NDArray> intermediate_args_map;
     std::map<std::string, NDArray> intermediate_aux_map;
-    SplitParamMap(parameters, &intermediate_args_map, &intermediate_aux_map, Context::cpu());
-    contrib::InitTensorRTParams(net_, &intermediate_args_map, &intermediate_aux_map);
-    ConvertParamMapToTargetContext(intermediate_args_map, &args_map_, global_ctx_);
-    ConvertParamMapToTargetContext(intermediate_aux_map, &aux_map_, global_ctx_);
+    SplitParamMap (parameters, &intermediate_args_map, &intermediate_aux_map,
+        Context::cpu ());
+    contrib::InitTensorRTParams (net_, &intermediate_args_map, &intermediate_aux_map);
+    ConvertParamMapToTargetContext (intermediate_args_map, &args_map_, global_ctx_);
+    ConvertParamMapToTargetContext (intermediate_aux_map, &aux_map_, global_ctx_);
   } else {
-    SplitParamMap(parameters, &args_map_, &aux_map_, global_ctx_);
+    SplitParamMap (parameters, &args_map_, &aux_map_, global_ctx_);
   }
   /*WaitAll is need when we copy data between GPU and the main memory*/
-  NDArray::WaitAll();
+  NDArray::WaitAll ();
 }
 
 /*
  * The following function split loaded param map into arg parm
  *   and aux param with target context
  */
-void Predictor::SplitParamMap(const std::map<std::string, NDArray> &paramMap,
+void
+Predictor::SplitParamMap (const std::map<std::string, NDArray> &paramMap,
     std::map<std::string, NDArray> *argParamInTargetContext,
-    std::map<std::string, NDArray> *auxParamInTargetContext,
-    Context targetContext) {
-  for (const auto& pair : paramMap) {
-    std::string type = pair.first.substr(0, 4);
-    std::string name = pair.first.substr(4);
+    std::map<std::string, NDArray> *auxParamInTargetContext, Context targetContext)
+{
+  for (const auto &pair : paramMap) {
+    std::string type = pair.first.substr (0, 4);
+    std::string name = pair.first.substr (4);
     if (type == "arg:") {
-      (*argParamInTargetContext)[name] = pair.second.Copy(targetContext);
+      (*argParamInTargetContext)[name] = pair.second.Copy (targetContext);
     } else if (type == "aux:") {
-      (*auxParamInTargetContext)[name] = pair.second.Copy(targetContext);
+      (*auxParamInTargetContext)[name] = pair.second.Copy (targetContext);
     }
   }
 }
@@ -337,11 +333,12 @@ void Predictor::SplitParamMap(const std::map<std::string, NDArray> &paramMap,
 /*
  * The following function copy the param map into the target context
  */
-void Predictor::ConvertParamMapToTargetContext(const std::map<std::string, NDArray> &paramMap,
-    std::map<std::string, NDArray> *paramMapInTargetContext,
-    Context targetContext) {
-  for (const auto& pair : paramMap) {
-    (*paramMapInTargetContext)[pair.first] = pair.second.Copy(targetContext);
+void
+Predictor::ConvertParamMapToTargetContext (const std::map<std::string, NDArray> &paramMap,
+    std::map<std::string, NDArray> *paramMapInTargetContext, Context targetContext)
+{
+  for (const auto &pair : paramMap) {
+    (*paramMapInTargetContext)[pair.first] = pair.second.Copy (targetContext);
   }
 }
 
@@ -349,51 +346,56 @@ void Predictor::ConvertParamMapToTargetContext(const std::map<std::string, NDArr
  * The following function runs the forward pass on the model
  * and use real data for testing accuracy and performance.
  */
-void Predictor::LogInferenceResult(std::vector<mx_float> &log_vector, int num_inference_batches) {
-  log_vector.reserve(num_inference_batches);
+void
+Predictor::LogInferenceResult (std::vector<mx_float> &log_vector, int num_inference_batches)
+{
+  log_vector.reserve (num_inference_batches);
   // Create metrics
   Accuracy val_acc;
 
-  val_iter_->Reset();
-  val_acc.Reset();
+  val_iter_->Reset ();
+  val_acc.Reset ();
   int nBatch = 0;
 
-  double ms = ms_now();
-  while (val_iter_->Next()) {
-    auto data_batch = val_iter_->GetDataBatch();
-    data_batch.data.CopyTo(&args_map_["data"]);
-    NDArray::WaitAll();
+  double ms = ms_now ();
+  while (val_iter_->Next ()) {
+    auto data_batch = val_iter_->GetDataBatch ();
+    data_batch.data.CopyTo (&args_map_["data"]);
+    NDArray::WaitAll ();
 
     // running on forward pass
-    executor_->Forward(false);
-    NDArray::WaitAll();
+    executor_->Forward (false);
+    NDArray::WaitAll ();
     NDArray result;
-    Operator("argmax_channel")(executor_->outputs[0]).Invoke(result);
+    Operator ("argmax_channel") (executor_->outputs[0]).Invoke (result);
 
     // Write to the log file
-    mx_uint len = result.GetShape()[0];
-    std::vector<mx_float> data_vector(len);
-    result.SyncCopyToCPU(&data_vector, len);
-    log_vector.push_back(data_vector[0]);
+    mx_uint len = result.GetShape ()[0];
+    std::vector<mx_float> data_vector (len);
+    result.SyncCopyToCPU (&data_vector, len);
+    log_vector.push_back (data_vector[0]);
 
     // Update score
-    val_acc.Update(data_batch.label, executor_->outputs[0]);
+    val_acc.Update (data_batch.label, executor_->outputs[0]);
     if (++nBatch >= num_inference_batches) {
       break;
     }
   }
 
-  ms = ms_now() - ms;
-  auto args_name = net_.ListArguments();
-  LG << "INFO:" << "Finished inference with: " << nBatch * input_shape_[0]
-     << " images ";
-  LG << "INFO:" << "Batch size = " << input_shape_[0] << " for inference";
-  LG << "INFO:" << "Accuracy: " << val_acc.Get();
-  LG << "INFO:" << "Throughput: " << (1000.0 * nBatch * input_shape_[0] / ms)
-     << " images per second";
+  ms = ms_now () - ms;
+  auto args_name = net_.ListArguments ();
+  LG << "INFO:"
+     << "Finished inference with: " << nBatch * input_shape_[0] << " images ";
+  LG << "INFO:"
+     << "Batch size = " << input_shape_[0] << " for inference";
+  LG << "INFO:"
+     << "Accuracy: " << val_acc.Get ();
+  LG << "INFO:"
+     << "Throughput: " << (1000.0 * nBatch * input_shape_[0] / ms) << " images per second";
 }
 
-Predictor::~Predictor() {
+Predictor::~Predictor ()
+{
   if (executor_) {
     delete executor_;
   }

--- a/tests/nnstreamer_filter_mxnet/Predictor.hh
+++ b/tests/nnstreamer_filter_mxnet/Predictor.hh
@@ -1,6 +1,19 @@
 /* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * @file    Predictor.hh
+ * @date    Apr 24 2022
+ * @brief   Unit test for mxnet tensor filter sub-plugin
+ * @author  Bumsik Kim <k.bumsik@gmail.com>
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @bug     No known bugs
+ * @details
+ * This file is almost copied from
+ * https://github.com/apache/incubator-mxnet/blob/1.7.0/cpp-package/example/inference/imagenet_inference.cpp
+ * for testing purposes.
+ *
+ */
 
-/*
+/**
  * This example demonstrates image classification workflow with pre-trained
  * models using MXNet C++ API. The example performs following tasks.
  * 1. Load the pre-trained model.
@@ -29,6 +42,8 @@
 
 using namespace mxnet::cpp;
 
+
+/** @brief return current time in milliseconds */
 double
 ms_now ()
 {
@@ -44,6 +59,7 @@ ms_now ()
   return ret;
 }
 
+/** @brief check given file exists */
 inline bool
 file_exists (const std::string &name)
 {
@@ -51,7 +67,7 @@ file_exists (const std::string &name)
   return fhandle.good ();
 }
 
-// define the data type for NDArray, aliged with the definition in mshadow/base.h
+/** @brief define the data type for NDArray, aliged with the definition in mshadow/base.h */
 enum TypeFlag {
   kFloat32 = 0,
   kFloat64 = 1,
@@ -62,15 +78,13 @@ enum TypeFlag {
   kInt64 = 6,
 };
 
-/*
- * class Predictor
- *
- * This class encapsulates the functionality to load the model, prepare dataset and run the forward pass.
+/**
+ * @brief This class encapsulates the functionality to load the model, prepare dataset and run the forward pass.
  */
-
 class Predictor
 {
   public:
+  /** @brief default constructor */
   Predictor ()
   {
   }
@@ -110,7 +124,9 @@ class Predictor
   std::string data_layer_type_;
 };
 
-/*
+/**
+ * @brief construct new Predictor from given model and parameter file
+ * @details
  * The constructor takes following parameters as input:
  *  1. model_json_file:  The model in json formatted file.
  *  2. model_params_file: File containing model parameters
@@ -163,8 +179,8 @@ Predictor::Predictor (const std::string &model_json_file, const std::string &mod
   executor_ = new Executor (net_, global_ctx_, arg_arrays, grad_arrays, grad_reqs, aux_arrays);
 }
 
-/*
- * The following function is used to get the data layer type for input data
+/**
+ * @brief this function is used to get the data layer type for input data
  */
 int
 Predictor::GetDataLayerType ()
@@ -183,8 +199,9 @@ Predictor::GetDataLayerType ()
   return ret_type;
 }
 
-/*
- * create a new ImageRecordIter according to the given parameters:
+/**
+ * @brief create a new ImageRecordIter according to the given parameters
+ * @details
  *  1. dataset: data file (.rec) to be used for inference
  *  2. input_shape: Shape of input data to the model. Since this class will be
  * running one inference at a time, the input shape is required to be in format
@@ -248,8 +265,8 @@ Predictor::CreateImageRecordIter (const std::string &dataset,
   return val_iter;
 }
 
-/*
- * The following function loads the model from json file.
+/**
+ * @brief loads the model from json file.
  */
 void
 Predictor::LoadModel (const std::string &model_json_file)
@@ -265,8 +282,8 @@ Predictor::LoadModel (const std::string &model_json_file)
   }
 }
 
-/*
- * The following function loads the model parameters.
+/**
+ * @brief loads the model parameters.
  */
 void
 Predictor::LoadParameters (const std::string &model_parameters_file)
@@ -293,9 +310,8 @@ Predictor::LoadParameters (const std::string &model_parameters_file)
   NDArray::WaitAll ();
 }
 
-/*
- * The following function split loaded param map into arg parm
- *   and aux param with target context
+/**
+ * @brief split loaded param map into arg parm and aux param with target context
  */
 void
 Predictor::SplitParamMap (const std::map<std::string, NDArray> &paramMap,
@@ -313,8 +329,8 @@ Predictor::SplitParamMap (const std::map<std::string, NDArray> &paramMap,
   }
 }
 
-/*
- * The following function copy the param map into the target context
+/**
+ * @brief copy the param map into the target context
  */
 void
 Predictor::ConvertParamMapToTargetContext (const std::map<std::string, NDArray> &paramMap,
@@ -325,9 +341,8 @@ Predictor::ConvertParamMapToTargetContext (const std::map<std::string, NDArray> 
   }
 }
 
-/*
- * The following function runs the forward pass on the model
- * and use real data for testing accuracy and performance.
+/**
+ * @brief runs the forward pass on the model and use real data for testing accuracy and performance.
  */
 void
 Predictor::LogInferenceResult (std::vector<mx_float> &log_vector, int num_inference_batches)
@@ -377,6 +392,9 @@ Predictor::LogInferenceResult (std::vector<mx_float> &log_vector, int num_infere
      << "Throughput: " << (1000.0 * nBatch * input_shape_[0] / ms) << " images per second";
 }
 
+/**
+ * @brief Destroy the Predictor::Predictor object
+ */
 Predictor::~Predictor ()
 {
   if (executor_) {

--- a/tests/nnstreamer_filter_mxnet/Predictor.hh
+++ b/tests/nnstreamer_filter_mxnet/Predictor.hh
@@ -1,21 +1,4 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+/* SPDX-License-Identifier: LGPL-2.1-only */
 
 /*
  * This example demonstrates image classification workflow with pre-trained

--- a/tests/nnstreamer_filter_mxnet/download_and_run.sh
+++ b/tests/nnstreamer_filter_mxnet/download_and_run.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+# wget with sha256 check
+wget_sha256()
+{
+  wget -nc "$1"
+  if ! (echo "$2 $(basename "$1")" | sha256sum --status -c); then
+    echo -e "$1: sha256sum validation failed!"
+    exit 1
+  fi
+}
+
+# create ./model directory if not existed
+if [ ! -d model ]; then
+    mkdir -p model
+fi
+# create ./data directory if not existed
+if [ ! -d data ]; then
+    mkdir -p data
+fi
+
+# Download the model if not existed
+model_file=./model/Inception-BN.json
+params_file=./model/Inception-BN.params
+if [ ! -f ${model_file} ] || [ ! -f ${params_file} ]; then
+    wget_sha256 http://data.mxnet.io/models/imagenet/inception-bn.tar.gz 9f0d62e4adfde8bf3fef65ba20b3497e7845786b803fa8fed717602b9878ea03
+    tar -xvzf inception-bn.tar.gz -C model
+    mv ./model/Inception-BN-symbol.json ${model_file}
+    mv ./model/Inception-BN-0126.params ${params_file}
+fi
+
+# Download ImageNet validation dataset "val_256_q90.rec", which is used by the MXNet community
+# The data format is RecordIO https://mxnet.apache.org/versions/1.7/api/faq/recordio
+# Also mentioned in: https://mxnet.apache.org/versions/1.6/api/python/docs/tutorials/performance/backend/mkldnn/mkldnn_quantization.html
+dataset_file=./data/val_256_q90.rec
+if [ ! -f ${dataset_file} ]; then
+    cd ./data
+    # Warning: it is 1.5GB
+    wget_sha256 http://data.mxnet.io/data/val_256_q90.rec 8d90f7c53e2a74dcd08ae072f0247067424545031e6f5deaf57694ccbbe1a79b
+    cd ..
+fi
+
+# Run test
+./simple_test_mxnet || $(echo "Testing Failed!" >&2 && false)

--- a/tests/nnstreamer_filter_mxnet/download_and_run.sh
+++ b/tests/nnstreamer_filter_mxnet/download_and_run.sh
@@ -1,21 +1,7 @@
 #!/usr/bin/env bash
-
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 
 set -e
 

--- a/tests/nnstreamer_filter_mxnet/meson.build
+++ b/tests/nnstreamer_filter_mxnet/meson.build
@@ -1,0 +1,19 @@
+if mxnet_support_is_available
+  test_mxnet_deps = [
+    nnstreamer_dep,
+    nnstreamer_filter_mxnet_dep,
+    gtest_dep,
+    mxnet_support_deps,
+    cc.find_library('opencv_core', required: true)
+  ]
+
+  test_filter_mxnet = executable ('simple_test_mxnet',
+    ['simple_test_mxnet.cc'],
+    dependencies : test_mxnet_deps,
+    cpp_args: ['-Wno-non-virtual-dtor'],
+  )
+
+  configure_file(input : 'download_and_run.sh', output : 'download_and_run.sh',
+    configuration : configuration_data()
+  )
+endif

--- a/tests/nnstreamer_filter_mxnet/meson.build
+++ b/tests/nnstreamer_filter_mxnet/meson.build
@@ -14,6 +14,6 @@ if mxnet_support_is_available
   )
 
   configure_file(input : 'download_and_run.sh', output : 'download_and_run.sh',
-    configuration : configuration_data()
+    copy: true
   )
 endif

--- a/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
+++ b/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
@@ -221,7 +221,7 @@ main (int argc, char *argv[])
           output=1 \
           outputtype=float32 \
           outputname=argmax_channel \
-          custom=input_rank=4 \
+          custom=input_rank=4,enable_tensorrt=false \
           accelerator=true:cpu,!npu,!gpu \
       ! appsink name=log_sink",
         NULL);

--- a/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
+++ b/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
@@ -1,0 +1,269 @@
+#include "Predictor.hh"
+#include <gst/app/gstappsrc.h>
+#include <gst/gst.h>
+#include <mxnet-cpp/io.h>
+#include <stdexcept>
+#include <string.h>
+#include <thread>
+
+#define NUM_INFERENCE_BATCHES (500)
+
+/* GStreamer app data struct */
+typedef struct {
+  GstElement *pipeline, *app_source, *app_sink;
+  guint sourceid; /* To control the GSource */
+  GMainLoop *main_loop; /* GLib's Main Loop */
+
+  /* For nnstreamer-filter-mxnet */
+  int num_batch;
+  std::unique_ptr<MXDataIter> data_iter;
+  std::vector<float> *log;
+} AppData;
+
+/* Get MXNet Predictor using default parameters
+ * The code is from main() in MXNet Predictor example:
+ *  https://github.com/apache/incubator-mxnet/blob/1.7.0/cpp-package/example/inference/imagenet_inference.cpp
+ */
+std::unique_ptr<Predictor>
+get_predictor (MXDataIter *data_iter)
+{
+  std::string model_file_json ("./model/Inception-BN.json");
+  std::string model_file_params ("./model/Inception-BN.params");
+  Shape input_data_shape (1, 3, 224, 224); // The first 1 is the batch size, which is 1 at a time.
+  std::string data_layer_type ("float32");
+  bool use_gpu = false;
+  bool enable_tensorrt = false;
+
+  return std::unique_ptr<Predictor> (new Predictor (model_file_json, model_file_params,
+      input_data_shape, data_layer_type, use_gpu, enable_tensorrt, data_iter));
+}
+
+/* Get MXNet RecordIO dataset iterator using default parameters
+ * The code is from main() in MXNet Predictor example:
+ *  https://github.com/apache/incubator-mxnet/blob/1.7.0/cpp-package/example/inference/imagenet_inference.cpp
+ */
+std::unique_ptr<MXDataIter>
+get_dataset ()
+{
+  std::string dataset ("./data/val_256_q90.rec");
+  std::vector<float> rgb_mean = { 123.68, 116.779, 103.939 };
+  std::vector<float> rgb_std = { 1, 1, 1 };
+  Shape input_data_shape (1, 3, 224, 224); // The first 1 is the batch size, which is 1 at a time.
+  std::string data_layer_type ("float32");
+  int seed = 48564309;
+  int shuffle_chunk_seed = 3982304;
+  int data_nthreads = 60;
+  bool use_gpu = false;
+
+  return std::unique_ptr<MXDataIter> (
+      Predictor::CreateImageRecordIter (dataset, input_data_shape, data_layer_type,
+          rgb_mean, rgb_std, shuffle_chunk_seed, seed, data_nthreads, use_gpu));
+}
+
+/* Push a dataset batch (one preprocessed image) to the pipeline */
+static gboolean
+push_data (AppData *data)
+{
+  GstFlowReturn ret;
+  GstBuffer *buffer;
+  GstMapInfo map;
+
+  if (data->num_batch >= NUM_INFERENCE_BATCHES) {
+    g_signal_emit_by_name (data->app_source, "end-of-stream", &ret);
+    return FALSE;
+  }
+
+  /* Next batch */
+  data->data_iter->Next ();
+  data->num_batch++;
+
+  const mx_uint len = Shape (1, 3, 224, 224).Size ();
+  const size_t len_bytes = len * sizeof (mx_float);
+  buffer = gst_buffer_new_and_alloc (len_bytes);
+
+  /* Move batch (image) data to the buffer object */
+  gst_buffer_map (buffer, &map, GST_MAP_WRITE);
+  auto data_batch = data->data_iter->GetDataBatch ();
+  data_batch.data.SyncCopyToCPU ((mx_float *)map.data, len);
+  NDArray::WaitAll ();
+  gst_buffer_unmap (buffer, &map);
+
+  /* Push the buffer into the appsrc */
+  g_signal_emit_by_name (data->app_source, "push-buffer", buffer, &ret);
+
+  /* Free the buffer */
+  gst_buffer_unref (buffer);
+
+  if (ret != GST_FLOW_OK) {
+    return FALSE;
+  }
+  return TRUE;
+}
+
+/* This signal callback triggers when appsrc needs data. Here, we add an idle
+ * handler to the mainloop to start pushing data into the appsrc */
+static void
+start_feed (GstElement *source, guint size, AppData *data)
+{
+  if (data->sourceid == 0) {
+    data->sourceid = g_idle_add ((GSourceFunc)push_data, data);
+  }
+}
+
+/* This callback triggers when appsrc has enough data and we can stop sending.
+ * We remove the idle handler from the mainloop */
+static void
+stop_feed (GstElement *source, AppData *data)
+{
+  if (data->sourceid != 0) {
+    g_source_remove (data->sourceid);
+    data->sourceid = 0;
+  }
+}
+
+/* Log the result when a new sample (result) is received */
+static GstFlowReturn
+new_sample (GstElement *sink, AppData *data)
+{
+  GstSample *sample;
+
+  /* Retrieve the buffer */
+  g_signal_emit_by_name (sink, "pull-sample", &sample);
+  if (sample) {
+    GstMapInfo map;
+    GstBuffer *buffer = gst_sample_get_buffer (sample);
+    gst_buffer_map (buffer, &map, GST_MAP_READ);
+
+    /* Log result */
+    mx_float *pred_data = (mx_float *)map.data;
+    data->log->push_back (pred_data[0]);
+
+    /* Free the buffer */
+    gst_buffer_unmap (buffer, &map);
+    gst_sample_unref (sample);
+    return GST_FLOW_OK;
+  }
+
+  return GST_FLOW_ERROR;
+}
+
+/* When the pipeline get EOS, we exit the mainloop. */
+static gboolean
+on_pipeline_message (GstBus *bus, GstMessage *message, AppData *data)
+{
+  switch (GST_MESSAGE_TYPE (message)) {
+  case GST_MESSAGE_EOS:
+    g_main_loop_quit (data->main_loop);
+    break;
+  case GST_MESSAGE_ERROR: {
+    g_print ("Received error\n");
+
+    GError *err = NULL;
+    gchar *dbg_info = NULL;
+
+    gst_message_parse_error (message, &err, &dbg_info);
+    g_printerr ("ERROR from element %s: %s\n", GST_OBJECT_NAME (message->src), err->message);
+    g_printerr ("Debugging info: %s\n", (dbg_info) ? dbg_info : "none");
+    g_error_free (err);
+    g_free (dbg_info);
+  }
+
+    g_main_loop_quit (data->main_loop);
+    break;
+  case GST_MESSAGE_STATE_CHANGED:
+    break;
+  default:
+    break;
+  }
+  return TRUE;
+}
+
+int
+main (int argc, char *argv[])
+{
+  std::vector<float> reference_result;
+  std::vector<float> nnstreamer_result;
+
+  /* Run the reference implementation first and save log */
+  {
+    std::unique_ptr<MXDataIter> dataset = get_dataset ();
+    std::unique_ptr<Predictor> predictor = get_predictor (dataset.get ());
+    predictor->LogInferenceResult (reference_result, NUM_INFERENCE_BATCHES);
+    std::cout << "Running the reference implementation finished." << std::endl;
+  }
+
+  /* Run the NNStreamer implementation */
+  {
+    AppData data;
+    GstBus *bus;
+    memset (&data, 0, sizeof (data));
+
+    /* Initialize dataset iterator */
+    data.data_iter = get_dataset ();
+    data.data_iter->Reset ();
+    data.num_batch = 0;
+    nnstreamer_result.reserve (NUM_INFERENCE_BATCHES);
+    data.log = &nnstreamer_result;
+
+    /* Initialize GStreamer */
+    gst_init (&argc, &argv);
+
+    /* Create the pipeline and set elements */
+    data.pipeline = gst_parse_launch (" \
+      appsrc name=recordio_src ! application/octet-stream \
+      ! tensor_converter input-dim=1:3:224:224 input-type=float32 \
+      ! tensor_filter \
+          framework=mxnet \
+          model=model/Inception-BN.json \
+          input=1:3:224:224 \
+          inputtype=float32 \
+          inputname=data \
+          output=1 \
+          outputtype=float32 \
+          outputname=argmax_channel \
+          custom=input_rank=4 \
+          accelerator=true:cpu,!npu,!gpu \
+      ! appsink name=log_sink",
+        NULL);
+
+    bus = gst_element_get_bus (data.pipeline);
+    gst_bus_add_watch (bus, (GstBusFunc)on_pipeline_message, &data);
+    gst_object_unref (bus);
+
+    data.app_source = gst_bin_get_by_name (GST_BIN (data.pipeline), "recordio_src");
+    data.app_sink = gst_bin_get_by_name (GST_BIN (data.pipeline), "log_sink");
+
+    if (!data.pipeline || !data.app_source || !data.app_sink) {
+      g_printerr ("Not all elements could be created.\n");
+      return -1;
+    }
+
+    /* Configure appsrc and appsink */
+    g_signal_connect (data.app_source, "need-data", G_CALLBACK (start_feed), &data);
+    g_signal_connect (data.app_source, "enough-data", G_CALLBACK (stop_feed), &data);
+
+    g_object_set (data.app_sink, "emit-signals", TRUE, NULL);
+    g_signal_connect (data.app_sink, "new-sample", G_CALLBACK (new_sample), &data);
+
+    /* Start playing the pipeline */
+    gst_element_set_state (data.pipeline, GST_STATE_PLAYING);
+
+    /* Create a GLib Main Loop and set it to run */
+    data.main_loop = g_main_loop_new (NULL, FALSE);
+    g_main_loop_run (data.main_loop);
+
+    /* Free resources */
+    gst_element_set_state (data.pipeline, GST_STATE_NULL);
+    gst_object_unref (data.pipeline);
+  }
+
+  /* Compare results */
+  if (reference_result != nnstreamer_result) {
+    std::cout << "The reference implementation and the NNStreamer implementation does not match!!"
+              << std::endl;
+    return 1;
+  } else {
+    std::cout << "Test passed" << std::endl;
+  }
+  return 0;
+}

--- a/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
+++ b/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
@@ -11,7 +11,9 @@
 
 #define NUM_INFERENCE_BATCHES (500)
 
-/* GStreamer app data struct */
+/**
+ * @brief GStreamer app data struct
+ */
 typedef struct {
   GstElement *pipeline, *app_source, *app_sink;
   guint sourceid; /* To control the GSource */
@@ -23,8 +25,9 @@ typedef struct {
   std::vector<float> *log;
 } AppData;
 
-/* Get MXNet Predictor using default parameters
- * The code is from main() in MXNet Predictor example:
+/**
+ * @brief Get MXNet Predictor using default parameters
+ * @note The code is from main() in MXNet Predictor example:
  *  https://github.com/apache/incubator-mxnet/blob/1.7.0/cpp-package/example/inference/imagenet_inference.cpp
  */
 std::unique_ptr<Predictor>
@@ -41,8 +44,9 @@ get_predictor (MXDataIter *data_iter)
       input_data_shape, data_layer_type, use_gpu, enable_tensorrt, data_iter));
 }
 
-/* Get MXNet RecordIO dataset iterator using default parameters
- * The code is from main() in MXNet Predictor example:
+/**
+ * @brief Get MXNet RecordIO dataset iterator using default parameters
+ * @note The code is from main() in MXNet Predictor example:
  *  https://github.com/apache/incubator-mxnet/blob/1.7.0/cpp-package/example/inference/imagenet_inference.cpp
  */
 std::unique_ptr<MXDataIter>
@@ -63,7 +67,9 @@ get_dataset ()
           rgb_mean, rgb_std, shuffle_chunk_seed, seed, data_nthreads, use_gpu));
 }
 
-/* Push a dataset batch (one preprocessed image) to the pipeline */
+/**
+ * @brief Push a dataset batch (one preprocessed image) to the pipeline
+ */
 static gboolean
 push_data (AppData *data)
 {
@@ -103,8 +109,10 @@ push_data (AppData *data)
   return TRUE;
 }
 
-/* This signal callback triggers when appsrc needs data. Here, we add an idle
- * handler to the mainloop to start pushing data into the appsrc */
+/**
+ * @brief This signal callback triggers when appsrc needs data.
+ * Here, we add an idle handler to the mainloop to start pushing data into the appsrc
+ */
 static void
 start_feed (GstElement *source, guint size, AppData *data)
 {
@@ -115,8 +123,11 @@ start_feed (GstElement *source, guint size, AppData *data)
   }
 }
 
-/* This callback triggers when appsrc has enough data and we can stop sending.
- * We remove the idle handler from the mainloop */
+/**
+ * @brief This callback triggers when appsrc has enough data and we can stop
+ * sending. We remove the idle handler from the mainloop
+ *
+ */
 static void
 stop_feed (GstElement *source, AppData *data)
 {
@@ -127,7 +138,9 @@ stop_feed (GstElement *source, AppData *data)
   }
 }
 
-/* Log the result when a new sample (result) is received */
+/**
+ * @brief Log the result when a new sample (result) is received
+ */
 static GstFlowReturn
 new_sample (GstElement *sink, AppData *data)
 {
@@ -153,7 +166,9 @@ new_sample (GstElement *sink, AppData *data)
   return GST_FLOW_ERROR;
 }
 
-/* When the pipeline get EOS, we exit the mainloop. */
+/**
+ * @brief When the pipeline get EOS, we exit the mainloop.
+ */
 static gboolean
 on_pipeline_message (GstBus *bus, GstMessage *message, AppData *data)
 {
@@ -187,6 +202,9 @@ on_pipeline_message (GstBus *bus, GstMessage *message, AppData *data)
   return TRUE;
 }
 
+/**
+ * @brief Main function: compute result of same task by MXNet and NNStreamer
+ */
 int
 main (int argc, char *argv[])
 {

--- a/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
+++ b/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * @file    simple_test_mxnet.cc
  * @date    Apr 24 2022

--- a/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
+++ b/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
@@ -210,6 +210,7 @@ main (int argc, char *argv[])
     data.data_iter = get_dataset ();
     data.data_iter->Reset ();
     data.num_batch = 0;
+    data.sourceid = 0;
     nnstreamer_result.reserve (NUM_INFERENCE_BATCHES);
     data.log = &nnstreamer_result;
 

--- a/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
+++ b/tests/nnstreamer_filter_mxnet/simple_test_mxnet.cc
@@ -1,3 +1,12 @@
+/**
+ * @file    simple_test_mxnet.cc
+ * @date    Apr 24 2022
+ * @brief   Unit test for mxnet tensor filter sub-plugin
+ * @author  Bumsik Kim <k.bumsik@gmail.com>
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @bug     No known bugs
+ *
+ */
 #include <gst/app/gstappsrc.h>
 #include <gst/gst.h>
 #include <mxnet-cpp/io.h>


### PR DESCRIPTION
**Based on PR #2831 by @kbumsik**

This PR is to newly add MXNet subplugin support for tensor_filter.

We did these things:
- Rebased the commits of PR #2831 on current main branch
- Fixed some bugs on the test code
- Add/Modify some comments into doxygen style
- Reformatted the code to follow the coding convention in `.clang-format` of the root directory

### Building MXNet
We can follow instructions on original PR #2831, but we tested on the latest version of MXNet.

### Self evaluation
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

### How to evaluate
Warning: The following test example will download >1.5GB of data from MXNet for dataset
```
cd nnstreamer-git
ninja -C build install
cd build/tests/nnstreamer_filter_mxnet
./download_and_run.sh    # This will run simple_test_mxnet
```

Note: I am working on this with @makesource @SungwonShim