### PR TITLE
[Filter/TFLite] Fix model tensors allocation not working for some del…

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -549,14 +549,14 @@ TFLiteInterpreter::loadModel (int num_threads, tflite_delegate_e delegate_e)
   delegate = getDelegate ();
   if (delegate != nullptr) {
     if (interpreter->ModifyGraphWithDelegate (delegate) != kTfLiteOk) {
-      ml_loge ("Failed to allocate tensors with delegate\n");
+      ml_loge ("Failed to apply delegate\n");
       return -2;
     }
-  } else {
-    if (interpreter->AllocateTensors () != kTfLiteOk) {
-      ml_loge ("Failed to allocate tensors\n");
-      return -2;
-    }
+  }
+
+  if (interpreter->AllocateTensors () != kTfLiteOk) {
+    ml_loge ("Failed to allocate tensors\n");
+    return -2;
   }
 
 #if (DBG)


### PR DESCRIPTION
…egates

This change is correction for error below reported by the TFlite library
during Invoke():

"Invoke called on model that is not ready."

Tensors allocation may be done by TFLite framework during call to
ModifyGraphWithDelegate() but that is not guaranteed.
Therefore, even if delegates are used, tensors allocation must be done
explicitly with AllocateTensors(), prior to inferencing with Invoke().

Signed-off-by: Julien Vuillaumier <julien.vuillaumier@nxp.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```

