### PR TITLE
[tensor_converter] Remove a seemingly unnecessary caps attribute views=1

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_converter.c
+++ b/gst/nnstreamer/elements/gsttensor_converter.c
@@ -1429,7 +1429,7 @@ gst_tensor_converter_parse_video (GstTensorConverter * self,
    */
   GstVideoInfo vinfo;
   GstVideoFormat format;
-  gint width, height;
+  gint width, height, views;
   guint i;
 
   g_return_val_if_fail (config != NULL, FALSE);
@@ -1449,6 +1449,13 @@ gst_tensor_converter_parse_video (GstTensorConverter * self,
   format = GST_VIDEO_INFO_FORMAT (&vinfo);
   width = GST_VIDEO_INFO_WIDTH (&vinfo);
   height = GST_VIDEO_INFO_HEIGHT (&vinfo);
+  views = GST_VIDEO_INFO_VIEWS (&vinfo);
+
+  if (views > 1) {
+    GST_WARNING_OBJECT (self,
+        "Incoming video caps should have 'views=(int)1 but has views=(int)%d - ignoring all but view #0. \n",
+        views);
+  }
 
   config->info.num_tensors = 1;
 

--- a/gst/nnstreamer/elements/gsttensor_converter_media_info_video.h
+++ b/gst/nnstreamer/elements/gsttensor_converter_media_info_video.h
@@ -27,7 +27,7 @@
  */
 #define VIDEO_CAPS_STR \
     GST_VIDEO_CAPS_MAKE ("{ RGB, BGR, RGBx, BGRx, xRGB, xBGR, RGBA, BGRA, ARGB, ABGR, GRAY8 }") \
-    ", views = (int) 1, interlace-mode = (string) progressive"
+    ", interlace-mode = (string) progressive"
 
 #define append_video_caps_template(caps) \
     gst_caps_append (caps, gst_caps_from_string (VIDEO_CAPS_STR))


### PR DESCRIPTION
This fix makes tensor_converter compatible with vaapih264dec and adds a WARNING if incoming video caps views>1.

The need for this workaround and warning has been surfaced because of a bug in vaapih264hdec https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/1712 which provides `video/x-raw, ... multiview-mode=(string)mono, ... views=(int)2`. The caps restriction of `views=(int)1` prohibits the successful negotiation.

This has been tested with a mono video but not with a truly stereoscopic video which might need further handling in the buffer processing.