### PR TITLE
[TEST] Unwinding macro to avoid no assertion test.

### DIFF
--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -7494,7 +7494,46 @@ TEST (testTensorCrop, infoDelayed_n)
  */
 TEST (testTensorSparse, utilConvert)
 {
-  RUN_SPARSE_CONVERT_TEST (_NNS_INT32, int32_t);
+  /**
+   * Unwinding the macro to avoid NO_ASSERTION test error.
+   * Same with RUN_SPARSE_CONVERT_TEST (_NNS_INT32, int32_t);
+   */
+  {
+    const gint sparse_test_data[40] = {
+      0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+      0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    };
+    GstMemory *sparse, *dense, *origin;
+    GstMapInfo map;
+    GstTensorInfo info;
+    GstTensorMetaInfo meta;
+    guint i;
+    gpointer data;
+    gsize data_size;
+    gst_tensor_info_init (&info);
+    info.type = _NNS_INT32;
+    gst_tensor_parse_dimension ("40", info.dimension);
+    gst_tensor_info_convert_to_meta (&info, &meta);
+    data_size = gst_tensor_info_get_size (&info);
+    data = g_malloc0 (data_size);
+    for (i = 0; i < 40U; i++)
+      ((int32_t *) data)[i] = (int32_t) sparse_test_data[i];
+    origin = gst_memory_new_wrapped (GST_MEMORY_FLAG_READONLY,
+        data, data_size, 0, data_size, data, g_free);
+    sparse = gst_tensor_sparse_from_dense (&meta, origin);
+    EXPECT_TRUE (sparse != NULL);
+    dense = gst_tensor_sparse_to_dense (&meta, sparse);
+    EXPECT_TRUE (dense != NULL);
+    ASSERT_TRUE (gst_memory_map (dense, &map, GST_MAP_READ));
+    for (i = 0; i < 40U; i++)
+      EXPECT_TRUE (((int32_t *) data)[i] == ((int32_t *) map.data)[i]);
+    gst_memory_unmap (dense, &map);
+    gst_tensor_info_free (&info);
+    gst_memory_unref (sparse);
+    gst_memory_unref (dense);
+    gst_memory_unref (origin);
+  }
+
   RUN_SPARSE_CONVERT_TEST (_NNS_UINT32, uint32_t);
   RUN_SPARSE_CONVERT_TEST (_NNS_INT16, int16_t);
   RUN_SPARSE_CONVERT_TEST (_NNS_UINT16, uint16_t);


### PR DESCRIPTION
Some code quality analyzer checks no assertion test.
testTesnrSparse_utilConvert has assert test, but the analyzer cannnot check macro.
So, to avoid the false-positive case, unwinding macro.
```
Check result:
-Analysis Time: 05-13-2022 12:21
-Total TCs: 575
-Positive TCs: 276
-Negative TCs: 299
-Undefined TCs: 0
-Total Alarms: 0
```

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


