### PR TITLE
Tools/Parser: Silence a warning about using a deprecated directive @open sesame 9/1 16:25

### DIFF
--- a/tools/development/parser/grammar.y
+++ b/tools/development/parser/grammar.y
@@ -369,7 +369,7 @@ static int yyerror (void *scanner, graph_t *graph, const char *s);
 %lex-param { void *scanner }
 %parse-param { void *scanner }
 %parse-param { graph_t *graph }
-%pure-parser
+%define api.pure full
 
 %start graph
 %%


### PR DESCRIPTION
This patch fixes the following warning about using a deprecated directive, '%pure-parser'. Note that '%pure-parser' is deprecated since Bison 2.3b (bison_min_version defined in meson.build is 2.4).

../tools/development/parser/grammar.y:372.1-12: warning: deprecated directive: ‘%pure-parser’, use ‘%define api.pure’ [-Wdeprecated]
  372 | %pure-parser
      | ^~~~~~~~~~~~
      | %define api.pure
../tools/development/parser/grammar.y: warning: fix-its can be applied.  Rerun with option '--update'. [-Wother]

Signed-off-by: Wook Song <wook16.song@samsung.com>

See also:  https://fossies.org/linux/bison/NEWS