### PR TITLE
[tests] change hardcoded dimension compare to use NNS_TENSOR_RANK_LIMIT

### DIFF
--- a/tests/cpp_methods/cppfilter_test.cc
+++ b/tests/cpp_methods/cppfilter_test.cc
@@ -28,7 +28,8 @@ filter_basic::getInputDim (GstTensorsInfo *info)
   info->info[0].dimension[0] = 3;
   info->info[0].dimension[1] = 4;
   info->info[0].dimension[2] = 4;
-  info->info[0].dimension[3] = 1;
+  for (int i = 3; i < NNS_TENSOR_RANK_LIMIT; i++)
+    info->info[0].dimension[i] = 1;
   return 0;
 }
 
@@ -42,6 +43,8 @@ filter_basic::getOutputDim (GstTensorsInfo *info)
   info->info[0].dimension[1] = 4;
   info->info[0].dimension[2] = 4;
   info->info[0].dimension[3] = 2;
+  for (int i = 4; i < NNS_TENSOR_RANK_LIMIT; i++)
+    info->info[0].dimension[i] = 1;
   return 0;
 }
 
@@ -162,7 +165,8 @@ filter_basic2::getInputDim (GstTensorsInfo *info)
   info->info[0].dimension[0] = 3;
   info->info[0].dimension[1] = 16;
   info->info[0].dimension[2] = 16;
-  info->info[0].dimension[3] = 1;
+  for (int i = 3; i < NNS_TENSOR_RANK_LIMIT; i++)
+    info->info[0].dimension[i] = 1;
   return 0;
 }
 
@@ -176,6 +180,8 @@ filter_basic2::getOutputDim (GstTensorsInfo *info)
   info->info[0].dimension[1] = 16;
   info->info[0].dimension[2] = 16;
   info->info[0].dimension[3] = 2;
+  for (int i = 4; i < NNS_TENSOR_RANK_LIMIT; i++)
+    info->info[0].dimension[i] = 1;
   return 0;
 }
 

--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
@@ -280,6 +280,7 @@ TEST (nnstreamer@EXT_ABBRV@BasicFunctions, setDimension)
   void *data = NULL;
   GstTensorsInfo set, get;
   gchar **model_files;
+  guint i;
 
   model_files = get_model_files ();
   ASSERT_TRUE (model_files != nullptr);
@@ -313,10 +314,9 @@ TEST (nnstreamer@EXT_ABBRV@BasicFunctions, setDimension)
   } else {
     set.num_tensors = 1;
     set.info[0].type = _NNS_INT8;
-    set.info[0].dimension[0] = 10;
-    set.info[0].dimension[1] = 9;
-    set.info[0].dimension[2] = 8;
-    set.info[0].dimension[3] = 7;
+    for (i = 0; i < NNS_TENSOR_RANK_LIMIT; ++i) {
+      set.info[0].dimension[i] = 10-i;
+    }
   }
 
   if (sp->setInputDimension) {
@@ -340,10 +340,9 @@ TEST (nnstreamer@EXT_ABBRV@BasicFunctions, setDimension)
       if (ret == 0) {
         EXPECT_EQ (set.num_tensors, get.num_tensors);
         EXPECT_EQ (set.info[0].type, get.info[0].type);
-        EXPECT_EQ (set.info[0].dimension[0], get.info[0].dimension[0]);
-        EXPECT_EQ (set.info[0].dimension[1], get.info[0].dimension[1]);
-        EXPECT_EQ (set.info[0].dimension[2], get.info[0].dimension[2]);
-        EXPECT_EQ (set.info[0].dimension[3], get.info[0].dimension[3]);
+        for (i = 0; i < NNS_TENSOR_RANK_LIMIT; ++i) {
+          EXPECT_EQ (set.info[0].dimension[i], get.info[0].dimension[i]);
+        }
       }
       gst_tensors_info_free (&get);
     }
@@ -460,9 +459,9 @@ TEST (nnstreamer@EXT_ABBRV@BasicFunctions, invoke)
       res.num_tensors = 1;
       res.info[0].type = _NNS_FLOAT32;
       res.info[0].dimension[0] = 10;
-      res.info[0].dimension[1] = 1;
-      res.info[0].dimension[2] = 1;
-      res.info[0].dimension[3] = 1;
+      for (i = 1; i < NNS_TENSOR_RANK_LIMIT; ++i) {
+        res.info[0].dimension[i] = 1;
+      }
 
       /** As get dimension failed, set dimension must pass */
       ret_set_in = sp->setInputDimension (&prop, &data, &res, &res);
@@ -471,9 +470,9 @@ TEST (nnstreamer@EXT_ABBRV@BasicFunctions, invoke)
       input_info.num_tensors = output_info.num_tensors = 1;
       input_info.info[0].type = output_info.info[0].type = _NNS_FLOAT32;
       input_info.info[0].dimension[0] = output_info.info[0].dimension[0] = 10;
-      input_info.info[0].dimension[1] = output_info.info[0].dimension[1] = 1;
-      input_info.info[0].dimension[2] = output_info.info[0].dimension[2] = 1;
-      input_info.info[0].dimension[3] = output_info.info[0].dimension[3] = 1;
+      for (i = 1; i < NNS_TENSOR_RANK_LIMIT; ++i) {
+        input_info.info[0].dimension[i] = output_info.info[0].dimension[i] = 1;
+      }
       gst_tensors_info_free (&res);
     }
   }

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -69,7 +69,7 @@ get_model_file ()
  */
 TEST (nnstreamerNnfwRuntimeRawFunctions, getDimension)
 {
-  int ret;
+  int ret, i;
   void *data = NULL;
   GstTensorsInfo info, res;
   gchar *model_file;
@@ -92,10 +92,8 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, getDimension)
 
   info.num_tensors = 1;
   info.info[0].type = _NNS_FLOAT32;
