### PR TITLE
filter:pytorch allow gcc only.

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -370,33 +370,37 @@ else # no tflite2
 endif
 
 if pytorch_support_is_available
-  filter_sub_torch_sources = ['tensor_filter_pytorch.cc']
+  if cxx.get_id() == 'gcc'
+    filter_sub_torch_sources = ['tensor_filter_pytorch.cc']
 
-  nnstreamer_filter_torch_sources = []
-  foreach s : filter_sub_torch_sources
-    nnstreamer_filter_torch_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
+    nnstreamer_filter_torch_sources = []
+    foreach s : filter_sub_torch_sources
+      nnstreamer_filter_torch_sources += join_paths(meson.current_source_dir(), s)
+    endforeach
 
-  nnstreamer_filter_torch_deps = pytorch_support_deps + [nnstreamer_single_dep]
+    nnstreamer_filter_torch_deps = pytorch_support_deps + [nnstreamer_single_dep]
 
-  # pytorch version
-  if pytorch_support_deps[0].version().version_compare('>=1.2.0')
-    nnstreamer_filter_torch_deps += declare_dependency(compile_args: ['-DPYTORCH_VER_ATLEAST_1_2_0=1'])
+    # pytorch version
+    if pytorch_support_deps[0].version().version_compare('>=1.2.0')
+      nnstreamer_filter_torch_deps += declare_dependency(compile_args: ['-DPYTORCH_VER_ATLEAST_1_2_0=1'])
+    endif
+
+    shared_library('nnstreamer_filter_pytorch',
+      nnstreamer_filter_torch_sources,
+      dependencies: nnstreamer_filter_torch_deps,
+      install: true,
+      install_dir: filter_subplugin_install_dir
+    )
+
+    static_library('nnstreamer_filter_pytorch',
+      nnstreamer_filter_torch_sources,
+      dependencies: nnstreamer_filter_torch_deps,
+      install: true,
+      install_dir: nnstreamer_libdir
+    )
+  else # Compilers is not gcc
+    warning('There are a few headers (Array.h and reverse_iterator.h) that require gcc for license issues. Disabling pytorch subplugin build')
   endif
-
-  shared_library('nnstreamer_filter_pytorch',
-    nnstreamer_filter_torch_sources,
-    dependencies: nnstreamer_filter_torch_deps,
-    install: true,
-    install_dir: filter_subplugin_install_dir
-  )
-
-  static_library('nnstreamer_filter_pytorch',
-    nnstreamer_filter_torch_sources,
-    dependencies: nnstreamer_filter_torch_deps,
-    install: true,
-    install_dir: nnstreamer_libdir
-  )
 endif
 
 if caffe2_support_is_available

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -36,6 +36,13 @@
 #include <nnstreamer_util.h>
 
 #include <torch/script.h>
+/**
+  * Array.h and reverse_iterator.h of PyTorch is GPL-3.0 w/ GCC runtime
+  * exception. Make sure that this is being compiled by GCC
+  */
+#ifndef __GNUC__
+#error There are PyTorch C++ headers (Array.h and reverser_iterator.h) having GPL3 with GCC runtime exception. To comply with its GCC runtime exception, we allow GCC only.
+#endif
 
 /**
  * @brief Macro for debug mode.

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -95,6 +95,7 @@ NNSTREAMER_FILTER_NNFW_SRCS := \
     $(NNSTREAMER_EXT_HOME)/tensor_filter/tensor_filter_nnfw.c
 
 # filter pytorch
+## NOTE: ndk does not support PYTORCH; it requires gcc.
 NNSTREAMER_FILTER_PYTORCH_SRCS := \
     $(NNSTREAMER_EXT_HOME)/tensor_filter/tensor_filter_pytorch.cc
 


### PR DESCRIPTION
Do not allow to build with other compilers.
Refer to #3873 and https://lfscanning.org/reports/lfai/nnstreamer-2022-07-02-8eb54f0b-f36e-43ff-826f-80e9f251e17e.html

This is to comply with GPL-3.0 GCC Runtime Exception License of a few headers in PyTorch.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

