### PR TITLE
[Tests/IF] Fix a build error related to -Winconsistent-missing-override

### DIFF
--- a/tests/nnstreamer_if/unittest_if.cc
+++ b/tests/nnstreamer_if/unittest_if.cc
@@ -62,7 +62,7 @@ class tensor_if_run : public ::testing::Test
   /**
    * @brief tear down the base fixture
    */
-  void TearDown ()
+  void TearDown () override
   {
     g_remove ("smpte.golden");
     g_remove ("gamut.golden");


### PR DESCRIPTION
This patch fixes the following build error while compiling with clang in macOS.

With clang in macOS:

../tests/nnstreamer_if/unittest_if.cc:65:8: error: 'TearDown' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  void TearDown ()
       ^
/opt/homebrew/Cellar/googletest/1.11.0/include/gtest/gtest.h:481:16: note: overridden virtual function is here
  virtual void TearDown();
               ^
1 error generated.

Signed-off-by: Wook Song <wook16.song@samsung.com>