### PR TITLE
[Meson] Don't use join_paths for library.

### DIFF
--- a/ext/nnstreamer/extra/meson.build
+++ b/ext/nnstreamer/extra/meson.build
@@ -15,13 +15,8 @@ if protobuf_support_is_available
   protobuf_util_sources = ['nnstreamer_protobuf.cc']
   protobuf_util_deps = [nnstreamer_dep, glib_dep, gst_dep, nns_protobuf_dep]
 
-  nns_protobuf_util_sources = []
-  foreach s : protobuf_util_sources
-    nns_protobuf_util_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   protobuf_util_dep = declare_dependency(
-    sources: nns_protobuf_util_sources,
+    sources: protobuf_util_sources,
     dependencies: protobuf_util_deps,
     include_directories: include_directories('.')
   )
@@ -29,29 +24,20 @@ endif
 
 if grpc_support_is_available
   grpc_common_src = ['nnstreamer_grpc_common.cc']
-  grpc_util_sources = []
   ignore_unused_param_auto_generated_files = declare_dependency(compile_args: ['-Wno-unused-parameter'])
 
-  foreach s : grpc_common_src
-    grpc_util_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   grpc_util_dep = declare_dependency(
-    sources: grpc_util_sources,
+    sources: grpc_common_src,
     dependencies: [nnstreamer_dep, glib_dep, gst_dep, libdl_dep, grpc_support_deps, ignore_unused_param_auto_generated_files],
     include_directories: include_directories('.')
   )
 
   if protobuf_support_is_available
     nns_protobuf_grpc_src = ['nnstreamer_grpc_protobuf.cc']
