### PR TITLE
[Test] Fix the test failure

### DIFF
--- a/tests/tizen_sensor/unittest_tizen_sensor.cc
+++ b/tests/tizen_sensor/unittest_tizen_sensor.cc
@@ -395,7 +395,9 @@ TEST (tizensensorAsSource, virtualSensorCreate07_n)
   pipeline = g_strdup_printf ("tensor_src_tizensensor type=invalid_sensor ! tensor_sink");
   pipe = gst_parse_launch (pipeline, &err);
 
-  if (pipe) {
+  if (err) {
+    failed = TRUE;
+  } else if (pipe) {
     ret = gst_element_set_state (pipe, GST_STATE_PAUSED);
     failed = (ret == GST_STATE_CHANGE_FAILURE);
     gst_object_unref (pipe);


### PR DESCRIPTION
After upgrading the version of GStreamer to 1.22.0, the test case of the Tizen sensor filter failed. This is mainly because `gst_parse_launch()` can return a non-NULL value even though the error is set. So `error` should be checked first before using the return value of `gst_parse_launch()`. This code fixes this bug.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

### Related issue
* Link: https://quickbuild.tizen.org/build/153434/gbs_reports/standard-armv7l
```bash
...
[  196s] [ RUN      ] tizensensorAsSource.virtualSensorCreate07_n
[  196s] 
[  196s] (unittest_tizen_sensor:272725): GStreamer-CRITICAL **: 01:09:02.734: 
[  196s] Trying to dispose element tensorsink1, but it is in READY instead of the NULL state.
[  196s] You need to explicitly set elements to the NULL state before
[  196s] dropping the final reference, to allow them to clean up.
[  196s] This problem may also be caused by a refcounting bug in the
[  196s] application or some element.
[  196s] 
[  196s] ../tests/tizen_sensor/unittest_tizen_sensor.cc:406: Failure
[  196s] Value of: failed
[  196s]   Actual: false
[  196s] Expected: true
[  196s] [  FAILED  ] tizensensorAsSource.virtualSensorCreate07_n (14 ms)
[  196s] [ RUN      ] tizensensorAsSource.getProperty1
...
```

