### PR TITLE
[Common] tensor format in struct

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.cc
@@ -143,7 +143,7 @@ ServiceImplFlatbuf::_get_tensors_from_buffer (GstBuffer *buffer,
   flatbuffers::Offset<Tensors> tensors;
   std::vector<flatbuffers::Offset<Tensor>> tensor_vector;
   Tensor_type tensor_type;
-  Tensor_format format = (Tensor_format) config_->format;
+  Tensor_format format = (Tensor_format) config_->info.format;
   unsigned int num_tensors = config_->info.num_tensors;
   frame_rate fr = frame_rate (config_->rate_n, config_->rate_d);
 

--- a/ext/nnstreamer/extra/nnstreamer_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.cc
@@ -71,7 +71,7 @@ gst_tensor_decoder_protobuf (const GstTensorsConfig *config,
   fr->set_rate_d (pbd_config.rate_d);
 
   tensors.set_format (
-      (nnstreamer::protobuf::Tensors::Tensor_format) pbd_config.format);
+      (nnstreamer::protobuf::Tensors::Tensor_format) pbd_config.info.format);
 
   for (unsigned int i = 0; i < num_tensors; ++i) {
     nnstreamer::protobuf::Tensor *tensor = tensors.add_tensor ();
@@ -157,7 +157,7 @@ gst_tensor_converter_protobuf (GstBuffer *in_buf, GstTensorsConfig *config, void
   tensors.ParseFromArray (in_info.data, in_info.size);
 
   config->info.num_tensors = tensors.num_tensor ();
-  config->format = (tensor_format) tensors.format ();
+  config->info.format = (tensor_format) tensors.format ();
   fr = tensors.mutable_fr ();
   config->rate_n = fr->rate_n ();
   config->rate_d = fr->rate_d ();

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flatbuf.cc
@@ -91,7 +91,7 @@ fbc_convert (GstBuffer *in_buf, GstTensorsConfig *config, void *priv_data)
   g_assert (tensors);
 
   config->info.num_tensors = tensors->num_tensor ();
-  config->format = (tensor_format) tensors->format ();
+  config->info.format = (tensor_format) tensors->format ();
 
   if (tensors->num_tensor () > NNS_TENSOR_SIZE_LIMIT) {
     nns_loge ("The number of tensors is limited to %d", NNS_TENSOR_SIZE_LIMIT);

--- a/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_flexbuf.cc
@@ -114,7 +114,7 @@ flxc_convert (GstBuffer *in_buf, GstTensorsConfig *config, void *priv_data)
   }
   config->rate_n = tensors["rate_n"].AsInt32 ();
   config->rate_d = tensors["rate_d"].AsInt32 ();
-  config->format = (tensor_format) tensors["format"].AsInt32 ();
+  config->info.format = (tensor_format) tensors["format"].AsInt32 ();
   out_buf = gst_buffer_new ();
 
   for (guint i = 0; i < config->info.num_tensors; i++) {

--- a/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
@@ -115,7 +115,7 @@ fbd_decode (void **pdata, const GstTensorsConfig *config,
 
   num_tensors = fbd_config.info.num_tensors;
   fr = frame_rate (fbd_config.rate_n, fbd_config.rate_d);
-  format = (Tensor_format) fbd_config.format;
+  format = (Tensor_format) fbd_config.info.format;
   /* Fill the info in tensor and puth to tensor vector */
   for (i = 0; i < num_tensors; i++) {
     unsigned char *tmp_buf;

--- a/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
@@ -140,7 +140,7 @@ flxd_decode (void **pdata, const GstTensorsConfig *config,
     fbb.UInt ("num_tensors", num_tensors);
     fbb.Int ("rate_n", flxd_config.rate_n);
     fbb.Int ("rate_d", flxd_config.rate_d);
-    fbb.Int ("format", flxd_config.format);
+    fbb.Int ("format", flxd_config.info.format);
     for (i = 0; i < num_tensors; i++) {
       gchar *tensor_key = g_strdup_printf ("tensor_%d", i);
       gchar *tensor_name = NULL;

--- a/gst/nnstreamer/elements/gsttensor_converter.c
+++ b/gst/nnstreamer/elements/gsttensor_converter.c
@@ -1164,11 +1164,11 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
       tmp.rate_n = config->rate_n;
       tmp.rate_d = config->rate_d;
 
-      tmp.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+      tmp.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
       buf = gst_tensor_buffer_from_config (buf, &tmp);
 
       /* type and dimension from buffer */
-      tmp.format = _NNS_TENSOR_FORMAT_STATIC;
+      tmp.info.format = _NNS_TENSOR_FORMAT_STATIC;
       tmp.info.num_tensors = gst_buffer_n_memory (buf);
 
       /* compare data size and append memory */
@@ -1258,7 +1258,7 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
         goto error;
       }
       self->do_not_append_header =
-          (new_config.format == _NNS_TENSOR_FORMAT_FLEXIBLE);
+          (new_config.info.format == _NNS_TENSOR_FORMAT_FLEXIBLE);
 
       frames_in = 1;
       frame_size = gst_buffer_get_size (inbuf);
@@ -1747,7 +1747,7 @@ gst_tensor_converter_parse_octet (GstTensorConverter * self,
    * If output is flexible, dimension should be updated in chain function with buffer size.
    */
   if (flexible) {
-    config->format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+    config->info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
 
     config->info.num_tensors = 1;
     config->info.info[0].type = _NNS_UINT8;

--- a/gst/nnstreamer/elements/gsttensor_crop.c
+++ b/gst/nnstreamer/elements/gsttensor_crop.c
@@ -459,7 +459,7 @@ gst_tensor_crop_negotiate (GstTensorCrop * self)
      * Output is always flexible tensor.
      */
     gst_tensors_config_init (&config);
-    config.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+    config.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
 
     walk = self->collect->data;
     while (walk) {

--- a/gst/nnstreamer/elements/gsttensor_demux.c
+++ b/gst/nnstreamer/elements/gsttensor_demux.c
@@ -324,7 +324,7 @@ gst_tensor_demux_get_tensor_config (GstTensorDemux * tensor_demux,
         &tensor_demux->tensors_config.info.info[nth]);
   }
 
-  config->format = tensor_demux->tensors_config.format;
+  config->info.format = tensor_demux->tensors_config.info.format;
   config->rate_n = tensor_demux->tensors_config.rate_n;
   config->rate_d = tensor_demux->tensors_config.rate_d;
   return TRUE;

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -1953,7 +1953,7 @@ gst_tensor_transform_transform_caps (GstBaseTransform * trans,
 
     if (gst_tensors_config_is_flexible (&in_config)) {
       /* output caps is also flexible */
-      out_config.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+      out_config.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
     } else {
       for (j = 0; j < in_config.info.num_tensors; j++) {
         gst_tensor_transform_convert_dimension (filter, direction,
@@ -2063,7 +2063,7 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
 
   /* compare type and dimension */
   gst_tensors_config_init (&config);
-  config.format = out_config.format;
+  config.info.format = out_config.info.format;
 
   config.rate_n = in_config.rate_n;
   config.rate_d = in_config.rate_d;

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
@@ -251,17 +251,17 @@ gst_tensors_config_to_string (const GstTensorsConfig * config);
 /**
  * @brief Macro to check stream format (static tensors for caps negotiation)
  */
-#define gst_tensors_config_is_static(c) ((c)->format == _NNS_TENSOR_FORMAT_STATIC)
+#define gst_tensors_config_is_static(c) ((c)->info.format == _NNS_TENSOR_FORMAT_STATIC)
 
 /**
  * @brief Macro to check stream format (flexible tensors for caps negotiation)
  */
-#define gst_tensors_config_is_flexible(c) ((c)->format == _NNS_TENSOR_FORMAT_FLEXIBLE)
+#define gst_tensors_config_is_flexible(c) ((c)->info.format == _NNS_TENSOR_FORMAT_FLEXIBLE)
 
 /**
  * @brief Macro to check stream format (sparse tensors for caps negotiation)
  */
-#define gst_tensors_config_is_sparse(c) ((c)->format == _NNS_TENSOR_FORMAT_SPARSE)
+#define gst_tensors_config_is_sparse(c) ((c)->info.format == _NNS_TENSOR_FORMAT_SPARSE)
 
 /**
  * @brief Check the tensor dimension is valid

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -244,6 +244,7 @@ typedef struct
 {
   unsigned int num_tensors; /**< The number of tensors */
   GstTensorInfo info[NNS_TENSOR_SIZE_LIMIT]; /**< The list of tensor info */
+  tensor_format format; /**< tensor stream type */
 } GstTensorsInfo;
 
 /**
@@ -252,7 +253,6 @@ typedef struct
 typedef struct
 {
   GstTensorsInfo info; /**< tensor info*/
-  tensor_format format; /**< tensor stream type */
   int rate_n; /**< framerate is in fraction, which is numerator/denominator */
   int rate_d; /**< framerate is in fraction, which is numerator/denominator */
 } GstTensorsConfig;

--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -395,13 +395,13 @@ gst_tensor_time_sync_buffer_from_collectpad (GstCollectPads * collect,
       g_assert ((counting + n_mem) < NNS_TENSOR_SIZE_LIMIT);
 
       if (gst_tensors_config_is_flexible (&in_configs))
-        configs->format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+        configs->info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
 
       for (i = 0; i < n_mem; ++i) {
         in_mem[counting] = gst_buffer_get_memory (buf, i);
 
         configs->info.info[counting] = in_configs.info.info[i];
-        in_formats[counting] = in_configs.format;
+        in_formats[counting] = in_configs.info.format;
         counting++;
       }
 
@@ -1141,11 +1141,11 @@ gst_tensors_config_from_structure (GstTensorsConfig * config,
             ("Invalid format %s, it should be one of %s. Suppose tensor format is static.",
             _STR_NULL (format_str), GST_TENSOR_FORMAT_ALL);
       } else {
-        config->format = format;
+        config->info.format = format;
       }
     }
 
-    if (config->format == _NNS_TENSOR_FORMAT_STATIC) {
+    if (config->info.format == _NNS_TENSOR_FORMAT_STATIC) {
       gst_structure_get_int (structure, "num_tensors",
           (gint *) (&config->info.num_tensors));
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -2275,6 +2275,7 @@ gst_tensor_filter_common_get_combined_out_info (GstTensorFilterPrivate * priv,
     }
 
     combined->num_tensors = idx;
+    combined->format = out->format;
   } else {
     gst_tensors_info_copy (combined, out);
   }

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -892,7 +892,7 @@ TEST (commonTensorsConfig, equal09_p)
   fill_tensors_config_for_test (&conf1, &conf2);
 
   /* compare flexible tensor */
-  conf1.format = conf2.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  conf1.info.format = conf2.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
 
   EXPECT_TRUE (gst_tensors_config_is_equal (&conf1, &conf2));
 }
@@ -907,7 +907,7 @@ TEST (commonTensorsConfig, equal10_n)
   fill_tensors_config_for_test (&conf1, &conf2);
 
   /* change format, this should not be compatible */
-  conf2.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  conf2.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
 
   EXPECT_FALSE (gst_tensors_config_is_equal (&conf1, &conf2));
 }
@@ -1746,7 +1746,7 @@ TEST (commonUtil, createStaticTensorBuffer)
   gsize data_size;
 
   gst_tensors_config_init (&config);
-  config.format = _NNS_TENSOR_FORMAT_STATIC;
+  config.info.format = _NNS_TENSOR_FORMAT_STATIC;
   config.rate_n = config.rate_d = 1;
   config.info.num_tensors = 3U;
   gst_tensors_info_parse_dimensions_string (&config.info, "20,40,50");
@@ -1797,7 +1797,7 @@ TEST (commonUtil, createFlexTensorBuffer)
   gsize data_size, offset, hsize[3], dsize[3];
 
   gst_tensors_config_init (&config);
-  config.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  config.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
   config.rate_n = config.rate_d = 1;
   config.info.num_tensors = 3U;
   gst_tensors_info_parse_dimensions_string (&config.info, "20,30,40");
@@ -1871,7 +1871,7 @@ TEST (commonUtil, createTensorBufferNullParam_n)
   gsize data_size;
 
   gst_tensors_config_init (&config);
-  config.format = _NNS_TENSOR_FORMAT_STATIC;
+  config.info.format = _NNS_TENSOR_FORMAT_STATIC;
   config.rate_n = config.rate_d = 1;
   config.info.num_tensors = 3U;
   gst_tensors_info_parse_dimensions_string (&config.info, "20,40,50");
@@ -1898,7 +1898,7 @@ TEST (commonUtil, createTensorBufferInvalidSize_n)
   gsize data_size;
 
   gst_tensors_config_init (&config);
-  config.format = _NNS_TENSOR_FORMAT_STATIC;
+  config.info.format = _NNS_TENSOR_FORMAT_STATIC;
   config.rate_n = config.rate_d = 1;
   config.info.num_tensors = 3U;
   gst_tensors_info_parse_dimensions_string (&config.info, "20,40,50");

--- a/tests/nnstreamer_decoder/unittest_decoder.cc
+++ b/tests/nnstreamer_decoder/unittest_decoder.cc
@@ -40,7 +40,7 @@ tensor_decoder_custom_cb (const GstTensorMemory *input,
     fbb.UInt ("num_tensors", num_tensors);
     fbb.Int ("rate_n", config->rate_n);
     fbb.Int ("rate_d", config->rate_d);
-    fbb.Int ("format", config->format);
+    fbb.Int ("format", config->info.format);
     for (i = 0; i < num_tensors; i++) {
       gchar *tensor_key = g_strdup_printf ("tensor_%d", i);
       gchar *tensor_name = NULL;

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -7012,7 +7012,7 @@ _crop_test_push_buffer (crop_test_data_s * crop_test)
   gst_tensors_config_init (&config);
   config.info.num_tensors = 1;
   config.info.info[0] = crop_test->raw_info;
-  config.format = crop_test->raw_format;
+  config.info.format = crop_test->raw_format;
   config.rate_n = 0;
   config.rate_d = 1;
 


### PR DESCRIPTION
Move enum flag - tensor_format into tensors-info struct.

To pass flexible tensors to filter sub-plugins, we should indicate tensor format in tensors-info struct, not tensors-config. Internally tensors-config struct is used for caps negotiation.

TODO: need discussion, should we separate format in each tensor info, so that each mem chunk can express its format. (then, nnstreamer will combine memories: static+flexible in gst-buffer.)

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
