### PR TITLE
[fix][tensor_filter] Fix the first output with garbage value with tflite

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -356,7 +356,11 @@ TFLiteInterpreter::invoke (const GstTensorMemory *input, GstTensorMemory *output
   start_time = g_get_monotonic_time ();
   status = interpreter->Invoke ();
 
-  if (is_xnnpack_delegated) {
+  /**
+   * After the very first invoke, the output buffer address may change.
+   * To handle the case, memcpy the output buffer directly.
+   */
+  if (is_xnnpack_delegated || !is_cached_after_first_invoke) {
     for (unsigned int i = 0; i < outputTensorMeta.num_tensors; ++i) {
       tensor_ptr = outputTensorPtr[i];
       g_assert(tensor_ptr->bytes == output[i].size);


### PR DESCRIPTION
- The output buffer address may change after the first invoke.
- To handle this case, Memcpy the output from tflite interpreter at the first invoke.

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped


