### PR TITLE
GitHub/Actions: Use a matrix strategy in the workflow for Ubuntu

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -9,7 +9,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Before resolving #3979, this PR applies a matrix strategy in our CI/CD workflow for Ubuntu as 'ubuntu-latest' is currently migrating from 20.04 to 22.04 [1].  You can see the result [here](https://github.com/wooksong/nnstreamer/pull/3).

[1] https://github.com/actions/runner-images#ongoing-migrations

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
