### PR TITLE
[spec] Disable AI Offloading on VD Cosmos infra

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -107,6 +107,7 @@
 %define		tvm_support 0
 %define		snpe_support 0
 %define		trix_engine_support 0
+%define		nnstreamer_edge_support 0
 %endif
 
 # DA requested to remove unnecessary module builds


### PR DESCRIPTION
This patch disables the AI offloading feature on VD Cosmos infra.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>


**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped


