### PR TITLE
[tensor_mux] Fix tensor_mux to support more than 16 sinkpads @open sesame 4/18 12:55

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_mux.c
+++ b/gst/nnstreamer/elements/gsttensor_mux.c
@@ -241,6 +241,8 @@ gst_tensor_mux_finalize (GObject * object)
     tensor_mux->sync.option = NULL;
   }
 
+  gst_tensors_config_free (&tensor_mux->tensors_config);
+
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 

--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -1383,8 +1383,8 @@ gst_tensors_config_from_structure (GstTensorsConfig * config,
           (gint *) (&config->info.num_tensors));
 
       if (config->info.num_tensors > NNS_TENSOR_SIZE_LIMIT) {
-        nns_logw ("Invalid param, max size is %d", NNS_TENSOR_SIZE_LIMIT);
-        config->info.num_tensors = NNS_TENSOR_SIZE_LIMIT;
+        /* create extra info */
+        gst_tensors_info_extra_create (&config->info);
       }
 
       /* parse dimensions */

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -6524,6 +6524,88 @@ TEST (extraTensors, manualextratensors)
 }
 
 /**
+ * @brief Callback for tensor sink signal. Using gst_tensors_get_nth_memory API
+ */
+static void
+_tensor_mux_extra_tensors_new_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  GstMemory *mem_res;
+  GstMapInfo info_res;
+  guint8 *output;
+  gint i;
+  gboolean ret;
+  GstTensorsInfo ts_info;
+
+  gst_tensors_info_init (&ts_info);
+  data_received++;
+  ts_info.num_tensors = 20;
+
+  for (i = 0; i < 20; ++i) {
+    mem_res = gst_tensor_buffer_get_nth_memory (buffer, &ts_info, (guint) i);
+    ret = gst_memory_map (mem_res, &info_res, GST_MAP_READ);
+    ASSERT_TRUE (ret);
+    output = (guint8 *) info_res.data;
+    EXPECT_EQ (16, *output);
+    gst_memory_unmap (mem_res, &info_res);
+    gst_memory_unref (mem_res);
+  }
+}
+
+/**
+ * @brief Test tensor_mux of more than 16 sinkpad.
+ */
+TEST (extraTensors, manualtensormux)
+{
+  gchar *str_pipeline = g_strdup (
+      "videotestsrc num-buffers=1 is-live=true ! videoscale ! videoconvert ! "
+      "video/x-raw,format=GRAY8,width=1,height=1,framerate=1/1 ! "
+      "tensor_converter ! other/tensors,format=static,num_tensors=1,types=(string)uint8,dimensions=(string)1:1 ! tee name=t "
+      "t. ! queue ! mux.sink_0 "
+      "t. ! queue ! mux.sink_1 "
+      "t. ! queue ! mux.sink_2 "
+      "t. ! queue ! mux.sink_3 "
+      "t. ! queue ! mux.sink_4 "
+      "t. ! queue ! mux.sink_5 "
+      "t. ! queue ! mux.sink_6 "
+      "t. ! queue ! mux.sink_7 "
+      "t. ! queue ! mux.sink_8 "
+      "t. ! queue ! mux.sink_9 "
+      "t. ! queue ! mux.sink_10 "
+      "t. ! queue ! mux.sink_11 "
+      "t. ! queue ! mux.sink_12 "
+      "t. ! queue ! mux.sink_13 "
+      "t. ! queue ! mux.sink_14 "
+      "t. ! queue ! mux.sink_15 "
+      "t. ! queue ! mux.sink_16 "
+      "t. ! queue ! mux.sink_17 "
+      "t. ! queue ! mux.sink_18 "
+      "t. ! queue ! mux.sink_19 "
+      "tensor_mux name=mux silent=false ! "
+      "tensor_sink name=sinkx async=false silent=false ");
+
+  GstElement *pipeline = gst_parse_launch (str_pipeline, NULL);
+  EXPECT_NE (pipeline, nullptr);
+
+  GstElement *sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  EXPECT_NE (sink_handle, nullptr);
+
+  g_signal_connect (sink_handle, "new-data", (GCallback) _tensor_mux_extra_tensors_new_data_cb, NULL);
+
+  data_received = 0;
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  g_usleep (1000000);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  g_usleep (1000000);
+
+  EXPECT_EQ (1, data_received);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (pipeline);
+  g_free (str_pipeline);
+}
+
+/**
  * @brief Main function for unit test.
  */
 int


### PR DESCRIPTION
- Update `gst_tensor_time_sync_buffer_from_collectpad` to support extra tensors
- Fix `gst_tensors_config_from_structure` to support extra tensors
- Add a testcase of tensor_mux with 20 sinkpads

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>