### PR TITLE
[Common] Add common utils for tensors dimension compare @open sesame 12/15 14:35

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
@@ -301,6 +301,13 @@ extern gchar *
 gst_tensor_get_rank_dimension_string (const tensor_dim dim, const unsigned int rank);
 
 /**
+ * @brief Compare dimension strings
+ * @return TRUE if equal, FALSE if given dimension strings are invalid or not equal.
+ */
+extern gboolean
+gst_tensor_dimension_string_is_equal (const gchar * dimstr1, const gchar * dimstr2);
+
+/**
  * @brief Count the number of elements of a tensor
  * @return The number of elements. 0 if error.
  * @param dim The tensor dimension

--- a/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
@@ -976,6 +976,53 @@ gst_tensor_get_rank_dimension_string (const tensor_dim dim,
 }
 
 /**
+ * @brief Compare dimension strings
+ * @return TRUE if equal, FALSE if given dimension strings are invalid or not equal.
+ */
+gboolean
+gst_tensor_dimension_string_is_equal (const gchar * dimstr1,
+    const gchar * dimstr2)
+{
+  tensor_dim dim1, dim2;
+  int rank1, rank2, i, j, num_tensors1, num_tensors2;
+  gchar **strv1;
+  gchar **strv2;
+  gboolean res = TRUE;
+
+  strv1 = g_strsplit_set (dimstr1, ",.", -1);
+  strv2 = g_strsplit_set (dimstr2, ",.", -1);
+
+  num_tensors1 = g_strv_length (strv1);
+  num_tensors2 = g_strv_length (strv2);
+
+  if (num_tensors1 != num_tensors2) {
+    res = FALSE;
+  } else {
+    for (i = 0; i < num_tensors1 && res; i++) {
+      rank1 = gst_tensor_parse_dimension (strv1[i], dim1);
+      rank2 = gst_tensor_parse_dimension (strv2[i], dim2);
+
+      if (!rank1 || !rank2) {
+        res = FALSE;
+        break;
+      }
+
+      for (j = 0; j < NNS_TENSOR_RANK_LIMIT; j++) {
+        if (dim1[j] != dim2[j]) {
+          res = FALSE;
+          break;
+        }
+      }
+    }
+  }
+
+  g_strfreev (strv1);
+  g_strfreev (strv2);
+
+  return res;
+}
+
+/**
  * @brief Count the number of elements of a tensor
  * @return The number of elements. 0 if error.
  * @param dim The tensor dimension

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -282,7 +282,7 @@ TEST (commonGetTensorDimension, case1)
   EXPECT_EQ (dim[3], 177U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
-  EXPECT_STREQ (dim_str, "345:123:433:177");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (dim_str, "345:123:433:177"));
   g_free (dim_str);
 }
 
@@ -303,7 +303,7 @@ TEST (commonGetTensorDimension, case2)
   EXPECT_EQ (dim[3], 1U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
-  EXPECT_STREQ (dim_str, "345:123:433:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (dim_str, "345:123:433:1"));
   g_free (dim_str);
 }
 
@@ -324,7 +324,7 @@ TEST (commonGetTensorDimension, case3)
   EXPECT_EQ (dim[3], 1U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
-  EXPECT_STREQ (dim_str, "345:123:1:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (dim_str, "345:123:1:1"));
   g_free (dim_str);
 }
 
@@ -345,7 +345,7 @@ TEST (commonGetTensorDimension, case4)
   EXPECT_EQ (dim[3], 1U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
-  EXPECT_STREQ (dim_str, "345:1:1:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (dim_str, "345:1:1:1"));
   g_free (dim_str);
 }
 
@@ -997,7 +997,7 @@ TEST (commonTensorsInfoString, dimensions)
   info.num_tensors = num_dims;
 
   str_dims = gst_tensors_info_get_dimensions_string (&info);
-  EXPECT_STREQ (str_dims, "1:2:3:4");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (str_dims, "1:2:3:4"));
   g_free (str_dims);
 
   /* 4 tensors info */
@@ -1007,7 +1007,7 @@ TEST (commonTensorsInfoString, dimensions)
   info.num_tensors = num_dims;
 
   str_dims = gst_tensors_info_get_dimensions_string (&info);
-  EXPECT_STREQ (str_dims, "1:1:1:1,2:2:1:1,3:3:3:1,4:4:4:4");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (str_dims, "1:1:1:1,2:2:1:1,3:3:3:1,4:4:4:4"));
   g_free (str_dims);
 
   /* max */

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -6190,7 +6190,7 @@ TEST_REQUIRE_TFLITE (testTensorFilter, propertyRank02)
 
   gchar *input_dim;
   g_object_get (filter, "input", &input_dim, NULL);
