### PR TITLE
[Svace] Fix the array overflow issue

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -699,7 +699,7 @@ nnsconf_subplugin_dump (gchar * str, gulong size)
     NNSCONF_PATH_TRAINERS
   };
   static const char *dump_list_str[] = {
-    "Filter", "Decoder", "Conterver"
+    "Filter", "Decoder", "Conterver", "Trainer"
   };
 
   dump_buf buf;


### PR DESCRIPTION
The result of 'sizeof (dump_list_type) / sizeof (nnsconf_type_path)' is 4 but dump_list_str array has only 3 items. Because of this reason, it can occur the array overflow issue. This patch fixes this issue.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

