### PR TITLE
[GithubAction] Remove ubuntu 18.04 build

### DIFF
--- a/.github/workflows/risc-v.yml
+++ b/.github/workflows/risc-v.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: Build on alpine RISC-V
     steps:
       - uses: actions/checkout@v2.1.0

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Remove ubuntu 18.04 build since this distro has benn deprecated.

refer:
```
Annotations
2 errors and 5 warnings
build (ubuntu-18.04)
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04 or ubuntu-22.04 (ubuntu-latest). For more details, see https://github.com/actions/runner-images/issues/6002 build (ubuntu-18.04)
GitHub Actions has encountered an internal error when running your job.
```

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


