### PR TITLE
[tensor_converter] Remove a seemingly unnecessary caps attribute 'views' to make tensor_converter compatible with vaapih264dec.

### DIFF
--- a/debian/nnstreamer-single-dev.install
+++ b/debian/nnstreamer-single-dev.install
@@ -1,6 +1,7 @@
 /usr/include/nnstreamer/nnstreamer_version.h
 /usr/include/nnstreamer/tensor_typedef.h
 /usr/include/nnstreamer/nnstreamer_plugin_api_filter.h
+/usr/include/nnstreamer/nnstreamer_plugin_api_trainer.h
 /usr/include/nnstreamer/nnstreamer_plugin_api_util.h
 /usr/lib/*/pkgconfig/nnstreamer-single.pc
 /usr/lib/*/libnnstreamer-single.a

--- a/gst/nnstreamer/elements/gsttensor_converter.c
+++ b/gst/nnstreamer/elements/gsttensor_converter.c
@@ -1429,7 +1429,7 @@ gst_tensor_converter_parse_video (GstTensorConverter * self,
    */
   GstVideoInfo vinfo;
   GstVideoFormat format;
-  gint width, height;
+  gint width, height, views;
   guint i;
 
   g_return_val_if_fail (config != NULL, FALSE);
@@ -1440,8 +1440,8 @@ gst_tensor_converter_parse_video (GstTensorConverter * self,
   if (!gst_video_info_from_caps (&vinfo, caps)) {
     char *capstr = gst_caps_to_string (caps);
     GST_ERROR_OBJECT (self,
-        "Failed to get video info from caps; gst_video_info_from_caps (&info, \"%s\") has returned FALSE, which means the given caps cannot be parsed as a video.",
-        capstr);
+      "Failed to get video info from caps; gst_video_info_from_caps (&info, \"%s\") has returned FALSE, which means the given caps cannot be parsed as a video.",
+      capstr);
     g_free (capstr);
     return FALSE;
   }
@@ -1449,6 +1449,13 @@ gst_tensor_converter_parse_video (GstTensorConverter * self,
   format = GST_VIDEO_INFO_FORMAT (&vinfo);
   width = GST_VIDEO_INFO_WIDTH (&vinfo);
   height = GST_VIDEO_INFO_HEIGHT (&vinfo);
+  views = GST_VIDEO_INFO_VIEWS(&vinfo);
+
+  if (views > 1) {
+    GST_WARNING_OBJECT (self,
+      "Incoming video caps should have 'views=(int)1 but has views=(int)%d - ignoring all but view #0. \n",
+      views);
+  }
 
   config->info.num_tensors = 1;
 

--- a/gst/nnstreamer/elements/gsttensor_converter_media_info_video.h
+++ b/gst/nnstreamer/elements/gsttensor_converter_media_info_video.h
@@ -27,7 +27,7 @@
  */
 #define VIDEO_CAPS_STR \
     GST_VIDEO_CAPS_MAKE ("{ RGB, BGR, RGBx, BGRx, xRGB, xBGR, RGBA, BGRA, ARGB, ABGR, GRAY8 }") \
-    ", views = (int) 1, interlace-mode = (string) progressive"
+    ", interlace-mode = (string) progressive"
 
 #define append_video_caps_template(caps) \
     gst_caps_append (caps, gst_caps_from_string (VIDEO_CAPS_STR))

--- a/gst/nnstreamer/include/meson.build
+++ b/gst/nnstreamer/include/meson.build
@@ -7,6 +7,7 @@ nnstreamer_headers += files(
   'tensor_converter_custom.h',
   'tensor_decoder_custom.h',
   'nnstreamer_plugin_api_filter.h',
+  'nnstreamer_plugin_api_trainer.h',
   'nnstreamer_plugin_api_decoder.h',
   'nnstreamer_plugin_api_converter.h',
   'nnstreamer_plugin_api_util.h',

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -38,7 +38,7 @@ typedef struct _GstTensorTrainerProperties
   int64_t num_train_samples;    /**< The number of train sample used to train the model. */
   int64_t num_valid_samples;    /**< The number of valid sample used to train the model. */
 
-  GCond *train_complete_cond;    /**< Tensor trainer wait when receive EOS before model training is complete, subplugin should send signal when model train is complete */
+  GCond *train_complete_cond;    /**< Tensor trainer wait when receive EOS before model training is complete, subplugin should send signal when model train is complete. */
 } GstTensorTrainerProperties;
 
 /**
@@ -49,6 +49,7 @@ typedef struct _GstTensorTrainerProperties
 typedef struct _GstTensorTrainerFrameworkInfo
 {
   const char *name;    /**< Name of the neural network framework, searchable by FRAMEWORK property. */
+  gboolean  train_complete;  /**< Check if train is complete */
 } GstTensorTrainerFrameworkInfo;
 
 typedef struct _GstTensorTrainerFramework GstTensorTrainerFramework;

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -1,0 +1,144 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * NNStreamer API for Tensor_Trainer Sub-Plugins
+ * Copyright (C) 2022 Hyunil Park <hyunil46.park@samsung.com>
+ */
+/**
+ * @file  nnstreamer_plugin_api_trainer.h
+ * @date  1 Dec 2022
+ * @brief Mandatory APIs for NNStreamer Trainer sub-plugins (No External Dependencies)
+ * @see https://github.com/nnstreamer/nnstreamer
+ * @author  Hyunil Park <hyunil46.park@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#ifndef __NNS_PLUGIN_API_TRAINER_H__
+#define __NNS_PLUGIN_API_TRAINER_H__
+
+#include "tensor_typedef.h"
+
+#define GST_TENSOR_TRAINER_FRAMEWORK_BASE (0xDEAFDEAD00000000ULL)
+#define GST_TENSOR_TRAINER_FRAMEWORK_V1 (GST_TENSOR_TRAINER_FRAMEWORK_BASE | 0x10000ULL)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief GstTensorTrainer's properties for neural network framework (internal data structure)
+ *
+ * Internal data of GstTensorTrainer required by tensor_trainer's custom subplugin.
+ */
+typedef struct _GstTensorTrainerProperties
+{
+  GstTensorsInfo input_meta;    /**< configured input tensor info */
+  const char *model_config;    /**< The configuration file path for creating model */
+  const char *model_save_path;    /**< The file path to save the model */
+  int64_t num_inputs;    /**< The number of input lists, the input is where framework receive the features to train the model, num_inputs indicates how many inputs there are. */
+  int64_t num_labels;    /**< The number of label lists, the label is where framework receive the class to train the model, num_labels indicates how many labels there are. */
+  int64_t num_train_samples;    /**< The number of train sample used to train the model. */
+  int64_t num_valid_samples;    /**< The number of valid sample used to train the model. */
+
+  GCond *train_complete_cond;    /**< Tensor trainer wait when receive EOS before model training is complete, subplugin should send signal when model train is complete */
+} GstTensorTrainerProperties;
+
+/**
+ * @brief Tensor_Trainer Subplugin framework related information
+ *
+ * All the information is provided statically.
+ */
+typedef struct _GstTensorTrainerFrameworkInfo
+{
+  const char *name;    /**< Name of the neural network framework, searchable by FRAMEWORK property. */
+} GstTensorTrainerFrameworkInfo;
+
+typedef struct _GstTensorTrainerFramework GstTensorTrainerFramework;
+
+/**
+ * @brief tensor_trainer Subplugin definition
+ *
+ * Common callback parameters:
+ * prop Trainer properties. Read Only.
+ * private_data Subplugin's private data. Set this (*private_data = XXX) if you want to change trainer->private_data.
+ */
+struct _GstTensorTrainerFramework
+{
+  uint64_t version;
+  /**< Version of the struct
+   * | 32bit (validity check) | 16bit (API version) | 16bit (Subplugin's internal version) |
+   */
+
+  int (*create) (const GstTensorTrainerFramework * self,
+      const GstTensorTrainerProperties * prop, void **private_data);
+  /**< tensor_trainer call this to create the model
+   * @param[in] prop read-only property values
+   * @param[in/out] private_data, a subplugin may save its internal private data here.
+   * @return 0 if ok. < 0 if error.
+   */
+
+  int (*destroy) (const GstTensorTrainerFramework * self,
+      const GstTensorTrainerProperties * prop, void **private_data);
+  /**< tensor_trainer call this to destroy the model, Set NULL after that.
+   * @param[in] prop read-only property values
+   * @param[in/out] private_data, a subplugin may save its internal private data here.
+   * @return 0 if ok. < 0 if error.
+   */
+
+  int (*train) (const GstTensorTrainerFramework * self,
+      const GstTensorTrainerProperties * prop, void *private_data);
+  /**< tensor_trainer call this to train the model
+   * @param[in] prop read-only property values
+   * @param[in] private_data, a subplugin may save its internal private data here.
+   * @return 0 if ok. < 0 if error.
+   */
+
+  int (*invoke) (const GstTensorTrainerFramework * self,
+      const GstTensorTrainerProperties * prop,
+      void *private_data, const GstTensorMemory * input);
+  /**< tensor_trainer call this to send tensor data to subplugin, subplugin constructs a data set using input.
+   * @param[in] prop read-only property values
+   * @param[in] private_data, a subplugin may save its internal private data here.
+   * @param[in] input The array of input tensors. Allocated and filled by tensor_trainer
+   * @return 0 if ok. < 0 if error.
+   */
+
+  int (*getFrameworkInfo) (const GstTensorTrainerFramework * self,
+      const GstTensorTrainerProperties * prop, void *private_data,
+      GstTensorTrainerFrameworkInfo *fw_info);
+  /**< Mandatory callback. Get the frameworks statically determined info.
+   * @param[in] prop read-only property values
+   * @param[in] private_data A subplugin may save its internal private data here.
+   * @param[out] fw_info struct to hold frameworks info. Must be allocated by the caller (return value).
+   * @return 0 if OK. non-zero if error.
+   *
+   * @note CAUTION: private_data can be NULL if the framework is not yet opened by the caller.
+   */
+
+  /* Need to make (*eventHandler)*/
+
+};
+
+/* extern functions for subplugin management, exist in tensor_trainer.c */
+/**
+ * @brief Trainer's sub-plugin should call this function to register itself.
+ * @param[in] ttsp tensor_trainer sub-plugin to be registered.
+ * @return TRUE if registered. FALSE is failed.
+ *
+ * @note Do not change the subplugins callbacks after probing the filter.
+ */
+extern int
+nnstreamer_trainer_probe (GstTensorTrainerFramework * ttsp);
+
+/**
+ * @brief Trainer's sub-plugin may call this to unregister itself.
+ * @param[in] ttsp tensor_trainer sub-plugin to be unregistered.
+ * @return TRUE if unregistered. FALSE is failed.
+ */
+
+extern int
+nnstreamer_trainer_exit (GstTensorTrainerFramework * ttsp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __NNS_PLUGIN_API_TRAINER_H__ */

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -37,6 +37,7 @@ typedef struct _GstTensorTrainerProperties
   int64_t num_labels;    /**< The number of label lists, the label is where framework receive the class to train the model, num_labels indicates how many labels there are. */
   int64_t num_train_samples;    /**< The number of train sample used to train the model. */
   int64_t num_valid_samples;    /**< The number of valid sample used to train the model. */
+  int64_t num_epochs;    /**< The number of repetition of total train and valid sample. subplugin must receive total samples((num_train_samples + num_valid_samples) * num_epochs) */
 
   GCond *train_complete_cond;    /**< Tensor trainer wait when receive EOS before model training is complete, subplugin should send signal when model train is complete. */
 } GstTensorTrainerProperties;
@@ -50,6 +51,7 @@ typedef struct _GstTensorTrainerFrameworkInfo
 {
   const char *name;    /**< Name of the neural network framework, searchable by FRAMEWORK property. */
   gboolean  train_complete;  /**< Check if train is complete */
+  int64_t epoch_cnt;    /**< Number of currently completed epochs */
 } GstTensorTrainerFrameworkInfo;
 
 typedef struct _GstTensorTrainerFramework GstTensorTrainerFramework;

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -50,7 +50,7 @@ typedef struct _GstTensorTrainerProperties
 typedef struct _GstTensorTrainerFrameworkInfo
 {
   const char *name;    /**< Name of the neural network framework, searchable by FRAMEWORK property. */
-  gboolean  train_complete;  /**< Check if train is complete */
+  int train_complete;  /**< Check if train is complete, Use int instead of gboolean because this is refered by custom plugins. */
   int64_t epoch_cnt;    /**< Number of currently completed epochs */
 } GstTensorTrainerFrameworkInfo;
 

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -86,18 +86,18 @@ struct _GstTensorTrainerFramework
    * @return 0 if ok. < 0 if error.
    */
 
-  int (*train) (const GstTensorTrainerFramework * self,
+  int (*start) (const GstTensorTrainerFramework * self,
       const GstTensorTrainerProperties * prop, void *private_data);
-  /**< tensor_trainer call this to train the model
+  /**< tensor_trainer call this to start training the model
    * @param[in] prop read-only property values
    * @param[in] private_data, a subplugin may save its internal private data here.
    * @return 0 if ok. < 0 if error.
    */
 
-  int (*invoke) (const GstTensorTrainerFramework * self,
+  int (*push_data) (const GstTensorTrainerFramework * self,
       const GstTensorTrainerProperties * prop,
       void *private_data, const GstTensorMemory * input);
-  /**< tensor_trainer call this to send tensor data to subplugin, subplugin constructs a data set using input.
+  /**< tensor_trainer call this to push tensor data to subplugin, subplugin constructs a data set using input.
    * @param[in] prop read-only property values
    * @param[in] private_data, a subplugin may save its internal private data here.
    * @param[in] input The array of input tensors. Allocated and filled by tensor_trainer

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -50,16 +50,8 @@ typedef struct _GstTensorTrainerProperties
 typedef struct _GstTensorTrainerFrameworkInfo
 {
   const char *name;    /**< Name of the neural network framework, searchable by FRAMEWORK property. */
-<<<<<<< HEAD
   int train_complete;  /**< Check if train is complete, Use int instead of gboolean because this is refered by custom plugins. */
   int64_t epoch_cnt;    /**< Number of currently completed epochs */
-=======
-  gboolean  train_complete;  /**< Check if train is complete */
-<<<<<<< HEAD
->>>>>>> 56ee2c43 ([API][trainer] Add train_complete to GstTensorTrainerFrameworkInfo)
-=======
-  int64_t epoch_cnt;    /**< Number of currently completed epochs */
->>>>>>> 5ea682a9 ([API][trainer] Add number of epoch and epoch count)
 } GstTensorTrainerFrameworkInfo;
 
 typedef struct _GstTensorTrainerFramework GstTensorTrainerFramework;

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -50,8 +50,12 @@ typedef struct _GstTensorTrainerProperties
 typedef struct _GstTensorTrainerFrameworkInfo
 {
   const char *name;    /**< Name of the neural network framework, searchable by FRAMEWORK property. */
+<<<<<<< HEAD
   int train_complete;  /**< Check if train is complete, Use int instead of gboolean because this is refered by custom plugins. */
   int64_t epoch_cnt;    /**< Number of currently completed epochs */
+=======
+  gboolean  train_complete;  /**< Check if train is complete */
+>>>>>>> 56ee2c43 ([API][trainer] Add train_complete to GstTensorTrainerFrameworkInfo)
 } GstTensorTrainerFrameworkInfo;
 
 typedef struct _GstTensorTrainerFramework GstTensorTrainerFramework;

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -55,7 +55,11 @@ typedef struct _GstTensorTrainerFrameworkInfo
   int64_t epoch_cnt;    /**< Number of currently completed epochs */
 =======
   gboolean  train_complete;  /**< Check if train is complete */
+<<<<<<< HEAD
 >>>>>>> 56ee2c43 ([API][trainer] Add train_complete to GstTensorTrainerFrameworkInfo)
+=======
+  int64_t epoch_cnt;    /**< Number of currently completed epochs */
+>>>>>>> 5ea682a9 ([API][trainer] Add number of epoch and epoch count)
 } GstTensorTrainerFrameworkInfo;
 
 typedef struct _GstTensorTrainerFramework GstTensorTrainerFramework;

--- a/gst/nnstreamer/tensor_query/tensor_query_server.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.c
@@ -185,6 +185,33 @@ gst_tensor_query_server_set_configured (edge_server_handle server_h)
 }
 
 /**
+ * @brief set query server caps.
+ */
+void
+gst_tensor_query_server_set_caps (edge_server_handle server_h,
+    const char *caps_str)
+{
+  GstTensorQueryServer *data = (GstTensorQueryServer *) server_h;
+  gchar *prev_caps_str = NULL, *new_caps_str;
+
+  if (NULL == data) {
+    return;
+  }
+  g_mutex_lock (&data->lock);
+
+  nns_edge_get_info (data->edge_h, "CAPS", &prev_caps_str);
+  if (!prev_caps_str)
+    prev_caps_str = g_strdup ("");
+  new_caps_str = g_strdup_printf ("%s%s", prev_caps_str, caps_str);
+  nns_edge_set_info (data->edge_h, "CAPS", new_caps_str);
+
+  g_free (prev_caps_str);
+  g_free (new_caps_str);
+
+  g_mutex_unlock (&data->lock);
+}
+
+/**
  * @brief Initialize the query server.
  */
 static void

