### PR TITLE
[Tests] Remove unnecessary line feeds in the runTest.sh files @open sesame 07/07 14:15

### DIFF
--- a/tests/codegen/runTest.sh
+++ b/tests/codegen/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 if [ -z ${SO_EXT} ]; then

--- a/tests/nnstreamer_converter/runTest.sh
+++ b/tests/nnstreamer_converter/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_converter_python3/runTest.sh
+++ b/tests/nnstreamer_converter_python3/runTest.sh
@@ -13,8 +13,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_decoder/runTest.sh
+++ b/tests/nnstreamer_decoder/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_decoder_boundingbox/runTest.sh
+++ b/tests/nnstreamer_decoder_boundingbox/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_decoder_image_labeling/runTest.sh
+++ b/tests/nnstreamer_decoder_image_labeling/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_decoder_image_segment/runTest.sh
+++ b/tests/nnstreamer_decoder_image_segment/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_decoder_pose/runTest.sh
+++ b/tests/nnstreamer_decoder_pose/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_demux/runTest.sh
+++ b/tests/nnstreamer_demux/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_filter_caffe2/runTest.sh
+++ b/tests/nnstreamer_filter_caffe2/runTest.sh
@@ -13,8 +13,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_filter_custom/runTest.sh
+++ b/tests/nnstreamer_filter_custom/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_filter_deepview_rt/runTest.sh
+++ b/tests/nnstreamer_filter_deepview_rt/runTest.sh
@@ -11,8 +11,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_filter_lua/runTest.sh
+++ b/tests/nnstreamer_filter_lua/runTest.sh
@@ -13,8 +13,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_filter_python3/runTest.sh
+++ b/tests/nnstreamer_filter_python3/runTest.sh
@@ -13,8 +13,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_filter_pytorch/runTest.sh
+++ b/tests/nnstreamer_filter_pytorch/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_filter_reload/runTest.sh
+++ b/tests/nnstreamer_filter_reload/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 if [ -z ${SO_EXT} ]; then

--- a/tests/nnstreamer_filter_tensorflow/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow/runTest.sh
@@ -13,8 +13,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 if [ -z ${SO_EXT} ]; then

--- a/tests/nnstreamer_filter_tensorflow2_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow2_lite/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_filter_tensorrt/runTest.sh
+++ b/tests/nnstreamer_filter_tensorrt/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_merge/runTest.sh
+++ b/tests/nnstreamer_merge/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_mux/runTest.sh
+++ b/tests/nnstreamer_mux/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_query/runTest.sh
+++ b/tests/nnstreamer_query/runTest.sh
@@ -11,8 +11,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_rate/runTest.sh
+++ b/tests/nnstreamer_rate/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_repo/runTest.sh
+++ b/tests/nnstreamer_repo/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_repo_dynamicity/runTest.sh
+++ b/tests/nnstreamer_repo_dynamicity/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_repo_lstm/runTest.sh
+++ b/tests/nnstreamer_repo_lstm/runTest.sh
@@ -28,8 +28,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 testInit $1 # You may replace this with Test Group Name
 

--- a/tests/nnstreamer_repo_rnn/runTest.sh
+++ b/tests/nnstreamer_repo_rnn/runTest.sh
@@ -13,8 +13,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 testInit $1 # You may replace this with Test Group Name
 

--- a/tests/nnstreamer_sparse/runTest.sh
+++ b/tests/nnstreamer_sparse/runTest.sh
@@ -13,8 +13,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/nnstreamer_split/runTest.sh
+++ b/tests/nnstreamer_split/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/transform_arithmetic/runTest.sh
+++ b/tests/transform_arithmetic/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/transform_clamp/runTest.sh
+++ b/tests/transform_clamp/runTest.sh
@@ -13,8 +13,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/transform_dimchg/runTest.sh
+++ b/tests/transform_dimchg/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/transform_stand/runTest.sh
+++ b/tests/transform_stand/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/transform_transpose/runTest.sh
+++ b/tests/transform_transpose/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)

--- a/tests/transform_typecast/runTest.sh
+++ b/tests/transform_typecast/runTest.sh
@@ -12,8 +12,7 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
     INDEPENDENT=1
     search="ssat-api.sh"
     source $search
-    printf "${Blue}Independent Mode${NC}
-"
+    printf "${Blue}Independent Mode${NC}"
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)


### PR DESCRIPTION
This patch removes unnecessary line feed in the middle of the string from the runTest.sh files.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
