### PR TITLE
riscv64 alpine linux --> ubuntu

### DIFF
--- a/.github/workflows/risc-v.yml
+++ b/.github/workflows/risc-v.yml
@@ -1,4 +1,4 @@
-name: Run on architecture (RISCV64 Alpine)
+name: Test on RISCV64 Ubuntu 20.04
 
 on:
   push:
@@ -12,17 +12,15 @@ jobs:
     name: Build on alpine RISC-V
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: ProtoByter/run-on-arch-action@master
+      - uses: myungjoo/run-on-arch-action@master
         name: Run commands
         id: Build
         with:
           arch: riscv64
-          distro: alpine_latest
+          distro: ubuntu20.04
           githubToken: ${{ github.token }}
           run: |
-            uname -a
-            echo ::set-output name=uname::$(uname -a)
-            apk update
-            apk add meson ninja glib-dev gstreamer-dev gst-plugins-base-dev gcc g++ bash python3 lua-dev
+            apt-get -qy update
+            apt-get -qy install meson ninja-build libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libglib2.0-dev gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good libgtest-dev libpng-dev libopencv-dev python3 python3-dev python3-numpy pkg-config gcc g++ liblua5.1-dev
             meson build
-            ninja -C build test
+            ninja -C build


### PR DESCRIPTION
Try Ubuntu instead of alpine for riscv64 tests

Alpine linux provides a few developmental packages quite different from Ubuntu/Tizen, requiring too much exception handling in unit tests.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>