### PR TITLE
[Meson] Fix warnings related to the run_command call

### DIFF
--- a/ext/nnstreamer/meson.build
+++ b/ext/nnstreamer/meson.build
@@ -21,7 +21,7 @@ if grpc_support_is_available
   if protobuf_support_is_available
     # gRPC/Protobuf
     prog_which = find_program('which')
-    grpc_cpp_plugin_path = run_command(prog_which, 'grpc_cpp_plugin').stdout().strip()
+    grpc_cpp_plugin_path = run_command(prog_which, 'grpc_cpp_plugin', check : true).stdout().strip()
     if grpc_cpp_plugin_path == ''
       error('cannot find the path of grpc_cpp_plugin.')
     endif

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -526,17 +526,19 @@ if get_option('enable-mediapipe')
     error('Not Supported System & Architecture. Linux x86_64 is required')
   endif
 
-  cmd = run_command('sh', '-c', 'echo $MEDIAPIPE_HOME')
+  cmd = run_command('sh', '-c', 'echo $MEDIAPIPE_HOME', check : true)
   MEDIAPIPE_HOME = cmd.stdout().strip()
-
-  mediapipe_env_exist = run_command('[', '-z', MEDIAPIPE_HOME, ']').returncode()
-  mediapipe_dir_exist = run_command('[', '-d', MEDIAPIPE_HOME, ']').returncode()
-
-  if mediapipe_env_exist != 1 and mediapipe_dir_exist != 0
+  if MEDIAPIPE_HOME == ''
+    error('MEDIAPIPE_HOME is not set')
+  endif
+  message('MEDIAPIPE_HOME: ' + MEDIAPIPE_HOME)
+  # TODO: This is not a portable way to check if a directory exists
+  # After bumping up to 0.53.0, the following line can be replaced with one that uses FS module
+  mediapipe_dir_exist = run_command('[', '-d', MEDIAPIPE_HOME, ']', check : false).returncode()
+  if mediapipe_dir_exist != 0
     error('Cannot find MEDIAPIPE_HOME: ' + MEDIAPIPE_HOME)
   endif
 
-  message('MEDIAPIPE_HOME: ' + MEDIAPIPE_HOME)
   mediapipe_incdir = include_directories(
     MEDIAPIPE_HOME,
     join_paths(MEDIAPIPE_HOME, 'bazel-bin'),
@@ -544,10 +546,7 @@ if get_option('enable-mediapipe')
     join_paths(MEDIAPIPE_HOME, 'bazel-mediapipe/external/com_google_absl'),
   )
 
-  cmd = run_command('sh', '-c', meson.source_root() + '/tools/development/gen_mediapipe_libs.sh ' + nnstreamer_libdir)
-  if cmd.returncode() != 0
-    error(cmd.stderr().strip())
-  endif
+  run_command('sh', '-c', meson.source_root() + '/tools/development/gen_mediapipe_libs.sh ' + nnstreamer_libdir, check : true)
 
   mediapipe_internal_dep = cxx.find_library('mediapipe_internal', dirs: nnstreamer_libdir)
   mediapipe_external_dep = cxx.find_library('mediapipe_external', dirs: nnstreamer_libdir)
@@ -593,7 +592,7 @@ if get_option('enable-mediapipe')
   )
 endif
 
-run_command('sh', '-c', 'touch filter_snpe_list')
+run_command('sh', '-c', 'touch filter_snpe_list', check : true)
 if snpe_support_is_available
   filter_sub_snpe_sources = ['tensor_filter_snpe.cc']
 
@@ -622,7 +621,7 @@ if snpe_support_is_available
     install: true,
     install_dir: nnstreamer_libdir
   )
-  run_command('sh', '-c', 'echo "%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_snpe.so" >> filter_snpe_list')
+  run_command('sh', '-c', 'echo "%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_snpe.so" >> filter_snpe_list', check : true)
 endif
 
 if tensorrt_support_is_available

--- a/meson.build
+++ b/meson.build
@@ -157,7 +157,9 @@ flatc = find_program('flatc', required : get_option('flatbuf-support'))
 flatbuf_dep = disabler()
 flatbuf_version_check_dep = disabler()
 if flatc.found()
