### PR TITLE
[Wait for #4080 and #4070][tensor_trainer] Save the stats information of the model to output tensors

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -62,15 +62,17 @@ struct _GstTensorTrainer
   GstTensorsConfig out_config;
   GstTensorsConfig in_config;
 
-  gint64 total_push_data_cnt;      /**< number of total push data */
+  guint total_push_data_cnt;      /**< number of total push data in one eposh */
   gboolean fw_created;
 
   void *privateData; /**< NNFW plugin's private data is stored here */
   const GstTensorTrainerFramework *fw;  /* for test, need to make */
   GstTensorTrainerProperties prop; /**< NNFW plugin's properties */
 
-  GMutex trainer_lock;
+  GMutex training_complete_lock;
   GCond training_complete_cond;
+  GMutex epoch_complete_lock;
+  GCond epoch_complete_cond;
 };
 
 /**


### PR DESCRIPTION
Whenever one of the epochs is completed, the stats information of the model being trained in subplugin is stored in the output tensor.
    - Add GCond to signal the end of an epoch
    - Add function to write stats to output tensors

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped
