### PR TITLE
[API][trainer] Packaging nnstreamer_plugin_api_trainer.h into debian

### DIFF
--- a/debian/nnstreamer-single-dev.install
+++ b/debian/nnstreamer-single-dev.install
@@ -1,6 +1,7 @@
 /usr/include/nnstreamer/nnstreamer_version.h
 /usr/include/nnstreamer/tensor_typedef.h
 /usr/include/nnstreamer/nnstreamer_plugin_api_filter.h
+/usr/include/nnstreamer/nnstreamer_plugin_api_trainer.h
 /usr/include/nnstreamer/nnstreamer_plugin_api_util.h
 /usr/lib/*/pkgconfig/nnstreamer-single.pc
 /usr/lib/*/libnnstreamer-single.a


### PR DESCRIPTION
[API][trainer]  Packaging nnstreamer_plugin_api_trainer.h into debian
- Packaing header file to nnstreamer-single-dev.install

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped