### PR TITLE
Initial RISC-V Github-Action Infra

### DIFF
--- a/.github/workflows/risc-v.yml
+++ b/.github/workflows/risc-v.yml
@@ -1,0 +1,28 @@
+name: Run on architecture (RISCV64 Alpine)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build_job:
+    runs-on: ubuntu-18.04
+    name: Build on alpine RISC-V
+    steps:
+      - uses: actions/checkout@v2.1.0
+      - uses: ProtoByter/run-on-arch-action@master
+        name: Run commands
+        id: Build
+        with:
+          arch: riscv64
+          distro: alpine_latest
+          githubToken: ${{ github.token }}
+          run: |
+            uname -a
+            echo ::set-output name=uname::$(uname -a)
+            apk update
+            apk add meson ninja glib-dev gstreamer-dev gst-plugins-base-dev gcc g++ bash python3 lua-dev
+            meson build
+            ninja -C build test

--- a/gst/nnstreamer/nnstreamer_log.c
+++ b/gst/nnstreamer/nnstreamer_log.c
@@ -8,7 +8,13 @@
  * @bug		No known bugs except for NYI items
  */
 
-#ifndef __ANDROID__
+#ifdef __ANDROID__
+#ifndef _NO_EXECINFO_
+#define _NO_EXECINFO_
+#endif
+#endif
+
+#ifndef _NO_EXECINFO_
 /* Android does not have execinfo.h. It has unwind.h instead. */
 #include <execinfo.h>
 #endif
@@ -29,7 +35,7 @@ char *
 _backtrace_to_string (void)
 {
   char *retstr = NULL;
-#ifndef __ANDROID__
+#ifndef _NO_EXECINFO_
 /* Android does not have execinfo.h. It has unwind.h instead. */
   void *array[20];
   char **strings;

--- a/meson.build
+++ b/meson.build
@@ -641,6 +641,11 @@ if get_option('enable-float16')
 
 endif
 
+# A few distros do not have execinfo.h
+if not cc.has_header('execinfo.h')
+  add_project_arguments('-D_NO_EXECINFO_', language: ['c', 'cpp'])
+endif
+
 # See if src-iio can be built or not
 gst18_dep = dependency('gstreamer-' + gst_api_verision, version : '>=1.8', required : false)
 tensor_src_iio_build = false

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -25,6 +25,7 @@ option('tvm-support', type: 'feature', value: 'auto')
 option('trix-engine-support', type: 'feature', value: 'auto')
 option('nnstreamer-edge-support', type: 'feature', value: 'auto')
 option('mxnet-support', type: 'feature', value: 'auto')
+option('parser-support', type: 'feature', value: 'auto') # gstreamer pipeline description <--> pbtxt pipeline
 
 # booleans & other options
 option('enable-test', type: 'boolean', value: true)

--- a/tools/development/parser/meson.build
+++ b/tools/development/parser/meson.build
@@ -1,6 +1,12 @@
 # Find flex, configure lex generator
 flex_min_version='2.5.31'
-flex = find_program('flex', 'win_flex', version: '>=' + flex_min_version)
+flex = find_program('flex', 'win_flex', version: '>=' + flex_min_version, required : false)
+if not flex.found()
+  if get_option('parser-support').enabled()
+    error('flex is required if parser-support is enabled')
+  endif
+  subdir_done()
+endif
 flex_cdata = configuration_data()
 flex_cdata.set('FLEX', flex.path())
 if cc.get_id() == 'msvc'
@@ -15,7 +21,13 @@ gen_lex = configure_file(input : 'gen_lex.py.in',
 
 # Find bison, configure grammar generator
 bison_min_version='2.4'
-bison = find_program('bison', 'win_bison', version: '>=' + bison_min_version)
+bison = find_program('bison', 'win_bison', version: '>=' + bison_min_version, required : false)
+if not bison.found()
+  if get_option('parser-support').enabled()
+    error('bison is required if parser-support is enabled')
+  endif
+  subdir_done()
+endif
 bison_cdata = configuration_data()
 bison_cdata.set('BISON', bison.path())
 bison_cdata.set('BISON_ARGS', '')


### PR DESCRIPTION
This enables Github-Action for RISC-V build & unit tests.


commit 48973d86af8669d7bef2982a897a900cd8eb1714 (HEAD -> action/riscv, github-fork/action/riscv)
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Thu Nov 24 16:47:52 2022 +0900

    log: control dependency on execinfo with find_library
    
    Like Android, Alpine linux does not ahve execinfo, too.
    Determine whether to use execinfo or not based on
    find_library results.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 1ed71a72e19849bd114872aa8c96f411f1b3fbaf
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Thu Nov 24 13:46:19 2022 +0900

    github-action: Add RISC-V build
    
    This tries to enable RISC-V build in github-action
    based on https://github.com/marketplace/actions/run-on-architecture-riscv64-alpine
    
    In order to build in more primitive distro,
    configure bixon/flex optional.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 80135f2ac8099898d62350a313e64abd08a38ce5
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Thu Nov 24 15:27:18 2022 +0900

    Make parser optional with meson_option.
    
    For simpler distro or other OS, make parser support optional.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
