### PR TITLE
[tensor] remove padded value of dimensions (0-init) @open sesame 08/03 15:25

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -1045,8 +1045,10 @@ bb_getOutCaps (void **pdata, const GstTensorsConfig * config)
     g_return_val_if_fail (dim1[1] == 1, NULL);
     max_detection = dim1[2];
     g_return_val_if_fail (max_detection > 0, NULL);
+
+    /** @todo unused dimension value should be 0 */
     for (i = 3; i < NNS_TENSOR_RANK_LIMIT; i++)
-      g_return_val_if_fail (dim1[i] == 1, NULL);
+      g_return_val_if_fail (dim1[i] == 0 || dim1[i] == 1, NULL);
 
     /* Check if the second tensor is compatible */
     dim2 = config->info.info[1].dimension;
@@ -1058,7 +1060,7 @@ bb_getOutCaps (void **pdata, const GstTensorsConfig * config)
           max_label, data->label_path, data->labeldata.total_labels);
     g_return_val_if_fail (max_detection == dim2[1], NULL);
     for (i = 2; i < NNS_TENSOR_RANK_LIMIT; i++)
-      g_return_val_if_fail (dim2[i] == 1, NULL);
+      g_return_val_if_fail (dim2[i] == 0 || dim2[i] == 1, NULL);
 
     /* Check consistency with max_detection */
     if (!_set_max_detection (data, max_detection, MOBILENET_SSD_DETECTION_MAX)) {
@@ -1086,7 +1088,7 @@ bb_getOutCaps (void **pdata, const GstTensorsConfig * config)
     dim1 = config->info.info[num_idx].dimension;
     g_return_val_if_fail (dim1[0] == 1, NULL);
     for (i = 1; i < NNS_TENSOR_RANK_LIMIT; ++i)
-      g_return_val_if_fail (dim1[i] == 1, NULL);
+      g_return_val_if_fail (dim1[i] == 0 || dim1[i] == 1, NULL);
 
     /* Check if the classes & scores tensors are compatible */
     dim2 = config->info.info[classes_idx].dimension;
@@ -1094,8 +1096,8 @@ bb_getOutCaps (void **pdata, const GstTensorsConfig * config)
     g_return_val_if_fail (dim3[0] == dim2[0], NULL);
     max_detection = dim2[0];
     for (i = 1; i < NNS_TENSOR_RANK_LIMIT; ++i) {
-      g_return_val_if_fail (dim2[i] == 1, NULL);
-      g_return_val_if_fail (dim3[i] == 1, NULL);
+      g_return_val_if_fail (dim2[i] == 0 || dim2[i] == 1, NULL);
+      g_return_val_if_fail (dim3[i] == 0 || dim3[i] == 1, NULL);
     }
 
     /* Check if the bbox locations tensor is compatible */
@@ -1103,7 +1105,7 @@ bb_getOutCaps (void **pdata, const GstTensorsConfig * config)
     g_return_val_if_fail (BOX_SIZE == dim4[0], NULL);
     g_return_val_if_fail (max_detection == dim4[1], NULL);
     for (i = 2; i < NNS_TENSOR_RANK_LIMIT; ++i)
-      g_return_val_if_fail (dim4[i] == 1, NULL);
+      g_return_val_if_fail (dim4[i] == 0 || dim4[i] == 1, NULL);
 
     /* Check consistency with max_detection */
     if (!_set_max_detection (data, max_detection,
@@ -1126,7 +1128,7 @@ bb_getOutCaps (void **pdata, const GstTensorsConfig * config)
         NULL);
     g_return_val_if_fail (dim[1] == OV_PERSON_DETECTION_MAX, NULL);
     for (i = 2; i < NNS_TENSOR_RANK_LIMIT; ++i)
-      g_return_val_if_fail (dim[i] == 1, NULL);
+      g_return_val_if_fail (dim[i] == 0 || dim[i] == 1, NULL);
   } else if (data->mode == YOLOV5_BOUNDING_BOX) {
     const guint *dim = config->info.info[0].dimension;
     if (!_check_tensors (config, 1U))
@@ -1155,14 +1157,14 @@ bb_getOutCaps (void **pdata, const GstTensorsConfig * config)
     g_return_val_if_fail (max_detection > 0, NULL);
     g_return_val_if_fail (dim1[2] == 1, NULL);
     for (i = 3; i < NNS_TENSOR_RANK_LIMIT; i++)
-      g_return_val_if_fail (dim1[i] == 1, NULL);
+      g_return_val_if_fail (dim1[i] == 0 || dim1[i] == 1, NULL);
 
     /* Check if the second tensor is compatible */
     dim2 = config->info.info[1].dimension;
     g_return_val_if_fail (dim2[0] == 1, NULL);
     g_return_val_if_fail (max_detection == dim2[1], NULL);
     for (i = 2; i < NNS_TENSOR_RANK_LIMIT; i++)
-      g_return_val_if_fail (dim2[i] == 1, NULL);
+      g_return_val_if_fail (dim2[i] == 0 || dim2[i] == 1, NULL);
 
     /* Check consistency with max_detection */
     if (!_set_max_detection (data, max_detection, MP_PALM_DETECTION_DETECTION_MAX)) {

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
@@ -121,7 +121,7 @@ il_getOutCaps (void **pdata, const GstTensorsConfig * config)
   /* This allows N:1 only! */
   g_return_val_if_fail (dim[0] > 0 && dim[1] == 1, NULL);
   for (i = 2; i < NNS_TENSOR_RANK_LIMIT; i++)
-    g_return_val_if_fail (dim[i] == 1, NULL);
+    g_return_val_if_fail (dim[i] == 0, NULL);
 
   caps = gst_caps_from_string (DECODER_IL_TEXT_CAPS_STR);
   setFramerateFromConfig (caps, config);

--- a/ext/nnstreamer/tensor_decoder/tensordec-tensor_region.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-tensor_region.c
@@ -714,8 +714,9 @@ tr_getOutCaps (void **pdata, const GstTensorsConfig *config)
   g_return_val_if_fail (dim1[1] == 1, NULL);
   max_detection = dim1[2];
   g_return_val_if_fail (max_detection > 0, NULL);
+  /** @todo unused dimension value should be 0 */
   for (i = 3; i < NNS_TENSOR_RANK_LIMIT; i++)
-    g_return_val_if_fail (dim1[i] == 1, NULL);
+    g_return_val_if_fail (dim1[i] == 0 || dim1[i] == 1, NULL);
 
   /**Check if the second tensor is compatible */
   dim2 = config->info.info[1].dimension;
@@ -726,7 +727,7 @@ tr_getOutCaps (void **pdata, const GstTensorsConfig *config)
         max_label, data->label_path, data->labeldata.total_labels);
   g_return_val_if_fail (max_detection == dim2[1], NULL);
   for (i = 2; i < NNS_TENSOR_RANK_LIMIT; i++)
-    g_return_val_if_fail (dim2[i] == 1, NULL);
+    g_return_val_if_fail (dim2[i] == 0 || dim2[i] == 1, NULL);
 
   /**Check consistency with max_detection */
   if (!_set_max_detection (data, max_detection, MOBILENET_SSD_DETECTION_MAX)) {

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -404,9 +404,6 @@ nnfw_convert_to_gst_info (const nnfw_tinfo_s * nnfw_info,
 
     for (idx = ninfo->rank - 1; idx >= 0; idx--)
       ginfo->dimension[idx] = ninfo->dims[ninfo->rank - idx - 1];
-
-    for (idx = NNS_TENSOR_RANK_LIMIT - 1; idx >= ninfo->rank; idx--)
-      ginfo->dimension[idx] = 1;
   }
 
   gst_info->num_tensors = nnfw_info->num_tensors;

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -641,12 +641,6 @@ TFLiteInterpreter::getTensorDim (int tensor_idx, tensor_dim dim)
   /* the order of dimension is reversed at CAPS negotiation */
   std::reverse_copy (tensor_dims->data, tensor_dims->data + len, dim);
 
-  /** @todo remove below lines (dno not fill 1) */
-  /* fill the remnants with 1 */
-  for (int i = len; i < NNS_TENSOR_RANK_LIMIT; ++i) {
-    dim[i] = 1;
-  }
-
   return 0;
 }
 

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -1152,15 +1152,28 @@ gst_tensor_transform_dimchg (GstTensorTransform * filter,
      *
      * @todo CRITICAL-TODO: Optimize the performance!
      */
-    for (i = NNS_TENSOR_RANK_LIMIT - 1; i > to; i--)
+    for (i = NNS_TENSOR_RANK_LIMIT - 1; i > to; i--) {
+      if (toDim[i] == 0)
+        continue;
       loopLimit *= toDim[i];
-    for (i = 0; i < to; i++)
-      loopBlockSize *= toDim[i];
+    }
 
-    for (i = 0; i < from; i++)
+    for (i = 0; i < to; i++) {
+      if (toDim[i] == 0)
+        break;
+      loopBlockSize *= toDim[i];
+    }
+
+    for (i = 0; i < from; i++) {
+      if (fromDim[i] == 0)
+        break;
       copyblocksize *= fromDim[i];
-    for (i = 0; i < to; i++)
+    }
+    for (i = 0; i < to; i++) {
+      if (toDim[i] == 0)
+        break;
       copyblocklimit *= toDim[i];
+    }
 
     for (i = 0; i < loopLimit; i++) {
       /* [i1][i2][...][iN][b][...] i = i1 x i2 x ... x iN */
@@ -1470,7 +1483,10 @@ gst_tensor_transform_transpose (GstTensorTransform * filter,
 
   indexI = filter->data_transpose.trans_order[0];
   indexJ = filter->data_transpose.trans_order[1];
-  SL = fromDim[3], SI = fromDim[0], SJ = fromDim[1], SK = fromDim[2];
+  SL = fromDim[3] > 0 ? fromDim[3] : 1;
+  SI = fromDim[0] > 0 ? fromDim[0] : 1;
+  SJ = fromDim[1] > 0 ? fromDim[1] : 1;
+  SK = fromDim[2] > 0 ? fromDim[2] : 1;
 
   switch (indexI) {
     case 0:

--- a/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
@@ -270,10 +270,7 @@ gst_tensor_info_convert_to_meta (GstTensorInfo * info, GstTensorMetaInfo * meta)
 
   for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
     /** @todo handle rank from info.dimension */
-    if (info->dimension[i] > 0)
-      meta->dimension[i] = info->dimension[i];
-    else
-      break;
+    meta->dimension[i] = info->dimension[i];
   }
 
   return TRUE;
@@ -287,17 +284,9 @@ gst_tensor_info_convert_to_meta (GstTensorInfo * info, GstTensorMetaInfo * meta)
 guint
 gst_tensor_info_get_rank (const GstTensorInfo * info)
 {
-  gint idx;
-
   g_return_val_if_fail (info != NULL, 0);
 
-  /** rank is at least 1 */
-  for (idx = NNS_TENSOR_RANK_LIMIT - 1; idx > 0; idx--) {
-    if (info->dimension[idx] != 1)
-      break;
-  }
-  /** @todo use gst_tensor_dimension_get_rank (info->dimension) after 0-init dim is done */
-  return idx + 1;
+  return gst_tensor_dimension_get_rank (info->dimension);
 }
 
 /**
@@ -1095,13 +1084,6 @@ gst_tensor_parse_dimension (const gchar * dimstr, tensor_dim dim)
     rank = i + 1;
   }
 
-  /**
-   * @todo remove below lines
-   * (0-initialized before parsing the string, filled remained dimension with 0)
-   */
-  for (; i < NNS_TENSOR_RANK_LIMIT; i++)
-    dim[i] = 1;
-
   g_strfreev (strv);
   g_free (dim_string);
   return rank;
@@ -1622,8 +1604,7 @@ gst_tensor_meta_info_convert (GstTensorMetaInfo * meta, GstTensorInfo * info)
       break;
     }
 
-    /** @todo handle rank from info.dimension (Fill 0, not 1) */
-    info->dimension[i] = (meta->dimension[i] > 0) ? meta->dimension[i] : 1;
+    info->dimension[i] = meta->dimension[i];
   }
 
   return TRUE;

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -300,7 +300,6 @@ TEST (commonGetTensorDimension, case2)
   EXPECT_EQ (dim[0], 345U);
   EXPECT_EQ (dim[1], 123U);
   EXPECT_EQ (dim[2], 433U);
-  EXPECT_EQ (dim[3], 1U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
   EXPECT_TRUE (gst_tensor_dimension_string_is_equal (dim_str, "345:123:433:1"));
@@ -320,8 +319,6 @@ TEST (commonGetTensorDimension, case3)
   EXPECT_EQ (rank, 2U);
   EXPECT_EQ (dim[0], 345U);
   EXPECT_EQ (dim[1], 123U);
-  EXPECT_EQ (dim[2], 1U);
-  EXPECT_EQ (dim[3], 1U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
   EXPECT_TRUE (gst_tensor_dimension_string_is_equal (dim_str, "345:123:1:1"));
@@ -340,9 +337,6 @@ TEST (commonGetTensorDimension, case4)
   rank = gst_tensor_parse_dimension ("345", dim);
   EXPECT_EQ (rank, 1U);
   EXPECT_EQ (dim[0], 345U);
-  EXPECT_EQ (dim[1], 1U);
-  EXPECT_EQ (dim[2], 1U);
-  EXPECT_EQ (dim[3], 1U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
   EXPECT_TRUE (gst_tensor_dimension_string_is_equal (dim_str, "345:1:1:1"));

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -2122,7 +2122,6 @@ TEST (testTensorTransform, arithmeticFlexTensor)
     gst_tensor_meta_info_parse_header (&meta, map.data);
     EXPECT_EQ (meta.type, _NNS_FLOAT32);
     EXPECT_EQ (meta.dimension[0], 5U);
-    EXPECT_EQ (meta.dimension[1], 1U);
 
     hsize = gst_tensor_meta_info_get_header_size (&meta);
     ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size + hsize);
@@ -6424,21 +6423,21 @@ TEST_REQUIRE_TFLITE (testTensorFilter, propertyRank02)
   EXPECT_TRUE (gst_tensor_dimension_string_is_equal (input_dim, "3:224:224:1"));
   g_free (input_dim);
 
-  /* Rank should be 3 since input dimension string is not given. */
+  /* Rank should be 4 since input dimension string is not given. */
   gchar *input_ranks;
   g_object_get (filter, "inputranks", &input_ranks, NULL);
-  EXPECT_STREQ (input_ranks, "3");
+  EXPECT_STREQ (input_ranks, "4");
   g_free (input_ranks);
 
   gchar *output_dim;
   g_object_get (filter, "output", &output_dim, NULL);
-  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (output_dim, "1001:1:1:1"));
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (output_dim, "1001:1"));
   g_free (output_dim);
 
-  /* Rank should be 1 since output dimension string is not given. */
+  /* Rank should be 2 since output dimension string is not given. */
   gchar *output_ranks;
   g_object_get (filter, "outputranks", &output_ranks, NULL);
-  EXPECT_STREQ (output_ranks, "1");
+  EXPECT_STREQ (output_ranks, "2");
   g_free (output_ranks);
 
   g_object_unref (filter);

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -3045,8 +3045,6 @@ TEST (tensorStreamTest, octetCurrentTs)
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].type, _NNS_UINT8);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[0], 1U);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[1], 10U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[2], 1U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensors_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensors_config.rate_d, 1);
 
@@ -3092,8 +3090,6 @@ TEST (tensorStreamTest, octetFramerateTs)
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].type, _NNS_UINT8);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[0], 1U);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[1], 10U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[2], 1U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensors_config.rate_n, 10);
   EXPECT_EQ (g_test_data.tensors_config.rate_d, 1);
 
@@ -3166,8 +3162,6 @@ TEST (tensorStreamTest, octetValidTs)
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].type, _NNS_UINT8);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[0], 1U);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[1], 10U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[2], 1U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensors_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensors_config.rate_d, 1);
 
@@ -3240,8 +3234,6 @@ TEST (tensorStreamTest, octetInvalidTs)
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].type, _NNS_UINT8);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[0], 1U);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[1], 10U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[2], 1U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensors_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensors_config.rate_d, 1);
 
@@ -3314,8 +3306,6 @@ TEST (tensorStreamTest, octet2f)
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].type, _NNS_INT8);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[0], 1U);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[1], 5U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[2], 1U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensors_config.rate_n, 10);
   EXPECT_EQ (g_test_data.tensors_config.rate_d, 1);
 
@@ -3382,15 +3372,9 @@ TEST (tensorStreamTest, octetMultiTensors)
 
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].type, _NNS_INT32);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[0], 2U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[1], 1U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[2], 1U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[3], 1U);
 
   EXPECT_EQ (g_test_data.tensors_config.info.info[1].type, _NNS_INT8);
   EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[0], 2U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[1], 1U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[2], 1U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[3], 1U);
 
   EXPECT_EQ (g_test_data.tensors_config.rate_n, 10);
   EXPECT_EQ (g_test_data.tensors_config.rate_d, 1);