-  info.info[0].dimension[0] = 1;
-  info.info[0].dimension[1] = 1;
-  info.info[0].dimension[2] = 1;
-  info.info[0].dimension[3] = 1;
+  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
+    info.info[0].dimension[i] = 1;
 
   /** get input/output dimension successfully */
   ret = sp->getInputDimension (&prop, &data, &res);
@@ -103,20 +101,16 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, getDimension)
 
   EXPECT_EQ (res.num_tensors, info.num_tensors);
   EXPECT_EQ (res.info[0].type, info.info[0].type);
-  EXPECT_EQ (res.info[0].dimension[0], info.info[0].dimension[0]);
-  EXPECT_EQ (res.info[0].dimension[1], info.info[0].dimension[1]);
-  EXPECT_EQ (res.info[0].dimension[2], info.info[0].dimension[2]);
-  EXPECT_EQ (res.info[0].dimension[3], info.info[0].dimension[3]);
+  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
+    EXPECT_EQ (res.info[0].dimension[i], info.info[0].dimension[i]);
 
   ret = sp->getOutputDimension (&prop, &data, &res);
   EXPECT_EQ (ret, 0);
 
   EXPECT_EQ (res.num_tensors, info.num_tensors);
   EXPECT_EQ (res.info[0].type, info.info[0].type);
-  EXPECT_EQ (res.info[0].dimension[0], info.info[0].dimension[0]);
-  EXPECT_EQ (res.info[0].dimension[1], info.info[0].dimension[1]);
-  EXPECT_EQ (res.info[0].dimension[2], info.info[0].dimension[2]);
-  EXPECT_EQ (res.info[0].dimension[3], info.info[0].dimension[3]);
+  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
+    EXPECT_EQ (res.info[0].dimension[i], info.info[0].dimension[i]);
 
   sp->close (&prop, &data);
 
@@ -130,7 +124,7 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, getDimension)
  */
 TEST (nnstreamerNnfwRuntimeRawFunctions, setDimension)
 {
-  int ret;
+  int ret, i;
   void *data = NULL;
   GstTensorsInfo in_info, out_info, res;
   GstTensorMemory input, output;
@@ -163,9 +157,8 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, setDimension)
   res.num_tensors = 1;
   res.info[0].type = _NNS_FLOAT32;
   res.info[0].dimension[0] = tensor_size;
-  res.info[0].dimension[1] = 1;
-  res.info[0].dimension[2] = 1;
-  res.info[0].dimension[3] = 1;
+  for (i = 1; i < NNS_TENSOR_RANK_LIMIT; i++)
+    res.info[0].dimension[i] = 1;
 
   /** get input/output dimension successfully */
   ret = sp->getInputDimension (&prop, &data, &in_info);
@@ -173,10 +166,10 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, setDimension)
 
   EXPECT_EQ (res.num_tensors, in_info.num_tensors);
   EXPECT_EQ (res.info[0].type, in_info.info[0].type);
+
   EXPECT_NE (res.info[0].dimension[0], in_info.info[0].dimension[0]);
-  EXPECT_EQ (res.info[0].dimension[1], in_info.info[0].dimension[1]);
-  EXPECT_EQ (res.info[0].dimension[2], in_info.info[0].dimension[2]);
-  EXPECT_EQ (res.info[0].dimension[3], in_info.info[0].dimension[3]);
+  for (i = 1; i < NNS_TENSOR_RANK_LIMIT; i++)
+    EXPECT_EQ (res.info[0].dimension[i], in_info.info[0].dimension[i]);
 
   ret = sp->setInputDimension (&prop, &data, &res, &out_info);
   EXPECT_EQ (ret, 0);
@@ -187,20 +180,17 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, setDimension)
 
   EXPECT_EQ (res.num_tensors, in_info.num_tensors);
   EXPECT_EQ (res.info[0].type, in_info.info[0].type);
-  EXPECT_EQ (res.info[0].dimension[0], in_info.info[0].dimension[0]);
-  EXPECT_EQ (res.info[0].dimension[1], in_info.info[0].dimension[1]);
-  EXPECT_EQ (res.info[0].dimension[2], in_info.info[0].dimension[2]);
-  EXPECT_EQ (res.info[0].dimension[3], in_info.info[0].dimension[3]);
+
+  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
+    EXPECT_EQ (res.info[0].dimension[i], in_info.info[0].dimension[i]);
 
   ret = sp->getOutputDimension (&prop, &data, &out_info);
   EXPECT_EQ (ret, 0);
 
   EXPECT_EQ (res.num_tensors, out_info.num_tensors);
   EXPECT_EQ (res.info[0].type, out_info.info[0].type);
-  EXPECT_EQ (res.info[0].dimension[0], out_info.info[0].dimension[0]);
-  EXPECT_EQ (res.info[0].dimension[1], out_info.info[0].dimension[1]);
-  EXPECT_EQ (res.info[0].dimension[2], out_info.info[0].dimension[2]);
-  EXPECT_EQ (res.info[0].dimension[3], out_info.info[0].dimension[3]);
+  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
+    EXPECT_EQ (res.info[0].dimension[i], out_info.info[0].dimension[i]);
 
   input.size = gst_tensor_info_get_size (&in_info.info[0]);
   output.size = gst_tensor_info_get_size (&out_info.info[0]);


### PR DESCRIPTION
This patch changes to use NNS_TENSOR_RANK_LIMIT instead of hardcoded dimension. 
It will be used for increasing NNS_TENSOR_RANK_LIMIT.

Signed-off-by: Yelin Jeong <yelini.jeong@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
