### PR TITLE
[LTS/2.0.y] Push cherry-picked commits for enabling gRPC sub plugins of 2.0.y 

### DIFF
--- a/ext/nnstreamer/extra/meson.build
+++ b/ext/nnstreamer/extra/meson.build
@@ -30,6 +30,7 @@ endif
 if grpc_support_is_available
   grpc_common_src = ['nnstreamer_grpc_common.cc']
   grpc_util_sources = []
+  ignore_unused_param_auto_generated_files = declare_dependency(compile_args: ['-Wno-unused-parameter'])
 
   foreach s : grpc_common_src
     grpc_util_sources += join_paths(meson.current_source_dir(), s)
@@ -37,7 +38,7 @@ if grpc_support_is_available
 
   grpc_util_dep = declare_dependency(
     sources: grpc_util_sources,
-    dependencies: [nnstreamer_dep, glib_dep, gst_dep, libdl_dep, grpc_support_deps],
+    dependencies: [nnstreamer_dep, glib_dep, gst_dep, libdl_dep, grpc_support_deps, ignore_unused_param_auto_generated_files],
     include_directories: include_directories('.')
   )
 
@@ -51,7 +52,7 @@ if grpc_support_is_available
     # Don't generate proto files twice
     nns_protobuf_grpc_lib = shared_library ('nnstreamer_grpc_protobuf',
       sources : [grpc_pb_gen_src, nns_protobuf_grpc_sources],
-      dependencies : [grpc_util_dep, nns_protobuf_dep],
+      dependencies : [grpc_util_dep, nns_protobuf_dep, ignore_unused_param_auto_generated_files],
       install: true,
       install_dir: nnstreamer_libdir
     )
@@ -68,7 +69,7 @@ if grpc_support_is_available
 
     nns_flatbuf_grpc_lib = shared_library ('nnstreamer_grpc_flatbuf',
       sources : [grpc_fb_gen_src, nns_flatbuf_grpc_sources],
-      dependencies : [grpc_util_dep, flatbuf_dep],
+      dependencies : [grpc_util_dep, flatbuf_dep, ignore_unused_param_auto_generated_files],
       install: true,
       install_dir: nnstreamer_libdir
     )

--- a/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
@@ -32,6 +32,7 @@
 #include <gst/gst.h>
 #include <mvnc2/mvnc.h>
 #include <nnstreamer_log.h>
+#include <nnstreamer_util.h>
 #define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
 #undef NO_ANONYMOUS_NESTED_STRUCT
