### PR TITLE
tensor-decoder: add ssd_mobilenet v3 support

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -114,7 +114,7 @@ void fini_bb (void) __attribute__ ((destructor));
 extern uint8_t rasters[][13];
 
 #define BOX_SIZE                                (4)
-#define MOBILENET_SSD_DETECTION_MAX             (1917)
+#define MOBILENET_SSD_DETECTION_MAX             (2034) /* add ssd_mobilenet v3 support */
 #define MOBILENET_SSD_MAX_TENSORS               (2U)
 #define MOBILENET_SSD_PP_DETECTION_MAX          (100)
 #define MOBILENET_SSD_PP_MAX_TENSORS            (4U)


### PR DESCRIPTION
ssd_mobilenet v3 models handle 2034 anchor boxes 
while previous models v2 and v1 handles only 1917 boxes
thus updating the MAX value to 2034 adds support for v3 models
this update is needed for models without post-processing layer.

Signed-off-by: Aymen Sghaier <aymen.sghaier@nxp.com>


