### PR TITLE
[AITT] Remove AITT build dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -425,10 +425,6 @@ features = {
   'mxnet-support': {
     'extra_deps': [ mxnet_dep ],
     'project_args': { 'ENABLE_MXNET' : 1 }
-  },
-  'aitt-support': {
-    'target': 'aitt',
-    'project_args': { 'ENABLE_AITT' : 1 }
   }
 }
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -25,7 +25,6 @@ option('tvm-support', type: 'feature', value: 'auto')
 option('trix-engine-support', type: 'feature', value: 'auto')
 option('nnstreamer-edge-support', type: 'feature', value: 'auto')
 option('mxnet-support', type: 'feature', value: 'auto')
-option('aitt-support', type: 'feature', value: 'auto')
 
 # booleans & other options
 option('enable-test', type: 'boolean', value: true)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -35,7 +35,6 @@
 %define		tvm_support 1
 %define		snpe_support 1
 %define		trix_engine_support 1
-%define		aitt_support 1
 # Support AI offloading (tensor_query) using nnstreamer-edge interface
 %define		nnstreamer_edge_support 1
 
@@ -109,7 +108,6 @@
 %define		snpe_support 0
 %define		trix_engine_support 0
 %define		nnstreamer_edge_support 0
-%define		aitt_support 0
 %endif
 
 # DA requested to remove unnecessary module builds
@@ -123,7 +121,6 @@
 %define		mqtt_support 0
 %define		tvm_support 0
 %define		trix_engine_support 0
-%define		aitt_support 0
 %endif
 
 # Release unit test suite as a subpackage only if check_test is enabled.
@@ -231,9 +228,6 @@ BuildConflicts: libarmcl-release
 
 %if 0%{?edgetpu_support}
 BuildRequires:	pkgconfig(edgetpu)
-%endif
-%if 0%{?aitt_support}
-BuildRequires:  aitt-devel
 %endif
 
 %if 0%{?testcoverage}


### PR DESCRIPTION
Remove build dependency of AITT and check whether the AITT lib is installed or not at run-time for AITT test.

tests/nnstreamer_edge/edge/runTest.sh
```
...
# Check AITT lib is exist or not.
/sbin/ldconfig -p | grep libaitt.so >/dev/null 2>&1
if [[ "$?" != 0 ]]; then
    echo "AITT lib is not installed. Skip AITT test."
...
```
Signed-off-by: gichan <gichan2.jang@samsung.com>


**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed [*]Skipped
2. Run test: [* ]Passed [ ]Failed [*]Skipped
