### PR TITLE
[Gst/MQTT/Sink] fix: Remove duplicated g_free for the message buffer

### DIFF
--- a/gst/mqtt/mqttsink.c
+++ b/gst/mqtt/mqttsink.c
@@ -470,7 +470,6 @@ gst_mqtt_sink_class_finalize (GObject * object)
   g_free (self->mqtt_topic);
   self->mqtt_topic = NULL;
   gst_caps_replace (&self->in_caps, NULL);
-  g_free (self->mqtt_msg_buf);
   g_free (self->mqtt_ntp_srvs);
   self->mqtt_ntp_srvs = NULL;
   self->mqtt_ntp_num_srvs = 0;


### PR DESCRIPTION
This patch remove duplicated g_free for the message buffer(self->mqtt_msg_buf).

Signed-off-by: Yechan Choi <yechan9.choi@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped