### PR TITLE
debian: remove tensorflow1 from PPA

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,8 +11,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  libflatbuffers-dev, flatbuffers-compiler,
  protobuf-compiler (>=3.12), libprotobuf-dev [amd64 arm64 armhf],
  libpaho-mqtt-dev,
- tensorflow2-lite-dev, tensorflow-lite-dev | gcc,
- tensorflow-dev [amd64] | gcc,
+ tensorflow2-lite-dev,
  pytorch, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
  openvino-dev, openvino-cpu-mkldnn [amd64],
  nnfw-dev [amd64] | gcc,
@@ -50,20 +49,6 @@ Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer Single-shot
  Element to use general neural network framework directly without gstreamer pipeline.
-
-Package: nnstreamer-tensorflow
-Architecture: amd64
-Multi-Arch: same
-Depends: nnstreamer, tensorflow | tensorflow-dev, ${shlibs:Depends}, ${misc:Depends}
-Description: NNStreamer TensorFlow 1.x Support
- This package allows nnstreamer to support tensorflow. Note that users must make sure that they have installed Tensorflow with compatible C-API (recommended to use the same version). However, having different options (e.g., GPU mode) should not affect the compatibility. When we have stable C-API from Tensorflow, we will release corresponding subplugin as well.
-
-Package: nnstreamer-tensorflow-lite
-Architecture: any
-Multi-Arch: same
-Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
-Description: NNStreamer TensorFlow Lite 1.x Support
- This package allows nnstreamer to support tensorflow-lite.
 
 Package: nnstreamer-tensorflow2-lite
 Architecture: any

--- a/debian/nnstreamer-tensorflow-lite.install
+++ b/debian/nnstreamer-tensorflow-lite.install
@@ -1,1 +1,0 @@
-/usr/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow1-lite.so

--- a/debian/nnstreamer-tensorflow.install
+++ b/debian/nnstreamer-tensorflow.install
@@ -1,1 +1,0 @@
-/usr/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow.so

--- a/debian/rules
+++ b/debian/rules
@@ -56,8 +56,6 @@ override_dh_auto_build:
 	ninja -C ${BUILDDIR}
 	# A few modules are not avaiable in Ubuntu 22.04. Don't try to create them if not available.
 	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_nnfw.so' ]; then echo "NNFW exists" ; else rm debian/nnstreamer-nnfw.install; fi
-	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_tensorflow.so' ]; then echo "Tensorflow exists" ; else rm debian/nnstreamer-tensorflow.install; fi
-	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_tensorflow1-lite.so' ]; then echo "Tensorflow1-lite exists" ; else rm debian/nnstreamer-tensorflow-lite.install; fi
 
 override_dh_auto_test:
 	./packaging/run_unittests_binaries.sh ./tests


### PR DESCRIPTION
Let's not build obsolete tensorflow1.x subplugins
and remove them from official PPA build.

Fixes #3969

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

