### PR TITLE
[Query] Prevent overwriting of the query server caps

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_server.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.c
@@ -185,6 +185,33 @@ gst_tensor_query_server_set_configured (edge_server_handle server_h)
 }
 
 /**
+ * @brief set query server caps.
+ */
+void
+gst_tensor_query_server_set_caps (edge_server_handle server_h,
+    const char *caps_str)
+{
+  GstTensorQueryServer *data = (GstTensorQueryServer *) server_h;
+  gchar *prev_caps_str = NULL, *new_caps_str;
+
+  if (NULL == data) {
+    return;
+  }
+  g_mutex_lock (&data->lock);
+
+  nns_edge_get_info (data->edge_h, "CAPS", &prev_caps_str);
+  if (!prev_caps_str)
+    prev_caps_str = g_strdup ("");
+  new_caps_str = g_strdup_printf ("%s%s", prev_caps_str, caps_str);
+  nns_edge_set_info (data->edge_h, "CAPS", new_caps_str);
+
+  g_free (prev_caps_str);
+  g_free (new_caps_str);
+
+  g_mutex_unlock (&data->lock);
+}
+
+/**
  * @brief Initialize the query server.
  */
 static void

--- a/gst/nnstreamer/tensor_query/tensor_query_server.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.h
@@ -73,6 +73,12 @@ gst_tensor_query_server_get_edge_handle (edge_server_handle server_h);
 void
 gst_tensor_query_server_set_configured (edge_server_handle server_h);
 
+/**
+ * @brief set query server caps.
+ */
+void
+gst_tensor_query_server_set_caps (edge_server_handle server_h, const char *caps_str);
+
 G_END_DECLS
 
 #endif /* __GST_TENSOR_QUERY_CLIENT_H__ */

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.c
@@ -217,17 +217,13 @@ static gboolean
 gst_tensor_query_serversink_set_caps (GstBaseSink * bsink, GstCaps * caps)
 {
   GstTensorQueryServerSink *sink = GST_TENSOR_QUERY_SERVERSINK (bsink);
-  gchar *caps_str, *prev_caps_str, *new_caps_str;
+  gchar *caps_str, *new_caps_str;
 
   caps_str = gst_caps_to_string (caps);
 
-  nns_edge_get_info (sink->edge_h, "CAPS", &prev_caps_str);
-  if (!prev_caps_str)
-    prev_caps_str = g_strdup ("");
-  new_caps_str = g_strdup_printf ("%s@query_server_sink_caps@%s",
-      prev_caps_str, caps_str);
-  nns_edge_set_info (sink->edge_h, "CAPS", new_caps_str);
-  g_free (prev_caps_str);
+  new_caps_str = g_strdup_printf ("@query_server_sink_caps@%s", caps_str);
+  gst_tensor_query_server_set_caps (sink->server_h, new_caps_str);
+
   g_free (new_caps_str);
   g_free (caps_str);
 

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
@@ -438,7 +438,7 @@ gst_tensor_query_serversrc_create (GstPushSrc * psrc, GstBuffer ** outbuf)
   GstBaseSrc *bsrc = GST_BASE_SRC (psrc);
 
   if (!src->configured) {
-    gchar *caps_str, *prev_caps_str, *new_caps_str;
+    gchar *caps_str, *new_caps_str;
 
     GstCaps *caps = gst_pad_peer_query_caps (GST_BASE_SRC_PAD (bsrc), NULL);
     if (gst_caps_is_fixed (caps)) {
@@ -447,13 +447,8 @@ gst_tensor_query_serversrc_create (GstPushSrc * psrc, GstBuffer ** outbuf)
 
     caps_str = gst_caps_to_string (caps);
 
-    nns_edge_get_info (src->edge_h, "CAPS", &prev_caps_str);
-    if (!prev_caps_str)
-      prev_caps_str = g_strdup ("");
-    new_caps_str = g_strdup_printf ("%s@query_server_src_caps@%s",
-        prev_caps_str, caps_str);
-    nns_edge_set_info (src->edge_h, "CAPS", new_caps_str);
-    g_free (prev_caps_str);
+    new_caps_str = g_strdup_printf ("@query_server_src_caps@%s", caps_str);
+    gst_tensor_query_server_set_caps (src->server_h, new_caps_str);
     g_free (new_caps_str);
     g_free (caps_str);
 


### PR DESCRIPTION
Add new function to set query server caps.
This patch prevents the race condition of the query server caps.

*Need group SR with https://github.com/nnstreamer/nnstreamer-edge/pull/147 to fix armv7l test failure.

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed [ ]Skipped
2. Run test: [* ]Passed [ ]Failed [ ]Skipped


