### PR TITLE
[Fix] fix svace issue. @open sesame 06/21 17:06

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -1297,8 +1297,8 @@ update_centroids (void **pdata, GArray * boxes)
         int bcy = box->y + box->height / 2;
 
         d->distance =
-            (guint64) ((c->cx - bcx) * (c->cx - bcx))
-                     +  (guint64) ((c->cy - bcy) * (c->cy - bcy));
+            (guint64) (c->cx - bcx) * (c->cx - bcx)
+                     +  (guint64) (c->cy - bcy) * (c->cy - bcy);
       }
     }
   }


### PR DESCRIPTION
 - Fix overflow before widen (distance value in 'g_array_set_size' func).

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


