### PR TITLE
[Python] path to python helper lib

### DIFF
--- a/debian/nnstreamer-python3.install
+++ b/debian/nnstreamer-python3.install
@@ -1,4 +1,4 @@
+/usr/lib/*/nnstreamer_python3.so
 /usr/lib/nnstreamer/filters/libnnstreamer_filter_python3.so
 /usr/lib/nnstreamer/converters/libnnstreamer_converter_python3.so
-/usr/lib/nnstreamer/extra/nnstreamer_python3.so
 /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_python3.so

--- a/debian/nnstreamer-python3.links
+++ b/debian/nnstreamer-python3.links
@@ -1,1 +1,1 @@
-/usr/lib/nnstreamer/extra/nnstreamer_python3.so /usr/lib/python3/dist-packages/nnstreamer_python.so
+/usr/lib/*/nnstreamer_python3.so /usr/lib/python3/dist-packages/nnstreamer_python.so

--- a/ext/nnstreamer/extra/meson.build
+++ b/ext/nnstreamer/extra/meson.build
@@ -92,7 +92,7 @@ if have_python3
     name_prefix: '',
     dependencies: nnstreamer_python3_deps,
     install: true,
-    install_dir: extra_install_dir
+    install_dir: nnstreamer_libdir
   )
 
   nnstreamer_python3_helper_dep = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -106,7 +106,6 @@ filter_subplugin_install_dir = join_paths(subplugin_install_prefix, 'filters')
 decoder_subplugin_install_dir = join_paths(subplugin_install_prefix, 'decoders')
 customfilter_install_dir = join_paths(subplugin_install_prefix, 'customfilters')
 converter_subplugin_install_dir = join_paths(subplugin_install_prefix, 'converters')
-extra_install_dir = join_paths(subplugin_install_prefix, 'extra')
 unittest_base_dir = join_paths(nnstreamer_bindir, 'unittest-nnstreamer')
 
 # Set default configuration

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -886,7 +886,7 @@ popd
 %if 0%{?python3_support}
 mkdir -p %{buildroot}%{python3_sitelib}
 pushd %{buildroot}%{python3_sitelib}
-ln -sf %{_prefix}/lib/nnstreamer/extra/nnstreamer_python3.so nnstreamer_python.so
+ln -sf %{_libdir}/nnstreamer_python3.so nnstreamer_python.so
 popd
 %endif
 
@@ -986,9 +986,9 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %files python3
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
+%{_libdir}/nnstreamer_python3.so
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_python3.so
 %{_prefix}/lib/nnstreamer/converters/libnnstreamer_converter_python3.so
-%{_prefix}/lib/nnstreamer/extra/nnstreamer_python3.so
 %{_prefix}/lib/nnstreamer/decoders/libnnstreamer_decoder_python3.so
 %{python3_sitelib}/nnstreamer_python.so
 %endif


### PR DESCRIPTION
Change install path for python-helper library.
This is to fix library link error.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
