### PR TITLE
[query] Add timeout prop for tensor_query_client

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_client.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_client.h
@@ -47,6 +47,8 @@ struct _GstTensorQueryClient
   gboolean silent; /**< True if logging is minimized */
   gchar *in_caps_str;
 
+  guint timeout; /**< timeout value (in ms) to wait message from server */
+
   /* Query-hybrid feature */
   gchar *topic; /**< Main operation such as 'object_detection' or 'image_segmentation' */
   gchar *host;

--- a/tests/nnstreamer_edge/query/unittest_query.cc
+++ b/tests/nnstreamer_edge/query/unittest_query.cc
@@ -230,6 +230,10 @@ TEST (tensorQuery, clientProperties0)
   g_object_get (client_handle, "port", &uint_val, NULL);
   EXPECT_EQ (5001U, uint_val);
 
+  g_object_set (client_handle, "timeout", 1000U, NULL);
+  g_object_get (client_handle, "timeout", &uint_val, NULL);
+  EXPECT_EQ (1000U, uint_val);
+
   g_object_set (client_handle, "silent", FALSE, NULL);
   g_object_get (client_handle, "silent", &bool_val, NULL);
   EXPECT_EQ (FALSE, bool_val);


### PR DESCRIPTION
- Add timeout prop to decide how much time to wait message from server.
- Default value is 0, no wait.
- Add simple unittest.

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
