### PR TITLE
query: fix null pointer access

### DIFF
--- a/gst/nnstreamer/tensor_query/nnstreamer_edge_internal.c
+++ b/gst/nnstreamer/tensor_query/nnstreamer_edge_internal.c
@@ -1040,7 +1040,7 @@ nns_edge_start (nns_edge_h edge_h, bool is_server)
         goto error;
       }
 
-      /* @todo Set unique device name.
+      /** @todo Set unique device name.
        * Device name should be unique. Consider using MAC address later.
        * Now, use ID received from the user.
        */
@@ -1331,7 +1331,7 @@ nns_edge_publish (nns_edge_h edge_h, nns_edge_data_h data_h)
     return NNS_EDGE_ERROR_INVALID_PARAMETER;
   }
 
-  /* @todo update code (publish data) */
+  /** @todo update code (publish data) */
 
   nns_edge_unlock (eh);
   return NNS_EDGE_ERROR_NONE;
@@ -1517,7 +1517,7 @@ nns_edge_set_info (nns_edge_h edge_h, const char *key, const char *value)
     return NNS_EDGE_ERROR_INVALID_PARAMETER;
   }
 
-  /*
+  /**
    * @todo User handles (replace or append) the capability of edge handle.
    * @todo Change key-value set as json or hash table.
    */
@@ -1574,7 +1574,7 @@ nns_edge_get_info (nns_edge_h edge_h, const char *key, char **value)
     return NNS_EDGE_ERROR_INVALID_PARAMETER;
   }
 
-  /*
+  /**
    * @todo User handles (replace or append) the capability of edge handle.
    * @todo Change key-value set as json or hash table.
    */

--- a/gst/nnstreamer/tensor_query/nnstreamer_edge_internal.c
+++ b/gst/nnstreamer/tensor_query/nnstreamer_edge_internal.c
@@ -988,7 +988,9 @@ _get_ip_address (void)
     }
     addrs = addrs->ifa_next;
   }
-  while ((addrs = addrs->ifa_next));
+
+  if (addrs)
+    while ((addrs = addrs->ifa_next));
 
   freeifaddrs (addrs);
 


### PR DESCRIPTION
After the while loop, addrs may be a nullptr.
This causes a segmentation fault found with pdebuild/ubuntu 22.04.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

CC: @gichan-jang @jaeyun-jung 
