### PR TITLE
[CodeClean] coverity issues

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_lua.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_lua.cc
@@ -454,8 +454,8 @@ lua_subplugin::configure_instance (const GstTensorFilterProperties *prop)
   if (!g_file_test (prop->model_files[0], G_FILE_TEST_EXISTS)) {
     nns_logi ("Given model file does not exist. Do script mode.");
     gchar *script = g_strjoinv (",", (gchar **) prop->model_files);
-    std::unique_ptr<gchar, decltype (&g_free)> script_ptr (
-        std::move (script), g_free);
+    std::unique_ptr<gchar, decltype (&g_free)> script_ptr (script, g_free);
+
     if (luaL_dostring (L, script_ptr.get ()) != 0) {
       throw std::invalid_argument (std::string ("Failed to run given Lua script. Error message: ") +
           lua_tostring (L, -1));

--- a/ext/nnstreamer/tensor_sink/tensor_sink_grpc.c
+++ b/ext/nnstreamer/tensor_sink/tensor_sink_grpc.c
@@ -41,7 +41,6 @@
 
 #include <tensor_typedef.h>
 #include <nnstreamer_plugin_api.h>
-#include <nnstreamer_log.h>
 
 #include "tensor_sink_grpc.h"
 #include "nnstreamer_grpc.h"

--- a/ext/nnstreamer/tensor_source/tensor_src_grpc.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_grpc.c
@@ -35,7 +35,6 @@
 
 #include <gst/gst.h>
 #include <glib.h>
-#include <gmodule.h>
 
 #include <tensor_typedef.h>
 #include <nnstreamer_plugin_api.h>

--- a/gst/mqtt/ntputil.c
+++ b/gst/mqtt/ntputil.c
@@ -14,7 +14,6 @@
 
 #include <errno.h>
 #include <netdb.h>
-#include <arpa/inet.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/gst/nnstreamer/elements/gsttensor_repo.c
+++ b/gst/nnstreamer/elements/gsttensor_repo.c
@@ -24,7 +24,6 @@
  */
 
 #include "gsttensor_repo.h"
-#include <nnstreamer_util.h>
 
 #ifndef DBG
 #define DBG FALSE

--- a/tests/nnstreamer_filter_reload/tensor_filter_reload_test.c
+++ b/tests/nnstreamer_filter_reload/tensor_filter_reload_test.c
@@ -12,7 +12,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <gst/gst.h>
-#include <tensor_common.h>
 #include <nnstreamer_util.h>
 
 #define _print_log(...) if (!silent) g_message (__VA_ARGS__)


### PR DESCRIPTION
Fix coverity issues, remove unnecessary header includes and std-move to mem ptr.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
