### PR TITLE
[datareposrc] Push GstBuffer according to framerate @open sesame 08/03 10:15

### DIFF
--- a/gst/datarepo/gstdatareposrc.h
+++ b/gst/datarepo/gstdatareposrc.h
@@ -89,6 +89,10 @@ struct _GstDataRepoSrc {
   guint sample_offset_array_len;
   guint tensor_size_array_len;
   guint tensor_count_array_len;
+
+  GstClockTime running_time;    /**< one frame running time */
+  gint rate_n, rate_d;
+  guint64 n_frame;
 };
 
 /**


### PR DESCRIPTION
datareposrc push GstBuffer according to framerate when sink element sets sync=true

- Set TIMESTAMP to GstBuffer
- Add function to calculate running_time for one frame

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
