### PR TITLE
[CI TC Fail Fix] test/grpc: correct parallel unit test calls @open sesame 6/10 13:24

### DIFF
--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -67,6 +67,25 @@ export LD_LIBRARY_PATH=${PATH_TO_PLUGIN_EXTRA}:${LD_LIBRARY_PATH}
 
 NUM_BUFFERS=10
 
+TIMEOUT_SEC=10
+## Check if a pipeline is launched and playing
+function waitformarker {
+  for i in $(seq 1 ${TIMEOUT_SEC})
+  do
+    if [ -f 'marker.log' ]; then
+      markersize=$(stat -c%s marker.log)
+      if [ $markersize -ge 48 ]; then
+        testResult 1 $1 "$2" 0 0
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  testResult 0 $1 "$2" 0 0
+  exit
+}
+WAIT4MARKER=" videotestsrc num-buffers=1 ! video/x-raw,format=RGB,height=4,width=4 ! filesink location=marker.log "
+
 ## Initial pipelines to generate reference outputs
 # passthrough, other/tensor
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! multifilesink location=original1_%1d.log" Initial-1 0 0 $PERFORMANCE
@@ -93,9 +112,13 @@ for BLOCKING in "${BLOCKING_LIST[@]}"; do
   fi
 
   # tensor_sink (client) --> tensor_src (server), other/tensor
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} blocking=${BLOCKING} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" ${INDEX}-1 0 0 $PERFORMANCE &
-  sleep 1
+  rm -f marker.log
+  timeout -k 11s 11s gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} blocking=${BLOCKING} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink async=false location=result_%1d.log ${WAIT4MARKER} &
+  pid=$!
+  waitformarker ${INDEX}-1 "tensor_src_grpc ${INDEX}-1 launching in parallel"
   gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL} blocking=${BLOCKING}" ${INDEX}-2 0 0 $PERFORMANCE
+  kill -9 $pid &> /dev/null
+  wait $pid
 
   for i in `seq 0 $((NUM_BUFFERS-1))`
   do
@@ -107,9 +130,13 @@ for BLOCKING in "${BLOCKING_LIST[@]}"; do
 
   PORT=`python3 ../get_available_port.py`
   # tensor_sink (server) --> tensor_src (client), other/tensor
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL} blocking=${BLOCKING}" ${INDEX}-1 0 0 $PERFORMANCE &
-  sleep 1
+  rm -f marker.log
+  timeout -k 11s 11s gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL} blocking=${BLOCKING} async=false ${WAIT4MARKER} &
+  pid=$!
+  waitformarker ${INDEX}-1 "tensor-sink_grpc ${INDEX}-1 launching in parallel"
   gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} server=false idl=${IDL} blocking=${BLOCKING} ! 'other/tensor,dimension=(string)3:640:480,type=(string)uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" ${INDEX}-2 0 0 $PERFORMANCE
+  kill -9 $pid &> /dev/null
+  wait $pid
 
   for i in `seq 0 $((NUM_BUFFERS-1))`
   do
@@ -121,9 +148,13 @@ for BLOCKING in "${BLOCKING_LIST[@]}"; do
 
   PORT=`python3 ../get_available_port.py`
   # tensor_sink (client) --> tensor_src (server), other/tensors
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} blocking=${BLOCKING} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" ${INDEX}-1 0 0 $PERFORMANCE &
-  sleep 1
+  rm -f marker.log
+  timeout -k 11s 11s gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} blocking=${BLOCKING} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink async=false location=result_%1d.log ${WAIT4MARKER} &
+  pid=$!
+  waitformarker ${INDEX}-1 "tensor-src-grpc ${INDEX}-1 launching in parallel"
   gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} idl=${IDL} blocking=${BLOCKING}" ${INDEX}-2 0 0 $PERFORMANCE
+  kill -9 $pid &> /dev/null
+  wait $pid
 
   for i in `seq 0 $((NUM_BUFFERS/2-1))`
   do
@@ -135,9 +166,13 @@ for BLOCKING in "${BLOCKING_LIST[@]}"; do
 
   PORT=`python3 ../get_available_port.py`
   # tensor_sink (server) --> tensor_src (client), other/tensors
-  gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL} blocking=${BLOCKING}" ${INDEX}-1 0 0 $PERFORMANCE &
-  sleep 1
+  rm -f marker.log
+  timeout -k 11s 11s gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL} blocking=${BLOCKING} async=false ${WAIT4MARKER} &
+  pid=$!
+  waitformarker ${INDEX}-1 "tensor-sink-grpc ${INDEX}-1 launching in parallel"
   gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) server=false idl=${IDL} blocking=${BLOCKING} ! 'other/tensors,num_tensors=2,dimensions=(string)3:640:480.3:640:480,types=(string)uint8.uint8,framerate=(fraction)5/1' ! multifilesink location=result_%1d.log" ${INDEX}-2 0 0 $PERFORMANCE
+  kill -9 $pid &> /dev/null
+  wait $pid
 
   for i in `seq 0 $((NUM_BUFFERS/2-1))`
   do


### PR DESCRIPTION
1. Do not fork ssat-api functions
2. Do not sleep constant time. Check the launch process.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