-  EXPECT_STREQ (input_dim, "3:224:224:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (input_dim, "3:224:224:1"));
   g_free (input_dim);
 
   /* Rank should be 3 since input dimension string is not given. */
@@ -6201,7 +6201,7 @@ TEST_REQUIRE_TFLITE (testTensorFilter, propertyRank02)
 
   gchar *output_dim;
   g_object_get (filter, "output", &output_dim, NULL);
-  EXPECT_STREQ (output_dim, "1001:1:1:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (output_dim, "1001:1:1:1"));
   g_free (output_dim);
 
   /* Rank should be 1 since output dimension string is not given. */

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -2771,7 +2771,7 @@ TEST (tensorStreamTest, textUtf83f)
   ASSERT_TRUE (convert != NULL);
 
   g_object_get (convert, "input-dim", &prop_str, NULL);
-  EXPECT_STREQ (prop_str, "30:1:1:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (prop_str, "30:1:1:1"));
   g_free (prop_str);
 
   g_object_get (convert, "input-type", &prop_str, NULL);
@@ -2939,7 +2939,7 @@ TEST (tensorStreamTest, octetValidTs)
   ASSERT_TRUE (convert != NULL);
 
   g_object_get (convert, "input-dim", &prop_str, NULL);
-  EXPECT_STREQ (prop_str, "1:10:1:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (prop_str, "1:10:1:1"));
   g_free (prop_str);
 
   g_object_get (convert, "input-type", &prop_str, NULL);
@@ -3013,7 +3013,7 @@ TEST (tensorStreamTest, octetInvalidTs)
   ASSERT_TRUE (convert != NULL);
 
   g_object_get (convert, "input-dim", &prop_str, NULL);
-  EXPECT_STREQ (prop_str, "1:10:1:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (prop_str, "1:10:1:1"));
   g_free (prop_str);
 
   g_object_get (convert, "input-type", &prop_str, NULL);
@@ -3087,7 +3087,7 @@ TEST (tensorStreamTest, octet2f)
   ASSERT_TRUE (convert != NULL);
 
   g_object_get (convert, "input-dim", &prop_str, NULL);
-  EXPECT_STREQ (prop_str, "1:5:1:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (prop_str, "1:5:1:1"));
   g_free (prop_str);
 
   g_object_get (convert, "input-type", &prop_str, NULL);
@@ -3160,7 +3160,7 @@ TEST (tensorStreamTest, octetMultiTensors)
   ASSERT_TRUE (convert != NULL);
 
   g_object_get (convert, "input-dim", &prop_str, NULL);
-  EXPECT_STREQ (prop_str, "2:1:1:1,2:1:1:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (prop_str, "2:1:1:1,2:1:1:1"));
   g_free (prop_str);
 
   g_object_get (convert, "input-type", &prop_str, NULL);
@@ -3633,7 +3633,7 @@ TEST (tensorStreamTest, filterProperties1)
 
   /* input */
   g_object_get (filter, "input", &str, NULL);
-  EXPECT_STREQ (str, "3:160:120:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (str, "3:160:120:1"));
   g_free (str);
 
   /* inputtype */
@@ -3648,7 +3648,7 @@ TEST (tensorStreamTest, filterProperties1)
 
   /* output */
   g_object_get (filter, "output", &str, NULL);
-  EXPECT_STREQ (str, "3:160:120:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (str, "3:160:120:1"));
   g_free (str);
 
   /* outputtype */
@@ -3765,7 +3765,7 @@ TEST (tensorStreamTest, filterProperties2)
 
   /* input */
   g_object_get (filter, "input", &str, NULL);
-  EXPECT_STREQ (str, "3:160:120:1,3:120:80:1,3:64:48:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (str, "3:160:120:1,3:120:80:1,3:64:48:1"));
   g_free (str);
 
   /* inputtype */
@@ -3780,7 +3780,7 @@ TEST (tensorStreamTest, filterProperties2)
 
   /* output */
   g_object_get (filter, "output", &str, NULL);
-  EXPECT_STREQ (str, "3:160:120:1,3:120:80:1,3:64:48:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (str, "3:160:120:1,3:120:80:1,3:64:48:1"));
   g_free (str);
 
   /* outputtype */
@@ -4949,7 +4949,7 @@ TEST (tensorStreamTest, videoSplit)
   g_free (str);
 
   g_object_get (split, "tensorseg", &str, NULL);
-  EXPECT_STREQ (str, "1:160:120:1,1:160:120:1,1:160:120:1");
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (str, "1:160:120:1,1:160:120:1,1:160:120:1"));
   g_free (str);
 
   g_object_get (split, "silent", &silent, NULL);


### PR DESCRIPTION
This patch adds common function for tensors dimension compare.
From https://github.com/nnstreamer/nnstreamer/pull/3987#pullrequestreview-1207979064

Signed-off-by: Yelin Jeong <yelini.jeong@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
