### PR TITLE
[Doc] fix broken link

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_sink.md
+++ b/gst/nnstreamer/elements/gsttensor_sink.md
@@ -46,4 +46,4 @@ One "Always" sink pad exists. The capability of sink pad is ```other/tensor``` a
 $ gst-launch-1.0 videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! tensor_converter ! tensor_sink
 ```
 
-For more details, see the [examples](https://github.com/nnstreamer/nnstreamer/tree/master/nnstreamer_example/example_sink) to handle the buffer from GstTensorSink.
+For more details, see the [examples](https://github.com/nnstreamer/nnstreamer-example/tree/main/native/example_sink) to handle the buffer from GstTensorSink.


### PR DESCRIPTION
This patch fixes broken link in tensor_sink documentation.

Signed-off-by: Yelin Jeong <yelini.jeong@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped