### PR TITLE
Fix last Ubuntu 22.04 test case issues @open sesame 8/3 08:53

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -43,7 +43,7 @@ override_dh_auto_configure:
 	mkdir -p ${BUILDDIR}
 ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo yes), yes)
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
-	-Denable-edgetpu=true -Denable-openvino=true -Dgrpc-support=disabled \
+	-Denable-edgetpu=true -Denable-openvino=true -Dgrpc-support=disabled -Dmqtt-support=enabled \
 	-Denable-tizen=false -Denable-test=true -Dinstall-test=true -Dsubplugindir=/usr/lib/nnstreamer $(FLOAT16) ${BUILDDIR}
 else
 	# Debian has less packages ready.


### PR DESCRIPTION
The following two commits are included:

commit 605ba3bdbee75528f917dc40267186ccbb5f89d8 (HEAD -> fix/python310)
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Tue Aug 2 14:49:29 2022 +0900

    join/test-case: remove undeterminism.
    
    Because of the undeterministic nature of parallel streams,
    the unittest case results sometime vary.
    Specify the synchronization policy so that the results
    become deterministic.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 7f952430cba64ca4ccbd5a82af11b85debccc31f
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Tue Aug 2 13:49:23 2022 +0900

    python: fix python 3.10 PyObject type errors.
    
    From Python 3.10 python->C/C++ object transfer
    has stricter type checks. Floats are no more
    supported by PyLong.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
