### PR TITLE
[github-action] Run GBS in github-action

### DIFF
--- a/.github/workflows/gbs_x64.yml
+++ b/.github/workflows/gbs_x64.yml
@@ -1,0 +1,24 @@
+name: GBS Tizen build for x64 from Ubuntu
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v1
+    - name: prepare deb sources for GBS
+      run: echo "deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_20.04/ /" | sudo tee /etc/apt/sources.list.d/tizen.list
+    - name: install GBS
+      run: sudo apt-get update && sudo apt-get install -y gbs
+    - name: configure GBS
+      run: cp .github/workflows/tizen.gbs.conf ~/.gbs.conf
+    - name: run GBS
+      run: gbs build

--- a/.github/workflows/tizen.gbs.conf
+++ b/.github/workflows/tizen.gbs.conf
@@ -1,0 +1,21 @@
+[general]
+profile = profile.tizen
+tmpdir = /var/tmp
+packaging_branch = tizen
+workdir = .
+
+[profile.tizen]
+url = https://api.tizen.org
+obs = obs.tizen
+
+repos = repo.base, repo.unified
+buildroot = ~/GBS-ROOT/
+
+[obs.tizen]
+url = https://api.tizen.org
+
+[repo.base]
+url = http://download.tizen.org/snapshots/tizen/base/latest/repos/standard/packages/
+
+[repo.unified]
+url = https://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/


### PR DESCRIPTION
Run gbs in github-action for more Tizen testing.

Tested. Github-action took 13m 57s to complete the gbs test. (gbs build took 13m 18s, gbs-install took 33s)

This commit can be used by other github repos who want to test Tizen gbs build.

Note: TAOS-CI's gbs build is much faster!

TODO: write a single .yml file for github-action marketplace.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

