### PR TITLE
[TEST] Skip query test temporarily @open sesame 04/26 13:29

### DIFF
--- a/tests/nnstreamer_query/runTest.sh
+++ b/tests/nnstreamer_query/runTest.sh
@@ -18,6 +18,15 @@ fi
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)
 testInit $1
 
+# Skip query test temporarily because of ppa build failure.
+# Related issue: https://github.com/nnstreamer/nnstreamer/issues/3657
+ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+if [ "$ID" = "ubuntu" ]; then
+    echo "Skip query test for ppa build"
+    report
+    exit
+fi
+
 PATH_TO_PLUGIN="../../build"
 PERFORMANCE=0
 # The client has to wait enough time for the server to be ready.


### PR DESCRIPTION
This patch skips query test temporarily because of ppa build failure.
See also: #3657 

Signed-off-by: yelini-jeong <yelini.jeong@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped