### PR TITLE
[datareposrc] Add tensor-sequence property @open sesame 4/21 16:51

### DIFF
--- a/gst/datarepo/gstdatareposrc.h
+++ b/gst/datarepo/gstdatareposrc.h
@@ -24,7 +24,7 @@ G_BEGIN_DECLS
 #define GST_DATA_REPO_SRC(obj) \
   (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_DATA_REPO_SRC,GstDataRepoSrc))
 #define GST_DATA_REPO_SRC_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_DATA_REPO_SRC,GstRepoSrcClass))
+  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_DATA_REPO_SRC,GstDataRepoSrcClass))
 #define GST_IS_DATA_REPO_SRC(obj) \
   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_DATA_REPO_SRC))
 #define GST_IS_DATA_REPO_SRC_CLASS(klass) \
@@ -49,28 +49,33 @@ struct _GstDataRepoSrc {
   gboolean successful_read;     /**< used for checking EOS when reading more than one images(multi-files) from a path */
   gint fd;                      /**< open file descriptor */
   guint64 read_position;        /**< position of fd */
-  guint64 offset;
+  guint64 offset;               /**< offset of fd */
   guint64 start_offset;         /**< start offset to read */
   guint64 last_offset;          /**< last offset to read */
-  guint tensors_size[MAX_ITEM];
-  guint num_tensors;
+  guint tensors_size[MAX_ITEM];   /**< each tensors size in a sample */
+  guint tensors_offset[MAX_ITEM]; /**< each tensors offset in a sample */
+  guint num_tensors;            /**< The number of tensors in a sample */
   gint current_sample_index;    /**< current index of sample or file to read */
   gboolean first_epoch_is_done;
-  gint total_samples;           /**< The number of total samples */
-  gint num_samples;             /**< The number of samples to be used out of the total samples in the file */
-  guint media_size;             /**< media size */
+  guint total_samples;           /**< The number of total samples */
+  guint num_samples;             /**< The number of samples to be used out of the total samples in the file */
+  guint sample_size;             /**< size of one sample */
   guint media_type;             /**< media type */
 
   /* property */
   gchar *filename;              /**< filename */
   gchar *json_filename;         /**< json filename containing meta information of the filename */
-  gint start_sample_index;      /**< start index of sample to read, in case of image, the starting index of the numbered files */
-  gint stop_sample_index;       /**< stop index of sample to read, in case of image, the stoppting index of the numbered files */
-  gint epochs;                  /**< repetition of range of files or samples to read */
+  gchar *tensors_seq_str;       /**< tensors in a sample are read into gstBuffer according to tensors_sequence */
+  guint start_sample_index;      /**< start index of sample to read, in case of image, the starting index of the numbered files */
+  guint stop_sample_index;       /**< stop index of sample to read, in case of image, the stoppting index of the numbered files */
+  guint epochs;                  /**< repetition of range of files or samples to read */
   gboolean is_shuffle;          /**< shuffle the sample index */
 
   GArray *shuffled_index_array; /**< shuffled sample index array */
-  gint array_index;             /**< element index of shuffled_index_array */
+  guint array_index;             /**< element index of shuffled_index_array */
+
+  guint tensors_seq[MAX_ITEM]; /**< tensors sequence in a sample that will be read into gstbuffer */
+  guint tensors_seq_cnt;
 };
 
 /**


### PR DESCRIPTION
    - Tensors in a sample are read into gstBuffer according to input sequence.
    - Only read the set tensors among all tensors in a sample.
    - It is for other/tensors and default value is NULL.
```
e.g, if a sample has '1:1:1:1', '1:1:10:1', '1:1:784:1' and each index is '0,1,2' , 
"tensors-sequence=2,1" means that only '1:1:784:1' then '1:1:10:1' are read. 
```
further explanation
```
I modify MNIST dataset that have two features and labels in a sample.
so..
     offset and sample_offset(byte size) are from 0.
      if the size of one sample is 6352 and num_tensors is 4, dimensions are  '1:1:784:1' , '1:1:10:1',
      '1:1:784:1' and '1:1:10:1' with float32.
      the offset of the second sample is as follows.
        -------------------------------------------------
          sample_offset: 6352
          tensors index: [ 0    | 1    | 2    | 3     ]
           tensors_size: [ 3136 | 40   | 3136 | 40    ]
         tensors_offset: [ 0    | 3136 | 3176 | 6312  ]
              fd offset: [ 6352 | 9488 | 9528 | 12664 ]
        -------------------------------------------------
      if user sets "tensor-sequence=2,1", datareposrc read offset 9528 then 9488.
```
**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped