### PR TITLE
[meson] Fix Yocto Kirkstone build issue

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -502,7 +502,10 @@ if not get_option('python3-support').disabled()
     python3_inc_args = []
     python3_inc_args += run_command(pg_pkgconfig, ['python3', '--cflags'], check : true).stdout().strip().split()
     python3_inc_args += run_command('python3', ['-c', 'import site\nfor i in site.getsitepackages(): print("-I" + i + "/numpy/core/include")'], check : true).stdout().strip().split()
-    python3_inc_args += '-I' + run_command('python3', ['-m', 'site', '--user-site'], check : true).stdout().strip() + '/numpy/core/include'
+    r = run_command('python3', ['-m', 'site', '--user-site'], check : false)
+    if r.returncode() == 0
+      python3_inc_args += '-I' + r.stdout().strip() + '/numpy/core/include'
+    endif
     python3_inc_valid_args = []
 
     foreach python3_inc_arg : python3_inc_args


### PR DESCRIPTION
Hello All,

We see a build issue with Yocto package on main branch during meson configuration.
This change fixes the problem for Yocto.

Thanks


A build configuration error is seen on Yocto Kirkstone (4.0)
coming from commit:
https://github.com/nnstreamer/nnstreamer/commit/0584ce06e30f1dbb188bce2b370df53d335046dd

Signature of error:
meson.build:505:4: ERROR: Command "//recipe-sysroot-native/usr/bin/python3-native/python3 -m site --user-site" failed with status 1

Building with Yocto, native tools are sandboxed in build workspace,
there is no python user site.
This change is to prevent meson configuration to break when no user
site package is present.

Signed-off-by: Julien Vuillaumier <julien.vuillaumier@nxp.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
