### PR TITLE
[Filter] PyTorch, ignore extra output tensors @open sesame 05/11 10:51

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -93,7 +93,7 @@ class TorchCore
   int processIValue (const torch::jit::IValue &value, GstTensorMemory *output,
       unsigned int idx);
   int serializeOutput (const torch::jit::IValue &value, GstTensorMemory *output,
-      unsigned int *idx);
+      unsigned int *idxm, unsigned int limit_idx);
 };
 
 extern "C" { /* accessed by android api */
@@ -446,9 +446,13 @@ TorchCore::processIValue (
  *         -3 if output is of unsupported format.
  */
 int
-TorchCore::serializeOutput (
-    const torch::jit::IValue &value, GstTensorMemory *output, unsigned int *idx)
+TorchCore::serializeOutput (const torch::jit::IValue &value,
+    GstTensorMemory *output, unsigned int *idx, unsigned int limit_idx)
 {
+  if (*idx >= limit_idx) {
+    return 0;
+  }
+
   /** serialize the output based on its type */
   if (value.isTensor ()) {
     if (processIValue (value, output, *idx)) {
@@ -460,7 +464,7 @@ TorchCore::serializeOutput (
   } else if (value.isTuple ()) {
     auto output_elements = value.toTuple ()->elements ();
     for (auto element : output_elements) {
-      if (serializeOutput (element, output, idx)) {
+      if (serializeOutput (element, output, idx, limit_idx)) {
         ml_loge ("Failed to process a tensor tuple. Output Tensor Information is not valid at index %d",
             *idx);
         return -2;
@@ -476,7 +480,7 @@ TorchCore::serializeOutput (
     c10::ArrayRef<torch::jit::IValue> output_list = value.toGenericListRef ();
 #endif
     for (auto &element : output_list) {
-      if (serializeOutput (element, output, idx)) {
+      if (serializeOutput (element, output, idx, limit_idx)) {
         ml_loge ("Failed to process a tensor list. Output Tensor Information is not valid at index %d",
             *idx);
         return -2;
@@ -558,7 +562,7 @@ TorchCore::invoke (const GstTensorFilterProperties *prop,
   }
 
   unsigned int idx = 0;
-  int retval = serializeOutput (output_value, output, &idx);
+  int retval = serializeOutput (output_value, output, &idx, outputTensorMeta.num_tensors);
   if (retval) {
     ml_loge ("Error %d: failed to serialize the output of the model at index %d.",
         retval, idx);


### PR DESCRIPTION
Allow tensor_filter to be configured with smaller number of output tensors than PyTorch returns native. This is useful e.g. when my Yolov7 converted model (TorchScript) has 4 output tensors, but I am really only interested in in the 1st. Without this fix, the code would crash with a memory overwrite in `TorchCore::serializeOutput` if the number of configured output tensors is smaller than the actual TorchScript model provides..