### PR TITLE
[common] Increase tensor_size_extra_limit to 240

### DIFF
--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -35,7 +35,14 @@
 #define NNS_TENSOR_RANK_LIMIT_PREV (4)
 #define NNS_TENSOR_SIZE_LIMIT	(16)
 #define NNS_TENSOR_SIZE_LIMIT_STR	"16"
-#define NNS_TENSOR_SIZE_EXTRA_LIMIT (100)
+
+/**
+ * @todo Set NNS_TENSOR_SIZE_LIMIT as 256,
+ * and define NNS_TENSOR_SIZE_LIMIT_STATIC as 16.
+ * And define NNS_TENSOR_SIZE_EXTRA_LIMIT as (NNS_TENSOR_SIZE_LIMIT - NNS_TENSOR_SIZE_LIMIT_STATIC).
+ * Then update other source codes accordingly.
+ */
+#define NNS_TENSOR_SIZE_EXTRA_LIMIT (240)
 #define NNS_TENSOR_DIM_NULL ({0, 0, 0, 0})
 
 /**


### PR DESCRIPTION
- Making the total size limit to be 256 (16 + 240)
TODO: Set NNS_TENSOR_SIZE as 256 and update other source codes accordingly

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
