### PR TITLE
[Tests/gRPC] Prepare a fallback value for PATH_TO_PLUGIN @open sesame 07/01 13:45

### DIFF
--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -27,6 +27,10 @@ fi
 
 # Check gRPC availability
 PATH_TO_PLUGIN=${NNSTREAMER_BUILD_ROOT_PATH}
+if [[ -z $PATH_TO_PLUGIN ]]; then
+  PATH_TO_PLUGIN="../../build"
+fi
+
 if [[ -d $PATH_TO_PLUGIN ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer"
     if [[ -d ${ini_path} ]]; then


### PR DESCRIPTION
In case NNSTREAMER_BUILD_ROOT_PATH is not defined, the test cases for gRPC might run in an unintentional way. To this end, this patch adds a fallback value for PATH_TO_PLUGIN to runTest.sh.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
