### PR TITLE
[datarepo] Add function to read and write sparse tensors @open sesame 07/24 16:00 

### DIFF
--- a/gst/datarepo/gstdatareposink.h
+++ b/gst/datarepo/gstdatareposink.h
@@ -46,9 +46,9 @@ struct _GstDataRepoSink
   JsonArray *sample_offset_array;   /**< offset array of sample */
   JsonArray *tensor_size_array;    /**< size array of flexible tensor */
   JsonArray *tensor_count_array;  /**< array for the number of cumulative tensors */
-  guint flexible_tensor_count;
+  guint cumulative_tensors;    /**< the number of cumulated tensors */
 
-  gboolean is_flexible_tensors;
+  gboolean is_static_tensors;
   gint fd;                        /**< open file descriptor*/
   GstDataRepoDataType data_type;  /**< data type */
   gint total_samples;             /**< The number of total samples, in the case of multi-files, it is used as an index. */

--- a/gst/datarepo/gstdatareposrc.h
+++ b/gst/datarepo/gstdatareposrc.h
@@ -45,7 +45,7 @@ struct _GstDataRepoSrc {
   GstPushSrc parent;            /**< parent object */
   GstPad *src_pad;
 
-  gboolean is_flexible_tensors;
+  gboolean is_static_tensors;
   gboolean is_start;            /**< check if datareposrc is started */
   gboolean successful_read;     /**< used for checking EOS when reading more than one images(multi-files) from a path */
   gint fd;                      /**< open file descriptor */


### PR DESCRIPTION
    - Add writing sparse tensors to datareposink
      To add memory to gstbuffer by the number of sparse tensors when reading a sample in datareposrc,
      sample_offset, tensor_size, and tensor_count fields are added to the JSON file
    - Add reading sparse tensors to datareposrc
      If the tensor format of JSON file is sparse, read a sample using the JSON meta information
      (sample_offset, tensor_size, tensor_count) and append memory to GstBuffer as many as the number
      of sparse tensors.
    - Add unit test
    - bug fix about shuffle index

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

