### PR TITLE
datarepo: dependency management.

### DIFF
--- a/gst/datarepo/meson.build
+++ b/gst/datarepo/meson.build
@@ -4,6 +4,8 @@ repo_sources = [
   'gstdatareposink.c'
 ]
 
+json_glib_dep = dependency('json-glib-1.0')
+
 gstdatarepo_shared = shared_library('gstdatarepo',
   repo_sources,
   dependencies: [nnstreamer_dep, json_glib_dep],

--- a/gst/meson.build
+++ b/gst/meson.build
@@ -6,4 +6,7 @@ if mqtt_support_is_available
   subdir('mqtt')
 endif
 subdir('nnstreamer')
-subdir('datarepo')
+
+if get_option('enable-datarepo')
+  subdir('datarepo')
+endif

--- a/meson.build
+++ b/meson.build
@@ -145,7 +145,6 @@ gst_video_dep = dependency('gstreamer-video-' + gst_api_verision)
 gst_audio_dep = dependency('gstreamer-audio-' + gst_api_verision)
 gst_app_dep = dependency('gstreamer-app-' + gst_api_verision)
 gst_check_dep = dependency('gstreamer-check-' + gst_api_verision)
-json_glib_dep = dependency('json-glib-1.0')
 
 libm_dep = cc.find_library('m') # cmath library
 libdl_dep = cc.find_library('dl') # DL library

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -50,6 +50,7 @@ option('framework-priority-bin', type: 'string', value: '', description: 'A comm
 option('skip-tflite-flatbuf-check', type: 'boolean', value: false, description: 'Do not check the availability of flatbuf for tensorflow-lite build. In some systems, flatbuffers\' dependency cannot be found with meson.')
 option('trix-engine-alias', type: 'string', value: 'srnpu', description: 'The alias name list of trix-engine sub-plugin. This option provides backward compatibility of the previous framework name.')
 option('enable-float16', type: 'boolean', value: false, description: 'Support float16 streams with GCC extensions')
+option('enable-datarepo', type: 'boolean', value: true, description: 'Data repository sink/src for in-pipeline training')
 
 # Utilities
 option('enable-nnstreamer-check', type: 'boolean', value: true)


### PR DESCRIPTION
Datarepo has its own unique dependency.
Thus, make datarepo optional at build so that
we can cut the dependency.

It's set "enabled by default" because most
releases will be using it anyway.

