### PR TITLE
[Common] Add new API to get tensor format of current pad caps

### DIFF
--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -1292,17 +1292,19 @@ gst_tensor_pad_possible_caps_from_config (GstPad * pad,
 }
 
 /**
- * @brief Check current pad caps is flexible tensor.
- * @param pad GstPad to check current caps
- * @return TRUE if pad has flexible tensor caps.
- */
-gboolean
-gst_tensor_pad_caps_is_flexible (GstPad * pad)
+  * @brief Get tensor format of current pad caps.
+  * @param pad GstPad to check current caps.
+  * @return The tensor_format of current pad caps.
+  *
+  * If pad does not have tensor caps return _NNS_TENSOR_FORMAT_END
+  */
+tensor_format
+gst_tensor_pad_get_format (GstPad * pad)
 {
   GstCaps *caps;
-  gboolean ret = FALSE;
+  tensor_format ret = _NNS_TENSOR_FORMAT_END;
 
-  g_return_val_if_fail (GST_IS_PAD (pad), FALSE);
+  g_return_val_if_fail (GST_IS_PAD (pad), _NNS_TENSOR_FORMAT_END);
 
   caps = gst_pad_get_current_caps (pad);
   if (caps) {
@@ -1310,9 +1312,9 @@ gst_tensor_pad_caps_is_flexible (GstPad * pad)
     GstTensorsConfig config;
 
     structure = gst_caps_get_structure (caps, 0);
-    if (gst_tensors_config_from_structure (&config, structure))
-      ret = gst_tensors_config_is_flexible (&config);
-
+    if (gst_tensors_config_from_structure (&config, structure)) {
+      ret = config.info.format;
+    }
     gst_caps_unref (caps);
     gst_tensors_config_free (&config);
   }

--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -212,12 +212,29 @@ extern GstCaps *
 gst_tensor_pad_possible_caps_from_config (GstPad * pad, const GstTensorsConfig * config);
 
 /**
- * @brief Check current pad caps is flexible tensor.
- * @param pad GstPad to check current caps
- * @return TRUE if pad has flexible tensor caps.
+  * @brief Get tensor format of current pad caps.
+  * @param pad GstPad to check current caps.
+  * @return The tensor_format of current pad caps.
+  *
+  * If pad does not have tensor caps return _NNS_TENSOR_FORMAT_END
+  */
+extern tensor_format
+gst_tensor_pad_get_format (GstPad *pad);
+
+/**
+ * @brief Macro to check current pad caps is static tensor.
  */
-extern gboolean
-gst_tensor_pad_caps_is_flexible (GstPad * pad);
+#define gst_tensor_pad_caps_is_static(p) (gst_tensor_pad_get_format (p) == _NNS_TENSOR_FORMAT_STATIC)
+
+/**
+ * @brief Macro to check current pad caps is flexible tensor.
+ */
+#define gst_tensor_pad_caps_is_flexible(p) (gst_tensor_pad_get_format (p) == _NNS_TENSOR_FORMAT_FLEXIBLE)
+
+/**
+ * @brief Macro to check current pad caps is sparse tensor.
+ */
+#define gst_tensor_pad_caps_is_sparse(p) (gst_tensor_pad_get_format (p) == _NNS_TENSOR_FORMAT_SPARSE)
 
 /**
  * @brief Gets new hash table for tensor aggregation.


### PR DESCRIPTION
- Add gst_tensor_pad_get_format()
- Replace gst_tensor_pad_caps_is_flexible() function to macro.
- Add gst_tensor_pad_caps_is_static and gst_tensor_pad_caps_is_sparse macro

review history: #4141
**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
