### PR TITLE
[Package] Add nnstreamer-edge dependency to nnstreamer-core

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,7 @@ Description: NNStreamer plugins for Gstreamer
 Package: nnstreamer-core
 Architecture: any
 Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: nnstreamer-edge, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer plugins for Gstreamer
  Gstreamer plugins, "NNStreamer", provides access to neural network frameworks for media streams.
  This package is core package without configuration.

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -335,6 +335,9 @@ nnstreamer-core and nnstreamer-configuration
 
 %package core
 Requires: gstreamer >= 1.8.0
+%if 0%{?nnstreamer_edge_support}
+Requires: nnstreamer-edge
+%endif
 Summary: NNStreamer core package
 %description core
 NNStreamer is a set of gstreamer plugins to support general neural networks


### PR DESCRIPTION
Add nnstreamer-edge dependency to nnstreamer-core.

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

