### PR TITLE
[common] Add extra info for 16+th tensors 

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
@@ -453,5 +453,19 @@ nnstreamer_version_string (void);
 extern void
 nnstreamer_version_fetch (guint * major, guint * minor, guint * micro);
 
+/**
+ * @brief Allocate and initialize the extra info in given tensors info.
+ * @param[in,out] info GstTensorsInfo to be updated.
+*/
+extern gboolean
+gst_tensors_info_extra_create (GstTensorsInfo * info);
+
+/**
+ * @brief Free allocated extra info in given tensors info.
+ * @param[in,out] info GstTensorsInfo to be updated
+*/
+extern void
+gst_tensors_info_extra_free (GstTensorsInfo * info);
+
 G_END_DECLS
 #endif /* __NNS_PLUGIN_API_UTIL_H__ */

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -246,6 +246,7 @@ typedef struct
 {
   unsigned int num_tensors; /**< The number of tensors */
   GstTensorInfo info[NNS_TENSOR_SIZE_LIMIT]; /**< The list of tensor info */
+  GstTensorInfo *extra; /**< The list of tensor info for tensors whose idx is larger than NNS_TENSOR_SIZE_LIMIT */
   tensor_format format; /**< tensor stream type */
 } GstTensorsInfo;
 

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -885,6 +885,25 @@ TEST (commonTensorsInfo, getNameInvalidParam1_n)
 }
 
 /**
+ * @brief Test for creating extra info with invalid param.
+ */
+TEST (commonTensorsInfo, createExtraInfo_n)
+{
+  EXPECT_FALSE (gst_tensors_info_extra_create (NULL));
+}
+
+/**
+ * @brief Test for creating extra info.
+*/
+TEST (commonTensorsInfo, createExtraInfo)
+{
+  GstTensorsInfo info;
+  gst_tensors_info_init (&info);
+  EXPECT_TRUE (gst_tensors_info_extra_create (&info));
+  gst_tensors_info_free (&info);
+}
+
+/**
  * @brief Test for same tensors config.
  */
 TEST (commonTensorsConfig, equal01_p)
@@ -1112,10 +1131,35 @@ TEST (commonTensorsInfoString, dimensions)
   EXPECT_TRUE (gst_tensor_dimension_string_is_equal (str_dims, "1:1:1:1,2:2:1:1,3:3:3:1,4:4:4:4"));
   g_free (str_dims);
 
-  /* max */
+  /* extra */
   num_dims = gst_tensors_info_parse_dimensions_string (&info,
       "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20");
-  EXPECT_EQ (num_dims, (guint)NNS_TENSOR_SIZE_LIMIT);
+  EXPECT_EQ (num_dims, 20U);
+  info.num_tensors = num_dims;
+
+  str_dims = gst_tensors_info_get_dimensions_string (&info);
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (str_dims,
+      "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"));
+
+  g_free (str_dims);
+
+  /* max (NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT) */
+  GString *max_dims = g_string_new (NULL);
+  guint exceed_lim = NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT + 11;
+  for (guint i = 0; i < exceed_lim; i++) {
+    g_string_append_printf (max_dims, "%d", i);
+    if (i < exceed_lim - 1)
+      g_string_append (max_dims, ",");
+  }
+
+  str_dims = g_string_free (max_dims, FALSE);
+
+  num_dims = gst_tensors_info_parse_dimensions_string (&info, str_dims);
+  EXPECT_NE (num_dims, exceed_lim);
+  EXPECT_EQ (num_dims, (guint) (NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT));
+
+  g_free (str_dims);
+  gst_tensors_info_free (&info);
 }
 
 /**
@@ -1149,11 +1193,36 @@ TEST (commonTensorsInfoString, types)
   EXPECT_STREQ (str_types, "int8,int16,int32,int64");
   g_free (str_types);
 
-  /* max */
+  /* extra */
   num_types = gst_tensors_info_parse_types_string (&info,
       "int8, int8, int8, int8, int8, int8, int8, int8, int8, int8, int8, "
       "int8, int8, int8, int8, int8, int8, int8, int8, int8, int8, int8");
-  EXPECT_EQ (num_types, (guint)NNS_TENSOR_SIZE_LIMIT);
+  EXPECT_EQ (num_types, 22U);
+
+  info.num_tensors = num_types;
+  str_types = gst_tensors_info_get_types_string (&info);
+  EXPECT_STREQ (str_types,
+      "int8,int8,int8,int8,int8,int8,int8,int8,int8,int8,int8,"
+      "int8,int8,int8,int8,int8,int8,int8,int8,int8,int8,int8");
+  g_free (str_types);
+
+  /* max (NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT) */
+  GString *max_types = g_string_new (NULL);
+  guint exceed_lim = NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT + 13;
+  for (guint i = 0; i < exceed_lim; i++) {
+    g_string_append_printf (max_types, "%s", "uint8");
+    if (i < exceed_lim - 1)
+      g_string_append (max_types, ",");
+  }
+
+  str_types = g_string_free (max_types, FALSE);
+
+  num_types = gst_tensors_info_parse_types_string (&info, str_types);
+  EXPECT_NE (num_types, exceed_lim);
+  EXPECT_EQ (num_types, (guint) (NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT));
+
+  g_free (str_types);
+  gst_tensors_info_free (&info);
 }
 
 /**
@@ -1202,12 +1271,35 @@ TEST (commonTensorsInfoString, names)
   g_free (str_names);
   gst_tensors_info_free (&info);
 
-  /* max */
+  /* extra */
+  gst_tensors_info_init (&info);
   num_names = gst_tensors_info_parse_names_string (&info,
       "t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, "
       "t16, t17, t18, t19, t20, t21, t22, t23, t24, t25, t26, t27, t28");
-  EXPECT_EQ (num_names, (guint)NNS_TENSOR_SIZE_LIMIT);
+  EXPECT_EQ (num_names, 28U);
   info.num_tensors = num_names;
+
+  str_names = gst_tensors_info_get_names_string (&info);
+  EXPECT_STREQ (str_names, "t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14,t15,"
+      "t16,t17,t18,t19,t20,t21,t22,t23,t24,t25,t26,t27,t28");
+  g_free (str_names);
+
+  /* max (NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT) */
+  GString *max_names = g_string_new (NULL);
+  guint exceed_lim = NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT + 17;
+  for (i = 0; i < exceed_lim; i++) {
+    g_string_append_printf (max_names, "t%d", i);
+    if (i < exceed_lim - 1)
+      g_string_append (max_names, ",");
+  }
+
+  str_names = g_string_free (max_names, FALSE);
+
+  num_names = gst_tensors_info_parse_names_string (&info, str_names);
+  EXPECT_NE (num_names, exceed_lim);
+  EXPECT_EQ (num_names, (guint) (NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT));
+
+  g_free (str_names);
   gst_tensors_info_free (&info);
 }
 

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -6431,6 +6431,8 @@ _manual_extra_tensors_new_data_cb (GstElement *element, GstBuffer *buffer, gpoin
   gint *output, i;
   gboolean ret;
   GstTensorsInfo ts_info;
+
+  gst_tensors_info_init (&ts_info);
   ts_info.num_tensors = 20;
 
   data_received++;
@@ -6443,10 +6445,12 @@ _manual_extra_tensors_new_data_cb (GstElement *element, GstBuffer *buffer, gpoin
     gst_memory_unmap (mem_res, &info_res);
     gst_memory_unref (mem_res);
   }
+
+  gst_tensors_info_free (&ts_info);
 }
 
 /**
- * @brief TBU
+ * @brief Test for extra tensors which are created with gst_tensors_extra_append_memory_to_buffer API.
  */
 TEST (extraTensors, manualextratensors)
 {


### PR DESCRIPTION
- Add a pointer of GstTensorInfo in GstTensorsInfo struct. And name it  as "extra"
- Add create and free APIs for extra info
- Fix get/parse utils for type, dim, name of tensor_info
- Fix tests that check NNS_TENSOR_SIZE_LIMIT in get/parse type/dim/name of tensor_info

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>