### PR TITLE
[decoder/pose] Fix SEGV, ignore pixel when coordinates are out of bounds. @open sesame 11/10 08:29

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -514,6 +514,25 @@ typedef struct
 } pose;
 
 /**
+ * @brief Check if a value is within lower and upper bounds
+ * @param value the value to check
+ * @param lower_b the lower bound (inclusive)
+ * @param upper_b the uppoer bound (exlcusive)
+ * @return TRUE if the value is within the bounds, otherwise FALSE
+ */
+static gboolean
+is_value_within(int value, int lower_b, int upper_b)
+{
+    if (value < lower_b) {
+        return FALSE;
+    } else if (value >= upper_b) {
+        return FALSE;
+    } else {
+        return TRUE;
+    }
+}
+
+/**
  * @brief Fill in pixel with PIXEL_VALUE at x,y position. Make thicker (x+1, y+1)
  * @param[out] out_info The output buffer (RGBA plain)
  * @param[in] bdata The bouding-box internal data.
@@ -522,17 +541,19 @@ typedef struct
 static void
 setpixel (uint32_t * frame, pose_data * data, int x, int y)
 {
-  uint32_t *pos = &frame[y * data->width + x];
-  *pos = PIXEL_VALUE;
+    if (is_value_within(x, 0, data->width) && is_value_within(y, 0, data->height)) {
+        uint32_t *pos = &frame[y * data->width + x];
+        *pos = PIXEL_VALUE;
 
-  if (x + 1 < (int) data->width) {
-    pos = &frame[y * data->width + x + 1];
-    *pos = PIXEL_VALUE;
-  }
-  if (y + 1 < (int) data->height) {
-    pos = &frame[(y + 1) * data->width + x];
-    *pos = PIXEL_VALUE;
-  }
+        if (x + 1 < (int) data->width) {
+            pos = &frame[y * data->width + x + 1];
+            *pos = PIXEL_VALUE;
+        }
+        if (y + 1 < (int) data->height) {
+            pos = &frame[(y + 1) * data->width + x];
+            *pos = PIXEL_VALUE;
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Under some circumstances, setpixel() is called with y==data.height which causes a SEGV. While this might be a rounding error in the caller draw(), the added code gracefully ignores such out-of-bound pixels gracefully.

Steps to reproduce with modified nnstreamer example (different media):

```
gst-launch-1.0 \
souphttpsrc location=https://storage.googleapis.com/ts-video-test/test1_vlog.mp4 \
! qtdemux ! decodebin ! videoconvert \
! videoscale ! videorate ! video/x-raw,width=640,height=360,format=RGB \
  ! tee name=nnt \
  nnt. \
    ! queue \
    ! videoscale ! videorate ! video/x-raw,width=257,height=257,format=RGB \
    ! tensor_converter \
    ! tensor_transform mode=arithmetic option=typecast:float32,add:-127.5,div:127.5 \
    ! tensor_filter framework=tensorflow-lite \
      accelerator=true:gpu,npu,cpu \
      model=posenet_mobilenet_v1_100_257x257_multi_kpt_stripped.tflite \
    ! tensor_decoder mode=pose_estimation \
      option1=640:360 \
      option2=257:257 \
      option3=labels.txt \
      option4=heatmap-offset \
  ! nnmix.sink_0 \
  nnt. \
    ! queue \
    ! nnmix.sink_1 compositor name=nnmix sink_0::zorder=2 sink_1::zorder=1 \
  ! videoconvert ! autovideosink
```

Signed-off-by: Torsten Schulz <torsten.schulz@gmail.com>