### PR TITLE
README: Replace the broken link for the SSDC 2019 page @open sesame 12/3 19:11 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ neural network developers to manage neural network pipelines and their filters e
 [NNStreamer: Stream Processing Paradigm for Neural Networks ...](https://arxiv.org/abs/1901.04985) [[pdf/tech report](https://arxiv.org/pdf/1901.04985)]<br />
 [GStreamer Conference 2018, NNStreamer](https://gstreamer.freedesktop.org/conference/2018/talks-and-speakers.html#nnstreamer-neural-networks-as-filters) [[media](https://github.com/nnstreamer/nnstreamer/wiki/Gstreamer-Conference-2018-Presentation-Video)] [[pdf/slides](https://github.com/nnstreamer/nnstreamer/wiki/slides/2018_GSTCON_Ham_181026.pdf)]<br />
 [Naver Tech Talk (Korean), 2018](https://www.facebook.com/naverengineering/posts/2255360384531425) [[media](https://youtu.be/XvXxcnbRjgU)] [[pdf/slides](https://www.slideshare.net/NaverEngineering/nnstreamer-stream-pipeline-for-arbitrary-neural-networks)]<br />
-[Samsung Developer Conference 2019, NNStreamer](https://www.samsungdeveloperconference.com/schedule/session/1089245) [[media](https://youtu.be/wVbMbpOjbkw)]<br />
+[Samsung Developer Conference 2019, NNStreamer (media)](https://youtu.be/wVbMbpOjbkw)<br />
 [ResearchGate Page of NNStreamer](https://www.researchgate.net/project/Neural-Network-Streamer-nnstreamer)
 
 


### PR DESCRIPTION
This patch replaces the link for the SSDC 2019 page, which exists no more (404 Not Found), in README.md with the YouTube link.

Signed-off-by: Wook Song <wook16.song@samsung.co