### PR TITLE
[Spec] Remove armcl dependency

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -223,8 +223,6 @@ BuildRequires: tensorflow-devel
 # for armnn
 %if 0%{?armnn_support}
 BuildRequires: armnn-devel
-BuildRequires:  libarmcl
-BuildConflicts: libarmcl-release
 %endif
 
 %if 0%{?edgetpu_support}
@@ -269,10 +267,6 @@ BuildRequires:	capi-system-sensor-devel
 # Tizen 5.5 M2+ support nn-runtime (nnfw)
 # As of 2019-09-24, unfortunately, nnfw does not support pkg-config
 BuildRequires:  nnfw-devel
-%ifarch %arm aarch64
-BuildRequires:  libarmcl
-BuildConflicts: libarmcl-release
-%endif
 %endif
 
 %if 0%{?pytorch_support}


### PR DESCRIPTION
This patch removes the armcl dependency from the Tizen packaging.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


