### PR TITLE
src/iio: clean up build logic

### DIFF
--- a/gst/nnstreamer/elements/meson.build
+++ b/gst/nnstreamer/elements/meson.build
@@ -19,19 +19,9 @@ tensor_element_sources = [
 ]
 
 # gsttensorsrc
-tensor_src_sources = []
-gst18_dep = dependency('gstreamer-' + gst_api_verision, version : '>=1.8', required : false)
-if gst18_dep.found()
-  tensor_src_sources += 'gsttensor_srciio.c'
-else
-  message('tensor_src_iio requires GStreamer >= 1.8. Skipping it')
+if tensor_src_iio_build
+  nnstreamer_sources += join_paths(meson.current_source_dir(), 'gsttensor_srciio.c')
 endif
-
-foreach s : tensor_src_sources
-  if build_platform != 'macos'
-    nnstreamer_sources += join_paths(meson.current_source_dir(), s)
-  endif
-endforeach
 
 # gsttensortransform
 if orcc_support_is_available

--- a/gst/nnstreamer/registerer/nnstreamer.c
+++ b/gst/nnstreamer/registerer/nnstreamer.c
@@ -64,9 +64,9 @@
 #include <elements/gsttensor_split.h>
 #include <elements/gsttensor_transform.h>
 
-#if defined(__gnu_linux__) && !defined(__ANDROID__)
+#ifdef _ENABLE_SRC_IIO
 #include <elements/gsttensor_srciio.h>
-#endif /* __gnu_linux__ && !__ANDROID__ */
+#endif
 
 #include <tensor_filter/tensor_filter.h>
 #if defined(ENABLE_NNSTREAMER_EDGE)
@@ -111,13 +111,9 @@ gst_nnstreamer_init (GstPlugin * plugin)
   NNSTREAMER_INIT (plugin, query_serversink, QUERY_SERVERSINK);
   NNSTREAMER_INIT (plugin, query_client, QUERY_CLIENT);
 #endif
-#if defined(__gnu_linux__) && !defined(__ANDROID__)
-  /* IIO requires Linux / non-Android */
-#if (GST_VERSION_MAJOR == 1) && (GST_VERSION_MINOR >= 8)
-  /* SRC-IIO code uses GST 1.8+ APIs. */
+#ifdef _ENABLE_SRC_IIO
   NNSTREAMER_INIT (plugin, src_iio, SRC_IIO);
 #endif
-#endif /* __gnu_linux__ && !__ANDROID__ */
   return TRUE;
 }
 

--- a/meson.build
+++ b/meson.build
@@ -641,6 +641,17 @@ if get_option('enable-float16')
 
 endif
 
+# See if src-iio can be built or not
+gst18_dep = dependency('gstreamer-' + gst_api_verision, version : '>=1.8', required : false)
+tensor_src_iio_build = false
+if gst18_dep.found() and build_platform != 'macos'
+  add_project_arguments('-D_ENABLE_SRC_IIO', language: ['c', 'cpp'])
+  message('tensor_src_iio enabled')
+  tensor_src_iio_build = true
+else
+  message('tensor_src_iio disabled: it requires GStreamer >= 1.8 and Linux')
+endif
+
 # Build nnstreamer (common, plugins)
 subdir('gst')
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -176,7 +176,7 @@ if gtest_dep.found()
     endif
 
     # Run unittest_src_iio
-    if build_platform != 'macos'
+    if tensor_src_iio_build
       unittest_src_iio = executable('unittest_src_iio',
         join_paths('nnstreamer_source', 'unittest_src_iio.cc'),
         dependencies: [nnstreamer_unittest_deps],


### PR DESCRIPTION
related logic rewritten:
- determine if src-iio is built
- determine if src-iio is registered
- determine if src-iio is tested via gtest

all the three decisions are unified for glitches in alpine build.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
