### PR TITLE
[tensor_trainer] Add event notifier, getStatus and new function to save the stats information of the model to output tensors

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -56,21 +56,26 @@ struct _GstTensorTrainer
   gboolean input_configured;
   gboolean output_configured;
   gboolean inputtype_configured;
+  gboolean fw_created;
+  gboolean is_training_complete;
+  gboolean is_epoch_complete;
   unsigned int input_ranks[NNS_TENSOR_SIZE_LIMIT];
   unsigned int output_ranks[NNS_TENSOR_SIZE_LIMIT];
   GstTensorsInfo output_meta;
   GstTensorsConfig out_config;
   GstTensorsConfig in_config;
 
-  gint64 total_push_data_cnt;      /**< number of total push data */
-  gboolean fw_created;
+  guint total_push_data_cnt;      /**< number of total push data in one eposh */
 
   void *privateData; /**< NNFW plugin's private data is stored here */
-  const GstTensorTrainerFramework *fw;  /* for test, need to make */
+  const GstTensorTrainerFramework *fw; /**< Subplugin definition */
   GstTensorTrainerProperties prop; /**< NNFW plugin's properties */
+  GstTensorTrainerEventNotifier notifier; /**< Event notifier */
 
-  GMutex trainer_lock;
-  GCond training_complete_cond;
+  GMutex training_completion_lock;
+  GCond training_completion_cond;
+  GMutex epoch_completion_lock;
+  GCond epoch_completion_cond;
 };
 
 /**

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -39,22 +39,50 @@ typedef struct _GstTensorTrainerProperties
   unsigned int num_validation_samples;    /**< The number of validation sample used to valid the model. */
   unsigned int num_epochs;    /**< The number of repetition of total training and validation sample. subplugin must receive total samples((num_training_samples + num_validation_samples) * num_epochs) */
 
-  GCond *training_complete_cond;    /**< Tensor trainer wait when receive EOS before model training is complete, subplugin should send signal when model training is complete. */
+  unsigned int epoch_count;    /**< Number of currently completed epochs */
+  double training_loss;    /**< Training loss of the model being trained in the subplugin */
+  double training_accuracy;    /**< Training accuracy of the model being trained in the subplugin */
+  double validation_loss;    /**< Validation loss of the model being trained in the subplugin */
+  double validation_accuracy;    /**< Validation accuracy of the model being trained in the subplugin */
 } GstTensorTrainerProperties;
 
 /**
- * @brief Tensor_Trainer Subplugin framework related information
+ * @brief GstTensorTrainer's Subplugin framework related information
  *
  * All the information is provided statically.
  */
 typedef struct _GstTensorTrainerFrameworkInfo
 {
   const char *name;    /**< Name of the neural network framework, searchable by FRAMEWORK property. */
-  unsigned int is_training_complete;  /**< Check if training is complete, Use unsigned int instead of gboolean because this is refered by custom plugins. */
-  unsigned int epoch_cnt;    /**< Number of currently completed epochs */
-} GstTensorTrainerFrameworkInfo;
+ } GstTensorTrainerFrameworkInfo;
 
 typedef struct _GstTensorTrainerFramework GstTensorTrainerFramework;
+
+/**
+ * @brief GstTensorTrainer's event type list
+ * 
+ * Event types that subplugins must send to tensor_trainer
+ */
+typedef enum
+{
+  TRAINER_EVENT_EPOCH_COMPLETION,    /**< one epoch is complete in subplugin */
+  TRAINER_EVENT_TRAINING_COMPLETION,    /**< training is complete in subplugin */
+  TRAINER_EVENT_UNKNOWN,    /**< unknown event */
+} GstTensorTrainerEventType;
+
+/**
+ * @brief GstTensorTrainer's event notifier
+ *
+ * Subplugins must send events to tensor_trainer with a notifier.
+ */
+typedef struct _GstTensorTrainerEventNotifier
+{
+  uint64_t version;
+  void * notifier;
+  /**< Version of the struct
+   * | 32bit (validity check) | 16bit (API version) | 16bit (Subplugin's internal version) |
+   */
+} GstTensorTrainerEventNotifier;
 
 /**
  * @brief tensor_trainer Subplugin definition
@@ -87,9 +115,11 @@ struct _GstTensorTrainerFramework
    */
 
   int (*start) (const GstTensorTrainerFramework * self,
-      const GstTensorTrainerProperties * prop, void *private_data);
+      const GstTensorTrainerProperties * prop, GstTensorTrainerEventNotifier * notifier,
+      void *private_data);
   /**< tensor_trainer call this to start training the model
    * @param[in] prop read-only property values
+   * @param[in] notify, a handle of event notify
    * @param[in] private_data, a subplugin may save its internal private data here.
    * @return 0 if ok. < 0 if error.
    */
@@ -104,6 +134,14 @@ struct _GstTensorTrainerFramework
    * @return 0 if ok. < 0 if error.
    */
 
+  int (*getStatus) (const GstTensorTrainerFramework *self,
+      GstTensorTrainerProperties *prop, void *private_data);
+  /**< tensor_trainer call this to get status of subplugin
+   * @param[in] prop property values
+   * @param[in] private_data, a subplugin may save its internal private data here.
+   * @return 0 if ok. < 0 if error.
+   */
+
   int (*getFrameworkInfo) (const GstTensorTrainerFramework * self,
       const GstTensorTrainerProperties * prop, void *private_data,
       GstTensorTrainerFrameworkInfo *fw_info);
@@ -111,13 +149,10 @@ struct _GstTensorTrainerFramework
    * @param[in] prop read-only property values
    * @param[in] private_data A subplugin may save its internal private data here.
    * @param[out] fw_info struct to hold frameworks info. Must be allocated by the caller (return value).
-   * @return 0 if OK. non-zero if error.
+   * @return 0 if OK. < 0 if error.
    *
    * @note CAUTION: private_data can be NULL if the framework is not yet opened by the caller.
    */
-
-  /* Need to make (*eventHandler)*/
-
 };
 
 /* extern functions for subplugin management, exist in tensor_trainer.c */
@@ -139,6 +174,17 @@ nnstreamer_trainer_probe (GstTensorTrainerFramework * ttsp);
 
 extern int
 nnstreamer_trainer_exit (GstTensorTrainerFramework * ttsp);
+
+/**
+ * @brief Trainer's sub-plugin call this to notify event
+ * 
+ * @param notifier sub-plugin must send events to tensor_trainer with a notifier.
+ * @param type Event types that subplugins must send to tensor_trainer
+ * @param data Optional data for the event
+ */
+extern void
+nnstreamer_trainer_notify_event (GstTensorTrainerEventNotifier * notifier,
+    GstTensorTrainerEventType type, void *data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
commit 1:
[API][tensor_trainer] Add event notifier and getStatus callback pointer
    
Add GstTensorTrainerEventNotifier to get event from subplugin
- subplugin must send event to tensor_trainer with this notifier by internal API
- Add GstTensorTrainerEventType
- Add new internal API: nnstreamer_trainer_notify_event(notifier, event_type, data)
   
Add getStatus callback pointer to GstTensorTrainerFramework.
- Call this to get status of subplugin

commit 2:
[tensor_trainer] Save the stats information of the model to output tensors
    
Whenever one of the epochs is completed, the stats information of the model being trained in subplugin is stored in the output tensor.

- Apply getModelRunStas to get stats from model being trained in subplugin
- Add new internal API(nnstreamer_trainer_notify_event()) to get event from subplugin
- Add function to write stats to output tensors

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped
