### PR TITLE
[TEST] Enable query test on ubuntu @open sesame 07/25 13:52

### DIFF
--- a/tests/nnstreamer_query/runTest.sh
+++ b/tests/nnstreamer_query/runTest.sh
@@ -17,17 +17,6 @@ fi
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)
 testInit $1
 
-# Skip query test temporarily because of ppa build failure.
-# Related issue: https://github.com/nnstreamer/nnstreamer/issues/3657
-if [ -f /etc/os-release ]; then
-    ID=$(cat /etc/os-release | grep ^ID= | cut -d '=' -f 2)
-    if [ "$ID" = "ubuntu" ]; then
-      echo "Skip query test for ppa build"
-      report
-      exit
-    fi
-fi
-
 PATH_TO_PLUGIN="../../build"
 PERFORMANCE=0
 # The client has to wait enough time for the server to be ready.


### PR DESCRIPTION
Let's enable query test on ubuntu.
It seems that the problem that the test sometimes failed has now been solved.

* Passed test more than 10 times on CI server.

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


