### PR TITLE
Query: fix protocol property handling

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_client.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_client.c
@@ -49,7 +49,6 @@ enum
 #define TCP_DEFAULT_SINK_PORT        3000
 #define TCP_DEFAULT_SRC_PORT        3001
 #define DEFAULT_SILENT TRUE
-#define DEFAULT_PROTOCOL        "tcp"
 
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_query_client_debug);
 #define GST_CAT_DEFAULT gst_tensor_query_client_debug
@@ -127,9 +126,10 @@ gst_tensor_query_client_class_init (GstTensorQueryClientClass * klass)
       g_param_spec_boolean ("silent", "Silent", "Produce verbose output",
           DEFAULT_SILENT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_PROTOCOL,
-      g_param_spec_string ("protocol", "Protocol",
-          "A protocol option for tensor query.",
-          DEFAULT_PROTOCOL, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+      g_param_spec_enum ("protocol", "Protocol",
+          "The network protocol to establish connections between client and server.",
+          GST_TYPE_QUERY_PROTOCOL, DEFAULT_PROTOCOL,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_OPERATION,
       g_param_spec_string ("operation", "Operation",
           "The main operation of the host.",
@@ -179,7 +179,7 @@ gst_tensor_query_client_init (GstTensorQueryClient * self)
 
   /* init properties */
   self->silent = DEFAULT_SILENT;
-  self->protocol = _TENSOR_QUERY_PROTOCOL_TCP;
+  self->protocol = DEFAULT_PROTOCOL;
   self->sink_conn = NULL;
   self->sink_host = g_strdup (TCP_DEFAULT_HOST);
   self->sink_port = TCP_DEFAULT_SINK_PORT;
@@ -258,8 +258,12 @@ gst_tensor_query_client_set_property (GObject * object, guint prop_id,
       self->src_port = g_value_get_uint (value);
       break;
     case PROP_PROTOCOL:
-      if (g_ascii_strcasecmp (g_value_get_string (value), "tcp") == 0)
-        self->protocol = _TENSOR_QUERY_PROTOCOL_TCP;
+    {
+        /** @todo expand when other protocols are ready */
+      TensorQueryProtocol protocol = g_value_get_enum (value);
+      if (protocol == _TENSOR_QUERY_PROTOCOL_TCP)
+        self->protocol = protocol;
+    }
       break;
     case PROP_OPERATION:
       if (!g_value_get_string (value)) {
@@ -313,13 +317,7 @@ gst_tensor_query_client_get_property (GObject * object, guint prop_id,
       g_value_set_uint (value, self->src_port);
       break;
     case PROP_PROTOCOL:
-      switch (self->protocol) {
-        case _TENSOR_QUERY_PROTOCOL_TCP:
-          g_value_set_string (value, "tcp");
-          break;
-        default:
-          break;
-      }
+      g_value_set_enum (value, self->protocol);
       break;
     case PROP_OPERATION:
       g_value_set_string (value, self->operation);

--- a/gst/nnstreamer/tensor_query/tensor_query_common.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.c
@@ -1105,3 +1105,25 @@ error:
 
   return buffer;
 }
+
+/**
+ * @brief register GEnumValue array for query protocol property handling
+ */
+GType
+gst_tensor_query_protocol_get_type (void)
+{
+  static GType protocol = 0;
+  if (protocol == 0) {
+    static GEnumValue protocols[] = {
+      {_TENSOR_QUERY_PROTOCOL_TCP, "TCP",
+          "Raw TCP protocol. Directly sending stream frames via TCP connections."},
+      {_TENSOR_QUERY_PROTOCOL_UDP, "UDP",
+          "Raw UDP protocol. Directly sending stream frames via UDP connections."},
+      {_TENSOR_QUERY_PROTOCOL_MQTT, "MQTT", "Connect with MQTT brokers."},
+      {0, NULL, NULL},
+    };
+    protocol = g_enum_register_static ("tensor_query_protocol", protocols);
+  }
+
+  return protocol;
+}

--- a/gst/nnstreamer/tensor_query/tensor_query_common.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.h
@@ -40,6 +40,15 @@ typedef enum
   _TENSOR_QUERY_PROTOCOL_END
 } TensorQueryProtocol;
 
+#define DEFAULT_HOST "localhost"
+#define DEFAULT_PROTOCOL (_TENSOR_QUERY_PROTOCOL_TCP)
+#define GST_TYPE_QUERY_PROTOCOL (gst_tensor_query_protocol_get_type ())
+/**
+ * @brief register GEnumValue array for query protocol property handling
+ */
+GType
+gst_tensor_query_protocol_get_type (void);
+
 /**
  * @brief Structures for tensor query commands.
  */

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.c
@@ -20,9 +20,7 @@
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_query_serversink_debug);
 #define GST_CAT_DEFAULT gst_tensor_query_serversink_debug
 
-#define DEFAULT_HOST "localhost"
 #define DEFAULT_PORT_SINK 3000
-#define DEFAULT_PROTOCOL _TENSOR_QUERY_PROTOCOL_TCP
 #define DEFAULT_METALESS_FRAME_LIMIT 1
 
 /**
@@ -88,9 +86,9 @@ gst_tensor_query_serversink_class_init (GstTensorQueryServerSinkClass * klass)
           65535, DEFAULT_PORT_SINK,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_PROTOCOL,
-      g_param_spec_int ("protocol", "Protocol",
-          "The network protocol to establish connection", 0,
-          _TENSOR_QUERY_PROTOCOL_END, DEFAULT_PROTOCOL,
+      g_param_spec_enum ("protocol", "Protocol",
+          "The network protocol to establish connection",
+          GST_TYPE_QUERY_PROTOCOL, DEFAULT_PROTOCOL,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_TIMEOUT,
       g_param_spec_uint ("timeout", "Timeout",
@@ -182,7 +180,7 @@ gst_tensor_query_serversink_set_property (GObject * object, guint prop_id,
       serversink->port = g_value_get_uint (value);
       break;
     case PROP_PROTOCOL:
-      serversink->protocol = g_value_get_int (value);
+      serversink->protocol = g_value_get_enum (value);
       break;
     case PROP_TIMEOUT:
       serversink->timeout = g_value_get_uint (value);
@@ -216,7 +214,7 @@ gst_tensor_query_serversink_get_property (GObject * object, guint prop_id,
       g_value_set_uint (value, serversink->port);
       break;
     case PROP_PROTOCOL:
-      g_value_set_int (value, serversink->protocol);
+      g_value_set_enum (value, serversink->protocol);
       break;
     case PROP_TIMEOUT:
       g_value_set_uint (value, serversink->timeout);

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
@@ -23,9 +23,7 @@
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_query_serversrc_debug);
 #define GST_CAT_DEFAULT gst_tensor_query_serversrc_debug
 
-#define DEFAULT_HOST "localhost"
 #define DEFAULT_PORT_SRC 3001
-#define DEFAULT_PROTOCOL _TENSOR_QUERY_PROTOCOL_TCP
 #define DEFAULT_IS_LIVE TRUE
 /**
  * @brief the capabilities of the outputs
@@ -95,9 +93,9 @@ gst_tensor_query_serversrc_class_init (GstTensorQueryServerSrcClass * klass)
           "The port to listen to (0=random available port)", 0,
           65535, DEFAULT_PORT_SRC, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_PROTOCOL,
-      g_param_spec_int ("protocol", "Protocol",
-          "The network protocol to establish connection", 0,
-          _TENSOR_QUERY_PROTOCOL_END, DEFAULT_PROTOCOL,
+      g_param_spec_enum ("protocol", "Protocol",
+          "The network protocol to establish connections between client and server.",
+          GST_TYPE_QUERY_PROTOCOL, DEFAULT_PROTOCOL,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_TIMEOUT,
       g_param_spec_uint ("timeout", "Timeout",
@@ -210,7 +208,7 @@ gst_tensor_query_serversrc_set_property (GObject * object, guint prop_id,
       serversrc->port = g_value_get_uint (value);
       break;
     case PROP_PROTOCOL:
-      serversrc->protocol = g_value_get_int (value);
+      serversrc->protocol = g_value_get_enum (value);
       break;
     case PROP_TIMEOUT:
       serversrc->timeout = g_value_get_uint (value);
@@ -265,7 +263,7 @@ gst_tensor_query_serversrc_get_property (GObject * object, guint prop_id,
       g_value_set_uint (value, serversrc->port);
       break;
     case PROP_PROTOCOL:
-      g_value_set_int (value, serversrc->protocol);
+      g_value_set_enum (value, serversrc->protocol);
       break;
     case PROP_TIMEOUT:
       g_value_set_uint (value, serversrc->timeout);

--- a/tests/nnstreamer_query/unittest_query.cc
+++ b/tests/nnstreamer_query/unittest_query.cc
@@ -165,6 +165,7 @@ TEST (tensorQuery, clientProperties0)
   gchar *pipeline;
   GstElement *gstpipe;
   GstElement *client_handle;
+  TensorQueryProtocol protocol;
   guint uint_val;
   gchar *str_val;
   gboolean bool_val;
@@ -172,7 +173,7 @@ TEST (tensorQuery, clientProperties0)
   /* Create a query client pipeline */
   pipeline = g_strdup_printf (
       "videotestsrc ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB !"
-      "tensor_converter ! tensor_query_client name=client protocol=tcp src-host=127.0.0.1 sink-host=127.0.0.1 ! tensor_sink");
+      "tensor_converter ! tensor_query_client name=client protocol=TCP src-host=127.0.0.1 sink-host=127.0.0.1 ! tensor_sink");
   gstpipe = gst_parse_launch (pipeline, NULL);
   EXPECT_NE (gstpipe, nullptr);
 
@@ -194,9 +195,8 @@ TEST (tensorQuery, clientProperties0)
   g_object_get (client_handle, "sink-port", &uint_val, NULL);
   EXPECT_EQ (3000U, uint_val);
 
-  g_object_get (client_handle, "protocol", &str_val, NULL);
-  EXPECT_STREQ ("tcp", str_val);
-  g_free (str_val);
+  g_object_get (client_handle, "protocol", &protocol, NULL);
+  EXPECT_EQ (protocol, _TENSOR_QUERY_PROTOCOL_TCP);
 
   g_object_get (client_handle, "silent", &bool_val, NULL);
   EXPECT_EQ (TRUE, bool_val);


### PR DESCRIPTION
Protocols are enum. Use enum-param, not int or string.
With this, users can use both numbers and enum-strings.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

PTAL: @jaeyun-jung @gichan-jang 
