### PR TITLE
[datareposrc] Add is-shuffle property

### DIFF
--- a/gst/datarepo/gstdatareposrc.h
+++ b/gst/datarepo/gstdatareposrc.h
@@ -54,16 +54,21 @@ struct _GstDataRepoSrc {
   guint64 last_offset;          /**< last offset to read */
   guint tensors_size[MAX_ITEM];
   guint num_tensors;
-
   gint current_sample_index;    /**< current index of sample or file to read */
+  gboolean first_epoch_is_done;
+  gint num_samples;             /**< The number of samples to be used out of the total samples in the file */
+  guint media_size;             /**< media size */
+  guint media_type;             /**< media type */
 
   /* property */
   gchar *filename;              /**< filename */
-  guint media_size;             /**< media size */
-  guint media_type;             /**< media type */
   gint start_sample_index;      /**< start index of sample to read, in case of image, the starting index of the numbered files */
   gint stop_sample_index;       /**< stop index of sample to read, in case of image, the stoppting index of the numbered files */
   gint epochs;                  /**< repetition of range of files or samples to read */
+  gboolean is_shuffle;          /**< shuffle the sample index */
+
+  GArray *shuffled_index_array; /**< shuffled sample index array */
+  gint array_index;             /**< element index of shuffled_index_array */
 };
 
 /**


### PR DESCRIPTION
If the value is true, samples index are shuffled, default value is true.
The sample index is the order in which samples are stored in the file, starting from 0.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped
