### PR TITLE
[spec] Fix spec to cut the depedency on custom tflite in 64-bit

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -198,7 +198,7 @@ BuildRequires: tensorflow-lite-devel
 BuildRequires: tensorflow2-lite-devel
 # tensorflow2-lite-custom requires scripts for rpm >= 4.9
 BuildRequires:  rpm >= 4.9
-%global __requires_exclude ^libtensorflow2-lite-custom.so$
+%global __requires_exclude ^libtensorflow2-lite-custom.*$
 %endif
 # custom_example_opencv filter requires opencv-devel
 BuildRequires: opencv-devel


### PR DESCRIPTION
- In 64-bit the dep is like "libtensorflow2-lite-custom.so()(64bit)"
- To cut this properly, replace "so" with "*"

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
