### PR TITLE
[trivial/build] Fix meson error when the disabled option is given

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -315,6 +315,7 @@ if not get_option('armnn-support').disabled()
 endif
 
 # mxnet
+mxnet_dep = dependency('', required: false)
 if not get_option('mxnet-support').disabled()
   mxnet_dep = cxx.find_library('mxnet', required: false)
   if not mxnet_dep.found()


### PR DESCRIPTION
- Fix meson config error when the 'disabled' options for mxnet is given explicitly

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped