### PR TITLE
[macOS/Doc] Replace 'nnsuite' with 'nnstreamer'

### DIFF
--- a/Documentation/getting-started-macos.md
+++ b/Documentation/getting-started-macos.md
@@ -37,7 +37,7 @@ $ brew update
 This is the most simple way to install NNStreamer into your macOS system.
 
 ```bash
-$ brew tap nnsuite/neural-network
+$ brew tap nnstreamer/neural-network
 $ brew install nnstreamer
 ```
 


### PR DESCRIPTION
This patch replaces the old organization name, nnsuite, remaining in the Getting Started document with the current one, nnstreamer.

See also: https://github.com/nnstreamer/homebrew-neural-network/issues/20
TODO: The Getting Started document for macOS looks out-of-date. It is required to be fully revised. 

Signed-off-by: Wook Song <wook16.song@samsung.com>
