### PR TITLE
[API][trainer] Change type of train_complete to int

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -50,7 +50,7 @@ typedef struct _GstTensorTrainerProperties
 typedef struct _GstTensorTrainerFrameworkInfo
 {
   const char *name;    /**< Name of the neural network framework, searchable by FRAMEWORK property. */
-  gboolean  train_complete;  /**< Check if train is complete */
+  int train_complete;  /**< Check if train is complete, Use int instead of gboolean because this is refered by custom plugins. */
   int64_t epoch_cnt;    /**< Number of currently completed epochs */
 } GstTensorTrainerFrameworkInfo;
 


### PR DESCRIPTION
 [API][trainer] Change type of train_complete to int 
 - Sub-plugin using c++ cannot access this type
<details><summary> error </summary>
<br/> 
tensor_trainer_nntrainer.cc:520:49: error: 'GstTensorTrainerFramework' {aka '_GstTensorTrainerFramework'} has no non-static data member named 'start'
[  539s]   520 |   .getFrameworkInfo = nntrainer_getFrameworkInfo};
</details>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped