### PR TITLE
Fixes build breaks of 2.0.y on macOS

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_common.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.c
@@ -28,6 +28,10 @@
 #define N_BACKLOG 10
 #define CLIENT_ID_LEN 4
 
+#ifndef EREMOTEIO
+#define EREMOTEIO 121           /* This is Linux-specific. Define this for non-Linux systems */
+#endif
+
 /**
  * @brief Query server dependent network data
  */
@@ -172,10 +176,10 @@ gst_tensor_query_connect (query_connection_handle conn_h)
   }
 
   /* create sending client socket */
-  /** @todo Support UDP protocol */
   conn->socket =
       g_socket_new (g_socket_address_get_family (saddr), G_SOCKET_TYPE_STREAM,
       G_SOCKET_PROTOCOL_TCP, &err);
+  /** @todo Support UDP protocol */
 
   if (!conn->socket) {
     nns_loge ("Failed to create new socket");

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -42,6 +42,10 @@ if have_python3
 endif
 
 sed_command = find_program('sed', required: true)
+sed_command_edit_in_place_option = '-i'
+if build_platform == 'macos'
+  sed_command_edit_in_place_option = '-i .bak'
+endif
 ext_test_template_prefix = 'unittest_tizen_'
 ext_test_template_str = ext_test_template_prefix + 'template.cc.in'
 ext_test_template = files (ext_test_template_str)
@@ -66,9 +70,9 @@ foreach ext : extensions
     input : ext_test_template,
     output : ext_test_path_each,
     command : [copy, '-f', '@INPUT@', '@OUTPUT@', \
-      '&&', 'sed', '-i', sed_ext_name_option, '@OUTPUT@', \
-      '&&', 'sed', '-i', sed_ext_abbrv_option, '@OUTPUT@', \
-      '&&', 'sed', '-i', sed_ext_mf_option, '@OUTPUT@']
+      '&&', 'sed', sed_command_edit_in_place_option, sed_ext_name_option, '@OUTPUT@', \
+      '&&', 'sed', sed_command_edit_in_place_option, sed_ext_abbrv_option, '@OUTPUT@', \
+      '&&', 'sed', sed_command_edit_in_place_option, sed_ext_mf_option, '@OUTPUT@']
   )
 
   exec = executable(

--- a/tests/nnstreamer_if/unittest_if.cc
+++ b/tests/nnstreamer_if/unittest_if.cc
@@ -62,7 +62,7 @@ class tensor_if_run : public ::testing::Test
   /**
    * @brief tear down the base fixture
    */
-  void TearDown ()
+  void TearDown () override
   {
     g_remove ("smpte.golden");
     g_remove ("gamut.golden");


### PR DESCRIPTION
This PR fixes build breaks of lts/2.0.y for macOS. The cherry-picked patches from the upstream branch are as follows:

- tensor-query: cross-platform compatibility (non-Linux)
- [macOS/meson] Add a missing parameter to the sed's in-place edit option
- [Tests/IF] Fix a build error related to -Winconsistent-missing-override

Signed-off-by: Wook Song <wook16.song@samsung.com>