### PR TITLE
[EDGE] Support AITT as connection type. @open sesame 09/21 17:21

### DIFF
--- a/gst/edge/edge_common.c
+++ b/gst/edge/edge_common.c
@@ -27,7 +27,8 @@ gst_edge_get_connect_type (void)
     static GEnumValue protocols[] = {
       {NNS_EDGE_CONNECT_TYPE_TCP, "TCP",
           "Directly sending stream frames via TCP connections."},
-          /** @todo support UDP, MQTT and HYBRID */
+      {NNS_EDGE_CONNECT_TYPE_AITT, "AITT",
+          "Sending stream frames via AITT connections."},
       {0, NULL, NULL},
     };
     protocol = g_enum_register_static ("edge_protocol", protocols);

--- a/gst/edge/edge_sink.h
+++ b/gst/edge/edge_sink.h
@@ -44,6 +44,9 @@ struct _GstEdgeSink
 
   gchar *host;
   guint16 port;
+  gchar *dest_host;
+  guint16 dest_port;
+  gchar *topic;
 
   nns_edge_connect_type_e connect_type;
   nns_edge_h edge_h;

--- a/gst/edge/edge_src.c
+++ b/gst/edge/edge_src.c
@@ -31,10 +31,12 @@ static GstStaticPadTemplate srctemplate = GST_STATIC_PAD_TEMPLATE ("src",
 enum
 {
   PROP_0,
-
+  PROP_HOST,
+  PROP_PORT,
   PROP_DEST_HOST,
   PROP_DEST_PORT,
   PROP_CONNECT_TYPE,
+  PROP_TOPIC,
 
   PROP_LAST
 };
@@ -78,6 +80,14 @@ gst_edgesrc_class_init (GstEdgeSrcClass * klass)
   gobject_class->get_property = gst_edgesrc_get_property;
   gobject_class->finalize = gst_edgesrc_class_finalize;
 
+  g_object_class_install_property (gobject_class, PROP_HOST,
+      g_param_spec_string ("host", "Host",
+          "A self host address", DEFAULT_HOST,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_PORT,
+      g_param_spec_uint ("port", "Port",
+          "A self port number.",
+          0, 65535, DEFAULT_PORT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_DEST_HOST,
       g_param_spec_string ("dest-host", "Destination Host",
           "A host address of edgesink to receive the packets from edgesink",
@@ -90,6 +100,11 @@ gst_edgesrc_class_init (GstEdgeSrcClass * klass)
       g_param_spec_enum ("connect-type", "Connect Type",
           "The connections type between edgesink and edgesrc.",
           GST_TYPE_EDGE_CONNECT_TYPE, DEFAULT_CONNECT_TYPE,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_TOPIC,
+      g_param_spec_string ("topic", "Topic",
+          "The main topic of the host and option if necessary. "
+          "(topic)/(optional topic for main topic).", "",
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   gst_element_class_add_pad_template (gstelement_class,
@@ -117,8 +132,11 @@ gst_edgesrc_init (GstEdgeSrc * self)
   gst_base_src_set_format (basesrc, GST_FORMAT_TIME);
   gst_base_src_set_async (basesrc, FALSE);
 
+  self->host = g_strdup (DEFAULT_HOST);
+  self->port = DEFAULT_PORT;
   self->dest_host = g_strdup (DEFAULT_HOST);
   self->dest_port = DEFAULT_PORT;
+  self->topic = NULL;
   self->msg_queue = g_async_queue_new ();
   self->connect_type = DEFAULT_CONNECT_TYPE;
 }
@@ -133,6 +151,17 @@ gst_edgesrc_set_property (GObject * object, guint prop_id, const GValue * value,
   GstEdgeSrc *self = GST_EDGESRC (object);
 
   switch (prop_id) {
+    case PROP_HOST:
+      if (!g_value_get_string (value)) {
+        nns_logw ("host property cannot be NULL");
+        break;
+      }
+      g_free (self->host);
+      self->host = g_value_dup_string (value);
+      break;
+    case PROP_PORT:
+      self->port = g_value_get_uint (value);
+      break;
     case PROP_DEST_HOST:
       gst_edgesrc_set_dest_host (self, g_value_get_string (value));
       break;
@@ -142,7 +171,14 @@ gst_edgesrc_set_property (GObject * object, guint prop_id, const GValue * value,
     case PROP_CONNECT_TYPE:
       gst_edgesrc_set_connect_type (self, g_value_get_enum (value));
       break;
-
+    case PROP_TOPIC:
+      if (!g_value_get_string (value)) {
+        nns_logw ("topic property cannot be NULL. Query-hybrid is disabled.");
+        break;
+      }
+      g_free (self->topic);
+      self->topic = g_value_dup_string (value);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -159,6 +195,12 @@ gst_edgesrc_get_property (GObject * object, guint prop_id, GValue * value,
   GstEdgeSrc *self = GST_EDGESRC (object);
 
   switch (prop_id) {
+    case PROP_HOST:
+      g_value_set_string (value, self->host);
+      break;
+    case PROP_PORT:
+      g_value_set_uint (value, self->port);
+      break;
     case PROP_DEST_HOST:
       g_value_set_string (value, gst_edgesrc_get_dest_host (self));
       break;
@@ -168,7 +210,9 @@ gst_edgesrc_get_property (GObject * object, guint prop_id, GValue * value,
     case PROP_CONNECT_TYPE:
       g_value_set_enum (value, gst_edgesrc_get_connect_type (self));
       break;
-
+    case PROP_TOPIC:
+      g_value_set_string (value, self->topic);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -247,7 +291,7 @@ gst_edgesrc_start (GstBaseSrc * basesrc)
   char *port = NULL;
 
   ret =
-      nns_edge_create_handle ("TEMP_ID", self->connect_type,
+      nns_edge_create_handle ("TEMP_ID_EDGE_SRC", self->connect_type,
       NNS_EDGE_NODE_TYPE_SUB, &self->edge_h);
 
   if (NNS_EDGE_ERROR_NONE != ret) {
@@ -261,10 +305,22 @@ gst_edgesrc_start (GstBaseSrc * basesrc)
     return FALSE;
   }
 
-  nns_edge_set_info (self->edge_h, "DEST_HOST", self->dest_host);
-  port = g_strdup_printf ("%d", self->dest_port);
-  nns_edge_set_info (self->edge_h, "DEST_PORT", port);
-  g_free (port);
+  if (self->host)
+    nns_edge_set_info (self->edge_h, "HOST", self->host);
+  if (self->port > 0) {
+    port = g_strdup_printf ("%u", self->port);
+    nns_edge_set_info (self->edge_h, "PORT", port);
+    g_free (port);
+  }
+  if (self->dest_host)
+    nns_edge_set_info (self->edge_h, "DEST_HOST", self->dest_host);
+  if (self->dest_port > 0) {
+    port = g_strdup_printf ("%u", self->dest_port);
+    nns_edge_set_info (self->edge_h, "DEST_PORT", port);
+    g_free (port);
+  }
+  if (self->topic)
+    nns_edge_set_info (self->edge_h, "TOPIC", self->topic);
 
   nns_edge_set_event_callback (self->edge_h, _nns_edge_event_cb, self);
 

--- a/gst/edge/edge_src.h
+++ b/gst/edge/edge_src.h
@@ -42,8 +42,11 @@ struct _GstEdgeSrc
 {
   GstBaseSrc element;
 
+  gchar *host;
+  guint16 port;
   gchar *dest_host;
   guint16 dest_port;
+  gchar *topic;
 
   nns_edge_connect_type_e connect_type;
   nns_edge_h edge_h;

--- a/meson.build
+++ b/meson.build
@@ -425,6 +425,10 @@ features = {
   'mxnet-support': {
     'extra_deps': [ mxnet_dep ],
     'project_args': { 'ENABLE_MXNET' : 1 }
+  },
+  'aitt-support': {
+    'target': 'aitt',
+    'project_args': { 'ENABLE_AITT' : 1 }
   }
 }
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -25,6 +25,7 @@ option('tvm-support', type: 'feature', value: 'auto')
 option('trix-engine-support', type: 'feature', value: 'auto')
 option('nnstreamer-edge-support', type: 'feature', value: 'auto')
 option('mxnet-support', type: 'feature', value: 'auto')
+option('aitt-support', type: 'feature', value: 'auto')
 
 # booleans & other options
 option('enable-test', type: 'boolean', value: true)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -35,6 +35,7 @@
 %define		tvm_support 1
 %define		snpe_support 1
 %define		trix_engine_support 1
+%define		aitt_support 1
 # Support AI offloading (tensor_query) using nnstreamer-edge interface
 %define		nnstreamer_edge_support 1
 
@@ -108,6 +109,7 @@
 %define		snpe_support 0
 %define		trix_engine_support 0
 %define		nnstreamer_edge_support 0
+%define		aitt_support 0
 %endif
 
 # DA requested to remove unnecessary module builds
@@ -121,6 +123,7 @@
 %define		mqtt_support 0
 %define		tvm_support 0
 %define		trix_engine_support 0
+%define		aitt_support 0
 %endif
 
 # Release unit test suite as a subpackage only if check_test is enabled.
@@ -228,6 +231,9 @@ BuildConflicts: libarmcl-release
 
 %if 0%{?edgetpu_support}
 BuildRequires:	pkgconfig(edgetpu)
+%endif
+%if 0%{?aitt_support}
+BuildRequires:  aitt-devel
 %endif
 
 %if 0%{?testcoverage}

--- a/tests/nnstreamer_edge/edge/runTest.sh
+++ b/tests/nnstreamer_edge/edge/runTest.sh
@@ -185,6 +185,34 @@ callCompareTestIfExist raw5_$((num+2)).log result5_2.log 5-5 "Compare 5-5" 1 0
 kill -9 $pid &> /dev/null
 wait $pid
 
+# Check AITT lib is exist or not.
+/sbin/ldconfig -p | grep libaitt.so >/dev/null 2>&1
+if [[ "$?" != 0 ]]; then
+    echo "AITT lib is not installed. Skip AITT test."
+    rm *.log
+    report
+    exit
+fi
+
+gstTestBackground "--gst-plugin-path=${PATH_TO_PLUGIN} \
+    videotestsrc is-live=true ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB ! tee name=t \
+        t. ! queue ! multifilesink location=raw6_%1d.log \
+        t. ! queue ! edgesink port=0 connect-type=AITT dest-host=127.0.0.1 dest-port=1883 topic=tempTopic async=false" 6-1 0 0 30
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+    edgesrc port=0 connect-type=AITT dest-host=127.0.0.1 dest-port=1883 topic=tempTopic num-buffers=10 ! multifilesink location=result6_0_%1d.log" 6-2 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+    edgesrc port=0 connect-type=AITT dest-host=127.0.0.1 dest-port=1883 topic=tempTopic num-buffers=10 ! multifilesink location=result6_1_%1d.log" 6-3 0 0 $PERFORMANCE
+findFirstMatchedFileNumber "raw6_" ".log" "result6_0_0.log" 6-4
+callCompareTestIfExist raw6_$((num+0)).log result6_0_0.log 2-4 "Compare 6-4" 1 0
+callCompareTestIfExist raw6_$((num+1)).log result6_0_1.log 2-5 "Compare 6-5" 1 0
+callCompareTestIfExist raw6_$((num+2)).log result6_0_2.log 2-6 "Compare 6-6" 1 0
+findFirstMatchedFileNumber "raw6_" ".log" "result6_1_0.log" 6-7
+callCompareTestIfExist raw6_$((num+0)).log result6_1_0.log 2-7 "Compare 6-7" 1 0
+callCompareTestIfExist raw6_$((num+1)).log result6_1_1.log 2-8 "Compare 6-8" 1 0
+callCompareTestIfExist raw6_$((num+2)).log result6_1_2.log 2-9 "Compare 6-9" 1 0
+kill -9 $pid &> /dev/null
+wait $pid
+
 rm *.log
 report
 exit

--- a/tests/nnstreamer_edge/query/unittest_query.cc
+++ b/tests/nnstreamer_edge/query/unittest_query.cc
@@ -14,39 +14,6 @@
 #include <tensor_common.h>
 #include <unittest_util.h>
 #include "../gst/nnstreamer/tensor_query/tensor_query_common.h"
-#include <gio/gio.h>
-#include <netinet/tcp.h>
-#include <netinet/in.h>
-/**
- * @brief Get available port number.
- */
-static guint
-_get_available_port (void)
-{
-  struct sockaddr_in sin;
-  guint port = 0;
-  gint sock;
-  socklen_t len = sizeof (struct sockaddr);
-
-  sin.sin_family = AF_INET;
-  sin.sin_addr.s_addr = INADDR_ANY;
-  sin.sin_port = htons(0);
-
-  sock = socket (AF_INET, SOCK_STREAM, 0);
-  EXPECT_TRUE (sock > 0);
-  if (sock < 0)
-    return 0;
-
-  if (bind (sock, (struct sockaddr *) &sin, sizeof (struct sockaddr)) == 0) {
-    if (getsockname (sock, (struct sockaddr *) &sin, &len) == 0) {
-      port = ntohs (sin.sin_port);
-    }
-  }
-  close (sock);
-
-  EXPECT_TRUE (port > 0);
-  return port;
-}
 
 /**
  * @brief Test for tensor_query_server get and set properties
@@ -61,7 +28,7 @@ TEST (tensorQuery, serverProperties0)
   gchar *str_val;
   guint src_port;
 
-  src_port = _get_available_port ();
+  src_port = get_available_port ();
 
   /* Create a nnstreamer pipeline */
   pipeline = g_strdup_printf (
@@ -167,7 +134,7 @@ TEST (tensorQuery, serverProperties2_n)
   GstElement *gstpipe;
   guint src_port;
 
-  src_port = _get_available_port ();
+  src_port = get_available_port ();
 
   /* Create a nnstreamer pipeline */
   pipeline = g_strdup_printf (
@@ -252,7 +219,7 @@ TEST (tensorQuery, serverRun)
   GstElement *gstpipe;
   guint src_port;
 
-  src_port = _get_available_port ();
+  src_port = get_available_port ();
 
   /* Create a nnstreamer pipeline */
   pipeline = g_strdup_printf (

--- a/tests/unittest_util.c
+++ b/tests/unittest_util.c
@@ -170,6 +170,35 @@ replace_string (gchar * source, const gchar * what, const gchar * to,
   return result;
 }
 
+/**
+ * @brief Get available port number.
+ */
+guint
+get_available_port (void)
+{
+  struct sockaddr_in sin;
+  guint port = 0;
+  gint sock;
+  socklen_t len = sizeof (struct sockaddr);
+
+  sin.sin_family = AF_INET;
+  sin.sin_addr.s_addr = INADDR_ANY;
+  sin.sin_port = htons(0);
+
+  sock = socket (AF_INET, SOCK_STREAM, 0);
+  if (sock < 0)
+    return 0;
+
+  if (bind (sock, (struct sockaddr *) &sin, sizeof (struct sockaddr)) == 0) {
+    if (getsockname (sock, (struct sockaddr *) &sin, &len) == 0) {
+      port = ntohs (sin.sin_port);
+    }
+  }
+  close (sock);
+
+  return port;
+}
+
 #ifdef FAKEDLOG
 /**
  * @brief Hijack dlog Tizen infra for unit testing to force printing out.

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -15,6 +15,9 @@
 #include <stdint.h>
 #include <errno.h>
 #include <glib/gstdio.h>
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+#include <gio/gio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,6 +62,12 @@ extern gboolean wait_pipeline_process_buffers (const guint * data_received, guin
  */
 extern gchar *
 replace_string (gchar * source, const gchar * what, const gchar * to, const gchar * delimiters, guint * count);
+
+/**
+ * @brief Get available port number.
+ */
+extern guint
+get_available_port (void);
 
 /**
  * @brief Wait until the pipeline saving the file


### PR DESCRIPTION
Edgesrc/sink support AITT as connection type.
Add unit test cases.

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped


