### PR TITLE
proto/flat/flex buffers: reorganize common data structure. @open sesame 08/11 20:51

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_flatbuf.h
+++ b/ext/nnstreamer/extra/nnstreamer_flatbuf.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+
+* @file        nnstreamer_flatbuf.h
+* @date        11 Aug 2022
+* @brief       Common contents for NNStreamer flatbuf-related subplugins.
+* @see         https://github.com/nnstreamer/nnstreamer
+* @author      MyungJoo Ham <myungjoo.ham@samsung.com>
+* @bug         No known bugs except for NYI items
+*
+*/
+#ifndef __NNSTREAMER_FLATBUF_H__
+#define __NNSTREAMER_FLATBUF_H__
+
+namespace nnstreamer
+{
+namespace flatbuf
+{
+
+/**
+ * @brief Default static capability for flatbuffers
+ * Flatbuf converter will convert this capability to other/tensor(s)
+ * @todo Move this definition to proper header file
+ */
+#define GST_FLATBUF_TENSOR_CAP_DEFAULT \
+    "other/flatbuf-tensor, " \
+    "framerate = " GST_TENSOR_RATE_RANGE
+
+}; /* Namespace flatbuf */
+}; /* Namespace nnstreamer */
+
+/**
+ * @brief Default static capability for flexbuffers
+ */
+#define GST_FLEXBUF_CAP_DEFAULT "other/flexbuf"
+
+#endif /* __NNSTREAMER_FLATBUF_H__ */

--- a/ext/nnstreamer/extra/nnstreamer_protobuf.h
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.h
@@ -20,6 +20,14 @@
 #include <nnstreamer_plugin_api.h>
 
 /**
+ * @brief Default static capability for Protocol Buffers
+ * protobuf converter will convert this capability to other/tensor(s)
+ */
+#define GST_PROTOBUF_TENSOR_CAP_DEFAULT \
+    "other/protobuf-tensor, " \
+    "framerate = " GST_TENSOR_RATE_RANGE
+
+/**
  * @brief tensordec-plugin's GstTensorDecoderDef callback
  * @param[in] config The structure of input tensor info.
  * @param[in] input The array of input tensor data. The maximum array size of input data is NNS_TENSOR_SIZE_LIMIT.

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
@@ -36,6 +36,7 @@
 #include <nnstreamer_util.h>
 #include <typeinfo>
 #include "tensor_converter_util.h"
+#include "../extra/nnstreamer_flatbuf.h"
 
 namespace nnstreamer
 {

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
@@ -62,6 +62,7 @@
 #include <nnstreamer_plugin_api_converter.h>
 #include <nnstreamer_util.h>
 #include <flatbuffers/flexbuffers.h>
+#include "../extra/nnstreamer_flatbuf.h"
 #include "tensor_converter_util.h"
 
 #ifdef __cplusplus

--- a/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
@@ -25,6 +25,7 @@
 #include <nnstreamer_util.h>
 #include <typeinfo>
 #include "tensordecutil.h"
+#include "../extra/nnstreamer_flatbuf.h"
 
 namespace nnstreamer
 {

--- a/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
@@ -62,6 +62,7 @@
 #include <nnstreamer_plugin_api.h>
 #include <nnstreamer_plugin_api_decoder.h>
 #include <nnstreamer_util.h>
+#include "../extra/nnstreamer_flatbuf.h"
 #include "tensordecutil.h"
 
 #ifdef __cplusplus

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -126,28 +126,6 @@
     GST_TENSORS_CAP_MAKE ("sparse")
 
 /**
- * @brief Default static capability for Protocol Buffers
- * protobuf converter will convert this capability to other/tensor(s)
- */
-#define GST_PROTOBUF_TENSOR_CAP_DEFAULT \
-    "other/protobuf-tensor, " \
-    "framerate = " GST_TENSOR_RATE_RANGE
-
-/**
- * @brief Default static capability for flatbuffers
- * Flatbuf converter will convert this capability to other/tensor(s)
- * @todo Move this definition to proper header file
- */
-#define GST_FLATBUF_TENSOR_CAP_DEFAULT \
-    "other/flatbuf-tensor, " \
-    "framerate = " GST_TENSOR_RATE_RANGE
-
-/**
- * @brief Default static capability for flexbuffers
- */
-#define GST_FLEXBUF_CAP_DEFAULT "other/flexbuf"
-
-/**
  * @brief Possible data element types of other/tensor.
  */
 typedef enum _nns_tensor_type


### PR DESCRIPTION
Do not have common data structures of ext modules in the
global-common directory. Put them in the ext modules
to avoid convoluted dependency.

Fixes #3837

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

