### PR TITLE
[Query] fix res leak case @open sesame 08/11 21:26

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_common.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.c
@@ -24,7 +24,7 @@
 #endif
 
 /**
- * @brief register GEnumValue array for query protocol property handling
+ * @brief Register GEnumValue array for query connect-type property.
  */
 GType
 gst_tensor_query_get_connect_type (void)

--- a/gst/nnstreamer/tensor_query/tensor_query_common.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.h
@@ -30,13 +30,12 @@ extern "C" {
 /**
  * @brief protocol options for tensor query.
  */
-
 #define DEFAULT_HOST "localhost"
 #define DEFAULT_CONNECT_TYPE (NNS_EDGE_CONNECT_TYPE_TCP)
 #define GST_TYPE_QUERY_CONNECT_TYPE (gst_tensor_query_get_connect_type ())
 
 /**
- * @brief register GEnumValue array for query protocol property handling
+ * @brief Register GEnumValue array for query connect-type property.
  */
 GType
 gst_tensor_query_get_connect_type (void);

--- a/gst/nnstreamer/tensor_query/tensor_query_server.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.h
@@ -41,13 +41,13 @@ typedef struct
  * @brief Get nnstreamer edge server handle.
  */
 edge_server_handle
-gst_tensor_query_server_get_handle (char *id);
+gst_tensor_query_server_get_handle (const char *id);
 
 /**
  * @brief Add GstTensorQueryServer.
  */
 edge_server_handle
-gst_tensor_query_server_add_data (char *id, nns_edge_connect_type_e connect_type);
+gst_tensor_query_server_add_data (const char *id, nns_edge_connect_type_e connect_type);
 
 /**
  * @brief Remove GstTensorQueryServer.


### PR DESCRIPTION
Fix res leak in query elements.
Add destroy-cb function in query-server table to prevent mem leak.
Prevent duplicated creation of edge-handle in event callback.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