-  flatc_ver = run_command(flatc, '--version').stdout().split()[2]
+  # TODO: After bumping up meson version to 0.62.0, we can use flatc.version()
+  # Please refer https://mesonbuild.com/Reference-manual_returned_external_program.html#external_programversion
+  flatc_ver = run_command(flatc, '--version', check : true).stdout().split()[2]
   flatbuf_dep = dependency('flatbuffers', version: flatc_ver,
       required : get_option('flatbuf-support'))
   flatbuf_version_check_dep = dependency('flatbuffers', version: '>=2.0.0',
@@ -191,11 +193,13 @@ if not get_option('snpe-support').disabled()
       message('Not Supported System & Architecture. Linux x86_64 is required for snpe sub-plugin')
     else
       # Check whether $SNPE_ROOT (where SNPE SDK is located) is set.
-      cmd = run_command('sh', '-c', 'echo $SNPE_ROOT')
+      cmd = run_command('sh', '-c', 'echo $SNPE_ROOT', check : true)
       SNPE_ROOT = cmd.stdout().strip()
       if SNPE_ROOT != ''
         message('Got $SNPE_ROOT: @0@'.format(SNPE_ROOT))
-        snpe_dir_not_exist = run_command('[', '-d', SNPE_ROOT, ']').returncode()
+        # TODO: This is not a portable way to check if a directory exists
+        # After bumping up to 0.53.0, the following line can be replaced with one that uses FS module
+        snpe_dir_not_exist = run_command('[', '-d', SNPE_ROOT, ']', check : false).returncode()
         if snpe_dir_not_exist != 0
           error('@0@ does not exists'.format(SNPE_ROOT))
         endif
@@ -496,9 +500,9 @@ if not get_option('python3-support').disabled()
     pg_pkgconfig = find_program('pkg-config')
 
     python3_inc_args = []
-    python3_inc_args += run_command(pg_pkgconfig, ['python3', '--cflags']).stdout().strip().split()
-    python3_inc_args += run_command('python3', ['-c', 'import site\nfor i in site.getsitepackages(): print("-I" + i + "/numpy/core/include")']).stdout().strip().split()
-    python3_inc_args += '-I' + run_command('python3', ['-m', 'site', '--user-site']).stdout().strip() + '/numpy/core/include'
+    python3_inc_args += run_command(pg_pkgconfig, ['python3', '--cflags'], check : true).stdout().strip().split()
+    python3_inc_args += run_command('python3', ['-c', 'import site\nfor i in site.getsitepackages(): print("-I" + i + "/numpy/core/include")'], check : true).stdout().strip().split()
+    python3_inc_args += '-I' + run_command('python3', ['-m', 'site', '--user-site'], check : true).stdout().strip() + '/numpy/core/include'
     python3_inc_valid_args = []
 
     foreach python3_inc_arg : python3_inc_args
@@ -584,7 +588,7 @@ configure_file(input: 'nnstreamer-internal.pc.in', output: 'nnstreamer-internal.
 )
 
 # Check whether mqtt broker is running or not.
-check_mosquitto = run_command ('bash', './tests/check_broker.sh').stdout()
+check_mosquitto = run_command ('bash', './tests/check_broker.sh', check : true).stdout()
 if check_mosquitto != ''
   add_project_arguments('-D__MQTT_BROKER_ENABLED__=1', language: ['c', 'cpp'])
 endif

--- a/tools/development/parser/meson.build
+++ b/tools/development/parser/meson.build
@@ -1,21 +1,7 @@
 # Find flex, configure lex generator
-flex_cdata = configuration_data()
-
 flex_min_version='2.5.31'
-flex = find_program('flex', 'win_flex')
-
-flexversion_res = run_command([flex, '--version'])
-if flexversion_res.returncode() != 0
-  error('Could not get flex version (@0@)'.format(flexversion_res.stderr()))
-endif
-
-flexversion = flexversion_res.stdout().split('\n')[0].split(' ')[1].strip()
-if flexversion.version_compare('<' + flex_min_version)
-  error('flex version @0@ >= @1@: NO'.format(flexversion, flex_min_version))
-else
-  message('flex version @0@ >= @1@: YES'.format(flexversion, flex_min_version))
-endif
-
+flex = find_program('flex', 'win_flex', version: '>=' + flex_min_version)
+flex_cdata = configuration_data()
 flex_cdata.set('FLEX', flex.path())
 if cc.get_id() == 'msvc'
   flex_cdata.set('FLEX_ARGS', '--nounistd')
@@ -28,23 +14,9 @@ gen_lex = configure_file(input : 'gen_lex.py.in',
   configuration : flex_cdata)
 
 # Find bison, configure grammar generator
-bison_cdata = configuration_data()
-
 bison_min_version='2.4'
-bison = find_program('bison', 'win_bison')
-
-bversion_res = run_command([bison, '--version'])
-if bversion_res.returncode() != 0
-  error('Could not get bison version (@0@)'.format(bversion_res.stderr()))
-endif
-
-bversion = bversion_res.stdout().split('\n')[0].split(' ')[-1].strip()
-if bversion.version_compare('<' + bison_min_version)
-  error('bison version @0@ >= @1@: NO'.format(bversion, bison_min_version))
-else
-  message('bison version @0@ >= @1@: YES'.format(bversion, bison_min_version))
-endif
-
+bison = find_program('bison', 'win_bison', version: '>=' + bison_min_version)
+bison_cdata = configuration_data()
 bison_cdata.set('BISON', bison.path())
 bison_cdata.set('BISON_ARGS', '')
 


### PR DESCRIPTION
This patch sets the keyword argument, 'check', of the run_command
function to true in order to fix the following warnings:

WARNING: You should add the boolean check kwarg to the run_command call.
         It currently defaults to false,
         but it will default to true in future releases of meson.
         See also: https://github.com/mesonbuild/meson/issues/9300

Signed-off-by: Wook Song <wook16.song@samsung.com>