### PR TITLE
[transform] fix transform transpose rank to 4 @open sesame 09/08 15:56

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -344,7 +344,10 @@ float16_not_supported (void)
 #endif
 
 #ifdef FLOAT16_SUPPORT
-/** @todo Remove this after applying SIMD or ORC */
+/**
+ * @brief Refrain from heavy operations on float16
+ * @todo Remove this after applying SIMD or ORC
+ * */
 static void
 refrain_from_heavy_op_on_float16 (gulong n)
 {


### PR DESCRIPTION
This patch fixes transform transpose rank to 3.
Increasing NNS_TENSOR_RANK_LIMIT will affect transform transpose.
It should be fixed to 3 until transform transpose supports rank N.

Signed-off-by: Yelin Jeong <yelini.jeong@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped


