### PR TITLE
github-action/risc-v test update

### DIFF
--- a/.github/workflows/risc-v.yml
+++ b/.github/workflows/risc-v.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build on Ubuntu 20.04 RISC-V 64
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: myungjoo/run-on-arch-action@master
+      - uses: nnstreamer/run-on-arch-action@master
         name: Run commands
         id: Build
         with:
@@ -21,7 +21,7 @@ jobs:
             apt-get -qy update
             apt-get -qy install meson ninja-build libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libglib2.0-dev libjson-glib-dev gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good libgtest-dev libpng-dev libopencv-dev python3 python3-dev python3-numpy pkg-config gcc g++ liblua5.1-dev bash wget libpng-dev
             bash .github/workflows/get_ssat.sh
-            meson build
+            meson build -Denable-tizen=false -Denable-test=true
             ninja -C build
             export NNSTREAMER_SOURCE_ROOT_PATH=$(pwd)
             export NNSTREAMER_BUILD_ROOT_PATH=$(pwd)/build


### PR DESCRIPTION
Use dockerfile of nnstreamer's fork designed for nnstreamer packages.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

