### PR TITLE
[TEST] Change test name.

### DIFF
--- a/tests/transform_typecast/runTest.sh
+++ b/tests/transform_typecast/runTest.sh
@@ -130,7 +130,7 @@ python3 checkResult.py typecast testcase12.noop.log testcase12.ops.log float16 2
 testResult $? 12 "float16 values * 1.0 + 1.0 - 1.0 == original test" $F16MAYFAIL 1
 
 python3 checkResult.py typecast testcase12.noop.log testcase13.ops.log float16 2 e float16 2 e
-testResult $? 13 "float16 values + 0.0001 < original + 0.001 test" $F16MAYFAIL 1
+testResult $? 13 "float16 values + 0.0001 is less than original + 0.001 test" $F16MAYFAIL 1
 
 python3 checkResult.py typecast testcase12.noop.log testcase14.ops.log float16 2 e float16 2 e
 val=$?


### PR DESCRIPTION
To fix xml parser error, change the test name.

Error message: Unescaped '<' not allowed in attributes values

Signed-off-by: gichan <gichan2.jang@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

