### PR TITLE
[Wait for #3949][New element][tensor_trainer] Improve tensor_trainer element

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_trainer.c
+++ b/gst/nnstreamer/elements/gsttensor_trainer.c
@@ -1,0 +1,989 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2022 Samsung Electronics Co., Ltd.
+ *
+ * @file	gsttensor_trainer.c
+ * @date	20 October 2022
+ * @brief	GStreamer plugin to train tensor data using NN Frameworks
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Hyunil Park <hyunil46.park@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ * ## Example launch line
+ * |[
+ * gst-launch-1.0 videotestsrc !
+ *    video/x-raw, format=RGB, width=640, height=480 ! tensor_converter ! 
+ *    tensor_trainer input=3:640:480 inputtype=uint8 output=1:1:1:1 outputtype=uint8 !
+ *    tensor_sink
+ * ]|
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <nnstreamer_subplugin.h>
+#include <nnstreamer_util.h>
+#include "gsttensor_trainer.h"
+
+/**
+ * @brief Default caps string for both sink and source pad.
+ */
+#define CAPS_STRING GST_TENSORS_CAP_MAKE ("{ static, flexible }")
+
+/**
+ * @brief The capabilities of the sink pad
+ */
+static GstStaticPadTemplate sinktemplate = GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS (CAPS_STRING));
+
+/**
+ * @brief The capabilities of the src pad
+ */
+static GstStaticPadTemplate srctemplate = GST_STATIC_PAD_TEMPLATE ("src",
+    GST_PAD_SRC,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS (CAPS_STRING));
+
+GST_DEBUG_CATEGORY_STATIC (gst_tensor_trainer_debug);
+#define GST_CAT_DEFAULT gst_tensor_trainer_debug
+#define gst_tensor_trainer_parent_class parent_class
+G_DEFINE_TYPE (GstTensorTrainer, gst_tensor_trainer, GST_TYPE_BASE_TRANSFORM);
+
+/**
+ * @brief Default framework property value
+ */
+#define DEFAULT_FRAMEWORK "nntrainer"
+
+/**
+ * @brief Default string property value 
+ */
+#define DEFAULT_STR_PROP_VALUE ""
+
+/**
+ * @brief Default string property value 
+ */
+enum
+{
+  PROP_0,
+  PROP_FRAMEWORK,
+  PROP_INPUT_DIM,
+  PROP_OUTPUT_DIM,
+  PROP_INPUT_TYPE,
+  PROP_OUTPUTTYPE
+};
+
+static void gst_tensor_trainer_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec);
+static void gst_tensor_trainer_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec);
+static gboolean gst_tensor_trainer_start (GstBaseTransform * trans);
+static gboolean gst_tensor_trainer_stop (GstBaseTransform * trans);
+static void gst_tensor_trainer_finalize (GObject * object);
+static gboolean gst_tensor_trainer_sink_event (GstBaseTransform * trans,
+    GstEvent * event);
+static gboolean gst_tensor_trainer_src_event (GstBaseTransform * trans,
+    GstEvent * event);
+static GstFlowReturn gst_tensor_trainer_transform (GstBaseTransform * trans,
+    GstBuffer * inbuf, GstBuffer * outbuf);
+static GstStateChangeReturn gst_tensor_trainer_change_state (GstElement *
+    element, GstStateChange transition);
+static GstCaps *gst_tensor_trainer_transform_caps (GstBaseTransform * trans,
+    GstPadDirection direction, GstCaps * caps, GstCaps * filter);
+static GstCaps *gst_tensor_trainer_fixate_caps (GstBaseTransform * trans,
+    GstPadDirection direction, GstCaps * caps, GstCaps * othercaps);
+static gboolean gst_tensor_trainer_set_caps (GstBaseTransform * trans,
+    GstCaps * incaps, GstCaps * outcaps);
+static gboolean gst_tensor_trainer_transform_size (GstBaseTransform * trans,
+    GstPadDirection direction, GstCaps * caps, gsize size, GstCaps * othercaps,
+    gsize * othersize);
+
+static void
+gst_tensor_trainer_set_prop_framework (GstTensorTrainer * trainer, const gchar * fw_name);
+static void gst_tensor_trainer_set_prop_dimension (GstTensorTrainer * trainer,
+    const GValue * value, const gboolean is_input);
+static void gst_tensor_trainer_set_prop_type (GstTensorTrainer * trainer,
+    const GValue * value, const gboolean is_input);
+static const GstTensorFilterFramework
+    *gst_tensor_trainer_find_best_framework (const char *names);
+static void gst_tensor_trainer_find_framework (GstTensorTrainer * trainer,
+    const char *name);
+static void gst_tensor_trainer_create_framework (GstTensorTrainer * trainer);
+static gsize gst_tensor_trainer_get_tensor_size (GstTensorTrainer * trainer,
+    guint index, gboolean is_input);
+
+/**
+ * @brief initialize the tensor_trainer's class
+ */
+static void
+gst_tensor_trainer_class_init (GstTensorTrainerClass * klass)
+{
+  GObjectClass *gobject_class;
+  GstBaseTransformClass *trans_class;
+  GstElementClass *gstelement_class;
+
+  GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, "tensor_trainer", 0,
+      "Tensor trainer to train neural network model");
+
+  gobject_class = G_OBJECT_CLASS (klass);
+  trans_class = GST_BASE_TRANSFORM_CLASS (klass);
+  gstelement_class = GST_ELEMENT_CLASS (klass);
+
+  gobject_class->set_property =
+      GST_DEBUG_FUNCPTR (gst_tensor_trainer_set_property);
+  gobject_class->get_property =
+      GST_DEBUG_FUNCPTR (gst_tensor_trainer_get_property);
+  gobject_class->finalize = GST_DEBUG_FUNCPTR (gst_tensor_trainer_finalize);
+
+  /* Called when the element's state changes */
+  gstelement_class->change_state =
+      GST_DEBUG_FUNCPTR (gst_tensor_trainer_change_state);
+
+  /* Called when the element starts processing */
+  trans_class->start = GST_DEBUG_FUNCPTR (gst_tensor_trainer_start);
+  /* Called when the element stop processing */
+  trans_class->stop = GST_DEBUG_FUNCPTR (gst_tensor_trainer_stop);
+
+  /* Event handler on sink pad or src pad */
+  trans_class->sink_event = GST_DEBUG_FUNCPTR (gst_tensor_trainer_sink_event);
+  trans_class->src_event = GST_DEBUG_FUNCPTR (gst_tensor_trainer_src_event);
+
+  /* Transforms incoming buffer */
+  trans_class->transform = GST_DEBUG_FUNCPTR (gst_tensor_trainer_transform);
+
+  /* Caps Negotiation */
+  trans_class->transform_caps =
+      GST_DEBUG_FUNCPTR (gst_tensor_trainer_transform_caps);
+  trans_class->fixate_caps = GST_DEBUG_FUNCPTR (gst_tensor_trainer_fixate_caps);
+  trans_class->set_caps = GST_DEBUG_FUNCPTR (gst_tensor_trainer_set_caps);
+
+  /* Allocation initial outbuffer size */
+  trans_class->transform_size =
+      GST_DEBUG_FUNCPTR (gst_tensor_trainer_transform_size);
+
+  /* Install properties for tensor_trainer */
+  g_object_class_install_property (gobject_class, PROP_FRAMEWORK,
+      g_param_spec_string ("framework", "Framework", "Neural network framework",
+          DEFAULT_FRAMEWORK,
+          G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
+          G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_INPUT_DIM,
+      g_param_spec_string ("input-dim", "Input dimension",
+          "Input tensors dimension from inner array, up to 4 dimensions ?", "",
+          G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
+          G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_OUTPUT_DIM,
+      g_param_spec_string ("output-dim", "Output dimension",
+          "Output tensors dimension from inner array, up to 4 dimensions ?", "",
+          G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
+          G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_INPUT_TYPE,
+      g_param_spec_string ("input-type", "Input tensor element type",
+          "Type of each element of the input tensor ?", "",
+          G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
+          G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_OUTPUT_TYPE,
+      g_param_spec_string ("output-type", "Output tensor element type",
+          "Type of each element of the input tensor ?", "",
+          G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
+          G_PARAM_STATIC_STRINGS));
+
+  gst_element_class_set_details_simple (gstelement_class, "TensorTrainer",
+      "Trainer/Tensor", "Train tensor data using NN Frameworks",
+      "Samsung Electronics Co., Ltd.");
+
+  /* Add pad template */
+  gst_element_class_add_pad_template (gstelement_class,
+      gst_static_pad_template_get (&srctemplate));
+  gst_element_class_add_pad_template (gstelement_class,
+      gst_static_pad_template_get (&sinktemplate));
+}
+
+/**
+ * @brief Initialize tensor_trainer.
+ */
+static void
+gst_tensor_trainer_init (GstTensorTrainer * trainer)
+{
+  GST_DEBUG ("<ENTER>");
+  trainer->fw_name = g_strdup (DEFAULT_FRAMEWORK);
+  trainer->input_dimensions = g_strdup (DEFAULT_STR_PROP_VALUE);
+  trainer->output_dimensions = g_strdup (DEFAULT_STR_PROP_VALUE);
+  trainer->input_type = g_strdup (DEFAULT_STR_PROP_VALUE);
+  trainer->output_type = g_strdup (DEFAULT_STR_PROP_VALUE);
+
+  trainer->fw = NULL;
+  trainer->fw_opened = 0; /* for test */
+  trainer->configured = 0;
+  trainer->input_configured = 0;
+  trainer->output_configured = 0;
+  trainer->inputtype_configured = 0;
+  trainer->outputtype_configured = 0;
+}
+
+/**
+ * @brief Function to finalize instance.
+ */
+static void
+gst_tensor_trainer_finalize (GObject * object)
+{
+  GstTensorTrainer *trainer;
+
+  trainer = GST_TENSOR_TRAINER (object);
+
+  g_free (trainer->fw_name);
+  g_free (trainer->input_dimensions);
+  g_free (trainer->output_dimensions);
+  g_free (trainer->input_type);
+  g_free (trainer->output_type);
+
+  G_OBJECT_CLASS (parent_class)->finalize (object);
+}
+
+/**
+ * @brief Setter for tensor_trainsink properties.
+ */
+static void
+gst_tensor_trainer_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  GstTensorTrainer *trainer;
+
+  trainer = GST_TENSOR_TRAINER (object);
+
+  switch (prop_id) {
+
+    case PROP_FRAMEWORK:
+      gst_tensor_trainer_set_prop_framework (trainer, g_value_get_string (value));
+      break;
+    case PROP_INPUT_DIM:
+      gst_tensor_trainer_set_prop_dimension (trainer, value, TRUE);
+      break;
+    case PROP_OUTPUT_DIM:
+      gst_tensor_trainer_set_prop_dimension (trainer, value, FALSE);
+      break;
+    case PROP_INPUT_TYPE:
+      gst_tensor_trainer_set_prop_type (trainer, value, TRUE);
+      break;
+    case PROP_OUTPUT_TYPE:
+      gst_tensor_trainer_set_prop_type (trainer, value, FALSE);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief Getter tensor_trainsink properties.
+ */
+static void
+gst_tensor_trainer_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  GstTensorTrainer *trainer;
+
+  trainer = GST_TENSOR_TRAINER (object);
+
+  switch (prop_id) {
+    case PROP_FRAMEWORK:
+      g_value_set_string (value, trainer->fw_name);
+      break;
+    case PROP_INPUT_DIM:
+      g_value_set_string (value, trainer->input_dimensions);
+      break;
+    case PROP_OUTPUT_DIM:
+      g_value_set_string (value, trainer->output_dimensions);
+      break;
+    case PROP_INPUT_TYPE:
+      g_value_set_string (value, trainer->input_type);
+      break;
+    case PROP_OUTPUT_TYPE:
+      g_value_set_string (value, trainer->output_type);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief Change state of tensor_trainsink.
+ */
+static GstStateChangeReturn
+gst_tensor_trainer_change_state (GstElement * element,
+    GstStateChange transition)
+{
+  GstTensorTrainer *trainer = GST_TENSOR_TRAINER (element);
+  GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+
+  switch (transition) {
+    case GST_STATE_CHANGE_NULL_TO_READY:
+      GST_INFO_OBJECT (trainer, "NULL_TO_READY");
+      break;
+
+    case GST_STATE_CHANGE_READY_TO_PAUSED:
+      GST_INFO_OBJECT (trainer, "READY_TO_PAUSED");
+      break;
+
+    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
+      GST_INFO_OBJECT (trainer, "PAUSED_TO_PLAYING");
+      /* start or resume model train */
+      break;
+
+    default:
+      break;
+  }
+
+  ret = GST_ELEMENT_CLASS (parent_class)->change_state (element, transition);
+
+  switch (transition) {
+    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
+      GST_INFO_OBJECT (trainer, "PLAYING_TO_PAUSED");
+      /* pause model train */
+      break;
+
+    case GST_STATE_CHANGE_PAUSED_TO_READY:
+      GST_INFO_OBJECT (trainer, "PAUSED_TO_READY");
+      /* stop model train */
+      break;
+
+    case GST_STATE_CHANGE_READY_TO_NULL:
+      GST_INFO_OBJECT (trainer, "READY_TO_NULL");
+      /* destroy or reset model ? */
+      break;
+
+    default:
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief Event handler for sink pad of tensor_trainer
+ */
+static gboolean
+gst_tensor_trainer_sink_event (GstBaseTransform * trans, GstEvent * event)
+{
+  GstTensorTrainer *trainer;
+  trainer = GST_TENSOR_TRAINER_CAST (trans);
+
+  GST_INFO_OBJECT (trainer, "sink pad got event (%s)",
+      gst_event_type_get_name (GST_EVENT_TYPE (event)));
+
+  switch (GST_EVENT_TYPE (event)) {
+    case GST_EVENT_EOS:
+      GST_INFO_OBJECT (trainer, "get GST_EVENT_EOS event..state is %d",
+          GST_STATE (trainer));
+      break;
+    case GST_EVENT_FLUSH_START:
+      GST_INFO_OBJECT (trainer, "get GST_EVENT_FLUSH_START event");
+      break;
+    case GST_EVENT_FLUSH_STOP:
+      GST_INFO_OBJECT (trainer, "get GST_EVENT_FLUSH_STOP event");
+      break;
+    default:
+      break;
+  }
+
+  return GST_BASE_TRANSFORM_CLASS (parent_class)->sink_event (trans, event);
+}
+
+/**
+ * @brief Event handler for src pad of tensor_trainer
+ */
+static gboolean
+gst_tensor_trainer_src_event (GstBaseTransform * trans, GstEvent * event)
+{
+  GstTensorTrainer *trainer;
+  trainer = GST_TENSOR_TRAINER_CAST (trans);
+
+  GST_INFO_OBJECT (trainer, "src pad got event (%s)",
+      gst_event_type_get_name (GST_EVENT_TYPE (event)));
+
+  switch (GST_EVENT_TYPE (event)) {
+    case GST_EVENT_EOS:
+      GST_INFO_OBJECT (trainer, "get GST_EVENT_EOS event..state is %d",
+          GST_STATE (trainer));
+      break;
+    case GST_EVENT_FLUSH_START:
+      GST_INFO_OBJECT (trainer, "get GST_EVENT_FLUSH_START event");
+      break;
+    case GST_EVENT_FLUSH_STOP:
+      GST_INFO_OBJECT (trainer, "get GST_EVENT_FLUSH_STOP event");
+      break;
+    default:
+      break;
+  }
+
+  return GST_BASE_TRANSFORM_CLASS (parent_class)->src_event (trans, event);
+}
+
+
+/**
+ * @brief Called when the element starts processing. optional vmethod of BaseTransform
+ */
+static gboolean
+gst_tensor_trainer_start (GstBaseTransform * trans)
+{
+  GstTensorTrainer *trainer;
+  trainer = GST_TENSOR_TRAINER_CAST (trans);
+
+  if (trainer->fw_name)
+    gst_tensor_trainer_find_framework (trainer, trainer->fw_name);
+  if (trainer->fw) {
+    /* create, compile */
+    gst_tensor_trainer_create_framework (trainer);
+  }
+
+  return TRUE;
+}
+
+/**
+ * @brief Called when the element stops processing. optional vmethod of BaseTransform
+ */
+static gboolean
+gst_tensor_trainer_stop (GstBaseTransform * trans)
+{
+  GstTensorTrainer *trainer;
+  trainer = GST_TENSOR_TRAINER_CAST (trans);
+
+  UNUSED (trainer);
+
+  return TRUE;
+}
+
+/**
+ * @brief Transforms one incoming buffer to one outgoing buffer
+ */
+static GstFlowReturn
+gst_tensor_trainer_transform (GstBaseTransform * trans, GstBuffer * inbuf,
+    GstBuffer * outbuf)
+{
+  GstTensorTrainer *trainer;
+  gint ret = -1;
+  guint mem_blocks, i;
+  gsize header_size, expected;
+  gboolean in_flexible, out_flexible;
+  GstMemory *in_mem[NNS_TENSOR_SIZE_LIMIT] = { 0, };
+  GstMapInfo in_info[NNS_TENSOR_SIZE_LIMIT];
+  GstMemory *out_mem[NNS_TENSOR_SIZE_LIMIT] = { 0, };
+  GstMapInfo out_info[NNS_TENSOR_SIZE_LIMIT];
+  GstTensorMemory in_tensors[NNS_TENSOR_SIZE_LIMIT];
+  GstTensorMemory invoke_tensors[NNS_TENSOR_SIZE_LIMIT];
+  GstTensorMemory out_tensors[NNS_TENSOR_SIZE_LIMIT];
+  GstTensorMetaInfo in_meta[NNS_TENSOR_SIZE_LIMIT];
+  GstTensorMetaInfo out_meta[NNS_TENSOR_SIZE_LIMIT];
+
+  trainer = GST_TENSOR_TRAINER_CAST (trans);
+
+  /* Get all input tensors from inbuf */
+  mem_blocks = gst_buffer_n_memory (inbuf);
+  for (i = 0; i < mem_blocks; i++) {
+    in_mem[i] = gst_buffer_peek_memory (inbuf, i);
+    if (!gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ)) {
+      GST_ERROR_OBJECT (trainer, "Could not map in_mem[%d] GstMemory", i);
+      goto error;
+    }
+    in_flexible =
+        gst_tensor_pad_caps_is_flexible (GST_BASE_TRANSFORM_SINK_PAD (trans));
+    /* Get header size */
+    header_size = 0;
+    if (in_flexible) {
+      gst_tensor_meta_info_parse_header (&in_meta[i], &in_info[i].data);
+      header_size = gst_tensor_meta_info_get_header_size (&in_meta[i]);
+      GST_INFO ("flexible header size:%zd", header_size);
+    } else {
+      GST_INFO ("not flexible header size:%zd", header_size);
+    }
+
+    in_tensors[i].data = in_info[i].data + header_size;
+    in_tensors[i].size = in_info[i].size - header_size;
+  }
+
+  /* Prepare tensor to invoke */
+  /* Check number of input tensors */
+  if (mem_blocks != trainer->input_meta.num_tensors) {
+    GST_ERROR_OBJECT (trainer, "Invalid memory blocks(%d),"
+        "number of input tensors may be (%d)", mem_blocks,
+        trainer->input_meta.num_tensors);
+    goto error;
+  }
+
+  /* Check size of input tensors */
+  for (i = 0; i < trainer->input_meta.num_tensors; i++) {
+    expected = gst_tensor_trainer_get_tensor_size (trainer, i, TRUE);
+    if (expected != in_tensors[i].size) {
+      GST_ERROR_OBJECT (trainer, "Invalid tensor size (%u'th memory chunk: %zd)"
+          ", expected size (%zd)", i, in_tensors[i].size, expected);
+      goto error;
+    }
+    /* Copy to data pointer */
+    invoke_tensors[i] = in_tensors[i];
+  }
+
+  /* Prepare output tensor */
+  for (i = 0; i < trainer->output_meta.num_tensors; i++) {
+    out_tensors[i].data = NULL;
+    out_tensors[i].size =
+        gst_tensor_trainer_get_tensor_size (trainer, i, FALSE);
+
+    /* Get header size */
+    header_size = 0;
+    out_flexible =
+        gst_tensor_pad_caps_is_flexible (GST_BASE_TRANSFORM_SRC_PAD (trans));
+    if (out_flexible) {
+      gst_tensor_info_convert_to_meta (&trainer->output_meta.info[i],
+          &out_meta[i]);
+      header_size = gst_tensor_meta_info_get_header_size (&out_meta[i]);
+      GST_INFO ("flexible header size:%zd", header_size);
+    } else {
+      GST_INFO ("not flexible header size:%zd", header_size);
+    }
+
+    out_mem[i] =
+        gst_allocator_alloc (NULL, out_tensors[i].size + header_size, NULL);
+    if (!out_mem[i]) {
+      GST_ERROR_OBJECT (trainer, "Failed to allocate memory");
+      goto error;
+    }
+
+    if (!gst_memory_map (out_mem[i], &out_info[i], GST_MAP_WRITE)) {
+      GST_ERROR_OBJECT (trainer, "Could not map in_mem[%d] GstMemory", i);
+      goto error;
+    }
+
+    out_tensors[i].data = out_info[i].data + header_size;
+
+    /* Append header */
+    if (out_flexible) {
+      if (!gst_tensor_meta_info_update_header (&out_meta[i], out_info[i].data)) {
+        GST_ERROR_OBJECT (trainer, "Failed to update header ");
+        goto error;
+      }
+    }
+  }
+
+  /* Call the trainer-subplugin callback, invoke */
+  ret =
+      trainer->fw->invoke_NN (&trainer->prop, &trainer->privateData,
+      invoke_tensors, out_tensors);
+
+  /* Free map info and handle */
+  for (i = 0; i < mem_blocks; i++)
+    gst_memory_unmap (in_mem[i], &in_info[i]);
+
+  for (i = 0; i < trainer->output_meta.num_tensors; i++) {
+    gst_memory_unmap (out_mem[i], &out_info[i]);
+    //if (ret != 0) {
+    //  gst_allocator_free (out_mem[i]->allocator, out_mem[i]);
+    //}
+  }
+
+  if (ret < 0) {
+    GST_ERROR_OBJECT (trainer, "Invoke error");
+    // return GST_FLOW_ERROR;
+  } else if (ret > 0) {
+    /* drop this buffer */
+    // return GST_BASE_TRANSFORM_FLOW_DROPPED;
+  }
+
+  GST_INFO ("out buffer size : %zd", gst_buffer_get_size (outbuf));
+  /*Update result */
+  for (i = 0; i < trainer->output_meta.num_tensors; i++) {
+    /* append the memory block to outbuf */
+    gst_buffer_append_memory (outbuf, out_mem[i]);
+  }
+  GST_INFO ("after out buffer size : %zd", gst_buffer_get_size (outbuf));
+
+  return GST_FLOW_OK;
+
+error:
+  mem_blocks = gst_buffer_n_memory (inbuf);
+  for (i = 0; i < mem_blocks; i++) {
+    if (in_mem[i])
+      gst_memory_unmap (in_mem[i], &in_info[i]);
+  }
+
+  for (i = 0; i < trainer->output_meta.num_tensors; i++) {
+    if (out_mem[i]) {
+      gst_memory_unmap (out_mem[i], &out_info[i]);
+      gst_allocator_free (out_mem[i]->allocator, out_mem[i]);
+    }
+  }
+
+  return GST_FLOW_ERROR;
+}
+
+/**
+ * @brief configure tensor-srcpad cap from "proposed" cap.
+ */
+static GstCaps *
+gst_tensor_trainer_transform_caps (GstBaseTransform * trans,
+    GstPadDirection direction, GstCaps * caps, GstCaps * filter)
+{
+  GstTensorTrainer *trainer;
+  GstCaps *result;
+  GstPad *pad;
+  GstStructure *structure;
+  gboolean configured = FALSE;
+
+  GstTensorsConfig in_config, out_config;
+
+  trainer = GST_TENSOR_TRAINER_CAST (trans);
+
+  GST_DEBUG_OBJECT (trans,
+      "[In direction %s] Transforming caps %" GST_PTR_FORMAT "",
+      (direction == GST_PAD_SINK) ? "sink" : "src", caps);
+
+  if (direction == GST_PAD_SRC)
+    pad = GST_BASE_TRANSFORM_SINK_PAD (trans);
+  else
+    pad = GST_BASE_TRANSFORM_SRC_PAD (trans);
+
+  gst_tensors_config_init (&in_config);
+  gst_tensors_config_init (&out_config);
+  structure = gst_caps_get_structure (caps, 0);
+  gst_tensors_config_from_structure (&in_config, structure);
+
+  /* Set framerate from input config */
+  out_config.rate_n = in_config.rate_n;
+  out_config.rate_d = in_config.rate_d;
+
+  /* Need to set property (input, inputtype, output, outputtype)
+     for trainer->input_meta and trainer->output_meta */
+  if (direction == GST_PAD_SRC) {
+    if (trainer->input_configured) {
+      gst_tensors_info_copy (&out_config.info, &trainer->input_meta);
+      configured = TRUE;
+    }
+  } else {
+    if (trainer->output_configured) {
+      configured = TRUE;
+      gst_tensors_info_copy (&out_config.info, &trainer->output_meta);
+    }
+  }
+
+  if (configured)
+    /* Output info may be configured */
+    result = gst_tensor_pad_possible_caps_from_config (pad, &out_config);
+  else
+    result = gst_caps_from_string (CAPS_STRING);
+
+  GST_DEBUG_OBJECT (trans, "caps intersect without filter %" GST_PTR_FORMAT, result);
+
+  if (filter) {
+    GstCaps *intersection;
+    intersection =
+        gst_caps_intersect_full (result, filter, GST_CAPS_INTERSECT_FIRST);
+    gst_caps_unref (result);
+    result = intersection;
+    GST_DEBUG_OBJECT (trans, "result caps %" GST_PTR_FORMAT, result);
+  }
+  gst_tensors_config_free (&in_config);
+  gst_tensors_config_free (&out_config);
+
+  return result;
+}
+
+/**
+ * @brief fixate caps. required vmethod of GstBaseTransform.
+ */
+static GstCaps *
+gst_tensor_trainer_fixate_caps (GstBaseTransform * trans,
+    GstPadDirection direction, GstCaps * caps, GstCaps * othercaps)
+{
+  UNUSED (direction);
+  UNUSED (caps);
+
+  othercaps = gst_caps_fixate (othercaps);
+  GST_DEBUG_OBJECT (trans, "fixated to %" GST_PTR_FORMAT, othercaps);
+
+  return othercaps;
+}
+
+/**
+ * @brief set caps. required vmethod of GstBaseTransform.
+ */
+static gboolean
+gst_tensor_trainer_set_caps (GstBaseTransform * trans, GstCaps * incaps,
+    GstCaps * outcaps)
+{
+  GstTensorTrainer *trainer;
+  GstStructure *structure;
+  GstTensorsConfig in_config;
+
+  trainer = GST_TENSOR_TRAINER_CAST (trans);
+
+  GST_DEBUG_OBJECT (trainer, "[incaps] : %" GST_PTR_FORMAT, incaps);
+  GST_DEBUG_OBJECT (trainer, "[outcaps] : %" GST_PTR_FORMAT, outcaps);
+
+  gst_tensors_config_init (&in_config);
+  structure = gst_caps_get_structure (incaps, 0);
+  gst_tensors_config_from_structure (&in_config, structure);
+
+  if (!gst_tensors_info_is_equal (&in_config.info, &trainer->input_meta)) {
+    GST_ERROR_OBJECT (trainer,
+        "The input tensors info is different between incaps and set property value. "
+        "Please check pipeline's input tensor info and tensor_trainer's set property values"
+        "(input, inputtype, output and outputtype)");
+    return FALSE;
+  }
+
+  gst_tensors_config_free (&in_config);
+
+  return TRUE;
+}
+
+/**
+ * @brief Handle "PROP_FRAMEWORK" for set-property
+ */
+static void
+gst_tensor_trainer_set_prop_framework (GstTensorTrainer * trainer, const gchar * fw_name)
+{
+  g_free (trainer->fw_name);
+  trainer->fw_name = g_strdup (fw_name);
+  GST_INFO_OBJECT (trainer, "framework: %s", trainer->fw_name);
+
+  /** @todo Check valid framework */
+}
+
+/**
+ * @brief Handle "PROP_INPUT_DIM" and "PROP_OUTPUT_DIM" for set-property
+ */
+static void
+gst_tensor_trainer_set_prop_dimension (GstTensorTrainer * trainer,
+    const GValue * value, const gboolean is_input)
+{
+  GstTensorsInfo *info;
+  unsigned int *rank;
+  guint num_dims;
+  gchar **str_dims;
+  guint i;
+
+  if ((is_input && trainer->input_configured) || (!is_input
+          && trainer->output_configured)) {
+    GST_ERROR_OBJECT (trainer,
+        "Cannot change %s dimension" "the element/pipeline is configured.",
+        (is_input) ? "input" : "output");
+    return;
+  }
+
+  if (is_input) {
+    info = &trainer->input_meta;
+    rank = trainer->input_ranks;
+    trainer->input_configured = TRUE;
+    g_free (trainer->input_dimensions);
+    trainer->input_dimensions = g_value_dup_string (value);
+    GST_INFO_OBJECT (trainer, "input: %s", trainer->input_dimensions);
+  } else {
+    info = &trainer->output_meta;
+    rank = trainer->output_ranks;
+    trainer->output_configured = TRUE;
+    g_free (trainer->output_dimensions);
+    trainer->output_dimensions = g_value_dup_string (value);
+    GST_INFO_OBJECT (trainer, "output: %s", trainer->output_dimensions);
+  }
+
+  str_dims = g_strsplit_set (g_value_get_string (value), ",.", -1);
+  num_dims = g_strv_length (str_dims);
+
+  if (num_dims > NNS_TENSOR_SIZE_LIMIT) {
+    GST_WARNING_OBJECT (trainer, "Invalid param, dimensions(%d) max(%d)",
+        num_dims, NNS_TENSOR_SIZE_LIMIT);
+    num_dims = NNS_TENSOR_SIZE_LIMIT;
+  }
+
+  for (i = 0; i < num_dims; i++)
+    rank[i] = gst_tensor_parse_dimension (str_dims[i], info->info[i].dimension);
+
+  info->num_tensors = num_dims;
+
+  g_strfreev (str_dims);
+}
+
+/**
+ * @brief Handle "PROP_INPUT_TYPE" and "PROP_OUTPUT_TYPE" for set-property
+ */
+static void
+gst_tensor_trainer_set_prop_type (GstTensorTrainer * trainer,
+    const GValue * value, const gboolean is_input)
+{
+  GstTensorsInfo *info;
+  guint num_types;
+
+  if ((is_input && trainer->inputtype_configured) || (!is_input
+          && trainer->outputtype_configured)) {
+    GST_ERROR_OBJECT (trainer,
+        "Cannot change %stype" "the element/pipeline is configured.",
+        (is_input) ? "input" : "output");
+    return;
+  }
+
+  if (is_input) {
+    info = &trainer->input_meta;
+    trainer->inputtype_configured = TRUE;
+    g_free (trainer->input_type);
+    trainer->input_type = g_value_dup_string (value);
+    GST_INFO_OBJECT (trainer, "inputtype : %s", trainer->input_type);
+  } else {
+    info = &trainer->output_meta;
+    trainer->outputtype_configured = TRUE;
+    g_free (trainer->output_type);
+    trainer->output_type = g_value_dup_string (value);
+    GST_INFO_OBJECT (trainer, "outputtype : %s", trainer->output_type);
+  }
+
+  num_types =
+      gst_tensors_info_parse_types_string (info, g_value_get_string (value));
+
+  info->num_tensors = num_types;
+}
+
+/**
+ * @brief Find Trainer sub-plugin with the name.
+ */
+static void
+gst_tensor_trainer_find_framework (GstTensorTrainer * trainer, const char *name)
+{
+  const GstTensorFilterFramework *fw = NULL;
+  gchar *str;
+  g_return_if_fail (name != NULL);
+
+  GST_INFO ("find framework: %s", name);
+
+  /* Need to add trainer type to subpluginType */
+  fw = get_subplugin (NNS_SUBPLUGIN_FILTER, name);
+
+  if (fw == NULL) {
+    /*Get sub-plugin priority from ini file and find sub-plugin */
+    str = nnsconf_get_custom_value_string (name, "subplugin_priority");
+    fw = gst_tensor_trainer_find_best_framework (str);
+    g_free (str);
+  }
+
+  if (fw == NULL) {
+    /* Check the filter-alias from ini file */
+    str = nnsconf_get_custom_value_string ("filter-aliases", name);
+    fw = gst_tensor_trainer_find_best_framework (str);
+    g_free (str);
+  }
+
+  if (fw) {
+    GST_INFO_OBJECT (trainer, "find framework %s:%p", trainer->fw_name, fw);
+    trainer->fw = fw;
+  } else {
+    GST_ERROR_OBJECT (trainer, "Can not find framework(%s)", trainer->fw_name);
+  }
+}
+
+/**
+ * @brief Create NN framework.
+ */
+static void
+gst_tensor_trainer_create_framework (GstTensorTrainer * trainer)
+{
+  if (!trainer->fw || trainer->fw_opened) {
+    GST_ERROR_OBJECT (trainer, "fw is not opened(%d) or fw is null(%p)",
+        trainer->fw_opened, trainer->fw);
+    return;
+  }
+
+  /* For test */
+  if (!trainer->fw->open) {     /* fw->create, create model with configuration file */
+    GST_ERROR_OBJECT (trainer, "Could not find fw->create");
+    return;
+  }
+  /* Test code, need to create with load ini file */
+  if (trainer->fw->open (&trainer->prop, &trainer->privateData) >= 0)
+    trainer->fw_created = TRUE;
+}
+
+/**
+ * @brief Find sub-plugin trainer given the name list
+ */
+static const GstTensorFilterFramework *
+gst_tensor_trainer_find_best_framework (const char *names)
+{
+  const GstTensorFilterFramework *fw = NULL; /* need to change to GstTensorTrainerFramework */
+  gchar **subplugins;
+  guint i, len;
+
+  if (names == NULL || names[0] == '\0')
+    return NULL;
+
+  subplugins = g_strsplit_set (names, " ,;", -1);
+
+  len = g_strv_length (subplugins);
+
+  for (i = 0; i < len; i++) {
+    if (strlen (g_strstrip (subplugins[i])) == 0)
+      continue;
+
+    fw = get_subplugin (NNS_SUBPLUGIN_FILTER, subplugins[i]); /* need to add trainer type to subpluginType */
+    if (fw) {
+      GST_INFO ("i = %d found %s", i, subplugins[i]);
+      break;
+    }
+  }
+  g_strfreev (subplugins);
+
+  return fw;
+}
+
+/**
+ * @brief Calculate tensor buffer size
+ */
+gsize
+gst_tensor_trainer_get_tensor_size (GstTensorTrainer * trainer, guint index,
+    gboolean is_input)
+{
+  GstTensorsInfo *info;
+
+  if (is_input)
+    info = &trainer->input_meta;
+  else
+    info = &trainer->output_meta;
+
+  /* Internal Logic Error: out of bound */
+  if (index >= info->num_tensors) {
+    GST_ERROR_OBJECT (trainer, "has inconsistent data");
+    return 0;
+  }
+
+  return gst_tensor_info_get_size (&info->info[index]);
+}
+
+/**
+ * @brief Allocation initial outbuffer size
+ */
+static gboolean
+gst_tensor_trainer_transform_size (GstBaseTransform * trans,
+    GstPadDirection direction, GstCaps * caps, gsize size,
+    GstCaps * othercaps, gsize * othersize)
+{
+  GstTensorTrainer *trainer;
+
+  UNUSED (direction);
+  UNUSED (caps);
+  UNUSED (size);
+  UNUSED (othercaps);
+  trainer = GST_TENSOR_TRAINER_CAST (trans);
+
+  GST_DEBUG_OBJECT (trainer, "trainer->configured: %d", trainer->configured);
+
+  /** Internal Logic Error. Cannot proceed without configured pipeline */
+  //g_assert (trainer->configured);
+
+  *othersize = 0;
+
+  return TRUE;
+}

--- a/gst/nnstreamer/elements/gsttensor_trainer.c
+++ b/gst/nnstreamer/elements/gsttensor_trainer.c
@@ -11,11 +11,11 @@
  *
  * ## Example launch line
  * |[
- * gst-launch-1.0 filesrc location=mnist_trainingSet.dat blocksize = 3176 ! application/octet-stream ! \
- * tensor_converter input-dim=1:1:784:1,1:1:10:1 input-type=float32,float32 ! \
+ * gst-launch-1.0 repo_src location=mnist_trainingSet.dat ! \
+ * other/tensors, format=static, num_tensors=2, framerate=0/1, dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! \
  * tensor_trainer framework=nntrainer model-config=mnist.ini model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 \
  * input-type=float32,float32 num-lists=1 num-labels=1 num-training-samples=100 num-validation-samples=100 epochs=5 ! \
- * tensor_sink
+ * tensor_sink 
  * ]|
  *
  * Total number of data to be received is 1000((num-training-samples + num-validation-samples) * epochs)
@@ -673,61 +673,36 @@ static GstCaps *
 gst_tensor_trainer_query_caps (GstTensorTrainer * trainer,
     GstPad * pad, GstCaps * filter)
 {
-  GstCaps *result;
   GstCaps *caps;
-  GstStructure *structure;
-  gboolean configured = FALSE;
-  GstTensorsConfig in_config;
+  GstTensorsConfig *config;
 
   g_return_val_if_fail (trainer != NULL, NULL);
   g_return_val_if_fail (pad != NULL, NULL);
 
-  gst_tensors_config_init (&in_config);
+  gst_tensors_config_init (&trainer->in_config);
   gst_tensors_config_init (&trainer->out_config);
 
-  caps = gst_tensor_pad_possible_caps_from_config (pad, &in_config);
-  structure = gst_caps_get_structure (caps, 0);
-
-  if (!gst_tensors_config_from_structure (&in_config, structure))
-    return NULL;
-  gst_caps_unref (caps);
-
-  /** Need to set property (input, inputtype, output, outputtype)
-      for trainer->input_meta and trainer->output_meta */
-  if (pad == trainer->srcpad) {
-    if (trainer->input_configured) {
-      gst_tensors_info_copy (&trainer->out_config.info,
-          &trainer->prop.input_meta);
-      configured = TRUE;
-    }
+  /* tensor config info for given pad */
+  if (pad == trainer->sinkpad) {
+    config = &trainer->in_config;
   } else {
-    if (trainer->output_configured) {
-      configured = TRUE;
-      gst_tensors_info_copy (&trainer->out_config.info, &trainer->output_meta);
-    }
+    config = &trainer->out_config;
   }
 
-  if (configured)
-    /* Output info may be configured */
-    result =
-        gst_tensor_pad_possible_caps_from_config (pad, &trainer->out_config);
-  else
-    result = gst_caps_from_string (CAPS_STRING);
+  caps = gst_tensor_pad_possible_caps_from_config (pad, config);
+  GST_DEBUG_OBJECT (trainer, "caps %" GST_PTR_FORMAT, caps);
+  GST_DEBUG_OBJECT (trainer, "filter %" GST_PTR_FORMAT, filter);
 
-  GST_DEBUG_OBJECT (trainer, "caps intersect without filter %" GST_PTR_FORMAT,
-      result);
-
-  if (filter) {
-    GstCaps *intersection;
-    intersection =
-        gst_caps_intersect_full (result, filter, GST_CAPS_INTERSECT_FIRST);
-    gst_caps_unref (result);
-    result = intersection;
-    GST_DEBUG_OBJECT (trainer, "result caps %" GST_PTR_FORMAT, result);
+  if (caps && filter) {
+    GstCaps *result;
+    result = gst_caps_intersect_full (filter, caps, GST_CAPS_INTERSECT_FIRST);
+    gst_caps_unref (caps);
+    caps = result;
   }
-  gst_tensors_config_free (&in_config);
 
-  return result;
+  GST_DEBUG_OBJECT (trainer, "result caps %" GST_PTR_FORMAT, caps);
+
+  return caps;
 }
 
 /**
@@ -793,6 +768,8 @@ gst_tensor_trainer_sink_event (GstPad * sinkpad, GstObject * parent,
       trainer->out_config.rate_n = in_config.rate_n;
       trainer->out_config.rate_d = in_config.rate_d;
 
+      gst_tensors_info_copy (&trainer->out_config.info, &trainer->output_meta);
+
       out_caps =
           gst_tensor_pad_caps_from_config (trainer->srcpad,
           &trainer->out_config);
@@ -803,7 +780,7 @@ gst_tensor_trainer_sink_event (GstPad * sinkpad, GstObject * parent,
       gst_event_unref (event);
       gst_caps_unref (out_caps);
 
-      gst_tensors_config_free (&in_config);
+      gst_tensors_config_free (&trainer->in_config);
       gst_tensors_config_free (&trainer->out_config);
 
       return ret;

--- a/gst/nnstreamer/elements/gsttensor_trainer.c
+++ b/gst/nnstreamer/elements/gsttensor_trainer.c
@@ -16,9 +16,8 @@
  * ! mux.sink_0 filesrc location=mnist_label_200.dat blocksize=40 ! \
  * application/octet-stream, framerate=5/1 ! tensor_converter input_dim=1:1:10:1 input-type=float32 \
  * ! mux.sink_1 tensor_mux name=mux sync-mode=nosync ! tensor_trainer framework=nntrainer \
- * model-config=mnist.ini model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 \
- * input-type=float32,float32 num-inputs=1 mum-labels=1 num-training-samples=100 num-alidation-samples=100 \
- * ! tensor_sink
+ * model-config=mnist.ini model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 input-type=float32,float32 \
+ * num-lists=1 num-labels=1 num-training-samples=100 num-validation-samples=100 ! tensor_sink
  * ]|
  */
 
@@ -78,7 +77,6 @@ enum
   PROP_MODEL_SAVE_PATH,
   PROP_INPUT_DIM,
   PROP_INPUT_TYPE,
-  PROP_PUSH_OUTPUT,
   PROP_NUM_INPUTS,              /* number of input list */
   PROP_NUM_LABELS,              /* number of label list */
   PROP_NUM_TRAINING_SAMPLES,    /*number of training data */
@@ -184,12 +182,6 @@ gst_tensor_trainer_class_init (GstTensorTrainerClass * klass)
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
           G_PARAM_STATIC_STRINGS));
 
-  g_object_class_install_property (gobject_class, PROP_PUSH_OUTPUT,
-      g_param_spec_boolean ("push-output", "Push output tensor",
-          "Add output tensors to output GstBuffer", FALSE,
-          G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
-          G_PARAM_STATIC_STRINGS));
-
   g_object_class_install_property (gobject_class, PROP_NUM_INPUTS,
       g_param_spec_uint ("num-inputs", "Number of inputs",
           "An input in a tensor can have one or more features data,"
@@ -265,7 +257,6 @@ gst_tensor_trainer_init (GstTensorTrainer * trainer)
   trainer->output_dimensions = g_strdup (DEFAULT_STR_PROP_VALUE);
   trainer->input_type = g_strdup (DEFAULT_STR_PROP_VALUE);
   trainer->output_type = g_strdup (DEFAULT_STR_PROP_VALUE);
-  trainer->push_output = FALSE;
 
   trainer->fw = NULL;
   trainer->fw_created = FALSE;
@@ -337,11 +328,6 @@ gst_tensor_trainer_set_property (GObject * object, guint prop_id,
     case PROP_INPUT_TYPE:
       gst_tensor_trainer_set_prop_input_type (trainer, value);
       break;
-      break;
-    case PROP_PUSH_OUTPUT:
-      trainer->push_output = g_value_get_boolean (value);
-      GST_INFO_OBJECT (trainer, "push output: %d", trainer->push_output);
-      break;
     case PROP_NUM_INPUTS:
       trainer->prop.num_inputs = g_value_get_uint (value);
       break;
@@ -386,9 +372,6 @@ gst_tensor_trainer_get_property (GObject * object, guint prop_id,
       break;
     case PROP_INPUT_TYPE:
       g_value_set_string (value, trainer->input_type);
-      break;
-    case PROP_PUSH_OUTPUT:
-      g_value_set_boolean (value, trainer->push_output);
       break;
     case PROP_NUM_INPUTS:
       g_value_set_uint (value, trainer->prop.num_inputs);
@@ -537,8 +520,29 @@ gst_tensor_trainer_chain (GstPad * sinkpad, GstObject * parent,
     GST_INFO ("invoke_tensors[%d].data: %p", i, invoke_tensors[i].data);
   }
 
-  /* Prepare output tensor */
-  if (trainer->push_output) {
+  ret =
+      trainer->fw->push_data (trainer->fw, &trainer->prop, trainer->privateData,
+      invoke_tensors);
+  trainer->total_invoke_num++;
+
+  /* Free in info */
+  for (i = 0; i < mem_blocks; i++)
+    gst_memory_unmap (in_mem[i], &in_info[i]);
+
+  if (ret < 0) {
+    GST_ERROR_OBJECT (trainer, "Invoke error");
+    return GST_FLOW_ERROR;
+  }
+
+  /** Update result if one of epochs is complete,
+      push one outbuf is necessary to change pipeline state.
+      Scheduling with subplugin does not work.
+   */
+  if (trainer->total_invoke_num == 1
+      || trainer->total_invoke_num ==
+      trainer->prop.num_train_samples + trainer->prop.num_valid_samples) {
+
+    /* Prepare output tensor */
     for (i = 0; i < trainer->output_meta.num_tensors; i++) {
       out_tensors[i].data = NULL;
       out_tensors[i].size =
@@ -578,56 +582,35 @@ gst_tensor_trainer_chain (GstPad * sinkpad, GstObject * parent,
           goto error;
         }
       }
+#if 0
+      /** @todo Need to updatd out_tensors */
+      /* get loss, accuracy, val_loss, val_accuracy */
+      double data[4] = { 0, 0, 0, 0 };
+      ptr = out_info[i].data;
+      memcpy (ptr, data, sizeof (data));
+#endif
     }
-    /* Call the trainer-subplugin callback, invoke */
-    ret =
-        trainer->fw->push_data (trainer->fw, &trainer->prop,
-        trainer->privateData, invoke_tensors);
 
     /* Free out info */
     for (i = 0; i < trainer->output_meta.num_tensors; i++) {
       if (out_mem[i])
         gst_memory_unmap (out_mem[i], &out_info[i]);
-      //if (ret != 0) {
-      //  gst_allocator_free (out_mem[i]->allocator, out_mem[i]);
-      //}
     }
-  } else {
-    ret =
-        trainer->fw->push_data (trainer->fw, &trainer->prop,
-        trainer->privateData, invoke_tensors);
-  }
 
-  trainer->total_invoke_num++;
-
-  /* Free in info */
-  for (i = 0; i < mem_blocks; i++)
-    gst_memory_unmap (in_mem[i], &in_info[i]);
-
-  if (ret < 0) {
-    GST_ERROR_OBJECT (trainer, "Invoke error");
-    return GST_FLOW_ERROR;
-  }
-
-  /** Update result if one of epochs is complete,
-      push one outbuf is necessary to change pipeline state.
-      Scheduling with subplugin does not work.
-   */
-  if (trainer->total_invoke_num == 1
-      || trainer->total_invoke_num ==
-      trainer->prop.num_train_samples + trainer->prop.num_valid_samples) {
     outbuf = gst_buffer_new ();
     for (i = 0; i < trainer->output_meta.num_tensors; i++) {
       /* append the memory block to outbuf */
       gst_buffer_append_memory (outbuf, out_mem[i]);
     }
-    GST_INFO ("after out buffer size : %zd", gst_buffer_get_size (outbuf));
+    GST_INFO ("out_buffer size : %zd", gst_buffer_get_size (outbuf));
 
     gst_pad_push (trainer->srcpad, outbuf);
-    return GST_FLOW_OK;
   }
 
+  gst_buffer_unref (inbuf);
+
   return GST_FLOW_OK;
+
 error:
   mem_blocks = gst_buffer_n_memory (inbuf);
   for (i = 0; i < mem_blocks; i++) {
@@ -641,6 +624,8 @@ error:
       gst_allocator_free (out_mem[i]->allocator, out_mem[i]);
     }
   }
+
+  gst_buffer_unref (inbuf);
 
   return GST_FLOW_ERROR;
 }
@@ -1134,7 +1119,7 @@ gst_tensor_trainer_output_type (GstTensorTrainer * trainer)
   g_return_if_fail (trainer != NULL);
 
   info = &trainer->output_meta;
-  info->info[0].type = _NNS_FLOAT16;
+  info->info[0].type = _NNS_FLOAT64;
 }
 
 /**

--- a/gst/nnstreamer/elements/gsttensor_trainer.c
+++ b/gst/nnstreamer/elements/gsttensor_trainer.c
@@ -38,7 +38,7 @@
 /**
  * @brief The capabilities of the sink pad
  */
-static GstStaticPadTemplate sinktemplate = GST_STATIC_PAD_TEMPLATE ("sink",
+static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS (CAPS_STRING));
@@ -46,7 +46,7 @@ static GstStaticPadTemplate sinktemplate = GST_STATIC_PAD_TEMPLATE ("sink",
 /**
  * @brief The capabilities of the src pad
  */
-static GstStaticPadTemplate srctemplate = GST_STATIC_PAD_TEMPLATE ("src",
+static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS (CAPS_STRING));
@@ -54,7 +54,7 @@ static GstStaticPadTemplate srctemplate = GST_STATIC_PAD_TEMPLATE ("src",
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_trainer_debug);
 #define GST_CAT_DEFAULT gst_tensor_trainer_debug
 #define gst_tensor_trainer_parent_class parent_class
-G_DEFINE_TYPE (GstTensorTrainer, gst_tensor_trainer, GST_TYPE_BASE_TRANSFORM);
+G_DEFINE_TYPE (GstTensorTrainer, gst_tensor_trainer, GST_TYPE_ELEMENT);
 
 /**
  * @brief Default framework property value
@@ -92,25 +92,19 @@ static void gst_tensor_trainer_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec);
 static void gst_tensor_trainer_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec);
-static gboolean gst_tensor_trainer_stop (GstBaseTransform * trans);
 static void gst_tensor_trainer_finalize (GObject * object);
-static gboolean gst_tensor_trainer_sink_event (GstBaseTransform * trans,
-    GstEvent * event);
-static gboolean gst_tensor_trainer_src_event (GstBaseTransform * trans,
-    GstEvent * event);
-static GstFlowReturn gst_tensor_trainer_transform (GstBaseTransform * trans,
-    GstBuffer * inbuf, GstBuffer * outbuf);
+static gboolean gst_tensor_trainer_sink_event (GstPad * sinkpad,
+    GstObject * parent, GstEvent * event);
+static gboolean gst_tensor_trainer_sink_query (GstPad * sinkpad,
+    GstObject * parent, GstQuery * query);
+static gboolean gst_tensor_trainer_src_query (GstPad * srcpad,
+    GstObject * parent, GstQuery * query);
+static GstFlowReturn gst_tensor_trainer_chain (GstPad * sinkpad,
+    GstObject * parent, GstBuffer * inbuf);
+static GstCaps *gst_tensor_trainer_query_caps (GstTensorTrainer * trainer,
+    GstPad * pad, GstCaps * filter);
 static GstStateChangeReturn gst_tensor_trainer_change_state (GstElement *
     element, GstStateChange transition);
-static GstCaps *gst_tensor_trainer_transform_caps (GstBaseTransform * trans,
-    GstPadDirection direction, GstCaps * caps, GstCaps * filter);
-static GstCaps *gst_tensor_trainer_fixate_caps (GstBaseTransform * trans,
-    GstPadDirection direction, GstCaps * caps, GstCaps * othercaps);
-static gboolean gst_tensor_trainer_set_caps (GstBaseTransform * trans,
-    GstCaps * incaps, GstCaps * outcaps);
-static gboolean gst_tensor_trainer_transform_size (GstBaseTransform * trans,
-    GstPadDirection direction, GstCaps * caps, gsize size, GstCaps * othercaps,
-    gsize * othersize);
 
 static void gst_tensor_trainer_set_prop_framework (GstTensorTrainer * trainer,
     const GValue * value);
@@ -137,14 +131,12 @@ static void
 gst_tensor_trainer_class_init (GstTensorTrainerClass * klass)
 {
   GObjectClass *gobject_class;
-  GstBaseTransformClass *trans_class;
   GstElementClass *gstelement_class;
 
   GST_DEBUG_CATEGORY_INIT (GST_CAT_DEFAULT, "tensor_trainer", 0,
       "Tensor trainer to train neural network model");
 
   gobject_class = G_OBJECT_CLASS (klass);
-  trans_class = GST_BASE_TRANSFORM_CLASS (klass);
   gstelement_class = GST_ELEMENT_CLASS (klass);
 
   gobject_class->set_property =
@@ -156,26 +148,6 @@ gst_tensor_trainer_class_init (GstTensorTrainerClass * klass)
   /* Called when the element's state changes */
   gstelement_class->change_state =
       GST_DEBUG_FUNCPTR (gst_tensor_trainer_change_state);
-
-  /* Called when the element stop processing */
-  trans_class->stop = GST_DEBUG_FUNCPTR (gst_tensor_trainer_stop);
-
-  /* Event handler on sink pad or src pad */
-  trans_class->sink_event = GST_DEBUG_FUNCPTR (gst_tensor_trainer_sink_event);
-  trans_class->src_event = GST_DEBUG_FUNCPTR (gst_tensor_trainer_src_event);
-
-  /* Transforms incoming buffer */
-  trans_class->transform = GST_DEBUG_FUNCPTR (gst_tensor_trainer_transform);
-
-  /* Caps Negotiation */
-  trans_class->transform_caps =
-      GST_DEBUG_FUNCPTR (gst_tensor_trainer_transform_caps);
-  trans_class->fixate_caps = GST_DEBUG_FUNCPTR (gst_tensor_trainer_fixate_caps);
-  trans_class->set_caps = GST_DEBUG_FUNCPTR (gst_tensor_trainer_set_caps);
-
-  /* Allocation initial outbuffer size */
-  trans_class->transform_size =
-      GST_DEBUG_FUNCPTR (gst_tensor_trainer_transform_size);
 
   /* Install properties for tensor_trainer */
   g_object_class_install_property (gobject_class, PROP_FRAMEWORK,
@@ -268,9 +240,9 @@ gst_tensor_trainer_class_init (GstTensorTrainerClass * klass)
 
   /* Add pad template */
   gst_element_class_add_pad_template (gstelement_class,
-      gst_static_pad_template_get (&srctemplate));
+      gst_static_pad_template_get (&src_template));
   gst_element_class_add_pad_template (gstelement_class,
-      gst_static_pad_template_get (&sinktemplate));
+      gst_static_pad_template_get (&sink_template));
 }
 
 /**
@@ -280,6 +252,25 @@ static void
 gst_tensor_trainer_init (GstTensorTrainer * trainer)
 {
   GST_DEBUG ("<ENTER>");
+  /** setup sink pad */
+  trainer->sinkpad = gst_pad_new_from_static_template (&sink_template, "sink");
+  gst_pad_set_event_function (trainer->sinkpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_trainer_sink_event));
+  gst_pad_set_query_function (trainer->sinkpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_trainer_sink_query));
+  gst_pad_set_chain_function (trainer->sinkpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_trainer_chain));
+  GST_PAD_SET_PROXY_CAPS (trainer->sinkpad);
+  gst_element_add_pad (GST_ELEMENT (trainer), trainer->sinkpad);
+
+  /** setup src pad */
+  trainer->srcpad = gst_pad_new_from_static_template (&src_template, "src");
+  gst_pad_set_query_function (trainer->srcpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_trainer_src_query));
+  GST_PAD_SET_PROXY_CAPS (trainer->srcpad);
+  gst_element_add_pad (GST_ELEMENT (trainer), trainer->srcpad);
+
+  /** init properties */
   trainer->fw_name = g_strdup (DEFAULT_PROP_FRAMEWORK);
   trainer->model_config = g_strdup (DEFAULT_STR_PROP_VALUE);
   trainer->model_save_path = g_strdup (DEFAULT_STR_PROP_VALUE);
@@ -293,9 +284,11 @@ gst_tensor_trainer_init (GstTensorTrainer * trainer)
   trainer->fw_created = 0;      /* for test */
   trainer->configured = 0;
   trainer->input_configured = 0;
-  trainer->output_configured = 0;
+  trainer->output_configured = FALSE;
   trainer->inputtype_configured = 0;
   trainer->outputtype_configured = 0;
+
+  trainer->total_invoke_num = 0;
 
   g_cond_init (&trainer->train_complete_cond);
   g_mutex_init (&trainer->trainer_lock);
@@ -326,7 +319,6 @@ gst_tensor_trainer_finalize (GObject * object)
   if (trainer->fw_created && trainer->fw) {
     trainer->fw->destroy (trainer->fw, &trainer->prop, &trainer->privateData);
   }
-  /* need to free prop data */
 
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
@@ -496,91 +488,14 @@ gst_tensor_trainer_change_state (GstElement * element,
 }
 
 /**
- * @brief Event handler for sink pad of tensor_trainer
- */
-static gboolean
-gst_tensor_trainer_sink_event (GstBaseTransform * trans, GstEvent * event)
-{
-  GstTensorTrainer *trainer;
-  trainer = GST_TENSOR_TRAINER_CAST (trans);
-
-  GST_INFO_OBJECT (trainer, "sink pad got event (%s)",
-      gst_event_type_get_name (GST_EVENT_TYPE (event)));
-
-  switch (GST_EVENT_TYPE (event)) {
-    case GST_EVENT_EOS:
-      GST_INFO_OBJECT (trainer, "get GST_EVENT_EOS event..state is %d",
-          GST_STATE (trainer));
-      g_mutex_lock (&trainer->trainer_lock);
-      GST_INFO_OBJECT (trainer, "wait for train_complete_cond signal");
-      g_cond_wait (&trainer->train_complete_cond, &trainer->trainer_lock);
-      g_mutex_unlock (&trainer->trainer_lock);
-      break;
-    case GST_EVENT_FLUSH_START:
-      GST_INFO_OBJECT (trainer, "get GST_EVENT_FLUSH_START event");
-      break;
-    case GST_EVENT_FLUSH_STOP:
-      GST_INFO_OBJECT (trainer, "get GST_EVENT_FLUSH_STOP event");
-      break;
-    default:
-      break;
-  }
-
-  return GST_BASE_TRANSFORM_CLASS (parent_class)->sink_event (trans, event);
-}
-
-/**
- * @brief Event handler for src pad of tensor_trainer
- */
-static gboolean
-gst_tensor_trainer_src_event (GstBaseTransform * trans, GstEvent * event)
-{
-  GstTensorTrainer *trainer;
-  trainer = GST_TENSOR_TRAINER_CAST (trans);
-
-  GST_INFO_OBJECT (trainer, "src pad got event (%s)",
-      gst_event_type_get_name (GST_EVENT_TYPE (event)));
-
-  switch (GST_EVENT_TYPE (event)) {
-    case GST_EVENT_EOS:
-      GST_INFO_OBJECT (trainer, "get GST_EVENT_EOS event..state is %d",
-          GST_STATE (trainer));
-      break;
-    case GST_EVENT_FLUSH_START:
-      GST_INFO_OBJECT (trainer, "get GST_EVENT_FLUSH_START event");
-      break;
-    case GST_EVENT_FLUSH_STOP:
-      GST_INFO_OBJECT (trainer, "get GST_EVENT_FLUSH_STOP event");
-      break;
-    default:
-      break;
-  }
-
-  return GST_BASE_TRANSFORM_CLASS (parent_class)->src_event (trans, event);
-}
-
-/**
- * @brief Called when the element stops processing. optional vmethod of BaseTransform
- */
-static gboolean
-gst_tensor_trainer_stop (GstBaseTransform * trans)
-{
-  GstTensorTrainer *trainer;
-  trainer = GST_TENSOR_TRAINER_CAST (trans);
-
-  UNUSED (trainer);
-
-  return TRUE;
-}
-
-/**
- * @brief Transforms one incoming buffer to one outgoing buffer
+ * @brief Chain function, this function does the actual processing.
  */
 static GstFlowReturn
-gst_tensor_trainer_transform (GstBaseTransform * trans, GstBuffer * inbuf,
-    GstBuffer * outbuf)
+gst_tensor_trainer_chain (GstPad * sinkpad, GstObject * parent,
+    GstBuffer * inbuf)
 {
   GstTensorTrainer *trainer;
+  GstBuffer *outbuf = NULL;
   gint ret = -1;
   guint mem_blocks, i;
   gsize header_size, expected;
@@ -597,10 +512,11 @@ gst_tensor_trainer_transform (GstBaseTransform * trans, GstBuffer * inbuf,
 
   pid_t pid = getpid ();
   pid_t tid = syscall (SYS_gettid);
-  trainer = GST_TENSOR_TRAINER_CAST (trans);
-  GST_ERROR_OBJECT (trainer, "pid: %d, tid: %d", pid, tid);
 
-  /* Get all input tensors from inbuf */
+  trainer = GST_TENSOR_TRAINER (parent);
+
+  GST_DEBUG_OBJECT (trainer, "pid: %d, tid: %d", pid, tid);
+
   mem_blocks = gst_buffer_n_memory (inbuf);
   for (i = 0; i < mem_blocks; i++) {
     in_mem[i] = gst_buffer_peek_memory (inbuf, i);
@@ -608,8 +524,7 @@ gst_tensor_trainer_transform (GstBaseTransform * trans, GstBuffer * inbuf,
       GST_ERROR_OBJECT (trainer, "Could not map in_mem[%d] GstMemory", i);
       goto error;
     }
-    in_flexible =
-        gst_tensor_pad_caps_is_flexible (GST_BASE_TRANSFORM_SINK_PAD (trans));
+    in_flexible = gst_tensor_pad_caps_is_flexible (sinkpad);
     /* Get header size */
     header_size = 0;
     if (in_flexible) {
@@ -627,7 +542,8 @@ gst_tensor_trainer_transform (GstBaseTransform * trans, GstBuffer * inbuf,
 
   /* Prepare tensor to invoke */
   /* Check number of input tensors */
-  GST_ERROR ("num_tensors: %d", trainer->prop.input_meta.num_tensors);
+  GST_DEBUG_OBJECT (trainer, "num_tensors: %d",
+      trainer->prop.input_meta.num_tensors);
   if (mem_blocks != trainer->prop.input_meta.num_tensors) {
     GST_ERROR_OBJECT (trainer, "Invalid memory blocks(%d),"
         "number of input tensors may be (%d)", mem_blocks,
@@ -636,11 +552,11 @@ gst_tensor_trainer_transform (GstBaseTransform * trans, GstBuffer * inbuf,
   }
 
   /* Check size of input tensors */
-  GST_ERROR ("num_tensors: %d", trainer->prop.input_meta.num_tensors);
   for (i = 0; i < trainer->prop.input_meta.num_tensors; i++) {
     expected = gst_tensor_trainer_get_tensor_size (trainer, i, TRUE);
     if (expected != in_tensors[i].size) {
-      GST_ERROR_OBJECT (trainer, "Invalid tensor size (%u'th memory chunk: %zd)"
+      GST_ERROR_OBJECT (trainer,
+          "Invalid tensor size (%u'th memory chunk: %zd)"
           ", expected size (%zd)", i, in_tensors[i].size, expected);
       goto error;
     }
@@ -661,8 +577,7 @@ gst_tensor_trainer_transform (GstBaseTransform * trans, GstBuffer * inbuf,
 
       /* Get header size */
       header_size = 0;
-      out_flexible =
-          gst_tensor_pad_caps_is_flexible (GST_BASE_TRANSFORM_SRC_PAD (trans));
+      out_flexible = gst_tensor_pad_caps_is_flexible (trainer->srcpad);
       if (out_flexible) {
         gst_tensor_info_convert_to_meta (&trainer->output_meta.info[i],
             &out_meta[i]);
@@ -697,8 +612,8 @@ gst_tensor_trainer_transform (GstBaseTransform * trans, GstBuffer * inbuf,
     }
     /* Call the trainer-subplugin callback, invoke */
     ret =
-        trainer->fw->invoke (trainer->fw, &trainer->prop, trainer->privateData,
-        invoke_tensors, out_tensors);
+        trainer->fw->invoke (trainer->fw, &trainer->prop,
+        trainer->privateData, invoke_tensors);
 
     /* Free out info */
     for (i = 0; i < trainer->output_meta.num_tensors; i++) {
@@ -710,9 +625,11 @@ gst_tensor_trainer_transform (GstBaseTransform * trans, GstBuffer * inbuf,
     }
   } else {
     ret =
-        trainer->fw->invoke (trainer->fw, &trainer->prop, trainer->privateData,
-        invoke_tensors, NULL);
+        trainer->fw->invoke (trainer->fw, &trainer->prop,
+        trainer->privateData, invoke_tensors);
   }
+
+  trainer->total_invoke_num++;
 
   /* Free in info */
   for (i = 0; i < mem_blocks; i++)
@@ -720,24 +637,28 @@ gst_tensor_trainer_transform (GstBaseTransform * trans, GstBuffer * inbuf,
 
   if (ret < 0) {
     GST_ERROR_OBJECT (trainer, "Invoke error");
-    // return GST_FLOW_ERROR;
-  } else if (ret > 0) {
-    /* drop this buffer */
-    // return GST_BASE_TRANSFORM_FLOW_DROPPED;
+    return GST_FLOW_ERROR;
   }
 
-  /*Update result */
-  GST_INFO ("out buffer size : %zd", gst_buffer_get_size (outbuf));
-  if (trainer->push_output) {
+  /* Update result if one of epochs is complete,
+     push one outbuf is necessary to change pipeline state.
+     Scheduling with subplugin does not work.
+   */
+  if (trainer->total_invoke_num == 1
+      || trainer->total_invoke_num ==
+      trainer->prop.num_train_samples + trainer->prop.num_valid_samples) {
+    outbuf = gst_buffer_new ();
     for (i = 0; i < trainer->output_meta.num_tensors; i++) {
       /* append the memory block to outbuf */
       gst_buffer_append_memory (outbuf, out_mem[i]);
     }
     GST_INFO ("after out buffer size : %zd", gst_buffer_get_size (outbuf));
+
+    gst_pad_push (trainer->srcpad, outbuf);
+    return GST_FLOW_OK;
   }
 
   return GST_FLOW_OK;
-
 error:
   mem_blocks = gst_buffer_n_memory (inbuf);
   for (i = 0; i < mem_blocks; i++) {
@@ -756,63 +677,51 @@ error:
 }
 
 /**
- * @brief configure tensor-srcpad cap from "proposed" cap.
+ * @brief Get pad caps for caps negotiation.
  */
 static GstCaps *
-gst_tensor_trainer_transform_caps (GstBaseTransform * trans,
-    GstPadDirection direction, GstCaps * caps, GstCaps * filter)
+gst_tensor_trainer_query_caps (GstTensorTrainer * trainer,
+    GstPad * pad, GstCaps * filter)
 {
-  GstTensorTrainer *trainer;
   GstCaps *result;
-  GstPad *pad;
+  GstCaps *caps;
   GstStructure *structure;
   gboolean configured = FALSE;
-
-  GstTensorsConfig in_config, out_config;
-
-  trainer = GST_TENSOR_TRAINER_CAST (trans);
-
-  GST_DEBUG_OBJECT (trans,
-      "[In direction %s] Transforming caps %" GST_PTR_FORMAT "",
-      (direction == GST_PAD_SINK) ? "sink" : "src", caps);
-
-  if (direction == GST_PAD_SRC)
-    pad = GST_BASE_TRANSFORM_SINK_PAD (trans);
-  else
-    pad = GST_BASE_TRANSFORM_SRC_PAD (trans);
+  GstTensorsConfig in_config;
 
   gst_tensors_config_init (&in_config);
-  gst_tensors_config_init (&out_config);
+  gst_tensors_config_init (&trainer->out_config);
+
+  caps = gst_tensor_pad_possible_caps_from_config (pad, &in_config);
   structure = gst_caps_get_structure (caps, 0);
 
   if (!gst_tensors_config_from_structure (&in_config, structure))
     return NULL;
-
-  /* Set framerate from input config */
-  out_config.rate_n = in_config.rate_n;
-  out_config.rate_d = in_config.rate_d;
+  gst_caps_unref (caps);
 
   /* Need to set property (input, inputtype, output, outputtype)
      for trainer->input_meta and trainer->output_meta */
-  if (direction == GST_PAD_SRC) {
+  if (pad == trainer->srcpad) {
     if (trainer->input_configured) {
-      gst_tensors_info_copy (&out_config.info, &trainer->prop.input_meta);
+      gst_tensors_info_copy (&trainer->out_config.info,
+          &trainer->prop.input_meta);
       configured = TRUE;
     }
   } else {
     if (trainer->output_configured) {
       configured = TRUE;
-      gst_tensors_info_copy (&out_config.info, &trainer->output_meta);
+      gst_tensors_info_copy (&trainer->out_config.info, &trainer->output_meta);
     }
   }
 
   if (configured)
     /* Output info may be configured */
-    result = gst_tensor_pad_possible_caps_from_config (pad, &out_config);
+    result =
+        gst_tensor_pad_possible_caps_from_config (pad, &trainer->out_config);
   else
     result = gst_caps_from_string (CAPS_STRING);
 
-  GST_DEBUG_OBJECT (trans, "caps intersect without filter %" GST_PTR_FORMAT,
+  GST_DEBUG_OBJECT (trainer, "caps intersect without filter %" GST_PTR_FORMAT,
       result);
 
   if (filter) {
@@ -821,63 +730,186 @@ gst_tensor_trainer_transform_caps (GstBaseTransform * trans,
         gst_caps_intersect_full (result, filter, GST_CAPS_INTERSECT_FIRST);
     gst_caps_unref (result);
     result = intersection;
-    GST_DEBUG_OBJECT (trans, "result caps %" GST_PTR_FORMAT, result);
+    GST_DEBUG_OBJECT (trainer, "result caps %" GST_PTR_FORMAT, result);
   }
   gst_tensors_config_free (&in_config);
-  gst_tensors_config_free (&out_config);
 
   return result;
 }
 
 /**
- * @brief fixate caps. required vmethod of GstBaseTransform.
+ * @brief Event handler for sink pad of tensor_trainer
  */
-static GstCaps *
-gst_tensor_trainer_fixate_caps (GstBaseTransform * trans,
-    GstPadDirection direction, GstCaps * caps, GstCaps * othercaps)
+static gboolean
+gst_tensor_trainer_sink_event (GstPad * sinkpad, GstObject * parent,
+    GstEvent * event)
 {
-  UNUSED (direction);
-  UNUSED (caps);
+  GstTensorTrainer *trainer;
+  trainer = GST_TENSOR_TRAINER (parent);
 
-  othercaps = gst_caps_fixate (othercaps);
-  GST_DEBUG_OBJECT (trans, "fixated to %" GST_PTR_FORMAT, othercaps);
+  GST_DEBUG_OBJECT (trainer, "Received %s event: %" GST_PTR_FORMAT,
+      GST_EVENT_TYPE_NAME (event), event);
 
-  return othercaps;
+  switch (GST_EVENT_TYPE (event)) {
+    case GST_EVENT_EOS:
+      GST_INFO_OBJECT (trainer, "get GST_EVENT_EOS event..state is %d",
+          GST_STATE (trainer));
+      g_mutex_lock (&trainer->trainer_lock);
+      GST_INFO_OBJECT (trainer, "wait for train_complete_cond signal");
+      g_cond_wait (&trainer->train_complete_cond, &trainer->trainer_lock);
+      g_mutex_unlock (&trainer->trainer_lock);
+      break;
+    case GST_EVENT_FLUSH_START:
+      GST_INFO_OBJECT (trainer, "get GST_EVENT_FLUSH_START event");
+      break;
+    case GST_EVENT_FLUSH_STOP:
+      GST_INFO_OBJECT (trainer, "get GST_EVENT_FLUSH_STOP event");
+      break;
+    case GST_EVENT_CAPS:
+    {
+      GstCaps *in_caps;
+      GstCaps *out_caps;
+      GstStructure *structure;
+      GstTensorsConfig in_config;
+      gboolean ret = FALSE;
+
+      gst_event_parse_caps (event, &in_caps);
+      GST_INFO_OBJECT (trainer, "[in-caps] : %" GST_PTR_FORMAT, in_caps);
+      /* set out caps */
+
+      structure = gst_caps_get_structure (in_caps, 0);
+      if (!gst_tensors_config_from_structure (&in_config, structure))
+        return ret;
+
+      if (!gst_tensors_info_is_equal (&in_config.info,
+              &trainer->prop.input_meta)) {
+        GST_ERROR_OBJECT (trainer,
+            "The input tensors info is different between incaps and set property value. "
+            "Please check pipeline's input tensor info and tensor_trainer's set property values"
+            "(input, inputtype, output and outputtype)");
+        return ret;
+      }
+
+      trainer->out_config.rate_n = in_config.rate_n;
+      trainer->out_config.rate_d = in_config.rate_d;
+
+      out_caps =
+          gst_tensor_pad_caps_from_config (trainer->srcpad,
+          &trainer->out_config);
+      GST_INFO_OBJECT (trainer, "[out-caps] : %" GST_PTR_FORMAT, out_caps);
+
+      ret = gst_pad_set_caps (trainer->srcpad, out_caps);
+
+      gst_event_unref (event);
+      gst_caps_unref (out_caps);
+
+      gst_tensors_config_free (&in_config);
+      gst_tensors_config_free (&trainer->out_config);
+
+      return ret;
+    }
+    default:
+      break;
+  }
+
+  return gst_pad_event_default (sinkpad, parent, event);
 }
 
 /**
- * @brief set caps. required vmethod of GstBaseTransform.
+ * @brief This function handles sink pad query.
  */
 static gboolean
-gst_tensor_trainer_set_caps (GstBaseTransform * trans, GstCaps * incaps,
-    GstCaps * outcaps)
+gst_tensor_trainer_sink_query (GstPad * sinkpad, GstObject * parent,
+    GstQuery * query)
 {
   GstTensorTrainer *trainer;
-  GstStructure *structure;
-  GstTensorsConfig in_config;
+  trainer = GST_TENSOR_TRAINER (parent);
 
-  trainer = GST_TENSOR_TRAINER_CAST (trans);
+  GST_DEBUG_OBJECT (trainer, "Received '%s' query: %" GST_PTR_FORMAT,
+      GST_QUERY_TYPE_NAME (query), query);
 
-  GST_DEBUG_OBJECT (trainer, "[incaps] : %" GST_PTR_FORMAT, incaps);
-  GST_DEBUG_OBJECT (trainer, "[outcaps] : %" GST_PTR_FORMAT, outcaps);
+  switch (GST_QUERY_TYPE (query)) {
+    case GST_QUERY_CAPS:
+    {
+      GstCaps *caps;
+      GstCaps *filter;
 
-  gst_tensors_config_init (&in_config);
-  structure = gst_caps_get_structure (incaps, 0);
+      GST_DEBUG_OBJECT (trainer, "[GST_QUERY_CAPS]");
+      gst_query_parse_caps (query, &filter);
+      GST_DEBUG_OBJECT (trainer, "Caps from query : %" GST_PTR_FORMAT, filter);
 
-  if (!gst_tensors_config_from_structure (&in_config, structure))
-    return FALSE;
+      caps = gst_tensor_trainer_query_caps (trainer, sinkpad, filter);
 
-  if (!gst_tensors_info_is_equal (&in_config.info, &trainer->prop.input_meta)) {
-    GST_ERROR_OBJECT (trainer,
-        "The input tensors info is different between incaps and set property value. "
-        "Please check pipeline's input tensor info and tensor_trainer's set property values"
-        "(input, inputtype, output and outputtype)");
-    return FALSE;
+      GST_INFO_OBJECT (trainer, "[GST_QUERY_CAPS] : %" GST_PTR_FORMAT, caps);
+      gst_query_set_caps_result (query, caps);
+      gst_caps_unref (caps);
+
+      return TRUE;
+    }
+    case GST_QUERY_ACCEPT_CAPS:
+    {
+      GstCaps *caps;
+      GstCaps *template_caps;
+      gboolean result = FALSE;
+
+      GST_DEBUG_OBJECT (trainer, "[GST_QUERY_ACCEPT_CAPS]");
+      gst_query_parse_accept_caps (query, &caps);
+      GST_INFO_OBJECT (trainer, "Accept caps from query : %" GST_PTR_FORMAT,
+          caps);
+
+      if (gst_caps_is_fixed (caps)) {
+        template_caps = gst_pad_get_pad_template_caps (sinkpad);
+        GST_DEBUG_OBJECT (trainer, "sinkpad template_caps : %" GST_PTR_FORMAT,
+            template_caps);
+
+        result = gst_caps_can_intersect (template_caps, caps);
+        gst_caps_unref (template_caps);
+
+        GST_DEBUG_OBJECT (trainer, "intersect caps : %" GST_PTR_FORMAT, caps);
+      }
+
+      gst_query_set_accept_caps_result (query, result);
+      return TRUE;
+    }
+    default:
+      break;
   }
 
-  gst_tensors_config_free (&in_config);
+  return gst_pad_query_default (sinkpad, parent, query);
+}
 
-  return TRUE;
+/**
+ * @brief This function handles src pad query.
+ */
+static gboolean
+gst_tensor_trainer_src_query (GstPad * srcpad, GstObject * parent,
+    GstQuery * query)
+{
+  GstTensorTrainer *trainer;
+  trainer = GST_TENSOR_TRAINER (parent);
+
+  GST_DEBUG_OBJECT (trainer, "Received %s query: %" GST_PTR_FORMAT,
+      GST_QUERY_TYPE_NAME (query), query);
+
+  switch (GST_QUERY_TYPE (query)) {
+    case GST_QUERY_CAPS:
+    {
+      GstCaps *caps;
+      GstCaps *filter;
+      GST_DEBUG_OBJECT (trainer, "[GST_QUERY_CAPS]");
+      gst_query_parse_caps (query, &filter);
+      GST_DEBUG_OBJECT (trainer, "Caps from query : %" GST_PTR_FORMAT, filter);
+      caps = gst_tensor_trainer_query_caps (trainer, srcpad, filter);
+
+      GST_INFO_OBJECT (trainer, "[GST_QUERY_CAPS] : %" GST_PTR_FORMAT, caps);
+      gst_query_set_caps_result (query, caps);
+      gst_caps_unref (caps);
+      return TRUE;
+    }
+    default:
+      break;
+  }
+  return gst_pad_query_default (srcpad, parent, query);
 }
 
 /**
@@ -898,8 +930,8 @@ gst_tensor_trainer_set_prop_framework (GstTensorTrainer * trainer,
  * @brief Handle "PROP_MODEL_CONFIG" for set-property
  */
 static void
-gst_tensor_trainer_set_prop_model_config_file_path (GstTensorTrainer * trainer,
-    const GValue * value)
+gst_tensor_trainer_set_prop_model_config_file_path (GstTensorTrainer *
+    trainer, const GValue * value)
 {
   g_free (trainer->model_config);
   trainer->model_config = g_value_dup_string (value);
@@ -1042,8 +1074,10 @@ gst_tensor_trainer_find_framework (GstTensorTrainer * trainer, const char *name)
 static void
 gst_tensor_trainer_create_framework (GstTensorTrainer * trainer)
 {
+  pid_t pid = getpid ();
+  pid_t tid = syscall (SYS_gettid);
   g_return_if_fail (trainer != NULL);
-
+  GST_ERROR_OBJECT (trainer, "pid: %d, tid: %d", pid, tid);
   if (!trainer->fw || trainer->fw_created) {
     GST_ERROR_OBJECT (trainer, "fw is not opened(%d) or fw is null(%p)",
         trainer->fw_created, trainer->fw);
@@ -1067,8 +1101,8 @@ gst_tensor_trainer_create_framework (GstTensorTrainer * trainer)
  * @brief Calculate tensor buffer size
  */
 gsize
-gst_tensor_trainer_get_tensor_size (GstTensorTrainer * trainer, guint index,
-    gboolean is_input)
+gst_tensor_trainer_get_tensor_size (GstTensorTrainer * trainer,
+    guint index, gboolean is_input)
 {
   GstTensorsInfo *info;
 
@@ -1084,32 +1118,6 @@ gst_tensor_trainer_get_tensor_size (GstTensorTrainer * trainer, guint index,
   }
 
   return gst_tensor_info_get_size (&info->info[index]);
-}
-
-/**
- * @brief Allocation initial outbuffer size
- */
-static gboolean
-gst_tensor_trainer_transform_size (GstBaseTransform * trans,
-    GstPadDirection direction, GstCaps * caps, gsize size,
-    GstCaps * othercaps, gsize * othersize)
-{
-  GstTensorTrainer *trainer;
-
-  UNUSED (direction);
-  UNUSED (caps);
-  UNUSED (size);
-  UNUSED (othercaps);
-  trainer = GST_TENSOR_TRAINER_CAST (trans);
-
-  GST_DEBUG_OBJECT (trainer, "trainer->configured: %d", trainer->configured);
-
-  /** Internal Logic Error. Cannot proceed without configured pipeline */
-  //g_assert (trainer->configured);
-
-  *othersize = 0;
-
-  return TRUE;
 }
 
 /**

--- a/gst/nnstreamer/elements/gsttensor_trainer.c
+++ b/gst/nnstreamer/elements/gsttensor_trainer.c
@@ -11,14 +11,14 @@
  *
  * ## Example launch line
  * |[
- * gst-launch-1.0 filesrc location=mnist_input_200.dat blocksize=3136 ! \
- * application/octet-stream, framerate=5/1 ! tensor_converter input-dim=1:1:784:1 input-type=float32 \
- * ! mux.sink_0 filesrc location=mnist_label_200.dat blocksize=40 ! \
- * application/octet-stream, framerate=5/1 ! tensor_converter input_dim=1:1:10:1 input-type=float32 \
- * ! mux.sink_1 tensor_mux name=mux sync-mode=nosync ! tensor_trainer framework=nntrainer \
- * model-config=mnist.ini model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 input-type=float32,float32 \
- * num-lists=1 num-labels=1 num-training-samples=100 num-validation-samples=100 ! tensor_sink
+ * gst-launch-1.0 filesrc location=mnist_trainingSet.dat blocksize = 3176 ! application/octet-stream ! \
+ * tensor_converter input-dim=1:1:784:1,1:1:10:1 input-type=float32,float32 ! \
+ * tensor_trainer framework=nntrainer model-config=mnist.ini model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 \
+ * input-type=float32,float32 num-lists=1 num-labels=1 num-training-samples=100 num-validation-samples=100 epochs=5 ! \
+ * tensor_sink
  * ]|
+ *
+ * Total number of data to be received is 1000((num-training-samples + num-validation-samples) * epochs)
  */
 
 #ifdef HAVE_CONFIG_H
@@ -60,6 +60,11 @@ G_DEFINE_TYPE (GstTensorTrainer, gst_tensor_trainer, GST_TYPE_ELEMENT);
  * @brief Default framework property value
  */
 #define DEFAULT_PROP_FRAMEWORK "nntrainer"
+#define DEFAULT_PROP_INPUT_LIST 1
+#define DEFAULT_PROP_LABEL_LIST 1
+#define DEFAULT_PROP_TRAIN_SAMPLES 0
+#define DEFAULT_PROP_VALID_SAMPLES 0
+#define DEFAULT_PROP_EPOCHS 1
 
 /**
  * @brief Default string property value 
@@ -81,6 +86,7 @@ enum
   PROP_NUM_LABELS,              /* number of label list */
   PROP_NUM_TRAINING_SAMPLES,    /*number of training data */
   PROP_NUM_VALIDATION_SAMPLES,  /*number of validation data */
+  PROP_EPOCHS,
 };
 
 static void gst_tensor_trainer_set_property (GObject * object, guint prop_id,
@@ -172,44 +178,56 @@ gst_tensor_trainer_class_init (GstTensorTrainerClass * klass)
 
   g_object_class_install_property (gobject_class, PROP_INPUT_DIM,
       g_param_spec_string ("input-dim", "Input dimension",
-          "Input tensors dimension from inner array, up to 4 dimensions ?", "",
+          "Input tensors dimension from inner array, up to 4 dimensions ?",
+          DEFAULT_STR_PROP_VALUE,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
           G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_INPUT_TYPE,
       g_param_spec_string ("input-type", "Input tensor element type",
-          "Type of each element of the input tensor ?", "",
+          "Type of each element of the input tensor ?",
+          DEFAULT_STR_PROP_VALUE,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
           G_PARAM_STATIC_STRINGS));
 
+
   g_object_class_install_property (gobject_class, PROP_NUM_INPUTS,
-      g_param_spec_uint ("num-inputs", "Number of inputs",
+      g_param_spec_int64 ("num-inputs", "Number of inputs",
           "An input in a tensor can have one or more features data,"
           "set how many inputs are received", 0, NNS_TENSOR_SIZE_LIMIT, 1,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
           G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_NUM_LABELS,
-      g_param_spec_uint ("num-labels", "Number of labels",
+      g_param_spec_int64 ("num-labels", "Number of labels",
           "A label in a tensor can have one or more classes data,"
           "set how many labes are recevied", 0, NNS_TENSOR_SIZE_LIMIT, 1,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
           G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_NUM_TRAINING_SAMPLES,
-      g_param_spec_uint ("num-training-samples", "Number of training samples",
+      g_param_spec_int64 ("num-training-samples", "Number of training samples",
           "A sample can consist of muliple inputs and labels in tensors of a gstbuffer"
-          ", set how many samples are taken for training model", 0, G_MAXUINT,
-          1,
+          ", set how many samples are taken for training model",
+          0, G_MAXINT64, 1,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
           G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_NUM_VALIDATION_SAMPLES,
-      g_param_spec_uint ("num-validation-samples",
+      g_param_spec_int64 ("num-validation-samples",
           "Number of validation samples",
           "A sample can consist of muliple inputs and labels in tensors of a gstbuffer"
           ", set how many samples are taken for validation model",
-          0, G_MAXUINT, 1,
+          0, G_MAXINT64, 1,
+          G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
+          G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_EPOCHS,
+      g_param_spec_int64 ("epochs", "Number of epoch",
+          "Epochs are repetitions of training samples and validation smaples, "
+          "number of samples received for model training is "
+          "(num-training-samples+num-validation-samples)*epochs", 0, G_MAXINT64,
+          DEFAULT_PROP_EPOCHS,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
           G_PARAM_STATIC_STRINGS));
 
@@ -257,13 +275,18 @@ gst_tensor_trainer_init (GstTensorTrainer * trainer)
   trainer->output_dimensions = g_strdup (DEFAULT_STR_PROP_VALUE);
   trainer->input_type = g_strdup (DEFAULT_STR_PROP_VALUE);
   trainer->output_type = g_strdup (DEFAULT_STR_PROP_VALUE);
+  trainer->prop.num_inputs = DEFAULT_PROP_INPUT_LIST;
+  trainer->prop.num_labels = DEFAULT_PROP_LABEL_LIST;
+  trainer->prop.num_train_samples = DEFAULT_PROP_TRAIN_SAMPLES;
+  trainer->prop.num_valid_samples = DEFAULT_PROP_VALID_SAMPLES;
+  trainer->prop.num_epochs = DEFAULT_PROP_EPOCHS;
 
   trainer->fw = NULL;
   trainer->fw_created = FALSE;
   trainer->input_configured = FALSE;
   trainer->output_configured = FALSE;
   trainer->inputtype_configured = FALSE;
-  trainer->total_invoke_num = 0;
+  trainer->total_push_data_cnt = 0;
 
   g_cond_init (&trainer->train_complete_cond);
   g_mutex_init (&trainer->trainer_lock);
@@ -329,16 +352,19 @@ gst_tensor_trainer_set_property (GObject * object, guint prop_id,
       gst_tensor_trainer_set_prop_input_type (trainer, value);
       break;
     case PROP_NUM_INPUTS:
-      trainer->prop.num_inputs = g_value_get_uint (value);
+      trainer->prop.num_inputs = g_value_get_int64 (value);
       break;
     case PROP_NUM_LABELS:
-      trainer->prop.num_labels = g_value_get_uint (value);
+      trainer->prop.num_labels = g_value_get_int64 (value);
       break;
     case PROP_NUM_TRAINING_SAMPLES:
-      trainer->prop.num_train_samples = g_value_get_uint (value);
+      trainer->prop.num_train_samples = g_value_get_int64 (value);
       break;
     case PROP_NUM_VALIDATION_SAMPLES:
-      trainer->prop.num_valid_samples = g_value_get_uint (value);
+      trainer->prop.num_valid_samples = g_value_get_int64 (value);
+      break;
+    case PROP_EPOCHS:
+      trainer->prop.num_epochs = g_value_get_int64 (value);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -374,16 +400,19 @@ gst_tensor_trainer_get_property (GObject * object, guint prop_id,
       g_value_set_string (value, trainer->input_type);
       break;
     case PROP_NUM_INPUTS:
-      g_value_set_uint (value, trainer->prop.num_inputs);
+      g_value_set_int64 (value, trainer->prop.num_inputs);
       break;
     case PROP_NUM_LABELS:
-      g_value_set_uint (value, trainer->prop.num_labels);
+      g_value_set_int64 (value, trainer->prop.num_labels);
       break;
     case PROP_NUM_TRAINING_SAMPLES:
-      g_value_set_uint (value, trainer->prop.num_train_samples);
+      g_value_set_int64 (value, trainer->prop.num_train_samples);
       break;
     case PROP_NUM_VALIDATION_SAMPLES:
-      g_value_set_uint (value, trainer->prop.num_valid_samples);
+      g_value_set_int64 (value, trainer->prop.num_valid_samples);
+      break;
+    case PROP_EPOCHS:
+      g_value_set_int64 (value, trainer->prop.num_epochs);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -462,7 +491,7 @@ gst_tensor_trainer_chain (GstPad * sinkpad, GstObject * parent,
   GstMemory *out_mem[NNS_TENSOR_SIZE_LIMIT] = { 0, };
   GstMapInfo out_info[NNS_TENSOR_SIZE_LIMIT];
   GstTensorMemory in_tensors[NNS_TENSOR_SIZE_LIMIT];
-  GstTensorMemory invoke_tensors[NNS_TENSOR_SIZE_LIMIT];
+  GstTensorMemory push_tensors[NNS_TENSOR_SIZE_LIMIT];
   GstTensorMemory out_tensors[NNS_TENSOR_SIZE_LIMIT];
   GstTensorMetaInfo in_meta[NNS_TENSOR_SIZE_LIMIT];
   GstTensorMetaInfo out_meta[NNS_TENSOR_SIZE_LIMIT];
@@ -492,7 +521,7 @@ gst_tensor_trainer_chain (GstPad * sinkpad, GstObject * parent,
     GST_INFO ("tensor size: %zd", in_tensors[i].size);
   }
 
-  /* Prepare tensor to invoke */
+  /* Prepare tensor to push */
   /* Check number of input tensors */
   GST_DEBUG_OBJECT (trainer, "num_tensors: %d",
       trainer->prop.input_meta.num_tensors);
@@ -513,24 +542,24 @@ gst_tensor_trainer_chain (GstPad * sinkpad, GstObject * parent,
       goto error;
     }
     /* Copy to data pointer */
-    invoke_tensors[i] = in_tensors[i];
+    push_tensors[i] = in_tensors[i];
     GST_INFO ("in_tensors[%d].size= %zd", i, in_tensors[i].size);
     GST_INFO ("in_tensors[%d].data: %p", i, in_tensors[i].data);
-    GST_INFO ("invoke_tensors[%d].size= %zd", i, invoke_tensors[i].size);
-    GST_INFO ("invoke_tensors[%d].data: %p", i, invoke_tensors[i].data);
+    GST_INFO ("push_tensors[%d].size= %zd", i, push_tensors[i].size);
+    GST_INFO ("push_tensors[%d].data: %p", i, push_tensors[i].data);
   }
 
   ret =
       trainer->fw->push_data (trainer->fw, &trainer->prop, trainer->privateData,
-      invoke_tensors);
-  trainer->total_invoke_num++;
+      push_tensors);
+  trainer->total_push_data_cnt++;
 
   /* Free in info */
   for (i = 0; i < mem_blocks; i++)
     gst_memory_unmap (in_mem[i], &in_info[i]);
 
   if (ret < 0) {
-    GST_ERROR_OBJECT (trainer, "Invoke error");
+    GST_ERROR_OBJECT (trainer, "push error");
     return GST_FLOW_ERROR;
   }
 
@@ -538,17 +567,17 @@ gst_tensor_trainer_chain (GstPad * sinkpad, GstObject * parent,
       push one outbuf is necessary to change pipeline state.
       Scheduling with subplugin does not work.
    */
-  if (trainer->total_invoke_num == 1
-      || trainer->total_invoke_num ==
+  if (trainer->total_push_data_cnt == 1
+      || trainer->total_push_data_cnt ==
       trainer->prop.num_train_samples + trainer->prop.num_valid_samples) {
-/*
-    if (trainer->total_invoke_num != 1) {
+#if 0
+    if (trainer->total_push_data_cnt != 1) {
       g_mutex_lock (&trainer->trainer_lock);
       GST_INFO_OBJECT (trainer, "wait for train_complete_cond signal");
       g_cond_wait (&trainer->train_complete_cond, &trainer->trainer_lock);
       g_mutex_unlock (&trainer->trainer_lock);
     }
-*/
+#endif
     /* Prepare output tensor */
     for (i = 0; i < trainer->output_meta.num_tensors; i++) {
       out_tensors[i].data = NULL;
@@ -926,7 +955,7 @@ gst_tensor_trainer_set_model_save_path (GstTensorTrainer * trainer,
 }
 
 /**
- * @brief Handle "PROP_INPUT_DIM" and "PROP_OUTPUT_DIM" for set-property
+ * @brief Handle "PROP_INPUT_DIM" for set-property
  */
 static void
 gst_tensor_trainer_set_prop_input_dimension (GstTensorTrainer * trainer,
@@ -970,7 +999,7 @@ gst_tensor_trainer_set_prop_input_dimension (GstTensorTrainer * trainer,
 }
 
 /**
- * @brief Handle "PROP_INPUT_TYPE" and "PROP_OUTPUT_TYPE" for set-property
+ * @brief Handle "PROP_INPUT_TYPE" for set-property
  */
 static void
 gst_tensor_trainer_set_prop_input_type (GstTensorTrainer * trainer,

--- a/gst/nnstreamer/elements/gsttensor_trainer.c
+++ b/gst/nnstreamer/elements/gsttensor_trainer.c
@@ -16,8 +16,8 @@
  * ! mux.sink_0 filesrc location=mnist_label_200.dat blocksize=40 ! \
  * application/octet-stream, framerate=5/1 ! tensor_converter input_dim=1:1:10:1 input-type=float32 \
  * ! mux.sink_1 tensor_mux name=mux sync-mode=nosync ! tensor_trainer framework=nntrainer \
- * model-config=mnist.ini model-save-path=model.bin push-output=true input=1:1:784:1,1:1:10:1 \
- * inputtype=float32,float32 input-lists=1 label-lists=1 train-samples=100 valid-samples=100 \
+ * model-config=mnist.ini model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 \
+ * input-type=float32,float32 num-inputs=1 mum-labels=1 num-training-samples=100 num-alidation-samples=100 \
  * ! tensor_sink
  * ]|
  */
@@ -581,7 +581,7 @@ gst_tensor_trainer_chain (GstPad * sinkpad, GstObject * parent,
     }
     /* Call the trainer-subplugin callback, invoke */
     ret =
-        trainer->fw->invoke (trainer->fw, &trainer->prop,
+        trainer->fw->push_data (trainer->fw, &trainer->prop,
         trainer->privateData, invoke_tensors);
 
     /* Free out info */
@@ -594,7 +594,7 @@ gst_tensor_trainer_chain (GstPad * sinkpad, GstObject * parent,
     }
   } else {
     ret =
-        trainer->fw->invoke (trainer->fw, &trainer->prop,
+        trainer->fw->push_data (trainer->fw, &trainer->prop,
         trainer->privateData, invoke_tensors);
   }
 
@@ -1094,12 +1094,12 @@ gst_tensor_trainer_train_model (GstTensorTrainer * trainer)
   gint ret = -1;
   g_return_if_fail (trainer != NULL);
   g_return_if_fail (trainer->fw != NULL);
-  g_return_if_fail (trainer->fw->train != NULL);
+  g_return_if_fail (trainer->fw->start != NULL);
 
-  GST_DEBUG_OBJECT (trainer, "Start train model");
-  ret = trainer->fw->train (trainer->fw, &trainer->prop, trainer->privateData);
+  GST_DEBUG_OBJECT (trainer, "Start training model");
+  ret = trainer->fw->start (trainer->fw, &trainer->prop, trainer->privateData);
   if (ret != 0) {
-    GST_ERROR_OBJECT (trainer, "model train is failed");
+    GST_ERROR_OBJECT (trainer, "model training is failed");
   }
 }
 

--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -33,7 +33,6 @@ G_BEGIN_DECLS
   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_TENSOR_TRAINER))
 #define GST_IS_TENSOR_TRAINER_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_TRAINER))
-//#define GST_TENSOR_TRAINER_CAST(obj)  ((GstTensorTrainer *)(obj))
 
 typedef struct _GstTensorTrainer GstTensorTrainer;
 typedef struct _GstTensorTrainerClass GstTensorTrainerClass;
@@ -57,21 +56,16 @@ struct _GstTensorTrainer
   gchar *output_type;
   gboolean push_output;
 
-  gboolean configured;
-  int input_configured;
+  gboolean input_configured;
   gboolean output_configured;
-  int inputtype_configured;
-  int outputtype_configured;
+  gboolean inputtype_configured;
   unsigned int input_ranks[NNS_TENSOR_SIZE_LIMIT];
   unsigned int output_ranks[NNS_TENSOR_SIZE_LIMIT];
   GstTensorsInfo output_meta;
   GstTensorsConfig out_config;
 
   gint64 total_invoke_num;      /**< number of total invokes */
-
-  /* draft */
-  int fw_created;
-  int fw_stop;
+  gboolean fw_created;
 
   void *privateData; /**< NNFW plugin's private data is stored here */
   const GstTensorTrainerFramework *fw;  /* for test, need to make */

--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -15,7 +15,6 @@
 
 
 #include <gst/gst.h>
-#include <gst/base/gstbasetransform.h>
 #include <tensor_typedef.h>
 #include <tensor_common.h>
 
@@ -23,6 +22,7 @@
 #include <nnstreamer_plugin_api_trainer.h>
 
 G_BEGIN_DECLS
+
 #define GST_TYPE_TENSOR_TRAINER \
   (gst_tensor_trainer_get_type())
 #define GST_TENSOR_TRAINER(obj) \
@@ -33,7 +33,8 @@ G_BEGIN_DECLS
   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_TENSOR_TRAINER))
 #define GST_IS_TENSOR_TRAINER_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_TRAINER))
-#define GST_TENSOR_TRAINER_CAST(obj)  ((GstTensorTrainer *)(obj))
+//#define GST_TENSOR_TRAINER_CAST(obj)  ((GstTensorTrainer *)(obj))
+
 typedef struct _GstTensorTrainer GstTensorTrainer;
 typedef struct _GstTensorTrainerClass GstTensorTrainerClass;
 
@@ -42,7 +43,10 @@ typedef struct _GstTensorTrainerClass GstTensorTrainerClass;
  */
 struct _GstTensorTrainer
 {
-  GstBaseTransform element;
+  GstElement element; /**< parent object */
+
+  GstPad *sinkpad;
+  GstPad *srcpad;
 
   gchar *fw_name;
   gchar *model_config;
@@ -55,12 +59,15 @@ struct _GstTensorTrainer
 
   gboolean configured;
   int input_configured;
-  int output_configured;
+  gboolean output_configured;
   int inputtype_configured;
   int outputtype_configured;
   unsigned int input_ranks[NNS_TENSOR_SIZE_LIMIT];
   unsigned int output_ranks[NNS_TENSOR_SIZE_LIMIT];
   GstTensorsInfo output_meta;
+  GstTensorsConfig out_config;
+
+  gint64 total_invoke_num;      /**< number of total invokes */
 
   /* draft */
   int fw_created;
@@ -79,13 +86,14 @@ struct _GstTensorTrainer
  */
 struct _GstTensorTrainerClass
 {
-  GstBaseTransformClass parent_class;
+  GstElementClass parent_class; /**< parent class */
 };
 
 /**
- * @brief Get Type function required for gst elements
+ * @brief Function to get type of tensor_trainer.
  */
 GType gst_tensor_trainer_get_type (void);
 
 G_END_DECLS
+
 #endif /* __GST_TENSOR_TRAINER_H__ */

--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -63,7 +63,7 @@ struct _GstTensorTrainer
   GstTensorsInfo output_meta;
   GstTensorsConfig out_config;
 
-  gint64 total_invoke_num;      /**< number of total invokes */
+  gint64 total_push_data_cnt;      /**< number of total push data */
   gboolean fw_created;
 
   void *privateData; /**< NNFW plugin's private data is stored here */

--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (C) 2022 Samsung Electronics Co., Ltd.
+ *
+ * @file	gsttensor_trainer.h
+ * @date	20 October 2022
+ * @brief	GStreamer plugin to train tensor data using NN Frameworks
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Hyunil Park <hyunil46.park@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#ifndef __GST_TENSOR_TRAINER_H__
+#define __GST_TENSOR_TRAINER_H__
+
+
+#include <gst/gst.h>
+#include <gst/base/gstbasetransform.h>
+#include <tensor_typedef.h>
+#include <tensor_common.h>
+
+#include <nnstreamer_plugin_api_util.h>
+#include <nnstreamer_plugin_api_filter.h>
+
+G_BEGIN_DECLS
+#define GST_TYPE_TENSOR_TRAINER \
+  (gst_tensor_trainer_get_type())
+#define GST_TENSOR_TRAINER(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_TENSOR_TRAINER,GstTensorTrainer))
+#define GST_TENSOR_TRAINER_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_TENSOR_TRAINER,GstTensorTrainerClass))
+#define GST_IS_TENSOR_TRAINER(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_TENSOR_TRAINER))
+#define GST_IS_TENSOR_TRAINER_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_TRAINER))
+#define GST_TENSOR_TRAINER_CAST(obj)  ((GstTensorTrainer *)(obj))
+typedef struct _GstTensorTrainer GstTensorTrainer;
+typedef struct _GstTensorTrainerClass GstTensorTrainerClass;
+
+
+/**
+ * @brief GstTensorTrainer data structure
+ */
+struct _GstTensorTrainer
+{
+  GstBaseTransform element;
+
+  gchar *fw_name;
+  gchar *input_dimensions;
+  gchar *output_dimensions;
+  gchar *input_type;
+  gchar *output_type;
+  GstTensorsInfo input_meta;
+  GstTensorsInfo output_meta;
+
+  gboolean configured;
+
+  int input_configured;
+  int output_configured;
+  int inputtype_configured;
+  int outputtype_configured;
+  unsigned int input_ranks[NNS_TENSOR_SIZE_LIMIT];
+  unsigned int output_ranks[NNS_TENSOR_SIZE_LIMIT];
+
+  /* draft */
+  int fw_opened;
+  int fw_compiled;
+  int fw_fitted;
+  int fw_created;
+  int fw_stop;
+  int fw_paused;
+
+  void *privateData; /**< NNFW plugin's private data is stored here */
+  const GstTensorFilterFramework *fw;   /* for test, need to make */
+  GstTensorFilterProperties prop; /**< NNFW plugin's properties */
+};
+
+/**
+ * @brief GstTensorTrainerClass data structure.
+ */
+struct _GstTensorTrainerClass
+{
+  GstBaseTransformClass parent_class;
+};
+
+/**
+ * @brief Get Type function required for gst elements
+ */
+GType gst_tensor_trainer_get_type (void);
+
+G_END_DECLS
+#endif /* __GST_TENSOR_TRAINER_H__ */

--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -69,6 +69,9 @@ struct _GstTensorTrainer
   void *privateData; /**< NNFW plugin's private data is stored here */
   const GstTensorTrainerFramework *fw;  /* for test, need to make */
   GstTensorTrainerProperties prop; /**< NNFW plugin's properties */
+
+  GMutex trainer_lock;
+  GCond train_complete_cond;
 };
 
 /**

--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -20,7 +20,7 @@
 #include <tensor_common.h>
 
 #include <nnstreamer_plugin_api_util.h>
-#include <nnstreamer_plugin_api_filter.h>
+#include <nnstreamer_plugin_api_trainer.h>
 
 G_BEGIN_DECLS
 #define GST_TYPE_TENSOR_TRAINER \
@@ -37,7 +37,6 @@ G_BEGIN_DECLS
 typedef struct _GstTensorTrainer GstTensorTrainer;
 typedef struct _GstTensorTrainerClass GstTensorTrainerClass;
 
-
 /**
  * @brief GstTensorTrainer data structure
  */
@@ -47,42 +46,29 @@ struct _GstTensorTrainer
 
   gchar *fw_name;
   gchar *model_config;
+  gchar *model_save_path;
   gchar *input_dimensions;
   gchar *output_dimensions;
   gchar *input_type;
   gchar *output_type;
   gboolean push_output;
-  unsigned int num_inputs;
-  unsigned int num_labels;
-  unsigned int num_training_samples;
-  unsigned int num_validation_samples;
-
-  GstTensorsInfo input_meta;
-  GstTensorsInfo output_meta;
 
   gboolean configured;
-
   int input_configured;
   int output_configured;
   int inputtype_configured;
   int outputtype_configured;
   unsigned int input_ranks[NNS_TENSOR_SIZE_LIMIT];
   unsigned int output_ranks[NNS_TENSOR_SIZE_LIMIT];
-
-  tensor_type tensors_inputtype[NNS_TENSOR_SIZE_LIMIT];
-  unsigned int tensors_inputsize[NNS_TENSOR_SIZE_LIMIT];
+  GstTensorsInfo output_meta;
 
   /* draft */
-  int fw_opened;
-  int fw_compiled;
-  int fw_fitted;
   int fw_created;
   int fw_stop;
-  int fw_paused;
 
   void *privateData; /**< NNFW plugin's private data is stored here */
-  const GstTensorFilterFramework *fw;   /* for test, need to make */
-  GstTensorFilterProperties prop; /**< NNFW plugin's properties */
+  const GstTensorTrainerFramework *fw;  /* for test, need to make */
+  GstTensorTrainerProperties prop; /**< NNFW plugin's properties */
 };
 
 /**

--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -46,10 +46,17 @@ struct _GstTensorTrainer
   GstBaseTransform element;
 
   gchar *fw_name;
+  gchar *model_config;
   gchar *input_dimensions;
   gchar *output_dimensions;
   gchar *input_type;
   gchar *output_type;
+  gboolean push_output;
+  unsigned int num_inputs;
+  unsigned int num_labels;
+  unsigned int num_training_samples;
+  unsigned int num_validation_samples;
+
   GstTensorsInfo input_meta;
   GstTensorsInfo output_meta;
 
@@ -61,6 +68,9 @@ struct _GstTensorTrainer
   int outputtype_configured;
   unsigned int input_ranks[NNS_TENSOR_SIZE_LIMIT];
   unsigned int output_ranks[NNS_TENSOR_SIZE_LIMIT];
+
+  tensor_type tensors_inputtype[NNS_TENSOR_SIZE_LIMIT];
+  unsigned int tensors_inputsize[NNS_TENSOR_SIZE_LIMIT];
 
   /* draft */
   int fw_opened;

--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -54,7 +54,6 @@ struct _GstTensorTrainer
   gchar *output_dimensions;
   gchar *input_type;
   gchar *output_type;
-  gboolean push_output;
 
   gboolean input_configured;
   gboolean output_configured;

--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -62,6 +62,7 @@ struct _GstTensorTrainer
   unsigned int output_ranks[NNS_TENSOR_SIZE_LIMIT];
   GstTensorsInfo output_meta;
   GstTensorsConfig out_config;
+  GstTensorsConfig in_config;
 
   gint64 total_push_data_cnt;      /**< number of total push data */
   gboolean fw_created;

--- a/gst/nnstreamer/elements/meson.build
+++ b/gst/nnstreamer/elements/meson.build
@@ -17,7 +17,7 @@ nnstreamer_sources += files(
   'gsttensor_sparseenc.c',
   'gsttensor_sparseutil.c',
   'gsttensor_split.c',
-  'gsttensor_transform.c'
+  'gsttensor_transform.c',
   'gsttensor_trainer.c'
 )
 

--- a/gst/nnstreamer/elements/meson.build
+++ b/gst/nnstreamer/elements/meson.build
@@ -18,6 +18,7 @@ nnstreamer_sources += files(
   'gsttensor_sparseutil.c',
   'gsttensor_split.c',
   'gsttensor_transform.c'
+  'gsttensor_trainer.c'
 )
 
 # gsttensorsrc

--- a/gst/nnstreamer/registerer/nnstreamer.c
+++ b/gst/nnstreamer/registerer/nnstreamer.c
@@ -64,6 +64,7 @@
 #include <elements/gsttensor_sparseenc.h>
 #include <elements/gsttensor_split.h>
 #include <elements/gsttensor_transform.h>
+#include <elements/gsttensor_trainer.h>
 
 #ifdef _ENABLE_SRC_IIO
 #include <elements/gsttensor_srciio.h>
@@ -108,6 +109,7 @@ gst_nnstreamer_init (GstPlugin * plugin)
   NNSTREAMER_INIT (plugin, transform, TRANSFORM);
   NNSTREAMER_INIT (plugin, if, IF);
   NNSTREAMER_INIT (plugin, rate, RATE);
+  NNSTREAMER_INIT (plugin, trainer, TRAINER);
 #if defined(ENABLE_NNSTREAMER_EDGE)
   NNSTREAMER_INIT (plugin, query_serversrc, QUERY_SERVERSRC);
   NNSTREAMER_INIT (plugin, query_serversink, QUERY_SERVERSINK);

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -67,6 +67,7 @@ NNSTREAMER_PLUGINS_SRCS := \
     $(NNSTREAMER_GST_HOME)/elements/gsttensor_sparseenc.c \
     $(NNSTREAMER_GST_HOME)/elements/gsttensor_sparseutil.c \
     $(NNSTREAMER_GST_HOME)/elements/gsttensor_split.c \
+    $(NNSTREAMER_GST_HOME)/elements/gsttensor_trainer.c \
     $(NNSTREAMER_GST_HOME)/elements/gsttensor_transform.c \
     $(NNSTREAMER_GST_HOME)/tensor_filter/tensor_filter.c
 


### PR DESCRIPTION
Improve tensor_trainer element

<details><summary> [tensor_trainer] Modify tensor_trainer's output type</summary><br/>    
    
    output type is changed to float64
    
    Signed-off-by: hyunil park <hyunil46.park@samsung.com>
</details>
<details><summary>  [tensor_trainer] Change the condition for generating the output tensor</summary><br/> 
    
    - An output tensor is created when there is a epoch result
    - Remove push_output property
    
    Signed-off-by: hyunil park <hyunil46.park@samsung.com>
</details>
<details><summary> [tensor_trainer] Remove memory leak </summary><br/> 
    
    Check memory leak in gst_buffer_new_allocate() when running valgrind
    
    - Add gst_buffer_unref() in chain function to unref input gstbuffer
    
    Signed-off-by: hyunil park <hyunil46.park@samsung.com>

use : valgrind --tool=memcheck --leak-check=full --show-reachable=yes 
</details>

<details><summary> [tensor_trainer] Determined g_cond_wait by train_complete  when receive EOS </summary><br/>
    
    - To avoid dead lock, g_cond_wait is determined by train_complete value of
    GstTensorTrainerFrameworkInfo when receive EOS

    Signed-off-by: hyunil park <hyunil46.park@samsung.com>
</details>
<details><summary> [tensor_trainer] Add epochs property</summary><br/>
    
    - Add epochs property to inform the total amount of data subplugin can receive
    - tensor_trainer should receive total number of data (train-samples + valid-samples) * epochs

    Signed-off-by: hyunil park <hyunil46.park@samsung.com>
</details>

<details><summary> [tensor_trainer] change data type of some properties</summary><br/>
    
    - Change uint to int64
    
    Signed-off-by: hyunil park <hyunil46.park@samsung.com>
</details>
<details><summary> [tensor_trainer] Modify Example launch line</summary><br/>
    
    - Use setting mulitple tensors to tensor_converter
    
    Signed-off-by: hyunil park <hyunil46.park@samsung.com>
</details>
<details><summary> [tensor_trainer] Rename property name</summary><br/>
    
    - Rename from input and inputtype to input-dim and input-type
    
    Signed-off-by: hyunil park <hyunil46.park@samsung.com>
</details>
<details><summary>  [tensor_trainer] Renaming variables related to invoke</summary><br/>
    
    - remove 'invoke' and usd 'push'
    
    Signed-off-by: hyunil park <hyunil46.park@samsung.com>
</details>

<details><summary> [tensor_trainer] Modify query caps to support negotiation with fixed caps of peers</summary><br/>
    
    - Support negotiation without tensor_converter
    - Modify Example launch line
    
    Signed-off-by: hyunil park <hyunil46.park@samsung.com>
</details>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped