### PR TITLE
[fix][API] Fix a bug that free wrong memory area

### DIFF
--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -1661,7 +1661,7 @@ gst_tensors_extra_append_memory_to_buffer (GstBuffer * buffer,
   /* copy last_memory into new_memory */
   if (!gst_memory_map (last_memory, &last_memory_map, GST_MAP_READ)) {
     nns_loge ("Failed to map last memory");
-    gst_memory_unref (new_memory);
+    gst_memory_unref (last_memory);
     return FALSE;
   }
 


### PR DESCRIPTION
 Fix a bug that free wrong memory area
- Free last_memory instead of new_memory

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped
