### PR TITLE
[Query] remove mqtt connection type enum

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_common.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.c
@@ -36,8 +36,6 @@ gst_tensor_query_get_connect_type (void)
           "Directly sending stream frames via TCP connections."},
       {NNS_EDGE_CONNECT_TYPE_UDP, "UDP",
           "Directly sending stream frames via UDP connections."},
-      {NNS_EDGE_CONNECT_TYPE_MQTT, "MQTT",
-          "Connect and send stream frames with MQTT brokers."},
       {NNS_EDGE_CONNECT_TYPE_HYBRID, "HYBRID",
           "Connect with MQTT brokers and directly sending stream frames via TCP connections."},
       {0, NULL, NULL},


### PR DESCRIPTION
Since the tensor query does not send data through the mqtt, remove unnecessary enum.

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped
