### PR TITLE
test/query: revive pid retrieval

### DIFF
--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -99,6 +99,7 @@ for BLOCKING in "${BLOCKING_LIST[@]}"; do
 
   # tensor_sink (client) --> tensor_src (server), other/tensor
   gstTestBackground "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} idl=${IDL} blocking=${BLOCKING} ! other/tensor,dimension=3:640:480,type=uint8,framerate=5/1 ! multifilesink async=false location=result_%1d.log" ${INDEX}-1 0 0 ${TIMEOUT_SEC}
+  pid=$!
   gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} idl=${IDL} blocking=${BLOCKING}" ${INDEX}-2 0 0 $PERFORMANCE
   kill -9 $pid &> /dev/null
   wait $pid
@@ -114,6 +115,7 @@ for BLOCKING in "${BLOCKING_LIST[@]}"; do
   PORT=`python3 ../get_available_port.py`
   # tensor_sink (server) --> tensor_src (client), other/tensor
   gstTestBackground "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter ! tensor_sink_grpc port=${PORT} server=true idl=${IDL} blocking=${BLOCKING} async=false" ${INDEX}-1 0 0 ${TIMEOUT_SEC}
+  pid=$!
   gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=${NUM_BUFFERS} server=false idl=${IDL} blocking=${BLOCKING} ! other/tensor,dimension=3:640:480,type=uint8,framerate=5/1 ! multifilesink location=result_%1d.log" ${INDEX}-2 0 0 $PERFORMANCE
   kill -9 $pid &> /dev/null
   wait $pid
@@ -129,6 +131,7 @@ for BLOCKING in "${BLOCKING_LIST[@]}"; do
   PORT=`python3 ../get_available_port.py`
   # tensor_sink (client) --> tensor_src (server), other/tensors
   gstTestBackground "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) idl=${IDL} blocking=${BLOCKING} ! other/tensors,num_tensors=2,dimensions=3:640:480.3:640:480,types=uint8.uint8,framerate=5/1 ! multifilesink async=false location=result_%1d.log" ${INDEX}-1 0 0 ${TIMEOUT_SEC}
+  pid=$!
   gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} idl=${IDL} blocking=${BLOCKING}" ${INDEX}-2 0 0 $PERFORMANCE
   kill -9 $pid &> /dev/null
   wait $pid
@@ -144,6 +147,7 @@ for BLOCKING in "${BLOCKING_LIST[@]}"; do
   PORT=`python3 ../get_available_port.py`
   # tensor_sink (server) --> tensor_src (client), other/tensors
   gstTestBackground " --gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=${NUM_BUFFERS} ! video/x-raw,width=640,height=480,framerate=5/1 ! tensor_converter frames-per-tensor=2 ! tensor_sink_grpc port=${PORT} server=true idl=${IDL} blocking=${BLOCKING} async=false" ${INDEX}-1 0 0 ${TIMEOUT_SEC}
+  pid=$!
   gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_src_grpc port=${PORT} num-buffers=$((NUM_BUFFERS/2)) server=false idl=${IDL} blocking=${BLOCKING} ! other/tensors,num_tensors=2,dimensions=3:640:480.3:640:480,types=uint8.uint8,framerate=5/1 ! multifilesink location=result_%1d.log" ${INDEX}-2 0 0 $PERFORMANCE
   kill -9 $pid &> /dev/null
   wait $pid

