### PR TITLE
[tests/gRPC] Revise runTest.sh in a more portable way by using the SSAT API

### DIFF
--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -77,7 +77,7 @@ function waitformarker {
   for i in $(seq 1 ${TIMEOUT_SEC})
   do
     if [ -f 'marker.log' ]; then
-      markersize=$(stat -c%s marker.log)
+      markersize=$(${StatCmd_GetSize} marker.log)
       if [ $markersize -ge 48 ]; then
         testResult 1 $1 "$2" 0 0
         return 0

--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -34,7 +34,7 @@ fi
 if [[ -d $PATH_TO_PLUGIN ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer"
     if [[ -d ${ini_path} ]]; then
-        check=$(ls ${ini_path} | grep nnstreamer-grpc.so)
+        check=$(ls ${ini_path} | grep nnstreamer-grpc.${SO_EXT})
         if [[ ! $check ]]; then
             echo "Cannot find nnstreamer-grpc shared lib"
             report
@@ -52,12 +52,12 @@ TEST_FLATBUF=1
 if [[ -d $PATH_TO_PLUGIN_EXTRA ]]; then
   ini_path="${PATH_TO_PLUGIN_EXTRA}"
   if [[ -d ${ini_path} ]]; then
-    check=$(ls ${ini_path} | grep nnstreamer_grpc_protobuf.so)
+    check=$(ls ${ini_path} | grep nnstreamer_grpc_protobuf.${SO_EXT})
     if [[ ! $check ]]; then
       echo "Cannot find nnstreamer_grpc_protobuf shared lib"
       TEST_PROTOBUF=0
     fi
-    check=$(ls ${ini_path} | grep nnstreamer_grpc_flatbuf.so)
+    check=$(ls ${ini_path} | grep nnstreamer_grpc_flatbuf.${SO_EXT})
     if [[ ! $check ]]; then
       echo "Cannot find nnstreamer_grpc_flatbuf shared lib"
       TEST_FLATBUF=0


### PR DESCRIPTION
By using ```SO_EXT``` and  ```StatCmd_GetSize``` provided by the SSAT API, this PR revise the script, runTest.sh, in a more portable way.

ref: #3820

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

