### PR TITLE
Config file for properties

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_decoder.c
+++ b/gst/nnstreamer/elements/gsttensor_decoder.c
@@ -74,7 +74,8 @@ enum
   PROP_MODE_OPTION7,
   PROP_MODE_OPTION8,
   PROP_MODE_OPTION9,
-  PROP_SUBPLUGINS
+  PROP_SUBPLUGINS,
+  PROP_CONFIG
 };
 
 /**
@@ -358,6 +359,11 @@ gst_tensordec_class_init (GstTensorDecoderClass * klass)
           "Registrable sub-plugins list", "",
           G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
 
+  g_object_class_install_property (gobject_class, PROP_CONFIG,
+      g_param_spec_string ("config-file", "Configuration-file",
+          "sets config file path which contains plugins properties", "",
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
   gst_element_class_set_details_simple (gstelement_class,
       "TensorDecoder",
       "Converter/Tensor",
@@ -505,6 +511,12 @@ gst_tensordec_set_property (GObject * object, guint prop_id,
         gst_tensor_decoder_clean_plugin (self);
         self->decoder = NULL;
       }
+      break;
+    }
+    case PROP_CONFIG:
+    {
+      const gchar *config_path = g_value_get_string (value);
+      gst_tensor_parse_config_file (config_path, object);
       break;
     }
       PROP_MODE_OPTION (1);

--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -109,6 +109,21 @@ typedef struct
 } GstTensorPad;
 
 /**
+ * @brief Parses a configuration file and sets the corresponding properties on a GObject.
+ *
+ * This function reads the contents of the configuration file located at the given path
+ * and sets the properties of the specified GObject based on the configuration data.
+ *
+ * @param config_path The path to the configuration file.
+ * @param object      The GObject on which to set the properties.
+ *
+ * @note The responsibility of managing the memory of the GObject passed as a parameter
+ *       lies outside this function.
+ */
+extern void 
+gst_tensor_parse_config_file (const gchar *config_path, const GObject *object);
+
+/**
  * @brief Get the corresponding mode from the string value.
  * @param[in] str The string value for the mode.
  * @return Corresponding mode for the string. SYNC_END for errors.

--- a/tests/nnstreamer_decoder_boundingbox/config_file.0
+++ b/tests/nnstreamer_decoder_boundingbox/config_file.0
@@ -1,0 +1,5 @@
+mode=bounding_boxes
+option2=coco_labels_list.txt
+option3=box_priors.txt
+option4=160:120
+option5=300:300

--- a/tests/nnstreamer_decoder_boundingbox/config_file.1
+++ b/tests/nnstreamer_decoder_boundingbox/config_file.1
@@ -1,0 +1,4 @@
+mode=bounding_boxes
+option2=coco_labels_list.txt
+option4=160:120
+option5=640:480

--- a/tests/nnstreamer_decoder_boundingbox/config_file.2
+++ b/tests/nnstreamer_decoder_boundingbox/config_file.2
@@ -1,0 +1,5 @@
+mode=bounding_boxes
+option1=mp-palm-detection
+option3=0.5:4:1.0:1.0:0.5:0.5:8:16:16:16
+option4=160:120
+option5=300:300

--- a/tests/nnstreamer_decoder_boundingbox/runTest.sh
+++ b/tests/nnstreamer_decoder_boundingbox/runTest.sh
@@ -31,10 +31,22 @@ callCompareTest mobilenetssd_golden.0 mobilenetssd_output.0 0-1 "mobilenet-ssd D
 callCompareTest mobilenetssd_golden.1 mobilenetssd_output.1 0-2 "mobilenet-ssd Decode 2" 0
 rm mobilenetssd_output.*
 
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decoder option1=mobilenet-ssd config-file=config_file.0 ! videoconvert ! video/x-raw,format=BGRx ! multifilesink location=mobilenetssd_output.%d  multifilesrc name=fs1 location=mobilenetssd_tensors.0.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=4:1:1917:1 input-type=float32 ! mux.sink_0  multifilesrc name=fs2 location=mobilenetssd_tensors.1.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=91:1917:1 input-type=float32 ! mux.sink_1  " 0 0 0 $PERFORMANCE
+
+callCompareTest mobilenetssd_golden.0 mobilenetssd_output.0 0-1 "mobilenet-ssd Decode 1 (with config_file.0)" 0
+callCompareTest mobilenetssd_golden.1 mobilenetssd_output.1 0-2 "mobilenet-ssd Decode 2 (with config_file.0)" 0
+rm mobilenetssd_output.*
+
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decoder mode=bounding_boxes option1=tflite-ssd option2=coco_labels_list.txt option3=box_priors.txt option4=160:120 option5=300:300 ! videoconvert ! video/x-raw,format=BGRx ! multifilesink location=tflitessd_output.%d  multifilesrc name=fs1 location=mobilenetssd_tensors.0.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=4:1:1917:1 input-type=float32 ! mux.sink_0  multifilesrc name=fs2 location=mobilenetssd_tensors.1.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=91:1917:1 input-type=float32 ! mux.sink_1  " 0 0 0 $PERFORMANCE
 
 callCompareTest mobilenetssd_golden.0 tflitessd_output.0 0-1 "tflite-ssd(deprecated) Decode 1" 0
 callCompareTest mobilenetssd_golden.1 tflitessd_output.1 0-2 "tflite-ssd(deprecated) Decode 2" 0
+rm tflitessd_output.*
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decoder option1=tflite-ssd config-file=config_file.0 ! videoconvert ! video/x-raw,format=BGRx ! multifilesink location=tflitessd_output.%d  multifilesrc name=fs1 location=mobilenetssd_tensors.0.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=4:1:1917:1 input-type=float32 ! mux.sink_0  multifilesrc name=fs2 location=mobilenetssd_tensors.1.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=91:1917:1 input-type=float32 ! mux.sink_1  " 0 0 0 $PERFORMANCE
+
+callCompareTest mobilenetssd_golden.0 tflitessd_output.0 0-1 "tflite-ssd(deprecated) Decode 1 (with config_file.0)" 0
+callCompareTest mobilenetssd_golden.1 tflitessd_output.1 0-2 "tflite-ssd(deprecated) Decode 2 (with config_file.0)" 0
 rm tflitessd_output.*
 
 # mobilenet-ssd-post-process & tf-ssd(deprecated) case: 1, 100:1, 100:1, 4:100:1 --> 4:160:120:1
@@ -45,10 +57,22 @@ callCompareTest mobilenetssd_postprocess_golden.0 mobilenetssd_postprocess_outpu
 callCompareTest mobilenetssd_postprocess_golden.1 mobilenetssd_postprocess_output.1 0-2 "mobilenet-ssd-postprocess Decode 2" 0
 rm mobilenetssd_postprocess_output.*
 
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decoder option1=mobilenet-ssd-postprocess config-file=config_file.1 ! videoconvert ! video/x-raw,format=BGRx ! multifilesink location=mobilenetssd_postprocess_output.%d  multifilesrc name=fs1 location=mobilenetssd_postprocess_tensors.0.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=1 input-type=float32 ! mux.sink_0  multifilesrc name=fs2 location=mobilenetssd_postprocess_tensors.1.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=100:1 input-type=float32 ! mux.sink_1  multifilesrc name=fs3 location=mobilenetssd_postprocess_tensors.2.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=100:1 input-type=float32 ! mux.sink_2  multifilesrc name=fs4 location=mobilenetssd_postprocess_tensors.3.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=4:100:1 input-type=float32 ! mux.sink_3 " 1 0 0 $PERFORMANCE
+
+callCompareTest mobilenetssd_postprocess_golden.0 mobilenetssd_postprocess_output.0 0-1 "mobilenet-ssd-postprocess Decode 1 (with config_file.1)" 0
+callCompareTest mobilenetssd_postprocess_golden.1 mobilenetssd_postprocess_output.1 0-2 "mobilenet-ssd-postprocess Decode 2 (with config_file.1)" 0
+rm mobilenetssd_postprocess_output.*
+
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decoder mode=bounding_boxes option1=tf-ssd option2=coco_labels_list.txt option4=160:120 option5=640:480 ! videoconvert ! video/x-raw,format=BGRx ! multifilesink location=tfssd_postprocess_output.%d  multifilesrc name=fs1 location=mobilenetssd_postprocess_tensors.0.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=1 input-type=float32 ! mux.sink_0  multifilesrc name=fs2 location=mobilenetssd_postprocess_tensors.1.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=100:1 input-type=float32 ! mux.sink_1  multifilesrc name=fs3 location=mobilenetssd_postprocess_tensors.2.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=100:1 input-type=float32 ! mux.sink_2  multifilesrc name=fs4 location=mobilenetssd_postprocess_tensors.3.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=4:100:1 input-type=float32 ! mux.sink_3 " 1 0 0 $PERFORMANCE
 
 callCompareTest mobilenetssd_postprocess_golden.0 tfssd_postprocess_output.0 0-1 "tf-ssd(deprecated) Decode 1" 0
 callCompareTest mobilenetssd_postprocess_golden.1 tfssd_postprocess_output.1 0-2 "tf-ssd(deprecated) Decode 2" 0
+rm tfssd_postprocess_output.*
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decoder option1=tf-ssd config-file=config_file.1 ! videoconvert ! video/x-raw,format=BGRx ! multifilesink location=tfssd_postprocess_output.%d  multifilesrc name=fs1 location=mobilenetssd_postprocess_tensors.0.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=1 input-type=float32 ! mux.sink_0  multifilesrc name=fs2 location=mobilenetssd_postprocess_tensors.1.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=100:1 input-type=float32 ! mux.sink_1  multifilesrc name=fs3 location=mobilenetssd_postprocess_tensors.2.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=100:1 input-type=float32 ! mux.sink_2  multifilesrc name=fs4 location=mobilenetssd_postprocess_tensors.3.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=4:100:1 input-type=float32 ! mux.sink_3 " 1 0 0 $PERFORMANCE
+
+callCompareTest mobilenetssd_postprocess_golden.0 tfssd_postprocess_output.0 0-1 "tf-ssd(deprecated) Decode 1 (with config_file.1)" 0
+callCompareTest mobilenetssd_postprocess_golden.1 tfssd_postprocess_output.1 0-2 "tf-ssd(deprecated) Decode 2 (with config_file.1)" 0
 rm tfssd_postprocess_output.*
 
 # palm detection decoder test
@@ -58,6 +82,14 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decode
 
 callCompareTest palm_detection_result_golden.0 palm_detection_result_0.log 5-0 "palm detection Decode 0" 0
 callCompareTest palm_detection_result_golden.1 palm_detection_result_1.log 5-1 "palm detection Decode 1" 0
+rm palm_detection_result_*.log
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decoder config-file=config_file.2 ! videoconvert !  video/x-raw,format=RGBA ! multifilesink location=palm_detection_result_%1d.log \
+    multifilesrc location=palm_detection_input_0.%1d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=18:2016:1:1 input-type=float32 ! mux.sink_0 \
+    multifilesrc location=palm_detection_input_1.%1d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=1:2016:1:1 input-type=float32 ! mux.sink_1" 5 0 0 $PERFORMANCE
+
+callCompareTest palm_detection_result_golden.0 palm_detection_result_0.log 5-0 "palm detection Decode 0 (with config_file.2)" 0
+callCompareTest palm_detection_result_golden.1 palm_detection_result_1.log 5-1 "palm detection Decode 1 (with config_file.2)" 0
 rm palm_detection_result_*.log
 
 report


### PR DESCRIPTION
This includes an API named gst_tensor_parse_config_file defined in nnstreamer_plugin_api_impl.c.

For any plugin, install a new property for defining the config file path and use the API as follows:

```
case PROP_CONFIG:
    {
      const gchar *config_path = g_value_get_string (value);
      gst_tensor_parse_config_file (config_path, object);
      break;
    }
```
The config file is defined as:
```
mode=bounding_boxes
option1=mobilenet-ssd
option2=coco_labels_list.txt
option3=box_priors.txt
option4=640:480
option5=300:300
```

And the property can be used as:
`.. ! tensor_decoder config-file=configFile ! ..`