-    nns_protobuf_grpc_sources = []
-    foreach s : nns_protobuf_grpc_src
-      nns_protobuf_grpc_sources += join_paths(meson.current_source_dir(), s)
-    endforeach
 
     # Don't generate proto files twice
     nns_protobuf_grpc_lib = shared_library ('nnstreamer_grpc_protobuf',
-      sources : [grpc_pb_gen_src, nns_protobuf_grpc_sources],
+      sources : [grpc_pb_gen_src, nns_protobuf_grpc_src],
       dependencies : [grpc_util_dep, nns_protobuf_dep, ignore_unused_param_auto_generated_files],
       install: true,
       install_dir: nnstreamer_libdir
@@ -62,13 +48,9 @@ if grpc_support_is_available
 
   if flatbuf_support_is_available
     nns_flatbuf_grpc_src = ['nnstreamer_grpc_flatbuf.cc']
-    nns_flatbuf_grpc_sources = []
-    foreach s : nns_flatbuf_grpc_src
-      nns_flatbuf_grpc_sources += join_paths(meson.current_source_dir(), s)
-    endforeach
 
     nns_flatbuf_grpc_lib = shared_library ('nnstreamer_grpc_flatbuf',
-      sources : [grpc_fb_gen_src, nns_flatbuf_grpc_sources],
+      sources : [grpc_fb_gen_src, nns_flatbuf_grpc_src],
       dependencies : [grpc_util_dep, flatbuf_dep, ignore_unused_param_auto_generated_files],
       install: true,
       install_dir: nnstreamer_libdir
@@ -81,14 +63,9 @@ endif
 if have_python3
   nnstreamer_python3_deps = [python3_dep, libdl_dep, glib_dep, gst_dep, nnstreamer_dep]
   nnstreamer_python3_src = ['nnstreamer_python3_helper.cc']
-  nnstreamer_python3_sources = []
-
-  foreach s : nnstreamer_python3_src
-    nnstreamer_python3_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
 
   nnstreamer_python3_helper = shared_library('nnstreamer_python3',
-    sources: nnstreamer_python3_sources,
+    sources: nnstreamer_python3_src,
     name_prefix: '',
     dependencies: nnstreamer_python3_deps,
     install: true,

--- a/ext/nnstreamer/meson.build
+++ b/ext/nnstreamer/meson.build
@@ -54,21 +54,16 @@ subdir('tensor_sink')
 
 if get_option('enable-tizen-sensor')
   tizensensor_registerer_source_files = ['registerer/tizensensor.c']
-  tizensensor_registerer_sources = []
-
-  foreach s : tizensensor_registerer_source_files
-    tizensensor_registerer_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
 
   tizensensor_lib = shared_library('nnstreamer-tizen-sensor',
-    tizensensor_registerer_sources,
+    tizensensor_registerer_source_files,
     dependencies: tensor_src_tizensensor_dep,
     install: true,
     install_dir: plugins_install_dir
   )
 
   tizensensor_static = static_library('nnstreamer-tizen-sensor',
-    tizensensor_registerer_sources,
+    tizensensor_registerer_source_files,
     dependencies: tensor_src_tizensensor_dep,
     install: true,
     install_dir: nnstreamer_libdir
@@ -77,14 +72,9 @@ endif
 
 if grpc_support_is_available
   grpc_registerer_source_files = ['registerer/grpc.c']
-  grpc_registerer_sources = []
-
-  foreach s : grpc_registerer_source_files
-    grpc_registerer_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
 
   grpc_lib = shared_library('nnstreamer-grpc',
-    grpc_registerer_sources,
+    grpc_registerer_source_files,
     dependencies: [tensor_src_grpc_dep, tensor_sink_grpc_dep],
     install: true,
     install_dir: plugins_install_dir

--- a/ext/nnstreamer/registerer/meson.build
+++ b/ext/nnstreamer/registerer/meson.build
@@ -1,0 +1,28 @@
+if get_option('enable-tizen-sensor')
+  tizensensor_registerer_source_files = files('tizensensor.c')
+
+  tizensensor_lib = shared_library('nnstreamer-tizen-sensor',
+    tizensensor_registerer_source_files,
+    dependencies: tensor_src_tizensensor_dep,
+    install: true,
+    install_dir: plugins_install_dir
+  )
+
+  tizensensor_static = static_library('nnstreamer-tizen-sensor',
+    tizensensor_registerer_source_files,
+    dependencies: tensor_src_tizensensor_dep,
+    install: true,
+    install_dir: nnstreamer_libdir
+  )
+endif
+
+if grpc_support_is_available
+  grpc_registerer_source_files = files('grpc.c')
+
+  grpc_lib = shared_library('nnstreamer-grpc',
+    grpc_registerer_source_files,
+    dependencies: [tensor_src_grpc_dep, tensor_sink_grpc_dep],
+    install: true,
+    install_dir: plugins_install_dir
+  )
+endif

--- a/ext/nnstreamer/tensor_converter/meson.build
+++ b/ext/nnstreamer/tensor_converter/meson.build
@@ -2,16 +2,12 @@
 if flatbuf_support_is_available
   converter_sub_flatbuf_sources = [
     'tensor_converter_flatbuf.cc',
-    'tensor_converter_util.c'
-  ]
+    'tensor_converter_util.c']
 
-  nnstreamer_converter_flatbuf_sources = [fb_gen_src]
-  foreach s : converter_sub_flatbuf_sources
-    nnstreamer_converter_flatbuf_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
+  converter_sub_flatbuf_sources += fb_gen_src
 
   shared_library('nnstreamer_converter_flatbuf',
-    nnstreamer_converter_flatbuf_sources,
+    converter_sub_flatbuf_sources,
     dependencies: [nnstreamer_dep, glib_dep, gst_dep, flatbuf_dep],
     install: true,
     install_dir: converter_subplugin_install_dir
@@ -22,13 +18,8 @@ if flatbuf_support_is_available
     'tensor_converter_util.c'
   ]
 
-  nnstreamer_converter_flexbuf_sources = []
-  foreach s : converter_sub_flexbuf_sources
-    nnstreamer_converter_flexbuf_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   shared_library('nnstreamer_converter_flexbuf',
-    nnstreamer_converter_flexbuf_sources,
+    converter_sub_flexbuf_sources,
     dependencies: [nnstreamer_dep, glib_dep, gst_dep, flatbuf_dep],
     install: true,
     install_dir: converter_subplugin_install_dir
@@ -42,13 +33,8 @@ if protobuf_support_is_available
     'tensor_converter_util.c'
   ]
 
-  nnstreamer_converter_protobuf_sources = []
-  foreach s : converter_sub_protobuf_sources
-    nnstreamer_converter_protobuf_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   shared_library('nnstreamer_converter_protobuf',
-    nnstreamer_converter_protobuf_sources,
+    converter_sub_protobuf_sources,
     dependencies: [nnstreamer_dep, glib_dep, gst_dep, protobuf_util_dep],
     install: true,
     install_dir: converter_subplugin_install_dir
@@ -59,20 +45,15 @@ endif
 if have_python3
   converter_sub_python3_sources = ['tensor_converter_python3.cc']
 
-  nnstreamer_converter_python3_sources = []
-  foreach s : converter_sub_python3_sources
-    nnstreamer_converter_python3_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   shared_library('nnstreamer_converter_python3',
-    nnstreamer_converter_python3_sources,
+    converter_sub_python3_sources,
     dependencies: nnstreamer_python3_helper_dep,
     install: true,
     install_dir: converter_subplugin_install_dir
   )
 
   static_library('nnstreamer_converter_python3',
-    nnstreamer_converter_python3_sources,
+    converter_sub_python3_sources,
     dependencies: nnstreamer_python3_helper_dep,
     install: true,
     install_dir: nnstreamer_libdir

--- a/ext/nnstreamer/tensor_decoder/meson.build
+++ b/ext/nnstreamer/tensor_decoder/meson.build
@@ -4,19 +4,14 @@ decoder_sub_direct_video_sources = [
   'tensordecutil.c'
 ]
 
-nnstreamer_decoder_direct_video_sources = []
-foreach s : decoder_sub_direct_video_sources
-  nnstreamer_decoder_direct_video_sources += join_paths(meson.current_source_dir(), s)
-endforeach
-
 shared_library('nnstreamer_decoder_direct_video',
-  nnstreamer_decoder_direct_video_sources,
+  decoder_sub_direct_video_sources,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep],
   install: true,
   install_dir: decoder_subplugin_install_dir
 )
 static_library('nnstreamer_decoder_direct_video',
-  nnstreamer_decoder_direct_video_sources,
+  decoder_sub_direct_video_sources,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep],
   install: true,
   install_dir: nnstreamer_libdir
@@ -28,19 +23,14 @@ decoder_sub_image_labeling_sources = [
   'tensordecutil.c'
 ]
 
-nnstreamer_decoder_image_labeling_sources = []
-foreach s : decoder_sub_image_labeling_sources
-  nnstreamer_decoder_image_labeling_sources += join_paths(meson.current_source_dir(), s)
-endforeach
-
 shared_library('nnstreamer_decoder_image_labeling',
-  nnstreamer_decoder_image_labeling_sources,
+  decoder_sub_image_labeling_sources,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep],
   install: true,
   install_dir: decoder_subplugin_install_dir
 )
 static_library('nnstreamer_decoder_image_labeling',
-  nnstreamer_decoder_image_labeling_sources,
+  decoder_sub_image_labeling_sources,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep],
   install: true,
   install_dir: nnstreamer_libdir
@@ -53,19 +43,14 @@ decoder_sub_bounding_boxes_sources = [
   'tensordec-font.c'
 ]
 
-nnstreamer_decoder_bounding_boxes_sources = []
-foreach s : decoder_sub_bounding_boxes_sources
-  nnstreamer_decoder_bounding_boxes_sources += join_paths(meson.current_source_dir(), s)
-endforeach
-
 shared_library('nnstreamer_decoder_bounding_boxes',
-  nnstreamer_decoder_bounding_boxes_sources,
+  decoder_sub_bounding_boxes_sources,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep, libm_dep],
   install: true,
   install_dir: decoder_subplugin_install_dir
 )
 static_library('nnstreamer_decoder_bounding_boxes',
-  nnstreamer_decoder_bounding_boxes_sources,
+  decoder_sub_bounding_boxes_sources,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep, libm_dep],
   install: true,
   install_dir: nnstreamer_libdir
@@ -78,19 +63,14 @@ decoder_sub_pose_estimation_sources = [
   'tensordec-font.c'
 ]
 
-nnstreamer_decoder_pose_estimation_sources = []
-foreach s : decoder_sub_pose_estimation_sources
-  nnstreamer_decoder_pose_estimation_sources += join_paths(meson.current_source_dir(), s)
-endforeach
-
 shared_library('nnstreamer_decoder_pose_estimation',
-  nnstreamer_decoder_pose_estimation_sources,
+  decoder_sub_pose_estimation_sources,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep],
   install: true,
   install_dir: decoder_subplugin_install_dir
 )
 static_library('nnstreamer_decoder_pose_estimation',
-  nnstreamer_decoder_pose_estimation_sources,
+  decoder_sub_pose_estimation_sources,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep],
   install: true,
   install_dir: nnstreamer_libdir
@@ -102,19 +82,14 @@ decoder_sub_image_segment_sources = [
   'tensordecutil.c'
 ]
 
-nnstreamer_decoder_image_segment_sources = []
-foreach s : decoder_sub_image_segment_sources
-  nnstreamer_decoder_image_segment_sources += join_paths(meson.current_source_dir(), s)
-endforeach
-
 shared_library('nnstreamer_decoder_image_segment',
-  nnstreamer_decoder_image_segment_sources,
+  decoder_sub_image_segment_sources,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep],
   install: true,
   install_dir: decoder_subplugin_install_dir
 )
 static_library('nnstreamer_decoder_image_segment',
-  nnstreamer_decoder_image_segment_sources,
+  decoder_sub_image_segment_sources,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep],
   install: true,
   install_dir: nnstreamer_libdir
@@ -127,13 +102,8 @@ if protobuf_support_is_available
     'tensordecutil.c'
   ]
 
-  nnstreamer_decoder_protobuf_sources = []
-  foreach s : decoder_sub_protobuf_sources
-    nnstreamer_decoder_protobuf_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   shared_library('nnstreamer_decoder_protobuf',
-    nnstreamer_decoder_protobuf_sources,
+    decoder_sub_protobuf_sources,
     dependencies: [nnstreamer_dep, glib_dep, gst_dep, protobuf_util_dep],
     install: true,
     install_dir: decoder_subplugin_install_dir
@@ -147,13 +117,10 @@ if flatbuf_support_is_available
     'tensordecutil.c'
   ]
 
-  nnstreamer_decoder_flatbuf_sources = [fb_gen_src]
-  foreach s : decoder_sub_flatbuf_sources
-    nnstreamer_decoder_flatbuf_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
+  decoder_sub_flatbuf_sources += fb_gen_src
 
   shared_library('nnstreamer_decoder_flatbuf',
-    nnstreamer_decoder_flatbuf_sources,
+    decoder_sub_flatbuf_sources,
     dependencies: [nnstreamer_dep, glib_dep, gst_dep, flatbuf_dep],
     install: true,
     install_dir: decoder_subplugin_install_dir,
@@ -164,13 +131,8 @@ if flatbuf_support_is_available
     'tensordecutil.c'
   ]
 
-  nnstreamer_decoder_flexbuf_sources = []
-  foreach s : decoder_sub_flexbuf_sources
-    nnstreamer_decoder_flexbuf_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   shared_library('nnstreamer_decoder_flexbuf',
-    nnstreamer_decoder_flexbuf_sources,
+    decoder_sub_flexbuf_sources,
     dependencies: [nnstreamer_dep, glib_dep, gst_dep, flatbuf_dep],
     install: true,
     install_dir: decoder_subplugin_install_dir,
@@ -181,20 +143,15 @@ endif
 if have_python3
   decoder_sub_python3_sources = ['tensordec-python3.cc', 'tensordecutil.c']
 
-  nnstreamer_decoder_python3_sources = []
-  foreach s : decoder_sub_python3_sources
-    nnstreamer_decoder_python3_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   shared_library('nnstreamer_decoder_python3',
-    nnstreamer_decoder_python3_sources,
+    decoder_sub_python3_sources,
     dependencies: nnstreamer_python3_helper_dep,
     install: true,
     install_dir: decoder_subplugin_install_dir
   )
 
   static_library('nnstreamer_decoder_python3',
-    nnstreamer_decoder_python3_sources,
+    decoder_sub_python3_sources,
     dependencies: nnstreamer_python3_helper_dep,
     install: true,
     install_dir: nnstreamer_libdir
@@ -207,19 +164,14 @@ decoder_sub_octet_stream_sources = [
   'tensordecutil.c'
 ]
 
-nnstreamer_decoder_octet_stream_sources = []
-foreach s : decoder_sub_octet_stream_sources
-  nnstreamer_decoder_octet_stream_sources += join_paths(meson.current_source_dir(), s)
-endforeach
-
 shared_library('nnstreamer_decoder_octet_stream',
-  nnstreamer_decoder_octet_stream_sources,
+  decoder_sub_octet_stream_sources,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep],
   install: true,
   install_dir: decoder_subplugin_install_dir
 )
 static_library('nnstreamer_decoder_octet_stream',
-  nnstreamer_decoder_octet_stream_sources,
+  decoder_sub_octet_stream_sources,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep],
   install: true,
   install_dir: nnstreamer_libdir

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -1,11 +1,6 @@
 if nnfw_runtime_support_is_available
   filter_sub_nnfw_sources = ['tensor_filter_nnfw.c']
 
-  nnstreamer_filter_nnfw_sources = []
-  foreach s : filter_sub_nnfw_sources
-    nnstreamer_filter_nnfw_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   nnstreamer_filter_nnfw_deps = nnfw_runtime_support_deps + [nnstreamer_single_dep]
 
   # Check old function (@todo remove this definition later, nnfw ver >= 1.6.0)
@@ -14,13 +9,13 @@ if nnfw_runtime_support_is_available
   endif
 
   nnfw_plugin_lib = shared_library('nnstreamer_filter_nnfw',
-    nnstreamer_filter_nnfw_sources,
+    filter_sub_nnfw_sources,
     dependencies: nnstreamer_filter_nnfw_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
   static_library('nnstreamer_filter_nnfw',
-    nnstreamer_filter_nnfw_sources,
+    filter_sub_nnfw_sources,
     dependencies: nnstreamer_filter_nnfw_deps,
     install: true,
     install_dir: nnstreamer_libdir
@@ -34,11 +29,6 @@ if armnn_support_is_available
   filter_sub_armnn_sources = [
     'tensor_filter_armnn.cc'
   ]
-
-  nnstreamer_filter_armnn_sources = []
-  foreach s : filter_sub_armnn_sources
-    nnstreamer_filter_armnn_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
 
   if cxx.has_header('armnnCaffeParser/ICaffeParser.hpp')
     armnn_caffeparserlib = cxx.find_library('armnnCaffeParser', required: true)
@@ -56,13 +46,13 @@ if armnn_support_is_available
   nnstreamer_filter_armnn_deps = armnn_support_deps + [glib_dep, gst_dep, nnstreamer_dep ]
 
   armnn_plugin_lib = shared_library('nnstreamer_filter_armnn',
-    nnstreamer_filter_armnn_sources,
+    filter_sub_armnn_sources,
     dependencies: nnstreamer_filter_armnn_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
   static_library('nnstreamer_filter_armnn',
-    nnstreamer_filter_armnn_sources,
+    filter_sub_armnn_sources,
     dependencies: nnstreamer_filter_armnn_deps,
     install: true,
     install_dir: nnstreamer_libdir
@@ -91,23 +81,18 @@ if tf_support_is_available
 
   filter_sub_tf_sources = ['tensor_filter_tensorflow.cc']
 
-  nnstreamer_filter_tf_sources = []
-  foreach s : filter_sub_tf_sources
-    nnstreamer_filter_tf_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   nnstreamer_filter_tf_deps = tf_support_deps + [nnstreamer_single_dep]
   nnstreamer_filter_tf_deps += tf_ver_dep
 
   shared_library('nnstreamer_filter_tensorflow',
-    nnstreamer_filter_tf_sources,
+    filter_sub_tf_sources,
     dependencies: nnstreamer_filter_tf_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_tensorflow',
-    nnstreamer_filter_tf_sources,
+    filter_sub_tf_sources,
     dependencies: nnstreamer_filter_tf_deps,
     install: true,
     install_dir: nnstreamer_libdir
@@ -137,11 +122,6 @@ if tflite_support_is_available
   endif
 
   filter_sub_tflite_sources = ['tensor_filter_tensorflow_lite.cc']
-
-  nnstreamer_filter_tflite_sources = []
-  foreach s : filter_sub_tflite_sources
-    nnstreamer_filter_tflite_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
 
   nnstreamer_filter_tflite_deps = tflite_support_deps + [thread_dep, libdl_dep, glib_dep, nnstreamer_single_dep]
 
@@ -173,14 +153,14 @@ if tflite_support_is_available
   nnstreamer_filter_tflite_deps += tflite_ver_dep
 
   shared_library('nnstreamer_filter_tensorflow1-lite',
-    nnstreamer_filter_tflite_sources,
+    filter_sub_tflite_sources,
     dependencies: nnstreamer_filter_tflite_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_tensorflow1-lite',
-    nnstreamer_filter_tflite_sources,
+    filter_sub_tflite_sources,
     dependencies: nnstreamer_filter_tflite_deps,
     install: true,
     install_dir: nnstreamer_libdir
@@ -205,11 +185,6 @@ if tflite2_support_is_available
   message('TensorFlow2-lite version: ' + tflite2_ver)
 
   filter_sub_tflite2_sources = ['tensor_filter_tensorflow_lite.cc']
-
-  nnstreamer_filter_tflite2_sources = []
-  foreach s : filter_sub_tflite2_sources
-    nnstreamer_filter_tflite2_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
 
   nnstreamer_filter_tflite2_deps = tflite2_support_deps + [thread_dep, libdl_dep, nnstreamer_single_dep]
 
@@ -271,14 +246,14 @@ if tflite2_support_is_available
   nnstreamer_filter_tflite2_deps += tflite2_ver_dep
 
   shared_library('nnstreamer_filter_tensorflow2-lite',
-    nnstreamer_filter_tflite2_sources,
+    filter_sub_tflite2_sources,
     dependencies: nnstreamer_filter_tflite2_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_tensorflow2-lite',
-    nnstreamer_filter_tflite2_sources,
+    filter_sub_tflite2_sources,
     dependencies: nnstreamer_filter_tflite2_deps,
     install: true,
     install_dir: nnstreamer_libdir
@@ -352,7 +327,7 @@ if tflite2_support_is_available
         link_args: ['-L' + meson.current_build_dir(), '-ltensorflow2-lite-custom']
       )
       shared_library('nnstreamer_filter_tensorflow2-lite-custom',
-        nnstreamer_filter_tflite2_sources,
+        filter_sub_tflite2_sources,
         dependencies: [tflc_dep, thread_dep, libdl_dep, nnstreamer_single_dep, tflite2_ver_dep, tflite2_custom_extra_dep],
         install: true,
         install_dir:filter_subplugin_install_dir
@@ -376,11 +351,6 @@ if pytorch_support_is_available
     ignore_unused_params = declare_dependency(compile_args: ['-Wno-unused-parameter'])
     pytorch_support_deps += ignore_unused_params
 
-    nnstreamer_filter_torch_sources = []
-    foreach s : filter_sub_torch_sources
-      nnstreamer_filter_torch_sources += join_paths(meson.current_source_dir(), s)
-    endforeach
-
     nnstreamer_filter_torch_deps = pytorch_support_deps + [nnstreamer_single_dep]
 
     # pytorch version
@@ -389,14 +359,14 @@ if pytorch_support_is_available
     endif
 
     shared_library('nnstreamer_filter_pytorch',
-      nnstreamer_filter_torch_sources,
+      filter_sub_torch_sources,
       dependencies: nnstreamer_filter_torch_deps,
       install: true,
       install_dir: filter_subplugin_install_dir
     )
 
     static_library('nnstreamer_filter_pytorch',
-      nnstreamer_filter_torch_sources,
+      filter_sub_torch_sources,
       dependencies: nnstreamer_filter_torch_deps,
       install: true,
       install_dir: nnstreamer_libdir
@@ -409,22 +379,17 @@ endif
 if caffe2_support_is_available
   filter_sub_caffe2_sources = ['tensor_filter_caffe2.cc']
 
-  nnstreamer_filter_caffe2_sources = []
-  foreach s : filter_sub_caffe2_sources
-    nnstreamer_filter_caffe2_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   nnstreamer_filter_caffe2_deps = caffe2_support_deps + [protobuf_dep, glib_dep, nnstreamer_single_dep]
 
   shared_library('nnstreamer_filter_caffe2',
-    nnstreamer_filter_caffe2_sources,
+    filter_sub_caffe2_sources,
     dependencies: nnstreamer_filter_caffe2_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_caffe2',
-    nnstreamer_filter_caffe2_sources,
+    filter_sub_caffe2_sources,
     dependencies: nnstreamer_filter_caffe2_deps,
     install: true,
     install_dir: nnstreamer_libdir
@@ -436,20 +401,15 @@ if deepview_rt_support_is_available
 
   filter_sub_deepview_rt_sources = ['tensor_filter_deepview_rt.cc']
 
-  nnstreamer_filter_deepview_rt_sources = []
-  foreach s : filter_sub_deepview_rt_sources
-    nnstreamer_filter_deepview_rt_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   shared_library('nnstreamer_filter_deepview-rt',
-    nnstreamer_filter_deepview_rt_sources,
+    filter_sub_deepview_rt_sources,
     dependencies: nnstreamer_filter_deepview_rt_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_deepview-rt',
-    nnstreamer_filter_deepview_rt_sources,
+    filter_sub_deepview_rt_sources,
     dependencies: nnstreamer_filter_deepview_rt_deps,
     install: true,
     install_dir: nnstreamer_libdir
@@ -459,20 +419,15 @@ endif
 if have_python3
   filter_sub_python3_sources = ['tensor_filter_python3.cc']
 
-  nnstreamer_filter_python3_sources = []
-  foreach s : filter_sub_python3_sources
-    nnstreamer_filter_python3_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   shared_library('nnstreamer_filter_python3',
-    nnstreamer_filter_python3_sources,
+    filter_sub_python3_sources,
     dependencies: nnstreamer_python3_helper_dep,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_python3',
-    nnstreamer_filter_python3_sources,
+    filter_sub_python3_sources,
     dependencies: nnstreamer_python3_helper_dep,
     install: true,
     install_dir: nnstreamer_libdir
@@ -484,22 +439,17 @@ if mvncsdk2_support_is_available
     'tensor_filter_movidius_ncsdk2.c'
   ]
 
-  nnstreamer_filter_mvncsdk2_sources = []
-  foreach s : filter_sub_mvncsdk2_sources
-    nnstreamer_filter_mvncsdk2_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   nnstreamer_filter_mvncsdk2_deps = mvncsdk2_support_deps + [glib_dep, gst_dep, nnstreamer_dep]
 
   shared_library('nnstreamer_filter_movidius-ncsdk2',
-    nnstreamer_filter_mvncsdk2_sources,
+    filter_sub_mvncsdk2_sources,
     dependencies: nnstreamer_filter_mvncsdk2_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_movidius-ncsdk2',
-    nnstreamer_filter_mvncsdk2_sources,
+    filter_sub_mvncsdk2_sources,
     dependencies: nnstreamer_filter_mvncsdk2_deps,
     install: true,
     install_dir: nnstreamer_libdir
@@ -509,13 +459,8 @@ endif
 if get_option('enable-cppfilter')
   filter_sub_cpp_sources = ['tensor_filter_cpp.cc']
 
-  nnstreamer_filter_cpp_sources = []
-  foreach s : filter_sub_cpp_sources
-    nnstreamer_filter_cpp_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   nnstreamer_cpp_lib = shared_library('nnstreamer_filter_cpp',
-    nnstreamer_filter_cpp_sources,
+    filter_sub_cpp_sources,
     dependencies: nnstreamer_single_dep,
     install: true,
     install_dir: filter_subplugin_install_dir
@@ -566,11 +511,6 @@ if get_option('enable-edgetpu')
 
   filter_sub_edgetpu_sources = ['tensor_filter_edgetpu.cc']
 
-  nnstreamer_filter_edgetpu_sources = []
-  foreach s : filter_sub_edgetpu_sources
-    nnstreamer_filter_edgetpu_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   rpath_edgetpu_test_helper = ''
   if get_option('enable-test')
     '''
@@ -582,7 +522,7 @@ if get_option('enable-edgetpu')
   endif
 
   shared_library('nnstreamer_filter_edgetpu',
-    nnstreamer_filter_edgetpu_sources,
+    filter_sub_edgetpu_sources,
     dependencies: nnstreamer_filter_edgetpu_deps,
     install: true,
     install_dir: filter_subplugin_install_dir,
@@ -605,15 +545,10 @@ if get_option('enable-openvino')
   endif
   filter_sub_openvino_sources = ['tensor_filter_openvino.cc']
 
-  nnstreamer_filter_openvino_sources = []
-  foreach s : filter_sub_openvino_sources
-    nnstreamer_filter_openvino_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   nnstreamer_filter_openvino_deps = [glib_dep, gst_dep, nnstreamer_dep, openvino_deps]
 
   nnstreamer_filter_openvino_so_lib = shared_library('nnstreamer_filter_openvino',
-    nnstreamer_filter_openvino_sources,
+    filter_sub_openvino_sources,
     cpp_args: openvino_cpp_args,
     dependencies: nnstreamer_filter_openvino_deps,
     install: true,
@@ -621,7 +556,7 @@ if get_option('enable-openvino')
   )
 
   static_library('nnstreamer_filter_openvino',
-    nnstreamer_filter_openvino_sources,
+    filter_sub_openvino_sources,
     cpp_args: openvino_cpp_args,
     dependencies: nnstreamer_filter_openvino_deps,
     install: true,
@@ -697,13 +632,8 @@ if get_option('enable-mediapipe')
 
   filter_sub_mp_sources = ['tensor_filter_mediapipe.cc']
 
-  nnstreamer_filter_mediapipe_sources = []
-  foreach s : filter_sub_mp_sources
-    nnstreamer_filter_mediapipe_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   shared_library('nnstreamer_filter_mediapipe',
-    nnstreamer_filter_mediapipe_sources,
+    filter_sub_mp_sources,
     dependencies: nnstreamer_filter_mediapipe_deps,
     include_directories: mediapipe_incdir,
     install: true,
@@ -718,15 +648,10 @@ if snpe_support_is_available
   snpe_cpp_args = []
   snpe_cpp_args += '-Wno-terminate'
 
-  nnstreamer_filter_snpe_sources = []
-  foreach s : filter_sub_snpe_sources
-    nnstreamer_filter_snpe_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   nnstreamer_filter_snpe_deps = [glib_dep, gst_dep, nnstreamer_dep, snpe_support_deps]
 
   shared_library('nnstreamer_filter_snpe',
-    nnstreamer_filter_snpe_sources,
+    filter_sub_snpe_sources,
     cpp_args: snpe_cpp_args,
     dependencies: nnstreamer_filter_snpe_deps,
     install: true,
@@ -734,7 +659,7 @@ if snpe_support_is_available
   )
 
   static_library('nnstreamer_filter_snpe',
-    nnstreamer_filter_snpe_sources,
+    filter_sub_snpe_sources,
     cpp_args: snpe_cpp_args,
     dependencies: nnstreamer_filter_snpe_deps,
     install: true,
@@ -746,22 +671,17 @@ endif
 if tensorrt_support_is_available
   filter_sub_tensorrt_sources = ['tensor_filter_tensorrt.cc']
 
-  nnstreamer_filter_tensorrt_sources = []
-  foreach s : filter_sub_tensorrt_sources
-    nnstreamer_filter_tensorrt_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   nnstreamer_filter_tensorrt_deps = [glib_dep, gst_dep, nnstreamer_dep, tensorrt_support_deps]
 
   shared_library('nnstreamer_filter_tensorrt',
-    nnstreamer_filter_tensorrt_sources,
+    filter_sub_tensorrt_sources,
     dependencies: nnstreamer_filter_tensorrt_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_tensorrt',
-    nnstreamer_filter_tensorrt_sources,
+    filter_sub_tensorrt_sources,
     dependencies: nnstreamer_filter_tensorrt_deps,
     install: true,
     install_dir: nnstreamer_libdir
@@ -778,22 +698,17 @@ endif
 if lua_support_is_available
   filter_sub_lua_sources = ['tensor_filter_lua.cc']
 
-  nnstreamer_filter_lua_sources = []
-  foreach s : filter_sub_lua_sources
-    nnstreamer_filter_lua_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   nnstreamer_filter_lua_deps = [glib_dep, gst_dep, nnstreamer_dep, lua_support_deps]
 
   shared_library('nnstreamer_filter_lua',
-    nnstreamer_filter_lua_sources,
+    filter_sub_lua_sources,
     dependencies: nnstreamer_filter_lua_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_lua',
-    nnstreamer_filter_lua_sources,
+    filter_sub_lua_sources,
     dependencies: nnstreamer_filter_lua_deps,
     install: true,
     install_dir: nnstreamer_libdir
@@ -805,20 +720,15 @@ if tvm_support_is_available
 
   filter_sub_tvm_sources = ['tensor_filter_tvm.cc']
 
-  nnstreamer_filter_tvm_sources = []
-  foreach s : filter_sub_tvm_sources
-    nnstreamer_filter_tvm_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   shared_library('nnstreamer_filter_tvm',
-    nnstreamer_filter_tvm_sources,
+    filter_sub_tvm_sources,
     dependencies: nnstreamer_filter_tvm_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_tvm',
-    nnstreamer_filter_tvm_sources,
+    filter_sub_tvm_sources,
     dependencies: nnstreamer_filter_tvm_deps,
     install: true,
     install_dir: nnstreamer_libdir
@@ -830,20 +740,15 @@ if trix_engine_support_is_available
 
   filter_sub_trix_engine_sources = ['tensor_filter_trix_engine.cc']
 
-  nnstreamer_filter_trix_engine_sources = []
-  foreach s : filter_sub_trix_engine_sources
-    nnstreamer_filter_trix_engine_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   shared_library('nnstreamer_filter_trix-engine',
-    nnstreamer_filter_trix_engine_sources,
+    filter_sub_trix_engine_sources,
     dependencies: nnstreamer_filter_trix_engine_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_trix-engine',
-    nnstreamer_filter_trix_engine_sources,
+    filter_sub_trix_engine_sources,
     dependencies: nnstreamer_filter_trix_engine_deps,
     install: true,
     install_dir: nnstreamer_libdir
@@ -859,15 +764,10 @@ if mxnet_support_is_available
     'tensor_filter_mxnet.cc'
   ]
 
-  nnstreamer_filter_mxnet_sources = []
-  foreach s : filter_sub_mxnet_sources
-    nnstreamer_filter_mxnet_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
   nnstreamer_filter_mxnet_deps = mxnet_support_deps + [glib_dep, gst_dep, nnstreamer_dep, libdl_dep]
 
   nnstreamer_filter_mxnet_so_lib = shared_library('nnstreamer_filter_mxnet',
-    nnstreamer_filter_mxnet_sources,
+    filter_sub_mxnet_sources,
     dependencies: nnstreamer_filter_mxnet_deps,
     install: true,
     install_dir: filter_subplugin_install_dir,

--- a/ext/nnstreamer/tensor_sink/meson.build
+++ b/ext/nnstreamer/tensor_sink/meson.build
@@ -2,14 +2,9 @@ if grpc_support_is_available
   grpc_tensor_sink_source_files = [
     'tensor_sink_grpc.c'
   ]
-  grpc_tensor_sink_sources = []
-
-  foreach s : grpc_tensor_sink_source_files
-    grpc_tensor_sink_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
 
   tensor_sink_grpc_dep = declare_dependency(
-    sources : grpc_tensor_sink_sources,
+    sources : grpc_tensor_sink_source_files,
     dependencies : grpc_util_dep,
   )
 endif

--- a/ext/nnstreamer/tensor_source/meson.build
+++ b/ext/nnstreamer/tensor_source/meson.build
@@ -1,15 +1,10 @@
 if get_option('enable-tizen-sensor')
   tzn_tensor_src_source_files = ['tensor_src_tizensensor.c']
-  tzn_tensor_src_sources = []
-
-  foreach s : tzn_tensor_src_source_files
-    tzn_tensor_src_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
 
   tznsensor_dep = dependency('capi-system-sensor', required: true)
 
   tensor_src_tizensensor_dep = declare_dependency(
-    sources : tzn_tensor_src_sources,
+    sources : tzn_tensor_src_source_files,
     dependencies : [glib_dep, gst_dep, nnstreamer_dep, tznsensor_dep]
   )
 endif
@@ -19,14 +14,9 @@ if grpc_support_is_available
   grpc_tensor_src_source_files = [
     'tensor_src_grpc.c',
   ]
-  grpc_tensor_src_sources = []
-
-  foreach s : grpc_tensor_src_source_files
-    grpc_tensor_src_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
 
   tensor_src_grpc_dep = declare_dependency(
-    sources : grpc_tensor_src_sources,
+    sources : grpc_tensor_src_source_files,
     dependencies : grpc_util_dep
   )
 endif

--- a/gst/edge/meson.build
+++ b/gst/edge/meson.build
@@ -1,11 +1,10 @@
-edge_files = [
+edge_srcs = [
     'edge_common.c',
     'edge_elements.c',
     'edge_sink.c',
     'edge_src.c',
 ]
 
-edge_srcs = []
 edge_dep = [
     glib_dep,
     gst_base_dep,
@@ -19,10 +18,6 @@ elif cc.has_header_symbol('android/log.h', '__android_log_print')
   edge_dep += cc.find_library('log')
 endif
 
-foreach s : edge_files
-    edge_srcs += join_paths(meson.current_source_dir(), s)
-endforeach
-
 gstedge_shared = shared_library('gstedge',
   edge_srcs,
   dependencies: edge_dep,
@@ -32,7 +27,7 @@ gstedge_shared = shared_library('gstedge',
 )
 
 gstedge_dep = declare_dependency(
-    link_with: gstedge_shared, 
+    link_with: gstedge_shared,
     dependencies: edge_dep,
     include_directories: include_directories('.')
 )

--- a/gst/join/meson.build
+++ b/gst/join/meson.build
@@ -1,12 +1,6 @@
-join_files = [
+join_sources = [
   'gstjoin.c',
 ]
-
-join_sources = []
-
-foreach s : join_files
-  join_sources += join_paths(meson.current_source_dir(), s)
-endforeach
 
 gstjoin_shared = shared_library('gstjoin',
   join_sources,

--- a/gst/mqtt/meson.build
+++ b/gst/mqtt/meson.build
@@ -1,12 +1,7 @@
 # To resolve compiler warning. Remove this include after removing unused parameters.
 nns_util_inc = include_directories('../nnstreamer/include')
 
-mqtt_plugin_srcs = [
-  join_paths(meson.current_source_dir(), 'mqttsink.c'),
-  join_paths(meson.current_source_dir(), 'mqttsrc.c'),
-  join_paths(meson.current_source_dir(), 'mqttelements.c'),
-  join_paths(meson.current_source_dir(), 'ntputil.c'),
-]
+mqtt_plugin_srcs = ['mqttsink.c', 'mqttsrc.c', 'mqttelements.c', 'ntputil.c']
 
 gstmqtt_shared = shared_library('gstmqtt',
   mqtt_plugin_srcs,

--- a/gst/nnstreamer/elements/meson.build
+++ b/gst/nnstreamer/elements/meson.build
@@ -1,4 +1,4 @@
-tensor_element_sources = [
+nnstreamer_sources += files(
   'gsttensor_aggregator.c',
   'gsttensor_converter.c',
   'gsttensor_crop.c',
@@ -17,11 +17,12 @@ tensor_element_sources = [
   'gsttensor_sparseenc.c',
   'gsttensor_sparseutil.c',
   'gsttensor_split.c',
-]
+  'gsttensor_transform.c'
+)
 
 # gsttensorsrc
 if tensor_src_iio_build
-  nnstreamer_sources += join_paths(meson.current_source_dir(), 'gsttensor_srciio.c')
+  nnstreamer_sources += files('gsttensor_srciio.c')
 endif
 
 # gsttensortransform
@@ -48,8 +49,3 @@ if orcc_support_is_available
   nnstreamer_sources += [orc_c, orc_h]
   nnstreamer_internal_deps += declare_dependency(sources: orc_h)
 endif
-tensor_element_sources += 'gsttensor_transform.c'
-
-foreach s : tensor_element_sources
-  nnstreamer_sources += join_paths(meson.current_source_dir(), s)
-endforeach

--- a/gst/nnstreamer/include/meson.build
+++ b/gst/nnstreamer/include/meson.build
@@ -1,5 +1,5 @@
 # Common headers to be installed
-nnst_common_headers = [
+nnstreamer_headers += files(
   'tensor_if.h',
   'tensor_typedef.h',
   'tensor_filter_custom.h',
@@ -12,14 +12,10 @@ nnst_common_headers = [
   'nnstreamer_plugin_api_util.h',
   'nnstreamer_plugin_api.h',
   'nnstreamer_util.h'
-]
-
-foreach h : nnst_common_headers
-  nnstreamer_headers += join_paths(meson.current_source_dir(), h)
-endforeach
+)
 
 if get_option('enable-filter-cpp-class')
-  nnstreamer_headers += join_paths(meson.current_source_dir(), 'nnstreamer_cppplugin_api_filter.hh')
+  nnstreamer_headers += files('nnstreamer_cppplugin_api_filter.hh')
 endif
 
 version_conf = configuration_data()

--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -1,6 +1,4 @@
 nnstreamer_inc = include_directories('.', './include/')
-nnstreamer_single_sources = []
-nnstreamer_sources = []
 nnstreamer_headers = []
 
 # Dependencies
@@ -41,30 +39,22 @@ endif
 nnstreamer_internal_deps = []
 
 # Add nnstreamer single sources
-nnst_single_sources = [
+nnstreamer_single_sources = [
   'hw_accel.c',
   'nnstreamer_conf.c',
   'nnstreamer_log.c',
   'nnstreamer_subplugin.c',
-  'nnstreamer_plugin_api_util_impl.c',
+  'nnstreamer_plugin_api_util_impl.c'
 ]
 
 # Add nnstreamer registerer and common sources
-nnst_sources = [
+nnstreamer_sources = [
   'registerer/nnstreamer.c',
   'nnstreamer_plugin_api_impl.c',
   'tensor_allocator.c',
   'tensor_data.c',
   'tensor_meta.c'
 ]
-
-foreach s : nnst_single_sources
-  nnstreamer_single_sources += join_paths(meson.current_source_dir(), s)
-endforeach
-
-foreach s : nnst_sources
-  nnstreamer_sources += join_paths(meson.current_source_dir(), s)
-endforeach
 
 # Add plugins
 nnst_plugins = [
@@ -80,7 +70,7 @@ endforeach
 subdir('include')
 
 # Private header for sub-plugins and native APIs
-nnstreamer_headers += join_paths(meson.current_source_dir(), 'nnstreamer_internal.h')
+nnstreamer_headers += files('nnstreamer_internal.h')
 
 nnstreamer_single_shared = shared_library('nnstreamer-single',
   nnstreamer_single_sources,

--- a/gst/nnstreamer/tensor_filter/meson.build
+++ b/gst/nnstreamer/tensor_filter/meson.build
@@ -1,18 +1,15 @@
-tensor_filter_single_sources = [
+nnstreamer_single_sources += files(
   'tensor_filter_single.c',
   'tensor_filter_common.c',
   'tensor_filter_custom.c',
   'tensor_filter_custom_easy.c'
-]
+)
 
-foreach s : tensor_filter_single_sources
-  nnstreamer_single_sources += join_paths(meson.current_source_dir(), s)
-endforeach
-nnstreamer_headers += join_paths(meson.current_source_dir(), 'tensor_filter_single.h')
+nnstreamer_headers += files('tensor_filter_single.h')
 
-nnstreamer_sources += join_paths(meson.current_source_dir(), 'tensor_filter.c')
+nnstreamer_sources += files('tensor_filter.c')
 
 if get_option('enable-filter-cpp-class')
-  nnstreamer_sources += join_paths(meson.current_source_dir(), 'tensor_filter_support_cc.cc')
+  nnstreamer_sources += files('tensor_filter_support_cc.cc')
 endif
 

--- a/gst/nnstreamer/tensor_query/meson.build
+++ b/gst/nnstreamer/tensor_query/meson.build
@@ -1,14 +1,10 @@
-tensor_query_sources = [
-  'tensor_query_common.c',
-  'tensor_query_serversrc.c',
-  'tensor_query_serversink.c',
-  'tensor_query_client.c',
-  'tensor_query_server.c',
-]
-
 # tensor_query has dependency to nnstreamer-edge.
 if nnstreamer_edge_support_is_available
-  foreach s : tensor_query_sources
-    nnstreamer_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
+  nnstreamer_sources += files(
+    'tensor_query_common.c',
+    'tensor_query_serversrc.c',
+    'tensor_query_serversink.c',
+    'tensor_query_client.c',
+    'tensor_query_server.c',
+  )
 endif

--- a/tests/cpp_methods/meson.build
+++ b/tests/cpp_methods/meson.build
@@ -1,12 +1,12 @@
 cppfilter_test_lib = library('cppfilter_test',
-  join_paths(meson.current_source_dir(), 'cppfilter_test.cc'),
+  'cppfilter_test.cc',
   dependencies: [nnstreamer_cpp_dep],
   install: get_option('install-test'),
   install_dir: nnstreamer_libdir
 )
 
 unittest_cppfilter = executable('unittest_cppfilter',
-  join_paths(meson.current_source_dir(), 'unittest_cpp_methods.cc'),
+  'unittest_cpp_methods.cc',
   dependencies: [nnstreamer_unittest_deps, nnstreamer_cpp_dep],
   link_with: cppfilter_test_lib,
   install: get_option('install-test'),

--- a/tools/development/nnstreamerCodeGenCustomFilter.py
+++ b/tools/development/nnstreamerCodeGenCustomFilter.py
@@ -381,13 +381,8 @@ nnstreamer_single_dep = dependency('nnstreamer-single')
   '{fname}.c'
 ]
 
-{fname}_srcfiles_fullpath = []
-foreach s : {fname}_srcfiles
-  {fname}_srcfiles_fullpath += join_paths(meson.current_source_dir(), s)
-endforeach
-
 shared_library('{fname}',
-  {fname}_srcfiles_fullpath,
+  {fname}_srcfiles,
   dependencies: [glib_dep, gst_dep, nnstreamer_dep, nnstreamer_single_dep],
   install: true,
   install_dir: customfilter_install_dir
@@ -396,7 +391,7 @@ shared_library('{fname}',
 # @warning NYI. Static library mode of custom filter is not supported yet.
 # This will be supported after fixing #1182.
 # static_library('{fname}',
-#   {fname}_srcfiles_fullpath,
+#   {fname}_srcfiles,
 #   dependencies: [glib_dep, gst_dep, nnstreamer_dep, nnstreamer_single_dep],
 #   install: true,
 #   install_dir: {fname}_libdir,


### PR DESCRIPTION
Let's use `files` instead of `join_paths` to create a library. 
This patch prevents object file name containing the absolute path. 
Refer: https://mesonbuild.com/Reference-manual_functions.html#join_paths

@todo: Update the tests in the next PR.

Signed-off-by: gichan <gichan2.jang@samsung.com>


**Self evaluation:**
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped
