### PR TITLE
[build] Disable tflite-custom in cross build

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -285,7 +285,7 @@ if tflite2_support_is_available
   )
 
 
-  if get_option('tflite2-custom-support').enabled() or get_option('tflite2-custom-support').auto()
+  if (get_option('tflite2-custom-support').enabled() or get_option('tflite2-custom-support').auto()) and not meson.is_cross_build()
     ## Create libtensorflow2-lite-custom.so support.
 
     ## @todo This assumes the same tflite version with the above.


### PR DESCRIPTION
- In cross build, found tflite lib could have different arch with target system. Disable this feature for cross build.
- This fixes #3964

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

