### PR TITLE
[API][trainer] Rename some variable to use nouns instead of verbs

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -71,7 +71,7 @@ struct _GstTensorTrainer
   GstTensorTrainerProperties prop; /**< NNFW plugin's properties */
 
   GMutex trainer_lock;
-  GCond train_complete_cond;
+  GCond training_complete_cond;
 };
 
 /**

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -35,11 +35,11 @@ typedef struct _GstTensorTrainerProperties
   const char *model_save_path;    /**< The file path to save the model */
   int64_t num_inputs;    /**< The number of input lists, the input is where framework receive the features to train the model, num_inputs indicates how many inputs there are. */
   int64_t num_labels;    /**< The number of label lists, the label is where framework receive the class to train the model, num_labels indicates how many labels there are. */
-  int64_t num_train_samples;    /**< The number of train sample used to train the model. */
-  int64_t num_valid_samples;    /**< The number of valid sample used to train the model. */
-  int64_t num_epochs;    /**< The number of repetition of total train and valid sample. subplugin must receive total samples((num_train_samples + num_valid_samples) * num_epochs) */
+  int64_t num_training_samples;    /**< The number of training sample used to train the model. */
+  int64_t num_validation_samples;    /**< The number of validation sample used to valid the model. */
+  int64_t num_epochs;    /**< The number of repetition of total training and validation sample. subplugin must receive total samples((num_training_samples + num_validation_samples) * num_epochs) */
 
-  GCond *train_complete_cond;    /**< Tensor trainer wait when receive EOS before model training is complete, subplugin should send signal when model train is complete. */
+  GCond *training_complete_cond;    /**< Tensor trainer wait when receive EOS before model training is complete, subplugin should send signal when model training is complete. */
 } GstTensorTrainerProperties;
 
 /**
@@ -50,7 +50,7 @@ typedef struct _GstTensorTrainerProperties
 typedef struct _GstTensorTrainerFrameworkInfo
 {
   const char *name;    /**< Name of the neural network framework, searchable by FRAMEWORK property. */
-  int train_complete;  /**< Check if train is complete, Use int instead of gboolean because this is refered by custom plugins. */
+  int is_training_complete;  /**< Check if training is complete, Use int instead of gboolean because this is refered by custom plugins. */
   int64_t epoch_cnt;    /**< Number of currently completed epochs */
 } GstTensorTrainerFrameworkInfo;
 


### PR DESCRIPTION
Rename some variable to use nouns instead of verbs
- Rename 'train' and 'valid' to 'training' and 'validation'

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped
