### PR TITLE
test:query launch mosquitto for testing @open sesame @open sesame 8/31 14:32

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -311,6 +311,9 @@ BuildRequires:	pkgconfig(orc-0.4)
 BuildRequires:	flex
 BuildRequires:	bison
 
+# Mosquitto MQTT broker for unit testing
+BuildRequires:  mosquitto
+
 # Note that debug packages generate an additional build and storage cost.
 # If you do not need debug packages, run '$ gbs -c .TAOS-CI/.gbs.conf build ... --define "_skip_debug_rpm 1"'.
 

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -302,6 +302,8 @@ BuildRequires:	npu-engine-devel
 # Unit Testing Uses SSAT (https://github.com/myungjoo/SSAT.git)
 %if 0%{?unit_test} || 0%{?edge_test}
 BuildRequires:	ssat >= 1.1.0
+# Mosquitto MQTT broker for unit testing
+BuildRequires:  mosquitto
 %endif
 
 # For ORC (Oil Runtime Compiler)
@@ -310,9 +312,6 @@ BuildRequires:	pkgconfig(orc-0.4)
 # For nnstreamer-parser
 BuildRequires:	flex
 BuildRequires:	bison
-
-# Mosquitto MQTT broker for unit testing
-BuildRequires:  mosquitto
 
 # Note that debug packages generate an additional build and storage cost.
 # If you do not need debug packages, run '$ gbs -c .TAOS-CI/.gbs.conf build ... --define "_skip_debug_rpm 1"'.


### PR DESCRIPTION
commit 775ba31a891f6e29bee735309f052ad795797d65 (github-fork/mosq_in_gbs)
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Thu Aug 18 13:03:27 2022 +0900

    test:query launch mosquitto for testing
    
    Launch mosquitto with a random port for testing
    and terminate it after testing.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit d52222f138924cc28b30570f95411ca876699047
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Thu Aug 18 11:15:42 2022 +0900

    Tizen: add mosquitto at build-time for unit testing
    
    Mosquitto is not used for building nnstreamer.
    It is used for unit testing; thus, the built binaries
    shouldn't have dependencies on Mosquitto.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>