### PR TITLE
[datareposrc] Add supportable caps and function to read file

### DIFF
--- a/gst/datarepo/gstdatareposrc.c
+++ b/gst/datarepo/gstdatareposrc.c
@@ -12,16 +12,14 @@
  *
  * ## Example launch line
  * |[
- * gst-launch-1.0 repo_src location=mnist_trainingSet.dat ! \
+ * gst-launch-1.0 datareposrc location=mnist_trainingSet.dat ! \
  * other/tensors, format=static, num_tensors=2, framerate=0/1, \
  * dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! tensor_sink
  * ]|
- * 
  * |[
- * gst-launch-1.0 repo_src location=mnist_trainingSet.dat ! \
- * application/octet-stream ! \
- * tensor_converter input-dim=1:1:784:1,1:1:10:1 input-type=float32,float32 ! \
- * tensor_sink
+ * gst-launch-1.0 datareposrc location=image_%02ld.png ! pngdec ! fakesink
+ * gst-launch-1.0 datareposrc location=audiofile ! audio/x-raw, format=S8, rate=48000, channels=2 ! fakesink
+ * gst-launch-1.0 datareposrc location=videofile ! video/x-raw, format=RGB, width=320, height=240 ! fakesink
  * ]|
  */
 
@@ -29,7 +27,11 @@
 #include <config.h>
 #endif
 #include <gst/gst.h>
+#include <gst/video/video-info.h>
+#include <gst/audio/audio-info.h>
 #include <glib/gstdio.h>
+#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_util.h>
 #include <stdio.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -38,7 +40,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <inttypes.h>
-#include "nnstreamer_util.h"
 #include "gstdatareposrc.h"
 
 #define struct_stat struct stat
@@ -57,10 +58,52 @@
 #define O_BINARY (0)
 #endif
 
-static GstStaticPadTemplate srctemplate = GST_STATIC_PAD_TEMPLATE ("src",
-    GST_PAD_SRC,
-    GST_PAD_ALWAYS,
-    GST_STATIC_CAPS_ANY);
+/**
+ * @brief Default blocksize for reading
+ */
+#define DEFAULT_BLOCKSIZE       4*1024
+
+/**
+ * @brief Tensors caps
+ */
+#define TENSOR_CAPS GST_TENSORS_CAP_MAKE ("{ static, flexible }")
+/**
+ * @brief Video caps
+ */
+#define SUPPORTED_VIDEO_FORMAT \
+  "{RGB, BGR, RGBx, BGRx, xRGB, xBGR, RGBA, BGRA, ARGB, ABGR, GRAY8}"
+#define VIDEO_CAPS GST_VIDEO_CAPS_MAKE (SUPPORTED_VIDEO_FORMAT) "," \
+  "interlace-mode = (string) progressive"
+/**
+ * @brief Audio caps
+ */
+#define SUPPORTED_AUDIO_FORMAT \
+  "{S8, U8, S16LE, S16BE, U16LE, U16BE, S32LE, S32BE, U32LE, U32BE, F32LE, F32BE, F64LE, F64BE}"
+#define AUDIO_CAPS GST_AUDIO_CAPS_MAKE (SUPPORTED_AUDIO_FORMAT) "," \
+  "layout = (string) interleaved"
+/**
+ * @brief Text caps
+ */
+#define TEXT_CAPS "text/x-raw, format = (string) utf8"
+/**
+ * @brief Octet caps
+ */
+#define OCTET_CAPS "application/octet-stream"
+
+/**
+ * @brief Image caps
+ */
+#define IMAGE_CAPS \
+  "image/png, width = (int) [ 16, 1000000 ], height = (int) [ 16, 1000000 ], framerate = (fraction) [ 0/1, MAX];" \
+  "image/jpeg, width = (int) [ 16, 65535 ], height = (int) [ 16, 65535 ], framerate = (fraction) [ 0/1, MAX], sof-marker = (int) { 0, 1, 2, 4, 9 };" \
+  "image/tiff, endianness = (int) { BIG_ENDIAN, LITTLE_ENDIAN };" \
+  "image/gif"
+
+static GstStaticPadTemplate srctemplate =
+    GST_STATIC_PAD_TEMPLATE ("src", GST_PAD_SRC, GST_PAD_ALWAYS,
+    GST_STATIC_CAPS (TENSOR_CAPS ";" VIDEO_CAPS ";" AUDIO_CAPS ";" IMAGE_CAPS
+        ";" TEXT_CAPS ";" OCTET_CAPS));
+
 
 GST_DEBUG_CATEGORY_STATIC (gst_data_repo_src_debug);
 #define GST_CAT_DEFAULT gst_data_repo_src_debug
@@ -69,7 +112,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_data_repo_src_debug);
 enum
 {
   PROP_0,
-  PROP_LOCATION
+  PROP_LOCATION,
 };
 
 static void gst_data_repo_src_finalize (GObject * object);
@@ -79,6 +122,10 @@ static void gst_data_repo_src_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec);
 static gboolean gst_data_repo_src_start (GstBaseSrc * basesrc);
 static gboolean gst_data_repo_src_stop (GstBaseSrc * basesrc);
+static GstCaps *gst_data_repo_src_get_caps (GstBaseSrc * basesrc,
+    GstCaps * filter);
+static gboolean gst_data_repo_src_set_caps (GstBaseSrc * basesrc,
+    GstCaps * caps);
 static GstFlowReturn gst_data_repo_src_create (GstPushSrc * pushsrc,
     GstBuffer ** buffer);
 
@@ -107,7 +154,9 @@ gst_data_repo_src_class_init (GstDataRepoSrcClass * klass)
 
   g_object_class_install_property (gobject_class, PROP_LOCATION,
       g_param_spec_string ("location", "File Location",
-          "Location of the file to read", NULL,
+          "Location of the file to read that is stored in MLOps Data Repository"
+          "If the files are image, create pattern name like 'filename%04d.png'",
+          NULL,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS |
           GST_PARAM_MUTABLE_READY));
 
@@ -122,6 +171,8 @@ gst_data_repo_src_class_init (GstDataRepoSrcClass * klass)
 
   gstbasesrc_class->start = GST_DEBUG_FUNCPTR (gst_data_repo_src_start);
   gstbasesrc_class->stop = GST_DEBUG_FUNCPTR (gst_data_repo_src_stop);
+  gstbasesrc_class->get_caps = GST_DEBUG_FUNCPTR (gst_data_repo_src_get_caps);
+  gstbasesrc_class->set_caps = GST_DEBUG_FUNCPTR (gst_data_repo_src_set_caps);
   gstpushsrc_class->create = GST_DEBUG_FUNCPTR (gst_data_repo_src_create);
 
   if (sizeof (off_t) < 8) {
@@ -138,14 +189,14 @@ gst_data_repo_src_init (GstDataRepoSrc * src)
 {
   src->filename = NULL;
   src->fd = 0;
+  src->media_type = _NNS_TENSOR;
   src->offset = 0;
-  src->read_position = 0;
+  src->successful_read = FALSE;
 
-  /* for test */
-  src->length = 3176;           /* Calculation is required using property, 3176 is MNIST size */
-  //src->item_size[0] = 3136; /* Calculation is required using property */
-  //src->item_size[1] = 40; /* Calculation is required using property */
-  src->item_size[0] = 3176;
+/* let's set value by property */
+  src->frame_index = 0;
+  src->start_frame_index = 0;
+  src->stop_frame_index = 0;
 }
 
 /**
@@ -251,90 +302,6 @@ gst_data_repo_src_get_property (GObject * object, guint prop_id, GValue * value,
   }
 }
 
-#if 0
-/**
- * @brief Function to read octet_stream
- */
-static GstFlowReturn
-gst_data_repo_src_read_octet_stream (GstDataRepoSrc * src, GstBuffer ** buffer)
-{
-  int i = 0;
-  GstBuffer *buf;
-  guint to_read, byte_read;
-  int ret;
-  guint8 *data;
-  GstMemory *mem[MAX_ITEM] = { 0, };
-  GstMapInfo info[MAX_ITEM];
-  //guint length; //need to get property
-  //guint64 offset;
-
-  /* for test */
-  mem[0] = gst_allocator_alloc (NULL, src->item_size[0], NULL);
-
-  if (!gst_memory_map (mem[0], &info[0], GST_MAP_WRITE)) {
-    GST_ERROR_OBJECT (src, "Could not map in_mem[%d] GstMemory", i);
-    goto error;
-  }
-
-  data = info[0].data;
-
-  byte_read = 0;
-  to_read = src->length;
-  while (to_read > 0) {
-    GST_LOG_OBJECT (src, "Reading %d bytes at offset 0x%" G_GINT64_MODIFIER "x",
-        to_read, src->offset + byte_read);
-    errno = 0;
-    ret = read (src->fd, data + byte_read, to_read);
-    GST_LOG_OBJECT (src, "Read: %d", ret);
-    if (ret < 0) {
-      if (errno == EAGAIN || errno == EINTR)
-        continue;
-      goto could_not_read;
-    }
-    /* files should eos if they read 0 and more was requested */
-    if (ret == 0) {
-      /* .. but first we should return any remaining data */
-      if (byte_read > 0)
-        break;
-      goto eos;
-    }
-    to_read -= ret;
-    byte_read += ret;
-
-    src->read_position += ret;
-    src->offset += ret;
-  }
-
-  if (mem[0])
-    gst_memory_unmap (mem[0], &info[0]);
-
-  /* todo */
-  /*if (bytes_read != length) */
-  /* in case of media,if blocksize is smaller then frame size, need to check byte_read != length */
-  /* alloc memory using byte_read, memocpy data to new memory, and append */
-
-  buf = gst_buffer_new ();
-  gst_buffer_append_memory (buf, mem[0]);
-
-  *buffer = buf;
-  return GST_FLOW_OK;
-
-could_not_read:
-  {
-    GST_ELEMENT_ERROR (src, RESOURCE, READ, (NULL), GST_ERROR_SYSTEM);
-    gst_memory_unmap (mem[0], &info[0]);
-    return GST_FLOW_ERROR;
-  }
-eos:
-  {
-    GST_DEBUG ("EOS");
-    gst_memory_unmap (mem[0], &info[0]);
-    return GST_FLOW_EOS;
-  }
-error:
-  return GST_FLOW_ERROR;
-}
-#endif
 /**
  * @brief Function to read tensors
  */
@@ -349,24 +316,21 @@ gst_data_repo_src_read_tensors (GstDataRepoSrc * src, GstBuffer ** buffer)
   GstMemory *mem[MAX_ITEM] = { 0, };
   GstMapInfo info[MAX_ITEM];
 
-  /* for MNIST test */
-  src->item_size[0] = 3136;
-  src->item_size[1] = 40;
-
   buf = gst_buffer_new ();
 
+  /** @todo : features and labels indexing with featuer and label index property */
   for (i = 0; i < 2; i++) {
-    mem[i] = gst_allocator_alloc (NULL, src->item_size[i], NULL);
+    mem[i] = gst_allocator_alloc (NULL, src->tensors_size[i], NULL);
 
     if (!gst_memory_map (mem[i], &info[i], GST_MAP_WRITE)) {
-      GST_ERROR_OBJECT (src, "Could not map in_mem[%d] GstMemory", i);
+      GST_ERROR_OBJECT (src, "Could not map GstMemory[%d]", i);
       goto error;
     }
 
     data = info[i].data;
 
     byte_read = 0;
-    to_read = src->item_size[i];
+    to_read = src->tensors_size[i];
     while (to_read > 0) {
       GST_LOG_OBJECT (src,
           "Reading %d bytes at offset 0x%" G_GINT64_MODIFIER "x", to_read,
@@ -396,13 +360,9 @@ gst_data_repo_src_read_tensors (GstDataRepoSrc * src, GstBuffer ** buffer)
     if (mem[i])
       gst_memory_unmap (mem[i], &info[i]);
 
-    /* TODO */
-    /*if (bytes_read != length) */
-    /* in case of media,if blocksize is smaller then frame size, need to check byte_read != length */
-    /* alloc memory using byte_read, memocpy data to new memory, and append */
-
     gst_buffer_append_memory (buf, mem[i]);
   }
+
   *buffer = buf;
 
   return GST_FLOW_OK;
@@ -426,25 +386,188 @@ error:
   return GST_FLOW_ERROR;
 }
 
+
+/**
+ * @brief Get image filename
+ */
+static gchar *
+gst_data_repo_src_get_image_filename (GstDataRepoSrc * src)
+{
+  gchar *filename = NULL;
+
+  g_return_val_if_fail (src->media_type == _NNS_IMAGE, NULL);
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
+  /* let's set value by property */
+  filename = g_strdup_printf (src->filename, src->frame_index);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+  return filename;
+}
+
+/**
+ * @brief Function to read multi image files
+ */
+static GstFlowReturn
+gst_data_repo_src_read_multi_images (GstDataRepoSrc * src, GstBuffer ** buffer)
+{
+  gsize size;
+  gchar *data;
+  gchar *filename;
+  GstBuffer *buf;
+  gboolean ret;
+  GError *error = NULL;
+
+  filename = gst_data_repo_src_get_image_filename (src);
+  GST_DEBUG_OBJECT (src, "Reading from file \"%s\".", filename);
+
+  /* Try to read one image */
+  ret = g_file_get_contents (filename, &data, &size, &error);
+  if (!ret) {
+    if (src->successful_read) {
+      /* If we've read at least one buffer successfully, not finding the next file is EOS. */
+      g_free (filename);
+      if (error != NULL)
+        g_error_free (error);
+      return GST_FLOW_EOS;
+    }
+    goto handle_error;
+  }
+
+  /* Success reading on image */
+  src->successful_read = TRUE;
+  GST_DEBUG_OBJECT (src, "file size is %zd", size);
+  /* let's set value by property */
+  src->frame_index++;
+
+  buf = gst_buffer_new ();
+  gst_buffer_append_memory (buf,
+      gst_memory_new_wrapped (0, data, size, 0, size, data, g_free));
+  GST_DEBUG_OBJECT (src, "read file \"%s\".", filename);
+
+  g_free (filename);
+  *buffer = buf;
+
+  return GST_FLOW_OK;
+
+handle_error:
+  {
+    if (error != NULL) {
+      GST_ELEMENT_ERROR (src, RESOURCE, READ,
+          ("Error while reading from file \"%s\".", filename),
+          ("%s", error->message));
+      g_error_free (error);
+    } else {
+      GST_ELEMENT_ERROR (src, RESOURCE, READ,
+          ("Error while reading from file \"%s\".", filename),
+          ("%s", g_strerror (errno)));
+    }
+    g_free (filename);
+    return GST_FLOW_ERROR;
+  }
+}
+
+/**
+ * @brief Function to read others media type (video, audio, octet and text)
+ */
+static GstFlowReturn
+gst_data_repo_src_read_others (GstDataRepoSrc * src, GstBuffer ** buffer)
+{
+  GstBuffer *buf;
+  guint to_read, byte_read;
+  int ret;
+  guint8 *data;
+  GstMemory *mem;
+  GstMapInfo info;
+
+  mem = gst_allocator_alloc (NULL, src->media_size, NULL);
+
+  if (!gst_memory_map (mem, &info, GST_MAP_WRITE)) {
+    GST_ERROR_OBJECT (src, "Could not map GstMemory");
+    goto error;
+  }
+
+  data = info.data;
+
+  byte_read = 0;
+  to_read = src->media_size;
+  while (to_read > 0) {
+    GST_LOG_OBJECT (src, "Reading %d bytes at offset 0x%" G_GINT64_MODIFIER "x",
+        to_read, src->offset + byte_read);
+    errno = 0;
+    ret = read (src->fd, data + byte_read, to_read);
+    GST_LOG_OBJECT (src, "Read: %d", ret);
+    if (ret < 0) {
+      if (errno == EAGAIN || errno == EINTR)
+        continue;
+      goto could_not_read;
+    }
+    /* files should eos if they read 0 and more was requested */
+    if (ret == 0) {
+      /* .. but first we should return any remaining data */
+      if (byte_read > 0)
+        break;
+      goto eos;
+    }
+    to_read -= ret;
+    byte_read += ret;
+
+    src->read_position += ret;
+    src->offset += ret;
+  }
+
+  if (mem)
+    gst_memory_unmap (mem, &info);
+
+  buf = gst_buffer_new ();
+  gst_buffer_append_memory (buf, mem);
+
+  *buffer = buf;
+  return GST_FLOW_OK;
+
+could_not_read:
+  {
+    GST_ELEMENT_ERROR (src, RESOURCE, READ, (NULL), GST_ERROR_SYSTEM);
+    gst_memory_unmap (mem, &info);
+    return GST_FLOW_ERROR;
+  }
+eos:
+  {
+    GST_DEBUG ("EOS");
+    gst_memory_unmap (mem, &info);
+    return GST_FLOW_EOS;
+  }
+error:
+  return GST_FLOW_ERROR;
+}
+
 /**
  * @brief Function to create a buffer
  */
 static GstFlowReturn
 gst_data_repo_src_create (GstPushSrc * pushsrc, GstBuffer ** buffer)
 {
-  GstFlowReturn ret;
   GstDataRepoSrc *src;
   src = GST_DATA_REPO_SRC (pushsrc);
 
-  //let's read data by property?
-#if 0
-  /*case application/octet-stream */
-  ret = gst_data_repo_src_read_octet_stream (src, buffer);
-#else
-  ret = gst_data_repo_src_read_tensors (src, buffer);
-#endif
-
-  return ret;
+  switch (src->media_type) {
+    case _NNS_TENSOR:
+      return gst_data_repo_src_read_tensors (src, buffer);
+    case _NNS_IMAGE:
+      return gst_data_repo_src_read_multi_images (src, buffer);
+    case _NNS_VIDEO:
+    case _NNS_AUDIO:
+    case _NNS_TEXT:
+    case _NNS_OCTET:
+      return gst_data_repo_src_read_others (src, buffer);
+    default:
+      return GST_FLOW_ERROR;
+  }
 }
 
 /**
@@ -454,16 +577,26 @@ static gboolean
 gst_data_repo_src_start (GstBaseSrc * basesrc)
 {
   struct_stat stat_results;
+  gchar *filename = NULL;
   GstDataRepoSrc *src = GST_DATA_REPO_SRC (basesrc);
   int flags = O_RDONLY | O_BINARY;
 
   if (src->filename == NULL || src->filename[0] == '\0')
     goto no_filename;
 
-  GST_INFO_OBJECT (src, "opening file %s", src->filename);
+  /* let's set value by property */
+  src->frame_index = src->start_frame_index;
+
+  if (src->media_type == _NNS_IMAGE) {
+    filename = gst_data_repo_src_get_image_filename (src);
+  } else {
+    filename = g_strdup (src->filename);
+  }
+
+  GST_INFO_OBJECT (src, "opening file %s", filename);
 
   /* open the file */
-  src->fd = g_open (src->filename, flags, 0);
+  src->fd = g_open (filename, flags, 0);
 
   if (src->fd < 0)
     goto open_failed;
@@ -483,6 +616,14 @@ gst_data_repo_src_start (GstBaseSrc * basesrc)
     goto error_close;;
 
   src->read_position = 0;
+
+  if (src->media_type == _NNS_IMAGE) {
+    /* no longer used */
+    g_close (src->fd, NULL);
+    src->fd = 0;
+  }
+
+  g_free (filename);
 
   return TRUE;
 
@@ -528,8 +669,10 @@ was_socket:
   }
 
 error_close:
-  close (src->fd);
+  g_close (src->fd, NULL);
+  src->fd = 0;
 error_exit:
+  g_free (filename);
   return FALSE;
 }
 
@@ -546,4 +689,187 @@ gst_data_repo_src_stop (GstBaseSrc * basesrc)
   src->fd = 0;
 
   return TRUE;
+}
+
+/**
+ * @brief Get caps for caps negotiation
+ */
+static GstCaps *
+gst_data_repo_src_get_caps (GstBaseSrc * basesrc, GstCaps * filter)
+{
+  GstDataRepoSrc *src = GST_DATA_REPO_SRC (basesrc);
+  GstCaps *caps = NULL;
+
+  caps = gst_pad_get_pad_template_caps (GST_BASE_SRC_PAD (src));
+  caps = gst_caps_make_writable (caps);
+
+  GST_DEBUG_OBJECT (src, "get caps: %" GST_PTR_FORMAT, caps);
+
+  if (filter) {
+    GstCaps *intersection;
+
+    intersection =
+        gst_caps_intersect_full (filter, caps, GST_CAPS_INTERSECT_FIRST);
+    gst_caps_unref (caps);
+    caps = intersection;
+  }
+  GST_DEBUG_OBJECT (src, "get caps: %" GST_PTR_FORMAT, caps);
+  return caps;
+}
+
+/**
+ * @brief Get tensors size
+ */
+static guint
+gst_data_repo_src_get_tensors_size (GstDataRepoSrc * src, const GstCaps * caps)
+{
+  GstStructure *s;
+  GstTensorsConfig config;
+  guint size = 0;
+  guint i = 0;
+
+  g_return_val_if_fail (src != NULL, 0);
+  g_return_val_if_fail (caps != NULL, 0);
+
+  s = gst_caps_get_structure (caps, 0);
+  if (!gst_tensors_config_from_structure (&config, s))
+    return 0;
+
+  for (i = 0; i < config.info.num_tensors; i++) {
+    src->tensors_size[i] = gst_tensor_info_get_size (&config.info.info[i]);
+    GST_DEBUG ("%dth size is %d", i, src->tensors_size[i]);
+    size = size + src->tensors_size[i];
+  }
+
+  gst_tensors_config_free (&config);
+
+  return size;
+}
+
+/**
+ * @brief Get video size
+ */
+static guint
+gst_data_repo_src_get_video_size (const GstCaps * caps)
+{
+  GstStructure *s;
+  const gchar *format_str;
+  gint width = 0, height = 0;
+  GstVideoInfo video_info;
+  guint size = 0;
+
+  g_return_val_if_fail (caps != NULL, 0);
+
+  s = gst_caps_get_structure (caps, 0);
+  gst_video_info_init (&video_info);
+  gst_video_info_from_caps (&video_info, caps);
+
+  format_str = gst_structure_get_string (s, "format");
+  width = GST_VIDEO_INFO_WIDTH (&video_info);
+  height = GST_VIDEO_INFO_HEIGHT (&video_info);
+  /** https://gstreamer.freedesktop.org/documentation/additional/design/mediatype-video-raw.html?gi-language=c */
+  size = (guint) GST_VIDEO_INFO_SIZE (&video_info);
+  GST_DEBUG ("format(%s), width(%d), height(%d): %d Byte/frame", format_str,
+      width, height, size);
+
+  return size;
+}
+
+/**
+ * @brief Get audio size
+ */
+static guint
+gst_data_repo_src_get_audio_size (const GstCaps * caps)
+{
+  GstStructure *s;
+  const gchar *format_str;
+  guint size = 0;
+  gint rate = 0, channel = 0;
+  GstAudioInfo audio_info;
+  gint depth;
+
+  g_return_val_if_fail (caps != NULL, 0);
+
+  s = gst_caps_get_structure (caps, 0);
+  gst_audio_info_init (&audio_info);
+  gst_audio_info_from_caps (&audio_info, caps);
+
+  format_str = gst_structure_get_string (s, "format");
+  rate = GST_AUDIO_INFO_RATE (&audio_info);
+  channel = GST_AUDIO_INFO_CHANNELS (&audio_info);
+  depth = GST_AUDIO_INFO_DEPTH (&audio_info);
+
+  size = channel * (depth / 8) * rate;
+  GST_DEBUG ("format(%s), depth(%d), rate(%d), channel(%d): %d Bps", format_str,
+      depth, rate, channel, size);
+
+  return size;
+}
+
+/**
+ * @brief Get media info from caps
+ */
+static gboolean
+gst_data_repo_src_get_media_info (GstDataRepoSrc * src, const GstCaps * caps)
+{
+  GstStructure *s;
+  guint size = 0;
+
+  g_return_val_if_fail (src != NULL, FALSE);
+  g_return_val_if_fail (caps != NULL, FALSE);
+
+  s = gst_caps_get_structure (caps, 0);
+
+  if (gst_structure_has_name (s, "other/tensors")) {
+    size = gst_data_repo_src_get_tensors_size (src, caps);
+    src->media_type = _NNS_TENSOR;
+  } else if (gst_structure_has_name (s, "video/x-raw")) {
+    size = gst_data_repo_src_get_video_size (caps);
+    src->media_type = _NNS_VIDEO;
+  } else if (gst_structure_has_name (s, "audio/x-raw")) {
+    size = gst_data_repo_src_get_audio_size (caps);
+    src->media_type = _NNS_AUDIO;
+  } else if (gst_structure_has_name (s, "text/x-raw")) {
+    src->media_type = _NNS_TEXT;
+  } else if (gst_structure_has_name (s, "application/octet-stream")) {
+    src->media_type = _NNS_OCTET;
+    size = 3176;                /* for test, let's get size from file */
+  } else if (gst_structure_has_name (s, "image/png")
+      || gst_structure_has_name (s, "image/jpeg")
+      || gst_structure_has_name (s, "image/tiff")
+      || gst_structure_has_name (s, "image/gif")) {
+    src->media_type = _NNS_IMAGE;
+    size = DEFAULT_BLOCKSIZE;
+  } else {
+    GST_ERROR_OBJECT (src, "Could not get a media type");
+    return FALSE;
+  }
+
+  /** After caps negotiation, text, and octet only know the mimetype.
+   *  need to get size from file. */
+  if (!size) {
+    GST_ERROR_OBJECT (src, "Could not get size");
+    return FALSE;
+  }
+  src->media_size = size;
+
+  GST_DEBUG_OBJECT (src, "Get media type is %d", src->media_type);
+
+  return TRUE;
+}
+
+/**
+ * @brief caps after caps negotiation
+ */
+static gboolean
+gst_data_repo_src_set_caps (GstBaseSrc * basesrc, GstCaps * caps)
+{
+  int ret = FALSE;
+  GstDataRepoSrc *src = GST_DATA_REPO_SRC (basesrc);
+
+  GST_INFO_OBJECT (src, "set caps: %" GST_PTR_FORMAT, caps);
+
+  ret = gst_data_repo_src_get_media_info (src, caps);
+
+  return ret;
 }

--- a/gst/datarepo/gstdatareposrc.h
+++ b/gst/datarepo/gstdatareposrc.h
@@ -16,7 +16,7 @@
 #include <sys/types.h>
 #include <gst/gst.h>
 #include <gst/base/gstpushsrc.h>
-#include "tensor_typedef.h"
+#include <tensor_typedef.h>
 
 G_BEGIN_DECLS
 #define GST_TYPE_DATA_REPO_SRC \
@@ -30,6 +30,9 @@ G_BEGIN_DECLS
 #define GST_IS_DATA_REPO_SRC_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_DATA_REPO_SRC))
 
+/* media_type has not IMAGE type */
+#define _NNS_IMAGE 5  /**<supposedly image/png, image/jpeg and etc */
+
 #define MAX_ITEM NNS_TENSOR_SIZE_LIMIT
 
 typedef struct _GstDataRepoSrc GstDataRepoSrc;
@@ -42,14 +45,20 @@ struct _GstDataRepoSrc {
 
   GstPushSrc parent; /**< parent object */
 
+  gboolean successful_read; /**< Used for checking EOS when reading more than one images(multi-files) from a path */
   gint fd;	        			  /**< open file descriptor */
   guint64 read_position;		/**< position of fd */
   guint64 offset;
-  guint item_size[MAX_ITEM];
+  guint tensors_size[MAX_ITEM];   /**< For other/tensors media type, each tensor size is stored */
+
+  gint start_frame_index;   /**< Start index of sample to read, in case of image, the starting index of the numbered files */
+  gint stop_frame_index;    /**< End index of sample to read, in case of image, the endig index of the numbered files */
+  gint frame_index;         /**< Current index of sample or file to read */
 
   /* property */
   gchar *filename;          /**< filename */
-  guint length;             /**< buffer size */
+  guint media_size;         /**< media size */
+  guint media_type;         /**< media type */
 
 };
 

