### PR TITLE
[Tests/Meson] Copy bmp2png to the tests directory every build time @open sesame 07/05 10:15

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -18,8 +18,10 @@ if libpng_dep.found()
   custom_target('copy-bmp2png',
     input: b2p,
     output: 'b2p',
-    command: [copy, '@INPUT@', meson.current_source_dir()],
-    build_by_default: true
+    depends: b2p,
+    command: [copy, '@INPUT@', '@CURRENT_SOURCE_DIR@'],
+    build_by_default: true,
+    build_always_stale: true,
   )
 endif
 


### PR DESCRIPTION
In order to enforce to keep ./tests/bmp2png the same as the one in the build directory, this patch modifies the meson build script to copy bmp2png to the tests directory from the build directory every build time.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped