### PR TITLE
[tensor_trainer] Get TensorsInfo from negotiated caps instead of property

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -50,9 +50,7 @@ struct _GstTensorTrainer
   gchar *fw_name;
   gchar *model_config;
   gchar *model_save_path;
-  gchar *input_dimensions;
   gchar *output_dimensions;
-  gchar *input_type;
   gchar *output_type;
 
   gboolean input_configured;

--- a/tests/nnstreamer_trainer/unittest_trainer.cc
+++ b/tests/nnstreamer_trainer/unittest_trainer.cc
@@ -46,13 +46,11 @@ get_file_path (const gchar *filename)
  * framework: framework to use for training the model
  * model-config: model configuration file path. models are limited to creating
  * with configuration files. model-save-path: model save path by query in MLOps
- * input-dims:input dimensions, in case of MNIST, 1:1:784:1 is a input and
- * 1:1:10:1 is a label. input_type: data type. Sample(mnist.data)'s data type is
- * float32. num-inputs: sub-plugin supports multiple inputs, in case of MNIST,
- * num-inputs is 1. num-labels: sub-plugin supports multiple labels, in case of
- * MNIST, num-labels is 1. num-training-samples: Number of training samples, A
- * sample can consist of multiple inputs and labels in tensors(in case of MNIST,
- * all is 1), set how many samples are taken for training model.
+ * num-inputs: sub-plugin supports multiple inputs, in case of MNIST, num-inputs
+ * is 1. num-labels: sub-plugin supports multiple labels, in case of MNIST,
+ * num-labels is 1. num-training-samples: Number of training samples, A sample
+ * can consist of multiple inputs and labels in tensors(in case of MNIST, all is
+ * 1), set how many samples are taken for training model.
  * num-validation-samples: num-validation-samples, A sample can consist of
  * multiple inputs and labels in tensors(in case of MNIST, all is 1), set how
  * many samples are taken for validation model. epochs : epochs are repetitions
@@ -76,11 +74,8 @@ TEST (tensor_trainer, SetParams)
   gchar *str_pipeline = g_strdup_printf (
       "gst-launch-1.0 datareposrc location=%s json=%s "
       "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=1 ! "
-      "other/tensors, format=static, num_tensors=2, framerate=0/1, "
-      "dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! "
       "tensor_trainer name=tensor_trainer framework=nntrainer model-config=%s "
-      "model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 "
-      "input-type=float32,float32 num-inputs=1 num-labels=1 "
+      "model-save-path=model.bin num-inputs=1 num-labels=1 "
       "num-training-samples=100 num-validation-samples=100 epochs=1 ! "
       "tensor_sink",
       file_path, json_path, model_config_path);
@@ -99,16 +94,6 @@ TEST (tensor_trainer, SetParams)
 
   g_object_get (tensor_trainer, "model-save-path", &get_str, NULL);
   EXPECT_STREQ (get_str, "model.bin");
-
-  g_object_get (tensor_trainer, "input-dim", &get_str, NULL);
-  EXPECT_STREQ (get_str, "1:1:784:1,1:1:10:1");
-
-
-  g_object_get (tensor_trainer, "input-dim", &get_str, NULL);
-  EXPECT_STREQ (get_str, "1:1:784:1,1:1:10:1");
-
-  g_object_get (tensor_trainer, "input-type", &get_str, NULL);
-  EXPECT_STREQ (get_str, "float32,float32");
 
   g_object_get (tensor_trainer, "num-inputs", &get_value, NULL);
   ASSERT_EQ (get_value, 1U);
@@ -150,11 +135,8 @@ TEST (tensor_trainer, invalidFramework0_n)
   gchar *str_pipeline = g_strdup_printf (
       "gst-launch-1.0 datareposrc location=%s json=%s "
       "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=5 ! "
-      "other/tensors, format=static, num_tensors=2, framerate=0/1, "
-      "dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! "
       "tensor_trainer name=tensor_trainer model-config=%s "
-      "model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 "
-      "input-type=float32,float32 num-inputs=1 num-labels=1 "
+      "model-save-path=model.bin num-inputs=1 num-labels=1 "
       "num-training-samples=100 num-validation-samples=100 epochs=5 ! tensor_sink",
       file_path, json_path, model_config_path);
 
@@ -195,11 +177,8 @@ TEST (tensor_trainer, invalidFramework1_n)
   gchar *str_pipeline = g_strdup_printf (
       "gst-launch-1.0 datareposrc location=%s json=%s "
       "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=5 ! "
-      "other/tensors, format=static, num_tensors=2, framerate=0/1, "
-      "dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! "
       "tensor_trainer name=tensor_trainer model-config=%s "
-      "model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 "
-      "input-type=float32,float32 num-inputs=1 num-labels=1 "
+      "model-save-path=model.bin num-inputs=1 num-labels=1 "
       "num-training-samples=100 num-validation-samples=100 epochs=5 ! tensor_sink",
       file_path, json_path, model_config_path);
 
@@ -238,11 +217,8 @@ TEST (tensor_trainer, invalidModelConfig0_n)
   gchar *str_pipeline = g_strdup_printf (
       "gst-launch-1.0 datareposrc location=%s json=%s"
       "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=5 ! "
-      "other/tensors, format=static, num_tensors=2, framerate=0/1, "
-      "dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! "
       "tensor_trainer name=tensor_trainer framework=nntrainer"
-      "model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 "
-      "input-type=float32,float32 num-inputs=1 num-labels=1 "
+      "model-save-path=model.bin num-inputs=1 num-labels=1 "
       "num-training-samples=100 num-validation-samples=100 epochs=5 ! tensor_sink",
       file_path, json_path);
 
@@ -281,11 +257,9 @@ TEST (tensor_trainer, invalidModelSavePath0_n)
   gchar *str_pipeline = g_strdup_printf (
       "gst-launch-1.0 datareposrc location=%s json=%s "
       "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=5 ! "
-      "other/tensors, format=static, num_tensors=2, framerate=0/1, "
-      "dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! "
       "tensor_trainer name=tensor_trainer framework=nntrainer model-config=%s "
-      "input-dim=1:1:784:1,1:1:10:1 input-type=float32,float32 num-inputs=1 num-labels=1 "
-      "num-training-samples=100 num-validation-samples=100 epochs=5 ! tensor_sink",
+      "num-inputs=1 num-labels=1 num-training-samples=100 num-validation-samples=100 "
+      "epochs=5 ! tensor_sink",
       file_path, json_path, model_config_path);
 
   GstElement *pipeline = gst_parse_launch (str_pipeline, NULL);
@@ -300,92 +274,6 @@ TEST (tensor_trainer, invalidModelSavePath0_n)
 
   /* set invalid param */
   g_object_set (GST_OBJECT (tensor_trainer), "model-save-path", NULL, NULL);
-
-  /* state chagne failure is expected */
-  EXPECT_NE (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-
-  gst_object_unref (pipeline);
-}
-
-/**
- * @brief Model training test with invalid param (input-dim)
- */
-TEST (tensor_trainer, invalidInputDimension0_n)
-{
-  gchar *file_path = NULL;
-  gchar *json_path = NULL;
-  gchar *model_config_path = NULL;
-  GstElement *tensor_trainer = NULL;
-
-  file_path = get_file_path (filename);
-  json_path = get_file_path (json);
-  model_config_path = get_file_path (model_config);
-
-  gchar *str_pipeline = g_strdup_printf (
-      "gst-launch-1.0 datareposrc location=%s json=%s "
-      "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=5 ! "
-      "other/tensors, format=static, num_tensors=2, framerate=0/1, "
-      "dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! "
-      "tensor_trainer name=tensor_trainer framework=nntrainer model-config=%s "
-      "model-save-path=model.bin input-type=float32,float32 num-labels=1 num-labels=1 "
-      "num-training-samples=100 num-validation-samples=100 epochs=5 ! tensor_sink",
-      file_path, json_path, model_config_path);
-
-  GstElement *pipeline = gst_parse_launch (str_pipeline, NULL);
-  g_free (str_pipeline);
-  g_free (file_path);
-  g_free (json_path);
-  g_free (model_config_path);
-  ASSERT_NE (pipeline, nullptr);
-
-  tensor_trainer = gst_bin_get_by_name (GST_BIN (pipeline), "tensor_trainer");
-  ASSERT_NE (tensor_trainer, nullptr);
-
-  /* set invalid param */
-  g_object_set (GST_OBJECT (tensor_trainer), "input-dim", NULL, NULL);
-
-  /* state chagne failure is expected */
-  EXPECT_NE (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-
-  gst_object_unref (pipeline);
-}
-
-/**
- * @brief Model training test with invalid param (input-type)
- */
-TEST (tensor_trainer, invalidInputType0_n)
-{
-  gchar *file_path = NULL;
-  gchar *json_path = NULL;
-  gchar *model_config_path = NULL;
-  GstElement *tensor_trainer = NULL;
-
-  file_path = get_file_path (filename);
-  json_path = get_file_path (json);
-  model_config_path = get_file_path (model_config);
-
-  gchar *str_pipeline = g_strdup_printf (
-      "gst-launch-1.0 datareposrc location=%s json=%s "
-      "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=5 ! "
-      "other/tensors, format=static, num_tensors=2, framerate=0/1, "
-      "dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! "
-      "tensor_trainer name=tensor_trainer framework=nntrainer model-config=%s "
-      "model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 num-labels=1 num-labels=1 "
-      "num-training-samples=100 num-validation-samples=100 epochs=5 ! tensor_sink",
-      file_path, json_path, model_config_path);
-
-  GstElement *pipeline = gst_parse_launch (str_pipeline, NULL);
-  g_free (str_pipeline);
-  g_free (file_path);
-  g_free (json_path);
-  g_free (model_config_path);
-  ASSERT_NE (pipeline, nullptr);
-
-  tensor_trainer = gst_bin_get_by_name (GST_BIN (pipeline), "tensor_trainer");
-  ASSERT_NE (tensor_trainer, nullptr);
-
-  /* set invalid param */
-  g_object_set (GST_OBJECT (tensor_trainer), "input-type", NULL, NULL);
 
   /* state chagne failure is expected */
   EXPECT_NE (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
@@ -412,11 +300,8 @@ TEST (tensor_trainer, invalidModelNumTrainingSamples0_n)
   gchar *str_pipeline = g_strdup_printf (
       "gst-launch-1.0 datareposrc location=%s json=%s "
       "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=5 ! "
-      "other/tensors, format=static, num_tensors=2, framerate=0/1, "
-      "dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! "
       "tensor_trainer name=tensor_trainer framework=nntrainer model-config=%s "
-      "model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 "
-      "input-type=float32,float32 num-inputs=1 num-labels=1 "
+      "model-save-path=model.bin num-inputs=1 num-labels=1 "
       "num-validation-samples=100 epochs=5 ! tensor_sink",
       file_path, json_path, model_config_path);
 
@@ -460,11 +345,8 @@ TEST (tensor_trainer, invalidModelNumValidationSamples0_n)
   gchar *str_pipeline = g_strdup_printf (
       "gst-launch-1.0 datareposrc location=%s json=%s "
       "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=5 ! "
-      "other/tensors, format=static, num_tensors=2, framerate=0/1, "
-      "dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! "
       "tensor_trainer name=tensor_trainer framework=nntrainer model-config=%s "
-      "model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 "
-      "input-type=float32,float32 num-inputs=1 num-labels=1 "
+      "model-save-path=model.bin num-inputs=1 num-labels=1 "
       "num-training-samples=100 epochs=5 ! tensor_sink",
       file_path, json_path, model_config_path);
 
@@ -508,11 +390,8 @@ TEST (tensor_trainer, invalidEpochs0_n)
   gchar *str_pipeline = g_strdup_printf (
       "gst-launch-1.0 datareposrc location=%s json=%s "
       "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=5 ! "
-      "other/tensors, format=static, num_tensors=2, framerate=0/1, "
-      "dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! "
       "tensor_trainer name=tensor_trainer framework=nntrainer model-config=%s "
-      "model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 "
-      "input-type=float32,float32 num-inputs=1 num-labels=1 "
+      "model-save-path=model.bin num-inputs=1 num-labels=1 "
       "num-training-samples=100 num-validation-samples=100 ! tensor_sink",
       file_path, json_path, model_config_path);
 
@@ -556,11 +435,8 @@ TEST (tensor_trainer, invalidNumInputs0_n)
   gchar *str_pipeline = g_strdup_printf (
       "gst-launch-1.0 datareposrc location=%s json=%s "
       "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=5 ! "
-      "other/tensors, format=static, num_tensors=2, framerate=0/1, "
-      "dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! "
       "tensor_trainer name=tensor_trainer framework=nntrainer model-config=%s "
-      "model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 "
-      "input-type=float32,float32 num-labels=1 num-training-samples=100 "
+      "model-save-path=model.bin num-labels=1 num-training-samples=100 "
       "num-validation-samples=100 epochs=5 ! tensor_sink",
       file_path, json_path, model_config_path);
 
@@ -604,12 +480,8 @@ TEST (tensor_trainer, invalidNumLabels0_n)
   gchar *str_pipeline = g_strdup_printf (
       "gst-launch-1.0 datareposrc location=%s json=%s "
       "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=5 ! "
-      "other/tensors, format=static, num_tensors=2, framerate=0/1, "
-      "dimensions=1:1:784:1.1:1:10:1, types=float32.float32 ! "
       "tensor_trainer name=tensor_trainer framework=nntrainer model-config=%s"
-      "model-save-path=model.bin input-dim=1:1:784:1,1:1:10:1 "
-      "input-type=float32,float32 num-labels=1 num-labels=1 "
-      "num-training-samples=100 num-validation-samples=100 epochs=5 ! "
+      "model-save-path=model.bin num-inputs=1 num-validation-samples=100 epochs=5 ! "
       "tensor_sink",
       file_path, json_path, model_config_path);
 


### PR DESCRIPTION
 - Get TensorsInfo from negotiated caps
 - Remove input-type and input-dim property

**Self evaluation:**
1. Build test: [*]Passed []Failed []Skipped
2. Run test: [*]Passed []Failed []Skipped