### PR TITLE
decoder/converter::python make them thread safe. @open sesame 8/18 10:00

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_python3_helper.cc
+++ b/ext/nnstreamer/extra/nnstreamer_python3_helper.cc
@@ -562,6 +562,7 @@ void _refcnt_py_initalize()
   if (!ref_counter) {
     fprintf(stderr, "\n\nPY INIT\n\n\n");
     Py_Initialize();
+    PyEval_InitThreads_IfGood ();
   }
   ref_counter++;
 }

--- a/ext/nnstreamer/extra/nnstreamer_python3_helper.h
+++ b/ext/nnstreamer/extra/nnstreamer_python3_helper.h
@@ -61,6 +61,12 @@ extern "C" {
 #define Py_LOCK() PyGILState_Ensure()
 #define Py_UNLOCK(gstate) PyGILState_Release(gstate)
 
+#define _Py_BEGIN_THREAD_CONTROL \
+  PyEval_RestoreThread (ptst);
+
+#define _Py_END_THREAD_CONTROL \
+  ptst = PyEval_SaveThread ();
+
 extern tensor_type getTensorType (NPY_TYPES npyType);
 extern NPY_TYPES getNumpyType (tensor_type tType);
 extern int loadScript (PyObject **core_obj, const gchar *module_name, const gchar *class_name);
@@ -71,6 +77,9 @@ extern PyObject * PyTensorShape_New (PyObject * shape_cls, const GstTensorInfo *
 
 extern void _refcnt_py_initalize();
 extern void _refcnt_py_finalize();
+
+extern PyGILState_STATE _py_start ();
+extern void _py_end (PyGILState_STATE state);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/ext/nnstreamer/extra/nnstreamer_python3_helper.h
+++ b/ext/nnstreamer/extra/nnstreamer_python3_helper.h
@@ -58,6 +58,8 @@ extern "C" {
 #else
 #define PyEval_InitThreads_IfGood()     do { PyEval_InitThreads(); } while (0)
 #endif
+#define Py_LOCK() PyGILState_Ensure()
+#define Py_UNLOCK(gstate) PyGILState_Release(gstate)
 
 extern tensor_type getTensorType (NPY_TYPES npyType);
 extern NPY_TYPES getNumpyType (tensor_type tType);
@@ -66,6 +68,9 @@ extern int openPythonLib (void **handle);
 extern int addToSysPath (const gchar *path);
 extern int parseTensorsInfo (PyObject *result, GstTensorsInfo *info);
 extern PyObject * PyTensorShape_New (PyObject * shape_cls, const GstTensorInfo *info);
+
+extern void _refcnt_py_initalize();
+extern void _refcnt_py_finalize();
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/ext/nnstreamer/tensor_converter/tensor_converter_python3.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_python3.cc
@@ -117,11 +117,14 @@ PYConverterCore::convert (GstBuffer *in_buf, GstTensorsConfig *config)
   guint i, num;
   gsize mem_size;
   gpointer mem_data;
+  //PyThreadState *st;
 
   if (nullptr == in_buf)
     throw std::invalid_argument ("Null pointers are given to PYConverterCore::convert().\n");
   num = gst_tensor_buffer_get_count (in_buf);
   tensors_info = output = pyValue = param = nullptr;
+
+  fprintf(stderr, "%s:%d\n", __FILE__, __LINE__);
 
   PyGILState_STATE gstate = Py_LOCK ();
   param = PyList_New (num);
@@ -147,7 +150,9 @@ PYConverterCore::convert (GstBuffer *in_buf, GstTensorsConfig *config)
     goto done;
   }
 
+  //st = PyEval_SaveThread ();
   pyValue = PyObject_CallMethod (core_obj, "convert", "(O)", param);
+  //PyEval_RestoreThread (st);
 
   if (!PyArg_ParseTuple (pyValue, "OOii", &tensors_info, &output, &rate_n, &rate_d)) {
     Py_ERRMSG ("Failed to parse converting result");
@@ -368,8 +373,6 @@ init_converter_py (void)
 {
   /** Python should be initialized and finalized only once */
   _refcnt_py_initalize ();
-
-  PyEval_InitThreads_IfGood();
 
   registerExternalConverter (&Python);
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-python3.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-python3.cc
@@ -123,6 +123,8 @@ PYDecoderCore::decode (const GstTensorsConfig *config,
   GstFlowReturn ret = GST_FLOW_OK;
 
   PyGILState_STATE gstate = Py_LOCK ();
+  //PyThreadState *st;
+
   raw_data = PyList_New (config->info.num_tensors);
   in_info = PyList_New (config->info.num_tensors);
   rate_n = config->rate_n;
@@ -146,7 +148,9 @@ PYDecoderCore::decode (const GstTensorsConfig *config,
     goto done;
   }
 
+  //st = PyEval_SaveThread ();
   output = PyObject_CallMethod (core_obj, "decode", "OOii", raw_data, in_info, rate_n, rate_d);
+  //PyEval_RestoreThread (st);
 
   if (output) {
     need_alloc = (gst_buffer_get_size (outbuf) == 0);
@@ -199,6 +203,8 @@ PYDecoderCore::getOutCaps (const GstTensorsConfig *config)
   UNUSED (config);
 
   PyGILState_STATE gstate = Py_LOCK ();
+  //PyThreadState *st;
+
   if (!PyObject_HasAttrString (core_obj, (char *) "getOutCaps")) {
     ml_loge ("Cannot find 'getOutCaps'");
     ml_loge ("defualt caps is `application/octet-stream`");
@@ -206,7 +212,10 @@ PYDecoderCore::getOutCaps (const GstTensorsConfig *config)
     goto done;
   }
 
+  //st = PyEval_SaveThread ();
   result = PyObject_CallMethod (core_obj, (char *) "getOutCaps", NULL);
+  //PyEval_RestoreThread (st);
+
   if (result) {
     gchar *caps_str = PyBytes_AsString (result);
     caps = gst_caps_from_string (caps_str);
@@ -371,8 +380,6 @@ init_decoder_py (void)
 {
   /** Python should be initialized and finalized only once */
   _refcnt_py_initalize ();
-
-  PyEval_InitThreads_IfGood();
 
   nnstreamer_decoder_probe (&Python);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python3.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python3.cc
@@ -398,7 +398,9 @@ PYCore::getInputTensorDim (GstTensorsInfo *info)
 
   PyGILState_STATE gstate = Py_LOCK ();
 
+  //PyThreadState *st = PyEval_SaveThread ();
   PyObject *result = PyObject_CallMethod (core_obj, (char *) "getInputDim", NULL);
+  //PyEval_RestoreThread (st);
   if (result) {
     res = parseTensorsInfo (result, info);
     Py_SAFEDECREF (result);
@@ -428,7 +430,9 @@ PYCore::getOutputTensorDim (GstTensorsInfo *info)
 
   PyGILState_STATE gstate = Py_LOCK ();
 
+  //PyThreadState *st = PyEval_SaveThread ();
   PyObject *result = PyObject_CallMethod (core_obj, (char *) "getOutputDim", NULL);
+  //PyEval_RestoreThread (st);
   if (result) {
     res = parseTensorsInfo (result, info);
     Py_SAFEDECREF (result);
@@ -476,8 +480,10 @@ PYCore::setInputTensorDim (const GstTensorsInfo *in_info, GstTensorsInfo *out_in
     PyList_SetItem (param, i, shape);
   }
 
+  //PyThreadState *st = PyEval_SaveThread ();
   PyObject *result
       = PyObject_CallMethod (core_obj, (char *) "setInputDim", (char *) "(O)", param);
+  //PyEval_RestoreThread (st);
 
   Py_SAFEDECREF (param);
 
@@ -555,8 +561,9 @@ PYCore::run (const GstTensorMemory *input, GstTensorMemory *output)
     PyList_SetItem (param, i, input_array);
   }
 
-
+  //PyThreadState *st = PyEval_SaveThread ();
   result = PyObject_CallMethod (core_obj, (char *) "invoke", (char *) "(O)", param);
+  //PyEval_RestoreThread (st);
 
   if (result) {
     if ((unsigned int) PyList_Size (result) != outputTensorMeta.num_tensors) {
@@ -839,8 +846,6 @@ init_filter_py (void)
 {
   /** Python should be initialized and finalized only once */
   _refcnt_py_initalize ();
-
-  PyEval_InitThreads_IfGood ();
 
   nnstreamer_filter_probe (&NNS_support_python);
   nnstreamer_filter_set_custom_property_desc (filter_subplugin_python, "${GENERAL_STRING}",


### PR DESCRIPTION
Use GIL instead of mutex. Refer to #3832.

Fixes #3834

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