@@ -3547,9 +3531,6 @@ TEST (tensorStreamTest, flexToStatic)
   EXPECT_TRUE (gst_tensors_config_validate (&g_test_data.tensors_config));
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].type, _NNS_UINT8);
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[0], 10U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[1], 1U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[2], 1U);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensors_config.rate_n, 10);
   EXPECT_EQ (g_test_data.tensors_config.rate_d, 1);
 

--- a/tests/nnstreamer_sparse/runTest.sh
+++ b/tests/nnstreamer_sparse/runTest.sh
@@ -175,7 +175,9 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
 videotestsrc num-buffers=1 ! \
     video/x-raw,format=RGB,width=10,height=10,framerate=0/1 ! videoconvert ! \
     tensor_converter ! tensor_filter framework=lua \
-    model=\"${MAKE_SAMPLE_TENSORS_SCRIPT}\" ! tensor_sparse_enc ! filesink location=./sample1.sparse" 4 0 0 $PERFORMANCE
+    model=\"${MAKE_SAMPLE_TENSORS_SCRIPT}\" ! \
+    other/tensors,num_tensors=1,framerate=0/1,dimensions=1:3:4:1,types=uint8 ! \
+    tensor_sparse_enc ! filesink location=./sample1.sparse" 4 0 0 $PERFORMANCE
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
 filesrc location=sample1.sparse ! \

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -69,7 +69,7 @@ get_model_file ()
  */
 TEST (nnstreamerNnfwRuntimeRawFunctions, getDimension)
 {
-  int ret, i;
+  int ret;
   void *data = NULL;
   GstTensorsInfo info, res;
   gchar *model_file;
@@ -93,8 +93,7 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, getDimension)
 
   info.num_tensors = 1;
   info.info[0].type = _NNS_FLOAT32;
-  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
-    info.info[0].dimension[i] = 1;
+  info.info[0].dimension[0] = 1;
 
   /** get input/output dimension successfully */
   ret = sp->getInputDimension (&prop, &data, &res);
@@ -102,16 +101,14 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, getDimension)
 
   EXPECT_EQ (res.num_tensors, info.num_tensors);
   EXPECT_EQ (res.info[0].type, info.info[0].type);
-  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
-    EXPECT_EQ (res.info[0].dimension[i], info.info[0].dimension[i]);
+  EXPECT_EQ (res.info[0].dimension[0], info.info[0].dimension[0]);
 
   ret = sp->getOutputDimension (&prop, &data, &res);
   EXPECT_EQ (ret, 0);
 
   EXPECT_EQ (res.num_tensors, info.num_tensors);
   EXPECT_EQ (res.info[0].type, info.info[0].type);
-  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
-    EXPECT_EQ (res.info[0].dimension[i], info.info[0].dimension[i]);
+  EXPECT_EQ (res.info[0].dimension[0], info.info[0].dimension[0]);
 
   sp->close (&prop, &data);
 
@@ -159,8 +156,6 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, setDimension)
   res.num_tensors = 1;
   res.info[0].type = _NNS_FLOAT32;
   res.info[0].dimension[0] = tensor_size;
