### PR TITLE
[datareposink] Add function to write flexible tensors

### DIFF
--- a/gst/datarepo/gstdatareposink.h
+++ b/gst/datarepo/gstdatareposink.h
@@ -43,14 +43,17 @@ struct _GstDataRepoSink
 
   GstCaps *fixed_caps;            /**< to get meta info */
   JsonObject *json_object;        /**< JSON object */
-  JsonArray *json_offset_array;   /**< offset array for flexible tensors */
+  JsonArray *sample_offset_array;   /**< offset array of sample */
+  JsonArray *tensor_size_array;    /**< size array of flexible tensor */
+  JsonArray *tensor_count_array;  /**< array for the number of cumulative tensors */
+  guint flexible_tensor_count;
 
   gboolean is_flexible_tensors;
   gint fd;                        /**< open file descriptor*/
   GstDataRepoDataType data_type;  /**< data type */
   gint total_samples;             /**< The number of total samples, in the case of multi-files, it is used as an index. */
-  guint64 offset;                 /**< offset of fd */
-  guint sample_size;              /**< size of one sample */
+  guint64 fd_offset;              /**< offset of fd */
+  guint sample_size;             /**< size of one sample */
 
   /* property */
   gchar *filename;    /**< filename */


### PR DESCRIPTION
    - To add memory to gstbuffer by number of flexible tensors when read sample in datareposrc,
      sample_offset, tensor_size, and tensor_count field are added to the JSON file
    - Add unit test
    
    - Reference
      * If caps of sink pad is flexible, the input gstBuffer is saved as a flexible tensor
      * The size of the input gstBuffer is stored as sample_offset field in JSON file and
        it will be used when shuffle operation in datareposrc
      * Each flexible tensor size is stored as tensor_size field in JSON file and
        it will be used with gst_buffer_append_memory() in datareposrc

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

**Reference**
Test with "other/tensors,format=flexible"
```
gst-launch-1.0 videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=176,height=144,framerate=10/1 ! tensor_converter ! join0.sink_0 \
videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=320,height=240,framerate=10/1 ! tensor_converter ! join0.sink_1 \
videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=640,height=480,framerate=10/1 ! tensor_converter ! join0.sink_2 \
join name=join0 ! other/tensors,format=flexible ! mux.sink_0 \
videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=176,height=144,framerate=10/1 ! tensor_converter ! join1.sink_0 \
videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=320,height=240,framerate=10/1 ! tensor_converter ! join1.sink_1 \
videotestsrc num-buffers=3 ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=640,height=480,framerate=10/1 ! tensor_converter ! join1.sink_2 \
join name=join1 ! other/tensors,format=flexible ! mux.sink_1 \
tensor_mux name=mux sync-mode=nosync ! datareposink location=flexible.data json=flexible.json
```
$cat flexible.json
```
{
  "gst_caps" : "other/tensors, format=(string)flexible, framerate=(fraction)10/1",
  "total_samples" : 9,
  "sample_offset" : [
    0,           --------------> sample_0 start offset
    152320, --------------> sample_1 start offset and sample_0 size is 152320 byte(152320 - 0)
    1304576, ------------> sample_2 start offset and sample_1 size is 1152256 byte(1304576 - 152320)
    2456832,
    2609152,
    3761408,
    4913664,
    5065984,
    5527040
  ],
  "tensor_size" : [
    76160, ---------------> The size of  1st tensor of sample_0
    76160, ---------------> The size of 2nd tensor of sample_0
    921728,  ------------> The size of  1st tensor of sample_1
    230528, -------------> The size of  2nd tensor of sample_1
    230528,
    921728,
    76160,
    76160,
    921728,
    230528,
    230528,
    921728,
    76160,
    76160,
    230528,
    230528,
    921728,
    921728 
  ] -----------------> total count of tensor_size array is "18"
  "tensor_count" : [
    0,------> sample_0 consists of 2 tensors. because the next index value of sample_0 is 2. that is, (2 - 0)
    2, -----> sample_1 consists of 2 tensors,  that is, (4 - 2)
    4,
    6,
    8,
    10,
    12,
    14,
    16  -----> total count of tensor_size array is "18", that is, sample_8 consists of 2 tensors. (18 - 16)
  ] 
}
```
see #4129