--- a/gst/nnstreamer/tensor_query/tensor_query_server.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.h
@@ -73,6 +73,12 @@ gst_tensor_query_server_get_edge_handle (edge_server_handle server_h);
 void
 gst_tensor_query_server_set_configured (edge_server_handle server_h);
 
+/**
+ * @brief set query server caps.
+ */
+void
+gst_tensor_query_server_set_caps (edge_server_handle server_h, const char *caps_str);
+
 G_END_DECLS
 
 #endif /* __GST_TENSOR_QUERY_CLIENT_H__ */

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.c
@@ -217,17 +217,13 @@ static gboolean
 gst_tensor_query_serversink_set_caps (GstBaseSink * bsink, GstCaps * caps)
 {
   GstTensorQueryServerSink *sink = GST_TENSOR_QUERY_SERVERSINK (bsink);
-  gchar *caps_str, *prev_caps_str, *new_caps_str;
+  gchar *caps_str, *new_caps_str;
 
   caps_str = gst_caps_to_string (caps);
 
-  nns_edge_get_info (sink->edge_h, "CAPS", &prev_caps_str);
-  if (!prev_caps_str)
-    prev_caps_str = g_strdup ("");
-  new_caps_str = g_strdup_printf ("%s@query_server_sink_caps@%s",
-      prev_caps_str, caps_str);
-  nns_edge_set_info (sink->edge_h, "CAPS", new_caps_str);
-  g_free (prev_caps_str);
+  new_caps_str = g_strdup_printf ("@query_server_sink_caps@%s", caps_str);
+  gst_tensor_query_server_set_caps (sink->server_h, new_caps_str);
+
   g_free (new_caps_str);
   g_free (caps_str);
 

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
@@ -438,7 +438,7 @@ gst_tensor_query_serversrc_create (GstPushSrc * psrc, GstBuffer ** outbuf)
   GstBaseSrc *bsrc = GST_BASE_SRC (psrc);
 
   if (!src->configured) {
-    gchar *caps_str, *prev_caps_str, *new_caps_str;
+    gchar *caps_str, *new_caps_str;
 
     GstCaps *caps = gst_pad_peer_query_caps (GST_BASE_SRC_PAD (bsrc), NULL);
     if (gst_caps_is_fixed (caps)) {
@@ -447,13 +447,8 @@ gst_tensor_query_serversrc_create (GstPushSrc * psrc, GstBuffer ** outbuf)
 
     caps_str = gst_caps_to_string (caps);
 
-    nns_edge_get_info (src->edge_h, "CAPS", &prev_caps_str);
-    if (!prev_caps_str)
-      prev_caps_str = g_strdup ("");
-    new_caps_str = g_strdup_printf ("%s@query_server_src_caps@%s",
-        prev_caps_str, caps_str);
-    nns_edge_set_info (src->edge_h, "CAPS", new_caps_str);
-    g_free (prev_caps_str);
+    new_caps_str = g_strdup_printf ("@query_server_src_caps@%s", caps_str);
+    gst_tensor_query_server_set_caps (src->server_h, new_caps_str);
     g_free (new_caps_str);
     g_free (caps_str);
 

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -1137,6 +1137,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %files single-devel
 %{_includedir}/nnstreamer/tensor_typedef.h
 %{_includedir}/nnstreamer/nnstreamer_plugin_api_filter.h
+%{_includedir}/nnstreamer/nnstreamer_plugin_api_trainer.h
 %{_includedir}/nnstreamer/nnstreamer_plugin_api_util.h
 %{_includedir}/nnstreamer/nnstreamer_version.h
 %{_libdir}/pkgconfig/nnstreamer-single.pc


### PR DESCRIPTION
When using ` vaapih264dec` (gstreamer v1.20.1) to decode video, I have been unable to run a pipeline with `tensor_converter` successfully. GST_DEBUG=2 helps finding this warning hint:
```
0:00:08.260625980 48364 0x7ff988007520 WARN basetransform gstbasetransform.c:1370:gst_base_transform_setcaps:<videoconvert3> transform could not transform video/x-raw, format=(string)NV12, width=(int)1920, height=(int)1080, framerate=(fraction)30000/1001, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, multiview-mode=(string)mono, multiview-flags=(GstVideoMultiviewFlagsSet)0:ffffffff:/right-view-first/left-flipped/left-flopped/right-flipped/right-flopped/half-aspect/mixed-mono, views=(int)2, chroma-site=(string)mpeg2, colorimetry=(string)bt709 in anything we support
```

It looks like `vaapih264dec` produces a src caps like `video/x-raw, ... multiview-mode=(string)mono, ... views=(int)2`. But the caps restriction of `views=(int)1` prohibits the successful negotiation. 

Now, I don't fully understand the details and side effects, not do I understand if the VAAPI element behavior should be considered a bug or correct. In any case other sink elements can handle this gracefully (almost any other video element I've tried does so).