-  for (i = 1; i < NNS_TENSOR_RANK_LIMIT; i++)
-    res.info[0].dimension[i] = 1;
 
   /** get input/output dimension successfully */
   ret = sp->getInputDimension (&prop, &data, &in_info);
@@ -170,8 +165,6 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, setDimension)
   EXPECT_EQ (res.info[0].type, in_info.info[0].type);
 
   EXPECT_NE (res.info[0].dimension[0], in_info.info[0].dimension[0]);
-  for (i = 1; i < NNS_TENSOR_RANK_LIMIT; i++)
-    EXPECT_EQ (res.info[0].dimension[i], in_info.info[0].dimension[i]);
 
   ret = sp->setInputDimension (&prop, &data, &res, &out_info);
   EXPECT_EQ (ret, 0);
@@ -372,16 +365,11 @@ TEST (nnstreamerNnfwRuntimeRawFunctions, invokeAdvanced)
   info.info[0].type = _NNS_UINT8;
   info.info[0].dimension[0] = 1001;
   info.info[0].dimension[1] = 1;
-  info.info[0].dimension[2] = 1;
-  info.info[0].dimension[3] = 1;
 
   EXPECT_EQ (res.num_tensors, info.num_tensors);
   EXPECT_EQ (res.info[0].type, info.info[0].type);
   EXPECT_EQ (res.info[0].dimension[0], info.info[0].dimension[0]);
   EXPECT_EQ (res.info[0].dimension[1], info.info[0].dimension[1]);
-  EXPECT_EQ (res.info[0].dimension[2], info.info[0].dimension[2]);
-  EXPECT_EQ (res.info[0].dimension[3], info.info[0].dimension[3]);
-
   output.size = gst_tensor_info_get_size (&res.info[0]);
 
   input.data = NULL;


### PR DESCRIPTION
This PR removes padded value of dimensions.
Dimension in GstTensorInfo is 0 by default.

related to : https://github.com/nnstreamer/api/pull/338

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