--- a/gst/datarepo/meson.build
+++ b/gst/datarepo/meson.build
@@ -1,5 +1,3 @@
-gstdatarepo_src_inc = include_directories('.', '../nnstreamer/include/')
-
 repo_sources = [
   'datarepo_elements.c',
   'gstdatareposrc.c'
@@ -7,16 +5,14 @@ repo_sources = [
 
 gstdatarepo_shared = shared_library('gstdatarepo',
   repo_sources,
-  dependencies: [glib_dep, gst_dep, gst_base_dep],
-  include_directories: gstdatarepo_src_inc,
+  dependencies: [nnstreamer_dep],
   install: true,
   install_dir: plugins_install_dir
 )
 
 gstdatarepo_static = static_library('gstdatarepo',
   repo_sources,
-  dependencies: [glib_dep, gst_dep, gst_base_dep],
-  include_directories: gstdatarepo_src_inc,
+  dependencies: [nnstreamer_dep],
   install: true,
   install_dir: nnstreamer_libdir
 )


### PR DESCRIPTION
- Add supportable caps
  other/tensors, video/x-raw, audio/x-raw, text/x-raw, application/octet-stream
  image/png, image/jpeg, image/tiff, image/gif
    
- Add get_caps and set_caps function for caps negotiation

- Get media mimetype and media size after set_caps
   a. get video size (Byte/frame)
   b. get audio size (Bps)
   c. get tensor type size
    
 - Add function to read file from the MLOps Data repository
   a. In case of tensors, tensors data are added to a single gstbuffer.
   b. In case of image files, a image file is added to a single gstbuffer,
      Images are numbered files
   c. In other cases, data of size calculated in set_caps is added to a singgle gstbuffer

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped