### PR TITLE
Edge: allow edgesrc/sink in Tizen @open sesame 9/22 20:08

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -685,7 +685,7 @@ Provides additional gstreamer plugins for nnstreamer pipelines
 %define enable_tizen -Denable-tizen=true -Dtizen-version-major=0%{tizen_version_major}
 # Element allowance in Tizen
 %define allowed_element_base     'capsfilter input-selector output-selector queue tee valve appsink appsrc audioconvert audiorate audioresample audiomixer videoconvert videocrop videorate videoscale videoflip videomixer compositor fakesrc fakesink filesrc filesink audiotestsrc videotestsrc jpegparse jpegenc jpegdec pngenc pngdec tcpclientsink tcpclientsrc tcpserversink tcpserversrc xvimagesink ximagesink evasimagesink evaspixmapsink glimagesink theoraenc lame vorbisenc wavenc volume oggmux avimux matroskamux v4l2src avsysvideosrc camerasrc tvcamerasrc pulsesrc fimcconvert tizenwlsink gdppay gdpdepay join '
-%define allowed_element_edgeai   'rtpdec rtspsrc rtspclientsink zmqsrc zmqsink mqttsrc mqttsink udpsrc udpsink multiudpsink '
+%define allowed_element_edgeai   'rtpdec rtspsrc rtspclientsink zmqsrc zmqsink mqttsrc mqttsink udpsrc udpsink multiudpsink edgesrc edgesink '
 %define allowed_element_audio    'audioamplify audiochebband audiocheblimit audiodynamic audioecho audiofirfilter audioiirfilter audioinvert audiokaraoke audiopanorama audiowsincband audiowsinclimit scaletempo stereo '
 %if "%{?profile}" == "tv"
 %define allowed_element_vd       'tvdpbsrc '


### PR DESCRIPTION
With #3864, edgesrc/sink are added; however, in Tizen API, apps are restricted to use the allowed elements only. Add edgesrc/edgesink to that list.

ps. @gichan-jang @jaeyun-jung : please update and merge #3864 before Tizen 7 RC2. (RC1 if you can)

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>