--- a/tests/nnstreamer_query/runTest.sh
+++ b/tests/nnstreamer_query/runTest.sh
@@ -44,6 +44,7 @@ function _callCompareTest() {
 # Run tensor query server as echo server with default address option.
 PORT=`python3 ../get_available_port.py`
 gstTestBackground "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc port=${PORT} ! other/tensors,format=static,num_tensors=1,dimensions=(string)3:300:300:1,types=(string)uint8 ! tensor_query_serversink async=false" 1-1 0 0 30
+pid=$!
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc is-live=true num-buffers=10 ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! tee name = t t. ! queue ! multifilesink location= raw1_%1d.log t. ! queue ! tensor_query_client dest-port=${PORT} ! multifilesink location=result1_%1d.log sync=true " 1-2 0 0 $PERFORMANCE
 _callCompareTest raw1_0.log result1_0.log 1-3 "Compare 1-3" 1 0
 _callCompareTest raw1_1.log result1_1.log 1-4 "Compare 1-4" 1 0
@@ -55,6 +56,7 @@ wait $pid
 # Run tensor query server as echo server with given address option. (multi clients)
 PORT1=`python3 ../get_available_port.py`
 gstTestBackground "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc host=127.0.0.1 port=${PORT1} ! other/tensors,format=static,num_tensors=1,dimensions=(string)3:300:300:1,types=(string)uint8 ! tensor_query_serversink async=false" 2-1 0 0 30
+pid=$!
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc is-live=true num-buffers=10  ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! tee name = t t. ! queue ! multifilesink location= raw2_%1d.log t. ! queue ! tensor_query_client host=127.0.0.1 port=0 dest-host=127.0.0.1 dest-port=${PORT1} ! multifilesink location=result2_%1d.log" 2-2 0 0 $PERFORMANCE
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc is-live=true num-buffers=10  ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! tee name = t t. ! queue ! multifilesink location= raw2_2_%1d.log t. ! queue ! tensor_query_client host=127.0.0.1 port=0 dest-host=127.0.0.1 dest-port=${PORT1} ! multifilesink location=result2_2_%1d.log" 2-3 0 0 $PERFORMANCE
 _callCompareTest raw2_0.log result2_0.log 2-4 "Compare 2-4" 1 0
@@ -69,6 +71,7 @@ wait $pid
 # Test flexible tensors
 PORT=`python3 ../get_available_port.py`
 gstTestBackground "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc port=${PORT} ! other/tensors,format=flexible ! tensor_query_serversink async=false" 3-1 0 0 30
+pid=$!
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc is-live=true num-buffers=10  ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! other/tensors,format=flexible ! tee name = t t. ! queue ! multifilesink location= raw3_%1d.log t. ! queue ! tensor_query_client dest-port=${PORT} ! multifilesink location=result3_%1d.log" 3-2 0 0 $PERFORMANCE
 _callCompareTest raw3_0.log result3_0.log 3-3 "Compare 3-3" 1 0
 _callCompareTest raw3_1.log result3_1.log 3-4 "Compare 3-4" 1 0
@@ -81,6 +84,7 @@ PORT1=`python3 ../get_available_port.py`
 PORT2=`python3 ../get_available_port.py`
 gstTestBackground "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc id=0 port=${PORT1} ! other/tensors,format=flexible ! tensor_query_serversink id=0 async=false \
     tensor_query_serversrc id=1 port=${PORT2} ! other/tensors,format=flexible ! tensor_query_serversink id=1 async=false" 5-1 0 0 30
+pid=$!
 # Client pipeline 5-2 is connected to server ID 0.
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
     videotestsrc is-live=true num-buffers=10  ! videoconvert ! videoscale ! video/x-raw,width=640,height=480,format=RGB ! \
@@ -105,6 +109,7 @@ wait $pid
 # Sever src cap: Video, Server sink cap: Viedo test
 PORT=`python3 ../get_available_port.py`
 gstTestBackground "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc port=${PORT} ! video/x-raw,width=300,height=300,format=RGB,framerate=0/1 ! tensor_query_serversink async=false" 6-1 0 0 30
+pid=$!
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc is-live=true num-buffers=10  ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tee name = t t. ! queue ! multifilesink location= raw6_%1d.log t. ! queue ! tensor_query_client dest-port=${PORT} ! multifilesink location=result6_%1d.log" 6-2 0 0 $PERFORMANCE
 _callCompareTest raw6_0.log result6_0.log 6-3 "Compare 6-3" 1 0
 _callCompareTest raw6_1.log result6_1.log 6-4 "Compare 6-4" 1 0
@@ -115,6 +120,7 @@ wait $pid
 # Sever src cap: Video, Server sink cap: Tensor test
 PORT=`python3 ../get_available_port.py`
 gstTestBackground "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc port=${PORT} ! video/x-raw,width=300,height=300,format=RGB,framerate=0/1 ! tensor_converter ! tensor_query_serversink async=false" 7-1 0 0 30
+pid=$!
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc is-live=true num-buffers=10  ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tee name = t t. ! queue ! multifilesink location= raw7_%1d.log t. ! queue ! tensor_query_client dest-port=${PORT} ! multifilesink location=result7_%1d.log" 7-2 0 0 $PERFORMANCE
 _callCompareTest raw7_0.log result7_0.log 7-3 "Compare 7-3" 1 0
 _callCompareTest raw7_1.log result7_1.log 7-4 "Compare 7-4" 1 0
@@ -125,6 +131,7 @@ wait $pid
 # Sever src cap: Tensor, Server sink cap: Video test
 PORT=`python3 ../get_available_port.py`
 gstTestBackground "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc port=${PORT} ! other/tensors,format=static,num_tensors=1,dimensions=(string)3:300:300:1,types=(string)uint8,framerate=0/1 ! tensor_decoder mode=direct_video ! videoconvert ! tensor_query_serversink async=false" 8-1 0 0 30
+pid=$!
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc is-live=true num-buffers=10  ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! tee name = t t. ! queue ! multifilesink location= raw8_%1d.log t. ! queue ! tensor_query_client dest-port=${PORT} ! multifilesink location=result8_%1d.log" 8-2 0 0 $PERFORMANCE
 _callCompareTest raw8_0.log result8_0.log 8-3 "Compare 8-3" 1 0
 _callCompareTest raw8_1.log result8_1.log 8-4 "Compare 8-4" 1 0
@@ -150,6 +157,7 @@ fi
 
 # Test Query-hybrid. Get server info from broker.
 gstTestBackground "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_query_serversrc id=12345 port=0 topic=passthrough connect-type=HYBRID ! other/tensors,format=flexible,framerate=0/1 ! tee name = t t. ! queue ! multifilesink location=server1_%1d.log t. ! queue ! tensor_query_serversink id=12345 connect-type=HYBRID async=false" 4-1 0 0 5
+pid=$!
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=50 is-live=true ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tensor_converter ! other/tensors,format=flexible ! tee name = t t. ! queue ! multifilesink location= raw4_%1d.log t. ! queue ! tensor_query_client connect-type=HYBRID dest-host=tcp://localhost dest-port=1883 topic=passthrough ! multifilesink location=result4_%1d.log" 4-3 0 0 $PERFORMANCE
 _callCompareTest raw4_0.log result4_0.log 4-4 "Compare the raw file and client received file 4-4" 1 0
 _callCompareTest raw4_1.log result4_1.log 4-5 "Compare the raw file and client received file 4-5" 1 0


### PR DESCRIPTION
In recent commits, pid assignment after invoking background processes
has disappeared. Revivde pid assignment so that we can kill unnecessary
processes and avoid indefinite waits.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
