### PR TITLE
[trivial] Fix nms in bounding_box decoder

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -1497,8 +1497,11 @@ nms (GArray * results, gfloat threshold)
   guint boxes_size;
   guint i, j;
 
-  g_array_sort (results, compare_detection);
   boxes_size = results->len;
+  if (boxes_size == 0U)
+    return;
+
+  g_array_sort (results, compare_detection);
 
   for (i = 0; i < boxes_size; i++) {
     detectedObject *a = &g_array_index (results, detectedObject, i);


### PR DESCRIPTION
- Skip nms when the size of given array is 0

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
