### PR TITLE
Dist/Tizen: Fix a GBS build error due to #4007

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -641,7 +641,6 @@ if get_option('enable-mediapipe')
   )
 endif
 
-run_command('sh', '-c', 'touch filter_snpe_list', check : true)
 if snpe_support_is_available
   filter_sub_snpe_sources = ['tensor_filter_snpe.cc']
 
@@ -665,7 +664,6 @@ if snpe_support_is_available
     install: true,
     install_dir: nnstreamer_libdir
   )
-  run_command('sh', '-c', 'echo "%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_snpe.so" >> filter_snpe_list', check : true)
 endif
 
 if tensorrt_support_is_available

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -944,6 +944,13 @@ ln -sf %{_libdir}/nnstreamer_python3.so nnstreamer_python.so
 popd
 %endif
 
+%if 0%{?snpe_support}
+%define snpe_sub_plugin libnnstreamer_filter_snpe.so
+%define files_for_snpe_subpackage files_for_snpe_subpackage.txt
+rm -f %{files_for_snpe_subpackage}
+find %{buildroot} -type f -name '%{snpe_sub_plugin}' -printf '/%%P\n' > %{files_for_snpe_subpackage}
+%endif
+
 %if 0%{?testcoverage}
 ##
 # The included directories are:
@@ -1105,7 +1112,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %if 0%{?snpe_support}
 # Workaround: Conditionally enable nnstreamer-snpe rpm package
 # when existing actual snpe library (snpe.pc)
-%files snpe -f ext/nnstreamer/tensor_filter/filter_snpe_list
+%files snpe -f %{files_for_snpe_subpackage}
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
 %endif


### PR DESCRIPTION
This patch fixes a GBS build error caused by https://github.com/nnstreamer/nnstreamer/pull/4007 on the SNPE
sub-plugin for Tizen.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

See also: #4127 