### PR TITLE
tests: build error w/ higher gcc & lower gtest @open sesame 6/7 19:24

### DIFF
--- a/tests/cpp_methods/meson.build
+++ b/tests/cpp_methods/meson.build
@@ -7,7 +7,7 @@ cppfilter_test_lib = library('cppfilter_test',
 
 unittest_cppfilter = executable('unittest_cppfilter',
   join_paths(meson.current_source_dir(), 'unittest_cpp_methods.cc'),
-  dependencies: [gtest_dep, unittest_util_dep, nnstreamer_cpp_dep],
+  dependencies: [nnstreamer_unittest_deps, nnstreamer_cpp_dep],
   link_with: cppfilter_test_lib,
   install: get_option('install-test'),
   install_dir: unittest_install_dir

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -34,7 +34,7 @@ endif
 # gtest
 gtest_dep = dependency('gtest', required: false)
 if gtest_dep.found()
-  lesser_code_quality_accepted_for_unittest_code = declare_dependency(compile_args: ['-Wno-unused-parameter', '-Wno-missing-field-initializers'])
+  lesser_code_quality_accepted_for_unittest_code = declare_dependency(compile_args: ['-Wno-unused-parameter', '-Wno-missing-field-initializers', '-Wno-maybe-uninitialized'])
 
   # Shared library of internal APIs for nnstreamer-gtest
   unittest_util_shared = shared_library('nnstreamer_unittest_util',
@@ -52,7 +52,6 @@ if gtest_dep.found()
 
   nnstreamer_unittest_deps = [
     unittest_util_dep,
-    nnstreamer_internal_deps,
     glib_dep,
     gst_dep,
     gst_app_dep,
@@ -86,7 +85,7 @@ if gtest_dep.found()
     # Run unittest_plugins
     unittest_plugins = executable('unittest_plugins',
       join_paths('nnstreamer_plugins', 'unittest_plugins.cc'),
-      dependencies: [nnstreamer_unittest_deps],
+      dependencies: [nnstreamer_unittest_deps, nnstreamer_internal_deps],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -3,9 +3,7 @@ if not gtest_dep.found()
 endif
 
 tizen_apptest_deps = [
-  unittest_util_dep,
-  gtest_dep,
-  glib_dep
+  nnstreamer_unittest_deps
 ]
 
 # Format for adding subplugin into extensions -


### PR DESCRIPTION
If you have gcc >= 11 and gtest <= 1.8, you may have build errors:

/usr/src/gtest/src/gtest-death-test.cc: In function ‘bool testing::internal::StackGrowsDown()’:
/usr/src/gtest/src/gtest-death-test.cc:1009:24: error: ‘dummy’ may be used uninitialized [-Werror=maybe-uninitialized]
 1009 |   StackLowerThanAddress(&dummy, &result);
      |   ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/usr/src/gtest/src/gtest-death-test.cc:999:6: note: by argument 1 of type ‘const void*’ to ‘void testing::internal::StackLowerThanAddress(const void*, bool*)’ declared here
  999 | void StackLowerThanAddress(const void* ptr, bool* result) {
      |      ^~~~~~~~~~~~~~~~~~~~~
/usr/src/gtest/src/gtest-death-test.cc:1007:7: note: ‘dummy’ declared here
 1007 |   int dummy;
      |       ^~~~~

As gtest's code is not our test target, let the compiler ignore warnings of gtest codes.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

