### PR TITLE
[Filter/TFLite] Fix model tensors allocation not working for some delegates

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -549,14 +549,14 @@ TFLiteInterpreter::loadModel (int num_threads, tflite_delegate_e delegate_e)
   delegate = getDelegate ();
   if (delegate != nullptr) {
     if (interpreter->ModifyGraphWithDelegate (delegate) != kTfLiteOk) {
-      ml_loge ("Failed to allocate tensors with delegate\n");
+      ml_loge ("Failed to apply delegate\n");
       return -2;
     }
-  } else {
-    if (interpreter->AllocateTensors () != kTfLiteOk) {
-      ml_loge ("Failed to allocate tensors\n");
-      return -2;
-    }
+  }
+
+  if (interpreter->AllocateTensors () != kTfLiteOk) {
+    ml_loge ("Failed to allocate tensors\n");
+    return -2;
   }
 
 #if (DBG)


### PR DESCRIPTION
Hello all,
This is a bugfix for an issue detected with TFLite delegate supporting dynamic shape.
Tensors are not allocated and inference can not run.
AllocateTensors() has to be called consistently before Invoke() even in case of delegate usage.
That is the case in TFLite examples code.
Thanks


[Filter/TFLite] Fix model tensors allocation not working for some delegates

This change is correction for error below reported by the TFlite library
during Invoke():

"Invoke called on model that is not ready."

Tensors allocation may be done by TFLite framework during call to
ModifyGraphWithDelegate() but that is not guaranteed.
Therefore, even if delegates are used, tensors allocation must be done
explicitly with AllocateTensors(), prior to inferencing with Invoke().

Signed-off-by: Julien Vuillaumier <julien.vuillaumier@nxp.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ *]Passed [ ]Failed []Skipped

SSAT  test suite is passed.

