### PR TITLE
[demux] Let tensor_demux handle tensors # > 16

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_demux.c
+++ b/gst/nnstreamer/elements/gsttensor_demux.c
@@ -208,6 +208,7 @@ gst_tensor_demux_remove_src_pads (GstTensorDemux * tensor_demux)
   tensor_demux->srcpads = NULL;
   tensor_demux->num_srcpads = 0;
 
+  gst_tensors_config_free (&tensor_demux->tensors_config);
   gst_tensors_config_init (&tensor_demux->tensors_config);
 }
 
@@ -309,8 +310,9 @@ gst_tensor_demux_get_tensor_config (GstTensorDemux * tensor_demux,
       if (idx >= total)
         return FALSE;
 
-      gst_tensor_info_copy (&config->info.info[i],
-          &tensor_demux->tensors_config.info.info[idx]);
+      gst_tensor_info_copy (gst_tensors_info_get_nth_info (&config->info, i),
+          gst_tensors_info_get_nth_info (&tensor_demux->tensors_config.info,
+              idx));
     }
 
     config->info.num_tensors = num;
@@ -321,7 +323,8 @@ gst_tensor_demux_get_tensor_config (GstTensorDemux * tensor_demux,
 
     config->info.num_tensors = 1;
     gst_tensor_info_copy (&config->info.info[0],
-        &tensor_demux->tensors_config.info.info[nth]);
+        gst_tensors_info_get_nth_info (&tensor_demux->tensors_config.info,
+            nth));
   }
 
   config->info.format = tensor_demux->tensors_config.info.format;


### PR DESCRIPTION
- Let tensor_demux handle tensors # > 16
- Let `gst_tensor_time_sync_buffer_from_colletpad` support extra tensors as its input
- Add a TC to test MAX extra tensors with tensor_mux
- Add a TC to test tensor_demux handling extra tensors

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
