### PR TITLE
[Query] Remove UDP connection type from tensor_query @open sesame 03/16 14:27

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_common.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.c
@@ -34,8 +34,6 @@ gst_tensor_query_get_connect_type (void)
     static GEnumValue protocols[] = {
       {NNS_EDGE_CONNECT_TYPE_TCP, "TCP",
           "Directly sending stream frames via TCP connections."},
-      {NNS_EDGE_CONNECT_TYPE_UDP, "UDP",
-          "Directly sending stream frames via UDP connections."},
       {NNS_EDGE_CONNECT_TYPE_HYBRID, "HYBRID",
           "Connect with MQTT brokers and directly sending stream frames via TCP connections."},
       {0, NULL, NULL},

--- a/tests/nnstreamer_edge/query/unittest_query.cc
+++ b/tests/nnstreamer_edge/query/unittest_query.cc
@@ -74,9 +74,9 @@ TEST (tensorQuery, serverProperties0)
   g_object_get (srv_handle, "dest-port", &uint_val, NULL);
   EXPECT_EQ (5001U, uint_val);
 
-  g_object_set (srv_handle, "connect-type", 1, NULL);
+  g_object_set (srv_handle, "connect-type", 0, NULL);
   g_object_get (srv_handle, "connect-type", &int_val, NULL);
-  EXPECT_EQ (1, int_val);
+  EXPECT_EQ (0, int_val);
 
 
   g_object_set (srv_handle, "timeout", 20U, NULL);
@@ -104,9 +104,9 @@ TEST (tensorQuery, serverProperties0)
   g_object_get (srv_handle, "timeout", &uint_val, NULL);
   EXPECT_EQ (10U, uint_val);
 
-  g_object_set (srv_handle, "connect-type", 1, NULL);
+  g_object_set (srv_handle, "connect-type", 0, NULL);
   g_object_get (srv_handle, "connect-type", &int_val, NULL);
-  EXPECT_EQ (1, int_val);
+  EXPECT_EQ (0, int_val);
 
   g_object_set (srv_handle, "timeout", 20U, NULL);
   g_object_get (srv_handle, "timeout", &uint_val, NULL);


### PR DESCRIPTION
Remove UDP connection type because we don't have plan to support it for tensor query.

Signed-off-by: gichan <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

