### PR TITLE
[decoder/yolov5] Support scaled-output model for yolov5 bounding box decoder @open sesame 12/20 11:25

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -123,8 +123,8 @@ extern uint8_t rasters[][13];
 #define OV_PERSON_DETECTION_SIZE_DETECTION_DESC (7)
 #define OV_PERSON_DETECTION_CONF_THRESHOLD      (0.8)
 #define YOLOV5_DETECTION_NUM_INFO               (5)
-#define YOLOV5_DETECTION_CONF_THRESHOLD         (0.3)
-#define YOLOV5_DETECTION_IOU_THRESHOLD          (0.6)
+#define YOLOV5_DETECTION_CONF_THRESHOLD         (0.25)
+#define YOLOV5_DETECTION_IOU_THRESHOLD          (0.45)
 #define PIXEL_VALUE                             (0xFF0000FF)    /* RED 100% in RGBA */
 #define MP_PALM_DETECTION_INFO_SIZE             (18)
 #define MP_PALM_DETECTION_MAX_TENSORS           (2U)


### PR DESCRIPTION
**Changes proposed in this PR:**
- Set the conf and iou threshold values to follow the upstream https://github.com/ultralytics/yolov5.
- The yolov5 models released by github.com/ultralytics/yolov5 have different output semantics:
   - the output of tflite and tf models should be scaled to input image size.
   - torchscript and others return scaled output value.
- This patch support those two semantics by add option3:
  - option1=yolov5 ...  option3=0 ... (default) for tflite models
  - option1=yolov5 ...  option3=1 ... for other models


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

**How to evaluate:**
1. for tflite model
<pre>
gst-launch-1.0 filesrc location=bus.jpg ! jpegdec ! videoscale ! videoconvert ! \
video/x-raw,width=810,height=1080,format=RGB,framerate=0/1 ! tee name=t  \
t. ! queue ! videoscale ! video/x-raw,width=640,height=640,format=RGB ! tensor_converter ! \
other/tensors,num_tensors=1,types=uint8,format=static,dimensions=3:640:640:1 ! \
tensor_transform mode=arithmetic option=typecast:float32,div:255.0 ! queue ! \
tensor_filter framework=tensorflow2-lite model=./yolov5s-fp16.tflite ! \
other/tensors,num_tensors=1,format=static ! \
tensor_decoder mode=bounding_boxes option1=yolov5 option2=./coco.txt <b>option3=0</b> option4=810:1080 option5=640:640 ! \
video/x-raw,width=810,height=1080,format=RGBA ! mix.sink_0 \
t. ! queue ! mix.sink_1 compositor name=mix sink_0::zorder=2 sink_1::zorder=1 ! videoconvert ! \
pngenc ! filesink location=bus_boxes_tflite.png
</pre>

2. for torchscript model
<pre>
gst-launch-1.0 filesrc location=bus.jpg ! jpegdec ! videoscale ! videoconvert ! \
video/x-raw,width=810,height=1080,format=RGB,framerate=0/1 ! tee name=t  \
t. ! queue ! videoscale ! video/x-raw,width=640,height=640,format=RGB ! tensor_converter ! \
other/tensors,num_tensors=1,types=uint8,format=static,dimensions=3:640:640:1 ! \
tensor_transform mode=arithmetic option=typecast:float32,div:255.0 ! \
tensor_transform mode=transpose option=1:2:0:3 ! queue ! \
tensor_filter framework=pytorch model=./yolov5s.torchscript input=640:640:3:1 inputname=image inputtype=float32 output=85:25200:1:1 outputname=out outputtype=float32 ! \
other/tensors,num_tensors=1,format=static ! \
tensor_decoder mode=bounding_boxes option1=yolov5 option2=./coco.txt <b>option3=1</b> option4=810:1080 option5=640:640 ! \
video/x-raw,width=810,height=1080,format=RGBA ! mix.sink_0 \
t. ! queue ! mix.sink_1 compositor name=mix sink_0::zorder=2 sink_1::zorder=1 ! videoconvert ! \
pngenc ! filesink location=bus_boxes_torchscript.png
</pre>

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>
