### PR TITLE
github-action: Add libunwind-dev for jammy (22.04)

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v1
     - name: install minimal requirements
-      run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+      run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev
     - uses: BSFishy/meson-build@v1.0.3
       with:
         action: test


### PR DESCRIPTION
In the case of Ubuntu 22.04, the below error occurs since unmet dependencies. This patch fixes this bug.
- libunwind-14-dev : Breaks: libunwind-dev but 1.3.2-2build2 is to be installed

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