@@ -84,6 +85,7 @@ static void
 _mvncsdk2_close (const GstTensorFilterProperties * prop, void **private_data)
 {
   mvncsdk2_data *pdata = *private_data;
+  UNUSED (prop);
 
   if (pdata != NULL) {
     ncGraphDestroy (&(pdata->handle_graph));
@@ -367,6 +369,7 @@ _mvncsdk2_getInputDim (const GstTensorFilterProperties * prop,
   mvncsdk2_data *pdata = *private_data;
   struct ncTensorDescriptor_t *nc_input_desc = &(pdata->tensor_desc_input);
   GstTensorInfo *nns_input_tensor_info;
+  UNUSED (prop);
 
   /** MVNCSDK only supports one tensor at a time */
   info->num_tensors = NNS_MVNCSDK2_MAX_NUM_TENOSORS_SUPPORTED;
@@ -400,6 +403,7 @@ _mvncsdk2_getOutputDim (const GstTensorFilterProperties * prop,
   mvncsdk2_data *pdata = *private_data;
   struct ncTensorDescriptor_t *nc_output_desc = &(pdata->tensor_desc_output);
   GstTensorInfo *nns_output_info;
+  UNUSED (prop);
 
   /** MVNCSDK only supports one tensor at a time */
   info->num_tensors = NNS_MVNCSDK2_MAX_NUM_TENOSORS_SUPPORTED;

--- a/tests/bmp2png.c
+++ b/tests/bmp2png.c
@@ -101,14 +101,6 @@ save_png_to_file (bitmap_t * bitmap, const char *path)
   int depth = 8;
   int color_type;
 
-  if (bitmap->color_format == GRAY8) {
-    pixel_size = 1;
-    color_type = PNG_COLOR_TYPE_GRAY;
-  } else {
-    pixel_size = 3;
-    color_type = PNG_COLOR_TYPE_RGB;
-  }
-
   fp = fopen (path, "wb");
   if (!fp) {
     goto fopen_failed;
@@ -132,6 +124,13 @@ save_png_to_file (bitmap_t * bitmap, const char *path)
   }
 
   /** Set image attributes. */
+  if (bitmap->color_format == GRAY8) {
+    pixel_size = 1;
+    color_type = PNG_COLOR_TYPE_GRAY;
+  } else {
+    pixel_size = 3;
+    color_type = PNG_COLOR_TYPE_RGB;
+  }
 
   png_set_IHDR (png_ptr,
       info_ptr,

--- a/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.cc
+++ b/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.cc
@@ -11,6 +11,7 @@
  */
 
 #include "NCSDKTensorFilterTestHelper.hh"
+#include <nnstreamer_util.h>
 
 /* Static member variables for instance management */
 std::unique_ptr<NCSDKTensorFilterTestHelper> NCSDKTensorFilterTestHelper::mInstance;
@@ -143,7 +144,7 @@ NCSDKTensorFilterTestHelper::setFailStage (const fail_stage_t stage)
 /**
  * @brief Get the stage where the NCSDK fails
  */
-const fail_stage_t
+fail_stage_t
 NCSDKTensorFilterTestHelper::getFailStage ()
 {
   return this->mFailStage;
@@ -307,6 +308,7 @@ ncStatus_t
 NCSDKTensorFilterTestHelper::ncGraphGetOption (struct ncGraphHandle_t *graphHandle,
     int option, void *data, unsigned int *dataLength)
 {
+  UNUSED (graphHandle);
   switch (option) {
   case NC_RO_GRAPH_INPUT_TENSOR_DESCRIPTORS:
     if (this->mFailStage == fail_stage_t::FAIL_GRAPH_GET_INPUT_TENSOR_DESC) {
@@ -343,6 +345,11 @@ NCSDKTensorFilterTestHelper::ncGraphQueueInference (struct ncGraphHandle_t *grap
     struct ncFifoHandle_t **fifoIn, unsigned int inFifoCount,
     struct ncFifoHandle_t **fifoOut, unsigned int outFifoCount)
 {
+  UNUSED (graphHandle);
+  UNUSED (fifoIn);
+  UNUSED (inFifoCount);
+  UNUSED (fifoOut);
+  UNUSED (outFifoCount);
   if (this->mFailStage == fail_stage_t::FAIL_GRAPH_Q_INFER) {
     return NC_ERROR;
   }
@@ -381,6 +388,8 @@ ncStatus_t
 NCSDKTensorFilterTestHelper::ncFifoCreate (
     const char *name, ncFifoType_t type, struct ncFifoHandle_t **fifoHandle)
 {
+  UNUSED (type);
+  UNUSED (fifoHandle);
   if ((this->mFailStage == fail_stage_t::FAIL_FIFO_CREATE_INPUT)
       && !g_strcmp0 (name, NNS_MVNCSDK2_NAME_INPUT_FIFO)) {
     return NC_ERROR;
@@ -400,6 +409,9 @@ NCSDKTensorFilterTestHelper::ncFifoAllocate (struct ncFifoHandle_t *fifoHandle,
     struct ncDeviceHandle_t *device, struct ncTensorDescriptor_t *tensorDesc,
     unsigned int numElem)
 {
+  UNUSED (fifoHandle);
+  UNUSED (device);
+  UNUSED (numElem);
   if ((this->mFailStage == fail_stage_t::FAIL_FIFO_ALLOC_INPUT)
       && (compareTensorDesc (*tensorDesc, *(this->mTensorDescInput)))) {
     return NC_ERROR;
@@ -418,6 +430,10 @@ ncStatus_t
 NCSDKTensorFilterTestHelper::ncFifoSetOption (struct ncFifoHandle_t *fifoHandle,
     int option, const void *data, unsigned int dataLength)
 {
+  UNUSED (fifoHandle);
+  UNUSED (option);
+  UNUSED (data);
+  UNUSED (dataLength);
   return NC_OK;
 }
 
@@ -428,6 +444,10 @@ ncStatus_t
 NCSDKTensorFilterTestHelper::ncFifoGetOption (struct ncFifoHandle_t *fifoHandle,
     int option, void *data, unsigned int *dataLength)
 {
+  UNUSED (fifoHandle);
+  UNUSED (option);
+  UNUSED (data);
+  UNUSED (dataLength);
   return NC_OK;
 }
 
@@ -437,6 +457,7 @@ NCSDKTensorFilterTestHelper::ncFifoGetOption (struct ncFifoHandle_t *fifoHandle,
 ncStatus_t
 NCSDKTensorFilterTestHelper::ncFifoDestroy (struct ncFifoHandle_t **fifoHandle)
 {
+  UNUSED (fifoHandle);
   return NC_OK;
 }
 
@@ -447,6 +468,10 @@ ncStatus_t
 NCSDKTensorFilterTestHelper::ncFifoWriteElem (struct ncFifoHandle_t *fifoHandle,
     const void *inputTensor, unsigned int *inputTensorLength, void *userParam)
 {
+  UNUSED (fifoHandle);
+  UNUSED (inputTensor);
+  UNUSED (inputTensorLength);
+  UNUSED (userParam);
   if (this->mFailStage == fail_stage_t::FAIL_FIFO_WRT_ELEM) {
     return NC_ERROR;
   }
@@ -461,6 +486,10 @@ ncStatus_t
 NCSDKTensorFilterTestHelper::ncFifoReadElem (struct ncFifoHandle_t *fifoHandle,
     void *outputData, unsigned int *outputDataLen, void **userParam)
 {
+  UNUSED (fifoHandle);
+  UNUSED (outputData);
+  UNUSED (outputDataLen);
+  UNUSED (userParam);
   if (this->mFailStage == fail_stage_t::FAIL_FIFO_RD_ELEM) {
     return NC_ERROR;
   }
@@ -474,6 +503,7 @@ NCSDKTensorFilterTestHelper::ncFifoReadElem (struct ncFifoHandle_t *fifoHandle,
 ncStatus_t
 NCSDKTensorFilterTestHelper::ncFifoRemoveElem (struct ncFifoHandle_t *fifoHandle)
 {
+  UNUSED (fifoHandle);
   if (this->mFailStage == fail_stage_t::FAIL_FIFO_RM_ELEM) {
     return NC_ERROR;
   }

--- a/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.hh
+++ b/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.hh
@@ -69,10 +69,15 @@ typedef enum _fail_stage_t {
 
 typedef uint32_t ncsdk_ver_t[NC_VERSION_MAX_SIZE];
 
+/**
+ * @brief A helper class for testing the NCSDK tensor filter.
+ */
 class NCSDKTensorFilterTestHelper
 {
 public:
-  /* Make this class as a singletone */
+  /**
+   * @brief Make this class as a singletone
+   */
   static NCSDKTensorFilterTestHelper &getInstance () {
     call_once (NCSDKTensorFilterTestHelper::mOnceFlag, []() {
       mInstance.reset(new NCSDKTensorFilterTestHelper);
@@ -84,7 +89,7 @@ public:
   void release ();
   /* Set/Get fail-stage */
   void setFailStage (const fail_stage_t stage);
-  const fail_stage_t getFailStage ();
+  fail_stage_t getFailStage ();
 
   /* Mock methods that simulate NCSDK2 APIs */
   /* Mock Global APIs */

--- a/tests/nnstreamer_filter_mvncsdk2/meson.build
+++ b/tests/nnstreamer_filter_mvncsdk2/meson.build
@@ -1,6 +1,6 @@
 unittest_mvncsdk_helper = shared_library('mvncsdk_test',
   ['NCSDKTensorFilterTestHelper.cc'],
-  dependencies : [glib_dep, gst_base_dep, gst_dep],
+  dependencies : [glib_dep, gst_base_dep, gst_dep, nnstreamer_unittest_deps],
   install: get_option('install-test'),
   install_dir: nnstreamer_libdir
 )

--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -34,7 +34,7 @@ fi
 if [[ -d $PATH_TO_PLUGIN ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer"
     if [[ -d ${ini_path} ]]; then
-        check=$(ls ${ini_path} | grep nnstreamer-grpc.so)
+        check=$(ls ${ini_path} | grep nnstreamer-grpc.${SO_EXT})
         if [[ ! $check ]]; then
             echo "Cannot find nnstreamer-grpc shared lib"
             report
@@ -52,12 +52,12 @@ TEST_FLATBUF=1
 if [[ -d $PATH_TO_PLUGIN_EXTRA ]]; then
   ini_path="${PATH_TO_PLUGIN_EXTRA}"
   if [[ -d ${ini_path} ]]; then
-    check=$(ls ${ini_path} | grep nnstreamer_grpc_protobuf.so)
+    check=$(ls ${ini_path} | grep nnstreamer_grpc_protobuf.${SO_EXT})
     if [[ ! $check ]]; then
       echo "Cannot find nnstreamer_grpc_protobuf shared lib"
       TEST_PROTOBUF=0
     fi
-    check=$(ls ${ini_path} | grep nnstreamer_grpc_flatbuf.so)
+    check=$(ls ${ini_path} | grep nnstreamer_grpc_flatbuf.${SO_EXT})
     if [[ ! $check ]]; then
       echo "Cannot find nnstreamer_grpc_flatbuf shared lib"
       TEST_FLATBUF=0

--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -27,6 +27,10 @@ fi
 
 # Check gRPC availability
 PATH_TO_PLUGIN=${NNSTREAMER_BUILD_ROOT_PATH}
+if [[ -z $PATH_TO_PLUGIN ]]; then
+  PATH_TO_PLUGIN="../../build"
+fi
+
 if [[ -d $PATH_TO_PLUGIN ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer"
     if [[ -d ${ini_path} ]]; then


### PR DESCRIPTION
In order to enable gRPC sub-plugins of 2.0.y LTS on macOS, this PR includes the following commits cherry-picked from the main branch.
- [[gRPC/Common] Modify hard-coded strings indicating sub-plugins' names](https://github.com/nnstreamer/nnstreamer/commit/9f3cfa20f4af04fd975e89147f94fec7d94b514c)
- [[Tests/gRPC] Prepare a fallback value for PATH_TO_PLUGIN](https://github.com/nnstreamer/nnstreamer/commit/7c1063d87e4746373ddbe0a10565fe2e5fa32ab5)
- [[tests/gRPC] Change the hard-coded shared object's extension](https://github.com/nnstreamer/nnstreamer/commit/0451effca767585fab2511caaea400c0a013b35a)
- [Fix build error - unused param, sign comapre](https://github.com/nnstreamer/nnstreamer/commit/a1924848100c42a91c6d0df8c88d23e1a64e0f60)

This might be the last PR for macOS support of 2.0.y LTS.

Signed-off-by: Wook Song [wook16.song@samsung.com](mailto:wook16.song@samsung.com)

Self evaluation:

Build test: [*]Passed [ ]Failed [ ]Skipped
Run test: [*]Passed [ ]Failed [ ]Skipped