### PR TITLE
[macOS/meson] Add a missing parameter to the sed's in-place edit option

### DIFF
--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -48,6 +48,10 @@ if have_python3
 endif
 
 sed_command = find_program('sed', required: true)
+sed_command_edit_in_place_option = '-i'
+if build_platform == 'macos'
+  sed_command_edit_in_place_option = '-i .bak'
+endif
 ext_test_template_prefix = 'unittest_tizen_'
 ext_test_template_str = ext_test_template_prefix + 'template.cc.in'
 ext_test_template = files (ext_test_template_str)
@@ -72,9 +76,9 @@ foreach ext : extensions
     input : ext_test_template,
     output : ext_test_path_each,
     command : [copy, '-f', '@INPUT@', '@OUTPUT@', \
-      '&&', 'sed', '-i', sed_ext_name_option, '@OUTPUT@', \
-      '&&', 'sed', '-i', sed_ext_abbrv_option, '@OUTPUT@', \
-      '&&', 'sed', '-i', sed_ext_mf_option, '@OUTPUT@']
+      '&&', 'sed', sed_command_edit_in_place_option, sed_ext_name_option, '@OUTPUT@', \
+      '&&', 'sed', sed_command_edit_in_place_option, sed_ext_abbrv_option, '@OUTPUT@', \
+      '&&', 'sed', sed_command_edit_in_place_option, sed_ext_mf_option, '@OUTPUT@']
   )
 
   exec = executable(


### PR DESCRIPTION
In macOS, the '-i' option of the sed command requires a parameter to
tell what extension to use for the backup file. To this end, this patch
appends '.bak' to the '-i' option to fix the build errors on macOS.

Signed-off-by: Wook Song <wook16.song@samsung.com>