### PR TITLE
[datareposrc] Add function to read flexible tensors

### DIFF
--- a/gst/datarepo/gstdatareposrc.h
+++ b/gst/datarepo/gstdatareposrc.h
@@ -16,6 +16,7 @@
 #include <sys/types.h>
 #include <gst/gst.h>
 #include <gst/base/gstpushsrc.h>
+#include <json-glib/json-glib.h>
 #include <tensor_typedef.h>
 #include "gstdatarepo.h"
 
@@ -44,11 +45,13 @@ struct _GstDataRepoSrc {
   GstPushSrc parent;            /**< parent object */
   GstPad *src_pad;
 
+  gboolean is_flexible_tensors;
   gboolean is_start;            /**< check if datareposrc is started */
   gboolean successful_read;     /**< used for checking EOS when reading more than one images(multi-files) from a path */
   gint fd;                      /**< open file descriptor */
+  gint file_size;               /**< file size, in bytes */
   guint64 read_position;        /**< position of fd */
-  guint64 offset;               /**< offset of fd */
+  guint64 fd_offset;            /**< offset of fd */
   guint64 start_offset;         /**< start offset to read */
   guint64 last_offset;          /**< last offset to read */
   guint tensors_size[MAX_ITEM];   /**< each tensors size in a sample */
@@ -77,6 +80,15 @@ struct _GstDataRepoSrc {
   guint tensors_seq_cnt;
   gboolean need_changed_caps;   /**< When tensors-sequence changes, caps need to be changed */
   GstCaps *caps;                /**< optional property, datareposrc should get data format from JSON file caps field */
+
+  /* flexible tensors */
+  JsonArray *sample_offset_array;   /**< offset array of sample */
+  JsonArray *tensor_size_array;     /**< size array of flexible tensor to be stored in a Gstbuffer */
+  JsonArray *tensor_count_array;    /**< array for the number of cumulative tensors */
+  JsonParser *parser;               /**< Keep JSON data after parsing JSON file */
+  guint sample_offset_array_len;
+  guint tensor_size_array_len;
+  guint tensor_count_array_len;
 };
 
 /**


### PR DESCRIPTION
    - If the tensor format of the caps of the JSON file is flexible,
      Reads a sample using the flexible meta information (sample_offset, tensor_size, tensor_count)
      of the JSON file and appends memory to GstBuffer as many as the number of flexible tensors.
    - Add unit test
    - Add checking if it is a flexible tensor after writing data to GstMemory
    
    - Reference
      * The start offset for reading is sample_offset(sample size).
      * Save each flexible tensor stored in a sample to a gstbuffer according to each
        tensor_size, tensor_size can get tensor_size field in JSON file.
      * A shuffled index is mapped to an index of sample_offset field in JSON file.
      * A shuffled index is also mapped to an index of tensor_count field in JSON file
      * The index value is a number of cumulative tensors, so it is mapped to an index
        of tensor_size field in JSON file


**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

**Reference**
#4122 
If a shuffle index is 2, Let's see (1),(2),(3) how it works.
$cat flexible.json
```
{
  "gst_caps" : "other/tensors, format=(string)flexible, framerate=(fraction)10/1",
  "total_samples" : 9,
  "sample_offset" : [
    0, 
    152320, 
    1304576, ---------> (1) shuffle index 2, so do lseek(fd, 1304576, SET_SET)
    2456832,
    2609152,
    3761408,
    4913664,
    5065984,
    5527040
  ],
  "tensor_size" : [
    76160, 
    76160, 
    921728, 
    230528, 
    230528, --------> (3)tensor_count  is "4" and num_tensor is 2 when shuffle index 2, so datareposrc uses
    921728,          gst_buffer_append_memory() to append 230528byte and 921728byte memory to a Gstbuffer.
    76160,
    76160,
    921728,
    230528,
    230528,
    921728,
    76160,
    76160,
    230528,
    230528,
    921728,
    921728 
  ] ----------------> total count of tensor_size array is "18"
  "tensor_count" : [
    0,
    2,
    4, -------------> (2) shuffle index 2, so num_tensors is 2 (6 - 4), and current tensor_count  is "4"
    6,                        , "4" is index of tensor_size
    8,
    10,
    12,
    14,
    16 
  ] 
}
```
