### PR TITLE
[tensor_trainer] Add epochs property

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -63,7 +63,7 @@ struct _GstTensorTrainer
   GstTensorsInfo output_meta;
   GstTensorsConfig out_config;
 
-  gint64 total_invoke_num;      /**< number of total invokes */
+  gint64 total_push_data_cnt;      /**< number of total push data */
   gboolean fw_created;
 
   void *privateData; /**< NNFW plugin's private data is stored here */


### PR DESCRIPTION
 Add epochs property   
 - Add epochs property to inform the total amount of data subplugin can receive
 - tensor_trainer should receive total number of samples (num-training-samples + num-validation-samples) * epochs
 - Change data type of some properties from uint to int64
 - Modify Example launch

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped