### PR TITLE
[Edge] Add wait connection prop @open sesame 08/09 18:27

### DIFF
--- a/gst/edge/edge_sink.h
+++ b/gst/edge/edge_sink.h
@@ -50,6 +50,8 @@ struct _GstEdgeSink
 
   nns_edge_connect_type_e connect_type;
   nns_edge_h edge_h;
+  gboolean wait_connection;
+  guint64 connection_timeout;
 };
 
 /**


### PR DESCRIPTION
If wait-connection prop is set true, wait until edgesrc is connected and don't drop the buffers.

Wait https://github.com/nnstreamer/nnstreamer-edge/pull/170

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed [ ]Skipped
2. Run test: [* ]Passed [ ]Failed [ ]Skipped

