### PR TITLE
[query] Fix client_id type to long long in query_serversink @open sesame 09/14 16:06

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.c
@@ -271,7 +271,7 @@ gst_tensor_query_serversink_render (GstBaseSink * bsink, GstBuffer * buf)
       nns_edge_data_add (data_h, map[i].data, map[i].size, NULL);
     }
 
-    val = g_strdup_printf ("%ld", (long int) meta_query->client_id);
+    val = g_strdup_printf ("%lld", (long long) meta_query->client_id);
     nns_edge_data_set_info (data_h, "client_id", val);
     g_free (val);
 


### PR DESCRIPTION
- Fix client_id type to `long long` in query_serversink.

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
