### PR TITLE
[Edge] migrating edge library

### DIFF
--- a/debian/nnstreamer-core.install
+++ b/debian/nnstreamer-core.install
@@ -6,5 +6,5 @@
 /usr/lib/nnstreamer/decoders/libnnstreamer_decoder_octet_stream.so
 /usr/lib/nnstreamer/filters/libnnstreamer_filter_cpp.so
 /usr/lib/*/libnnstreamer.so
-/usr/lib/*/libnnstreamer-edge.so
+/usr/lib/*/libnnstreamer-edge-temp.so
 /usr/lib/*/gstreamer-1.0/libnnstreamer.so

--- a/gst/nnstreamer/tensor_query/meson.build
+++ b/gst/nnstreamer/tensor_query/meson.build
@@ -37,14 +37,14 @@ else
   endif
 endif
 
-nns_edge_lib = shared_library('nnstreamer-edge',
+nns_edge_lib = shared_library('nnstreamer-edge-temp',
   nnstreamer_edge_sources,
   dependencies: nnstreamer_edge_deps,
   install: true,
   install_dir: nnstreamer_libdir
 )
 
-static_library('nnstreamer-edge',
+static_library('nnstreamer-edge-temp',
   nnstreamer_edge_sources,
   dependencies: nnstreamer_edge_deps,
   install: true,

--- a/gst/nnstreamer/tensor_query/nnstreamer-edge.h
+++ b/gst/nnstreamer/tensor_query/nnstreamer-edge.h
@@ -121,7 +121,7 @@ int nns_edge_publish (nns_edge_h edge_h, nns_edge_data_h data_h);
 /**
  * @brief Request result to the server.
  */
-int nns_edge_request (nns_edge_h edge_h, nns_edge_data_h data_h, void *user_data);
+int nns_edge_request (nns_edge_h edge_h, nns_edge_data_h data_h);
 
 /**
  * @brief Respond to a request.
@@ -131,7 +131,7 @@ int nns_edge_respond (nns_edge_h edge_h, nns_edge_data_h data_h);
 /**
  * @brief Subscribe a message to a given topic.
  */
-int nns_edge_subscribe (nns_edge_h edge_h, nns_edge_data_h data_h, void *user_data);
+int nns_edge_subscribe (nns_edge_h edge_h, nns_edge_data_h data_h);
 
 /**
  * @brief Unsubscribe a message to a given topic.

--- a/gst/nnstreamer/tensor_query/nnstreamer_edge_internal.c
+++ b/gst/nnstreamer/tensor_query/nnstreamer_edge_internal.c
@@ -1189,7 +1189,7 @@ nns_edge_publish (nns_edge_h edge_h, nns_edge_data_h data_h)
  * @brief Request result to the server.
  */
 int
-nns_edge_request (nns_edge_h edge_h, nns_edge_data_h data_h, void *user_data)
+nns_edge_request (nns_edge_h edge_h, nns_edge_data_h data_h)
 {
   nns_edge_handle_s *eh;
   nns_edge_conn_data_s *conn_data;
@@ -1197,7 +1197,6 @@ nns_edge_request (nns_edge_h edge_h, nns_edge_data_h data_h, void *user_data)
   int ret;
   unsigned int i;
 
-  UNUSED (user_data);
   eh = (nns_edge_handle_s *) edge_h;
   if (!eh) {
     nns_edge_loge ("Invalid param, given edge handle is null.");
@@ -1241,11 +1240,10 @@ nns_edge_request (nns_edge_h edge_h, nns_edge_data_h data_h, void *user_data)
  * @brief Subscribe a message to a given topic.
  */
 int
-nns_edge_subscribe (nns_edge_h edge_h, nns_edge_data_h data_h, void *user_data)
+nns_edge_subscribe (nns_edge_h edge_h, nns_edge_data_h data_h)
 {
   nns_edge_handle_s *eh;
 
-  UNUSED (user_data);
   eh = (nns_edge_handle_s *) edge_h;
   if (!eh) {
     nns_edge_loge ("Invalid param, given edge handle is null.");

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -968,7 +968,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_cpp.so
 %{gstlibdir}/libnnstreamer.so
 # TODO migrate nnstreamer-edge and remove below library
-%{_libdir}/libnnstreamer-edge.so
+%{_libdir}/libnnstreamer-edge-temp.so
 %{_libdir}/libnnstreamer.so
 
 %files single


### PR DESCRIPTION
Prepare uploading edge library.
- temporally rename edge library in nnstreamer
- remove unnecessary param in edge APIs

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
