### PR TITLE
[util] Fix the signature of gst_tensor_buffer_get_nth_meory

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -126,7 +126,7 @@ gst_tensor_caps_can_intersect (GstCaps *caps1, GstCaps *caps2);
  * @return GstMemory if found, otherwise NULL (Caller should free returned memory using gst_memory_unref()).
  */
 extern GstMemory *
-gst_tensor_buffer_get_nth_memory (GstBuffer * buffer, const GstTensorsInfo * info, const guint index);
+gst_tensor_buffer_get_nth_memory (GstBuffer * buffer, const guint index);
 
 /**
  * @brief Append @a memory to given @a buffer.

--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -1523,10 +1523,9 @@ gst_tensor_extra_info_init (GstTensorExtraInfo * extra, gsize reserved_size)
  * @return GstMemory if found, otherwise NULL (Caller should free returned memory using gst_memory_unref()).
  */
 GstMemory *
-gst_tensor_buffer_get_nth_memory (GstBuffer * buffer,
-    const GstTensorsInfo * info, const guint index)
+gst_tensor_buffer_get_nth_memory (GstBuffer * buffer, const guint index)
 {
-  guint i, offset = 0;
+  guint i, num_tensors, offset = 0;
   GstMemory *extra_tensors_memory, *res_mem;
   GstMapInfo extra_tensors_map;
   GstTensorExtraInfo *extra_info;
@@ -1536,19 +1535,14 @@ gst_tensor_buffer_get_nth_memory (GstBuffer * buffer,
     return NULL;
   }
 
-  if (!info) {
-    nns_loge ("Failed to get tensors info (invalid input info).");
-    return NULL;
-  }
-
-  if (info->num_tensors <= 0) {
-    nns_loge ("num_tensors is 0. Please check the tensors info.");
+  num_tensors = gst_buffer_n_tensor (buffer);
+  if (num_tensors == 0U) {
+    nns_loge ("num_tensors is 0. Please check the buffer.");
     return NULL;
   }
 
   /* If num_tensors is less than or equal to NNS_TENSOR_SIZE_LIMIT, it's trivial. */
-  if (info->num_tensors <= NNS_TENSOR_SIZE_LIMIT
-      || index < NNS_TENSOR_SIZE_LIMIT - 1) {
+  if (num_tensors <= NNS_TENSOR_SIZE_LIMIT || index < NNS_TENSOR_SIZE_LIMIT - 1) {
     return gst_buffer_get_memory (buffer, index);
   }
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -688,7 +688,7 @@ gst_tensor_filter_transform (GstBaseTransform * trans,
   num_tensors = gst_buffer_n_tensor (inbuf);
 
   for (i = 0; i < num_tensors; i++) {
-    in_mem[i] = gst_tensor_buffer_get_nth_memory (inbuf, &prop->input_meta, i);
+    in_mem[i] = gst_tensor_buffer_get_nth_memory (inbuf, i);
     if (!gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ)) {
       ml_logf_stacktrace
           ("gst_tensor_filter_transform: For the given input buffer, tensor-filter (%s : %s) cannot map input memory from the buffer for reading. The %u-th memory chunk (%u-th tensor) has failed for memory map.\n",

--- a/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
+++ b/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
@@ -293,15 +293,11 @@ check_output_many (GstElement *element, GstBuffer *buffer, gpointer user_data)
   gboolean mapped;
   UNUSED (element);
 
-  GstTensorsInfo ts_info;
-  gst_tensors_info_init (&ts_info);
-  ts_info.num_tensors = 32;
-
   guint *data_received = (guint *) user_data;
   (*data_received)++;
 
   for (guint i = 0; i < 32; i++) {
-    mem_res = gst_tensor_buffer_get_nth_memory (buffer, &ts_info, i);
+    mem_res = gst_tensor_buffer_get_nth_memory (buffer, i);
     mapped = gst_memory_map (mem_res, &info_res, GST_MAP_READ);
     ASSERT_TRUE (mapped);
     gfloat *output = (gfloat *) info_res.data;

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -6451,14 +6451,10 @@ _manual_extra_tensors_new_data_cb (GstElement *element, GstBuffer *buffer, gpoin
   GstMapInfo info_res;
   gint *output, i;
   gboolean ret;
-  GstTensorsInfo ts_info;
-
-  gst_tensors_info_init (&ts_info);
-  ts_info.num_tensors = 20;
 
   data_received++;
   for (i = 0; i < 20; ++i) {
-    mem_res = gst_tensor_buffer_get_nth_memory (buffer, &ts_info, i);
+    mem_res = gst_tensor_buffer_get_nth_memory (buffer, i);
     ret = gst_memory_map (mem_res, &info_res, GST_MAP_READ);
     ASSERT_TRUE (ret);
     output = (gint *) info_res.data;
@@ -6466,8 +6462,6 @@ _manual_extra_tensors_new_data_cb (GstElement *element, GstBuffer *buffer, gpoin
     gst_memory_unmap (mem_res, &info_res);
     gst_memory_unref (mem_res);
   }
-
-  gst_tensors_info_free (&ts_info);
 }
 
 /**
@@ -6556,14 +6550,11 @@ _tensor_mux_extra_tensors_new_data_cb (GstElement *element, GstBuffer *buffer, g
   guint8 *output;
   gint i;
   gboolean ret;
-  GstTensorsInfo ts_info;
 
-  gst_tensors_info_init (&ts_info);
   data_received++;
-  ts_info.num_tensors = 20;
 
   for (i = 0; i < 20; ++i) {
-    mem_res = gst_tensor_buffer_get_nth_memory (buffer, &ts_info, (guint) i);
+    mem_res = gst_tensor_buffer_get_nth_memory (buffer, (guint) i);
     ret = gst_memory_map (mem_res, &info_res, GST_MAP_READ);
     ASSERT_TRUE (ret);
     output = (guint8 *) info_res.data;

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -4266,9 +4266,8 @@ test_custom_v0_handleEvent (event_ops ops, GstTensorFilterFrameworkEventData *da
  * @brief The mandatory callback for GstTensorFilterFramework (v1).
  */
 static int
-test_custom_v1_invoke (const GstTensorFilterFramework *self,
-    GstTensorFilterProperties *prop, void *private_data,
-    const GstTensorMemory *input, GstTensorMemory *output)
+test_custom_v1_invoke (const GstTensorFilterFramework *self, GstTensorFilterProperties *prop,
+    void *private_data, const GstTensorMemory *input, GstTensorMemory *output)
 {
   return test_custom_v0_invoke (prop, &private_data, input, output);
 }


### PR DESCRIPTION
- Remove unused argument of GstTensorsInfo.
- Fix used lines.
- Apply clang-format-15 to the file `unittest_sink.cc`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped