### PR TITLE
[common] Add header structure for 16+th tensors and simple APIs

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -135,5 +135,23 @@ gst_tensors_extra_init (GstTensorExtraInfo * extra, GstMemory * memory);
 extern GstMemory *
 gst_tensors_get_nth_memory (GstBuffer * buffer, const GstTensorsInfo * info, const guint index);
 
+/**
+ * @brief Check if given @a mem has extra tensors.
+ * @param[in] mem GstMemory to be checked.
+ * @return TRUE if @mem has extra tensors, otherwise FALSE.
+*/
+extern gboolean
+is_extra_tensors_memory (GstMemory * mem);
+
+/**
+ * @brief Append @a memory to given @a buffer.
+ * @param[in/out] buffer GstBuffer to be appended.
+ * @param[in] memory GstMemory to append. This function will take ownership of this.
+ * @param[in] tensor_info GstTensorInfo of given @a memory.
+ * @return TRUE if successfully appended, otherwise FALSE.
+*/
+extern gboolean
+gst_tensors_extra_append_memory_to_buffer (GstBuffer * buffer, GstMemory * memory, const GstTensorInfo * tensor_info);
+
 G_END_DECLS
 #endif /* __NNS_PLUGIN_API_H__ */

--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -117,5 +117,23 @@ gst_tensor_caps_update_dimension (GstCaps *caps, GstCaps *peer_caps);
 extern gboolean
 gst_tensor_caps_can_intersect (GstCaps *caps1, GstCaps *caps2);
 
+/**
+ * @brief Initialize GstTensorExtraInfo structure with given @a memory.
+ * @param[in/out] extra GstTensorExtraInfo to be initialized.
+ * @param[in] memory The information of given memory is used to initialize @a extra.
+*/
+extern void
+gst_tensors_extra_init (GstTensorExtraInfo * extra, GstMemory * memory);
+
+/**
+ * @brief Get the nth GstMemory from given @a buffer.
+ * @param[in] buffer GstBuffer to be parsed.
+ * @param[in] info GstTensorsInfo to be used in parsing buffer.
+ * @param[in] index Index of GstMemory to be returned.
+ * @return GstMemory if found, otherwise NULL (Caller should free returned memory using gst_memory_unref()).
+*/
+extern GstMemory *
+gst_tensors_get_nth_memory (GstBuffer * buffer, const GstTensorsInfo * info, const guint index);
+
 G_END_DECLS
 #endif /* __NNS_PLUGIN_API_H__ */

--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -133,7 +133,8 @@ gst_tensors_extra_init (GstTensorExtraInfo * extra, GstMemory * memory);
  * @return GstMemory if found, otherwise NULL (Caller should free returned memory using gst_memory_unref()).
 */
 extern GstMemory *
-gst_tensors_get_nth_memory (GstBuffer * buffer, const GstTensorsInfo * info, const guint index);
+gst_tensors_get_nth_memory (GstBuffer * buffer, const GstTensorsInfo * info,
+    const guint index);
 
 /**
  * @brief Check if given @a mem has extra tensors.
@@ -151,7 +152,8 @@ is_extra_tensors_memory (GstMemory * mem);
  * @return TRUE if successfully appended, otherwise FALSE.
 */
 extern gboolean
-gst_tensors_extra_append_memory_to_buffer (GstBuffer * buffer, GstMemory * memory, const GstTensorInfo * tensor_info);
+gst_tensors_extra_append_memory_to_buffer (GstBuffer * buffer,
+    GstMemory * memory, const GstTensorInfo * tensor_info);
 
 G_END_DECLS
 #endif /* __NNS_PLUGIN_API_H__ */

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -34,6 +34,7 @@
 #define NNS_TENSOR_RANK_LIMIT	(4)
 #define NNS_TENSOR_SIZE_LIMIT	(16)
 #define NNS_TENSOR_SIZE_LIMIT_STR	"16"
+#define NNS_TENSOR_SIZE_EXTRA_LIMIT (200)
 #define NNS_TENSOR_DIM_NULL ({0, 0, 0, 0})
 
 /**
@@ -292,5 +293,19 @@ typedef struct
   };
 
 } GstTensorMetaInfo;
+
+/**
+ * @brief Data structure to describe a "extra" tensor data.
+ * This represents the information of the NNS_TENSOR_SIZE_LIMIT-th memory block for tensor stream.
+*/
+typedef struct
+{
+  uint32_t magic;
+  uint32_t version;
+  uint32_t num_extra_tensors;
+  uint64_t reserved;
+  GstTensorInfo infos[NNS_TENSOR_SIZE_EXTRA_LIMIT];
+} GstTensorExtraInfo;
+
 
 #endif /*__GST_TENSOR_TYPEDEF_H__*/

--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -1460,7 +1460,8 @@ gst_tensors_extra_init (GstTensorExtraInfo * extra, GstMemory * memory)
  * @return GstMemory if found, otherwise NULL (Caller should free returned memory using gst_memory_unref()).
 */
 GstMemory *
-gst_tensors_get_nth_memory (GstBuffer * buffer, const GstTensorsInfo * info, const guint index)
+gst_tensors_get_nth_memory (GstBuffer * buffer, const GstTensorsInfo * info,
+    const guint index)
 {
   guint i, offset = 0;
   GstMemory *extra_tensors_memory, *res_mem;
@@ -1483,13 +1484,15 @@ gst_tensors_get_nth_memory (GstBuffer * buffer, const GstTensorsInfo * info, con
   }
 
   /* If num_tensors is less than or equal to NNS_TENSOR_SIZE_LIMIT, it's trivial. */
-  if (info->num_tensors <= NNS_TENSOR_SIZE_LIMIT || index < NNS_TENSOR_SIZE_LIMIT - 1) {
+  if (info->num_tensors <= NNS_TENSOR_SIZE_LIMIT
+      || index < NNS_TENSOR_SIZE_LIMIT - 1) {
     return gst_buffer_get_memory (buffer, index);
   }
 
   /* Check the buffer contains NNS_TENSOR_SIZE_LIMIT memory */
   if (gst_buffer_n_memory (buffer) != NNS_TENSOR_SIZE_LIMIT) {
-    nns_loge ("Failed to get %d-th memory from buffer (invalid buffer size).", index);
+    nns_loge ("Failed to get %d-th memory from buffer (invalid buffer size).",
+        index);
     return NULL;
   }
 
@@ -1531,7 +1534,8 @@ gst_tensors_get_nth_memory (GstBuffer * buffer, const GstTensorsInfo * info, con
 
   /* If index is NNS_TENSOR_SIZE_LIMIT - 1 */
   if (index == NNS_TENSOR_SIZE_LIMIT - 1) {
-    res_mem = gst_memory_share (extra_tensors_memory, offset, extra_info->reserved);
+    res_mem =
+        gst_memory_share (extra_tensors_memory, offset, extra_info->reserved);
     gst_memory_unmap (extra_tensors_memory, &extra_tensors_map);
     gst_memory_unref (extra_tensors_memory);
 
@@ -1597,7 +1601,8 @@ is_extra_tensors_memory (GstMemory * mem)
  * @return TRUE if successfully appended, otherwise FALSE.
 */
 gboolean
-gst_tensors_extra_append_memory_to_buffer (GstBuffer * buffer, GstMemory * memory, const GstTensorInfo * tensor_info)
+gst_tensors_extra_append_memory_to_buffer (GstBuffer * buffer,
+    GstMemory * memory, const GstTensorInfo * tensor_info)
 {
   guint num_mems, offset, i;
 
@@ -1670,9 +1675,10 @@ gst_tensors_extra_append_memory_to_buffer (GstBuffer * buffer, GstMemory * memor
     offset = 0;
   }
 
-  memcpy (new_memory_map.data + offset, last_memory_map.data, last_memory_map.size);
+  memcpy (new_memory_map.data + offset, last_memory_map.data,
+      last_memory_map.size);
 
-  /* copy incoming_memory into new_memory*/
+  /* copy incoming_memory into new_memory */
   if (!gst_memory_map (memory, &incoming_memory_map, GST_MAP_READ)) {
     nns_loge ("Failed to map incoming memory");
     gst_memory_unref (new_memory);
@@ -1686,7 +1692,8 @@ gst_tensors_extra_append_memory_to_buffer (GstBuffer * buffer, GstMemory * memor
     gst_tensor_info_copy (&new_memory_extra_info->infos[i], tensor_info);
   }
 
-  memcpy (new_memory_map.data + offset + last_memory_map.size, incoming_memory_map.data, incoming_memory_map.size);
+  memcpy (new_memory_map.data + offset + last_memory_map.size,
+      incoming_memory_map.data, incoming_memory_map.size);
 
   gst_memory_unmap (new_memory, &new_memory_map);
   gst_memory_unmap (memory, &incoming_memory_map);

--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -1556,3 +1556,144 @@ gst_tensors_get_nth_memory (GstBuffer * buffer, const GstTensorsInfo * info, con
 
   return res_mem;
 }
+
+/**
+ * @brief Check if given @a mem has extra tensors.
+ * @param[in] mem GstMemory to be checked.
+ * @return TRUE if @mem has extra tensors, otherwise FALSE.
+*/
+gboolean
+is_extra_tensors_memory (GstMemory * mem)
+{
+  GstMapInfo map;
+  GstTensorExtraInfo *extra_info;
+
+  g_return_val_if_fail (mem != NULL, FALSE);
+
+  if (!gst_memory_map (mem, &map, GST_MAP_READ)) {
+    nns_loge ("Failed to map extra memory");
+    return FALSE;
+  }
+
+  extra_info = (GstTensorExtraInfo *) map.data;
+  g_return_val_if_fail (extra_info != NULL, FALSE);
+
+  /* check header (extra info) of the memory */
+  /* check magic */
+  if (extra_info->magic != NNS_TENSOR_EXTRA_MAGIC) {
+    gst_memory_unmap (mem, &map);
+    return FALSE;
+  }
+
+  gst_memory_unmap (mem, &map);
+  return TRUE;
+}
+
+/**
+ * @brief Append @a memory to given @a buffer.
+ * @param[in/out] buffer GstBuffer to be appended.
+ * @param[in] memory GstMemory to append. This function will take ownership of this.
+ * @param[in] tensor_info GstTensorInfo of given @a memory.
+ * @return TRUE if successfully appended, otherwise FALSE.
+*/
+gboolean
+gst_tensors_extra_append_memory_to_buffer (GstBuffer * buffer, GstMemory * memory, const GstTensorInfo * tensor_info)
+{
+  guint num_mems, offset, i;
+
+  GstMemory *new_memory, *last_memory;
+  gsize new_mem_size;
+
+  GstMapInfo new_memory_map, last_memory_map, incoming_memory_map;
+  GstTensorExtraInfo *new_memory_extra_info;
+
+  if (!GST_IS_BUFFER (buffer)) {
+    nns_loge ("Failed to append memory, given buffer is invalid.");
+    return FALSE;
+  }
+
+  if (!memory) {
+    nns_loge ("Failed to append memory, given memory is NULL.");
+    return FALSE;
+  }
+
+  num_mems = gst_buffer_n_memory (buffer);
+
+  /* trivial call to gst_buffer_append_memory */
+  if (num_mems < NNS_TENSOR_SIZE_LIMIT) {
+    gst_buffer_append_memory (buffer, memory);
+    return TRUE;
+  }
+
+  /* given buffer has NNS_TENSOR_SIZE_LIMIT memory blocks */
+  last_memory = gst_buffer_peek_memory (buffer, num_mems - 1);
+  if (!last_memory) {
+    nns_loge ("Failed to get last memory");
+    return FALSE;
+  }
+
+  new_mem_size = gst_memory_get_sizes (last_memory, NULL, NULL);
+
+  /* if the memory does not have proper header, append it */
+  if (!is_extra_tensors_memory (last_memory)) {
+    new_mem_size += sizeof (GstTensorExtraInfo);
+  }
+
+  new_mem_size += gst_memory_get_sizes (memory, NULL, NULL);
+
+  new_memory = gst_allocator_alloc (NULL, new_mem_size, NULL);
+  if (!new_memory) {
+    nns_loge ("Failed to allocate memory for extra tensors.");
+    return FALSE;
+  }
+
+  if (!gst_memory_map (new_memory, &new_memory_map, GST_MAP_WRITE)) {
+    nns_loge ("Failed to map extra memory");
+    gst_memory_unref (new_memory);
+    return FALSE;
+  }
+
+  /* copy last_memory into new_memory */
+  if (!gst_memory_map (last_memory, &last_memory_map, GST_MAP_READ)) {
+    nns_loge ("Failed to map last memory");
+    gst_memory_unref (new_memory);
+    return FALSE;
+  }
+
+  /* if the last_memory does not have proper header, append it */
+  if (!is_extra_tensors_memory (last_memory)) {
+    GstTensorExtraInfo *extra_info = (GstTensorExtraInfo *) new_memory_map.data;
+    gst_tensors_extra_init (extra_info, last_memory);
+    extra_info->reserved = gst_memory_get_sizes (last_memory, NULL, NULL);
+    offset = sizeof (GstTensorExtraInfo);
+  } else {
+    offset = 0;
+  }
+
+  memcpy (new_memory_map.data + offset, last_memory_map.data, last_memory_map.size);
+
+  /* copy incoming_memory into new_memory*/
+  if (!gst_memory_map (memory, &incoming_memory_map, GST_MAP_READ)) {
+    nns_loge ("Failed to map incoming memory");
+    gst_memory_unref (new_memory);
+    return FALSE;
+  }
+
+  new_memory_extra_info = (GstTensorExtraInfo *) new_memory_map.data;
+  new_memory_extra_info->num_extra_tensors += 1;
+
+  for (i = 0; i < new_memory_extra_info->num_extra_tensors; ++i) {
+    gst_tensor_info_copy (&new_memory_extra_info->infos[i], tensor_info);
+  }
+
+  memcpy (new_memory_map.data + offset + last_memory_map.size, incoming_memory_map.data, incoming_memory_map.size);
+
+  gst_memory_unmap (new_memory, &new_memory_map);
+  gst_memory_unmap (memory, &incoming_memory_map);
+  gst_memory_unmap (last_memory, &last_memory_map);
+
+  gst_memory_unref (memory);
+  gst_buffer_replace_memory (buffer, num_mems - 1, new_memory);
+
+  return TRUE;
+}


### PR DESCRIPTION
- Add header structure for 16+th tensors
- Those tensors would be packed into 16th GstMemory in a GstBuffer.
- Define NNS_TENSOR_SIZE_EXTRA_LIMIT as 200
- Add an init API `gst_tensors_extra_init`
- Add an API `gst_tensors_get_nth_memory` which returns GstMemory from given GstBuffer with index larger than 16.

unittest:
- Add a simple TC which push and get 20 tensors.
- Note that the pipeline used in this TC does not care about the caps or negotiation.

TODO:
- Add APIs for `GstTensorInfo` of 16+th tensors. These will be used in each nnstreamer element for configuration and negotiation.
- Implement proper behavior of tensor_mux and tensor_merge.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>
