### PR TITLE
filter/armnn: fp16 support macro fix

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -464,7 +464,7 @@ ArmNNCore::getGstTensorType (armnn::DataType armType)
 #ifdef FLOAT16_SUPPORT
     return _NNS_FLOAT16;
 #else
-    ml_logw ("Unsupported armnn datatype Float16. Recompile with -DSUPPORT_FLOAT16 option.");
+    ml_logw ("Unsupported armnn datatype Float16. Recompile with -DFLOAT16_SUPPORT option.");
 #endif
     break;
   case armnn::DataType::QAsymmU8:


### PR DESCRIPTION
The preprocessor macro has a typo. Fix it.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

