### PR TITLE
[tensor_filter] Increase num tensors for tensor_filter_single

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -726,7 +726,7 @@ TFLiteInterpreter::setInputTensorsInfo (const GstTensorsInfo *info)
     tensor_type tf_type;
     const GstTensorInfo *tensor_info;
 
-    tensor_info = &info->info[tensor_idx];
+    tensor_info = gst_tensors_info_get_nth_info ((GstTensorsInfo *) info, tensor_idx);
 
     /** cannot change the type of input */
     tf_type = getTensorType (interpreter->tensor (input_idx_list[tensor_idx])->type);

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -690,6 +690,7 @@ TFLiteInterpreter::setTensorProp (
 int
 TFLiteInterpreter::setInputTensorProp ()
 {
+  gst_tensors_info_free (&inputTensorMeta);
   return setTensorProp (interpreter->inputs (), &inputTensorMeta);
 }
 
@@ -700,6 +701,7 @@ TFLiteInterpreter::setInputTensorProp ()
 int
 TFLiteInterpreter::setOutputTensorProp ()
 {
+  gst_tensors_info_free (&outputTensorMeta);
   return setTensorProp (interpreter->outputs (), &outputTensorMeta);
 }
 
@@ -1552,25 +1554,25 @@ tflite_setInputDim (const GstTensorFilterProperties *prop, void **private_data,
   /** get current input tensor info for resetting */
   status = core->getInputTensorDim (&cur_in_info);
   if (status != 0)
-    return status;
+    goto exit;
 
   /** set new input tensor info */
   status = core->setInputTensorDim (in_info);
   if (status != 0) {
     tflite_setInputDim_recovery (core, &cur_in_info, "while setting input tensor info", 0);
-    return status;
+    goto exit;
   }
 
   /** update input tensor info */
   if ((status = core->setInputTensorProp ()) != 0) {
     tflite_setInputDim_recovery (core, &cur_in_info, "while updating input tensor info", 1);
-    return status;
+    goto exit;
   }
 
   /** update output tensor info */
   if ((status = core->setOutputTensorProp ()) != 0) {
     tflite_setInputDim_recovery (core, &cur_in_info, "while updating output tensor info", 2);
-    return status;
+    goto exit;
   }
 
   /** update the input and output tensor cache */
@@ -1578,7 +1580,7 @@ tflite_setInputDim (const GstTensorFilterProperties *prop, void **private_data,
   if (status != 0) {
     tflite_setInputDim_recovery (
         core, &cur_in_info, "while updating input and output tensor cache", 2);
-    return status;
+    goto exit;
   }
 
   /** get output tensor info to be returned */
@@ -1586,10 +1588,13 @@ tflite_setInputDim (const GstTensorFilterProperties *prop, void **private_data,
   if (status != 0) {
     tflite_setInputDim_recovery (
         core, &cur_in_info, "while retreiving update output tensor info", 2);
-    return status;
+    goto exit;
   }
 
-  return 0;
+exit:
+  gst_tensors_info_free (&cur_in_info);
+
+  return status;
 }
 
 /**

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -128,7 +128,7 @@ typedef enum _nns_tensor_layout
   _NNS_LAYOUT_NONE,        /**< NONE: none of the above defined layouts */
 } tensor_layout;
 
-typedef tensor_layout tensors_layout[NNS_TENSOR_SIZE_LIMIT];
+typedef tensor_layout tensors_layout[NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT];
 
 /**
  * @brief GstTensorFilter's properties for NN framework (internal data structure)
@@ -146,12 +146,12 @@ typedef struct _GstTensorFilterProperties
   int input_configured; /**< TRUE if input tensor is configured. Use int instead of gboolean because this is refered by custom plugins. */
   GstTensorsInfo input_meta; /**< configured input tensor info */
   tensors_layout input_layout; /**< data layout info provided as a property to tensor_filter for the input, defaults to _NNS_LAYOUT_ANY for all the tensors */
-  unsigned int input_ranks[NNS_TENSOR_SIZE_LIMIT];  /**< the rank list of input tensors, it is calculated based on the dimension string. */
+  unsigned int input_ranks[NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT];  /**< the rank list of input tensors, it is calculated based on the dimension string. */
 
   int output_configured; /**< TRUE if output tensor is configured. Use int instead of gboolean because this is refered by custom plugins. */
   GstTensorsInfo output_meta; /**< configured output tensor info */
   tensors_layout output_layout; /**< data layout info provided as a property to tensor_filter for the output, defaults to _NNS_LAYOUT_ANY for all the tensors */
-  unsigned int output_ranks[NNS_TENSOR_SIZE_LIMIT];  /**< the rank list of output tensors, it is calculated based on the dimension string. */
+  unsigned int output_ranks[NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT];  /**< the rank list of output tensors, it is calculated based on the dimension string. */
 
   const char *custom_properties; /**< sub-plugin specific custom property values in string */
   accl_hw *hw_list; /**< accelerators supported by framework intersected with user provided accelerator preference, use in GstTensorFilterFramework V1 only */

--- a/gst/nnstreamer/tensor_filter/tensor_filter_single.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_single.c
@@ -324,7 +324,7 @@ g_tensor_filter_single_invoke (GTensorFilterSingle * self,
   GTensorFilterSinglePrivate *spriv;
   GstTensorFilterPrivate *priv;
   GstTensorMemory *_out;
-  GstTensorMemory out_tensors[NNS_TENSOR_SIZE_LIMIT] = { {0} };
+  GstTensorMemory out_tensors[NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT] = { {0} }; /** @todo refactor this local variable */
   guint i;
   gint status;
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_single.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_single.c
@@ -424,6 +424,9 @@ g_tensor_filter_set_input_info (GTensorFilterSingle * self,
   }
 
   if (status == 0) {
+    gst_tensors_info_free (&priv->prop.input_meta);
+    gst_tensors_info_free (&priv->prop.output_meta);
+
     gst_tensors_info_copy (&priv->prop.input_meta, in_info);
     gst_tensors_info_copy (&priv->prop.output_meta, out_info);
   }


### PR DESCRIPTION
Let tensor_filter_common handle extra tensors
  - Extend array length for layout and ranks
  - Replace accessing tensor_info with array index with util func `gst_tensors_info_get_nth_info`
  - Extend the array length of out GstTensorMemory to support invoke of many in/out tensors model with filter_single

- Add testcases for filter_single with 32 in/out tensors model 
- Add calls for `gst_tensors_info_free` (fix mem leak)


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
