### PR TITLE
GitHub/Actions: Enable binary tests defined in the meson script

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -18,7 +18,10 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v1
     - name: install minimal requirements
-      run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev
+      run: |
+          sudo apt-get update && \
+          sudo apt-get install -y libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev googletest \
+            gstreamer1.0-plugins-good
     - uses: BSFishy/meson-build@v1.0.3
       with:
         action: test


### PR DESCRIPTION
This patch makes the unit test cases defined in the meson build script run.

Signed-off-by: Wook Song wook16.song@samsung.com

#### Outputs
 1/12 unittest_common                         OK       0.47 s 
 2/12 unittest_sink                           OK      25.91 s 
 3/12 unittest_plugins                        OK      17.34 s 
 4/12 unittest_if                             OK       5.24 s 
 5/12 unittest_rate                           OK       0.37 s 
 6/12 unittest_latency                        OK      13.07 s 
 7/12 unittest_filter_single                  OK       0.01 s 
 8/12 unittest_join                           OK       0.62 s 
 9/12 unittest_src_iio                        OK      10.55 s 
10/12 unittest_tizen_custom                   OK       0.01 s 
11/12 unittest_tizen_custom-set               OK       0.01 s 
12/12 unittest_cppfilter                      OK       0.62 s 

Ok:                   12
Expected Fail:         0
Fail:                  0
Unexpected Pass:       0
Skipped:               0
Timeout:               0

Full log written to /home/runner/work/nnstreamer/nnstreamer/build/meson-logs/testlog.txt