### PR TITLE
[tensor_trainer] Add load_model_path to GstTensorTrainerProperties

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -48,8 +48,6 @@ struct _GstTensorTrainer
   GstPad *srcpad;
 
   gchar *fw_name;
-  gchar *model_config;
-  gchar *model_save_path;
   gchar *output_dimensions;
   gchar *output_type;
 

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -32,7 +32,8 @@ typedef struct _GstTensorTrainerProperties
 {
   GstTensorsInfo input_meta;    /**< configured input tensor info */
   const char *model_config;    /**< The configuration file path for creating model */
-  const char *model_save_path;    /**< The file path to save the model */
+  const char *model_save_path;    /**< The file path to save the new model */
+  const char *model_load_path;    /**< The file path to load an existing model to use for training a new model */
   unsigned int num_inputs;    /**< The number of input lists, the input is where framework receive the features to train the model, num_inputs indicates how many inputs there are. */
   unsigned int num_labels;    /**< The number of label lists, the label is where framework receive the class to train the model, num_labels indicates how many labels there are. */
   unsigned int num_training_samples;    /**< The number of training sample used to train the model. */

--- a/tests/nnstreamer_trainer/unittest_trainer.cc
+++ b/tests/nnstreamer_trainer/unittest_trainer.cc
@@ -73,7 +73,7 @@ TEST (tensor_trainer, SetParams)
       "gst-launch-1.0 datareposrc location=%s json=%s "
       "start-sample-index=3 stop-sample-index=202 tensors-sequence=0,1 epochs=1 ! "
       "tensor_trainer name=tensor_trainer framework=nntrainer model-config=%s "
-      "model-save-path=model.bin num-inputs=1 num-labels=1 "
+      "model-save-path=new_model.bin model-load-path=old_model.bin num-inputs=1 num-labels=1 "
       "num-training-samples=100 num-validation-samples=100 epochs=1 ! "
       "tensor_sink",
       file_path, json_path, model_config_path);
@@ -89,9 +89,22 @@ TEST (tensor_trainer, SetParams)
 
   g_object_get (tensor_trainer, "model-config", &get_str, NULL);
   EXPECT_STREQ (get_str, model_config_path);
+  g_free (get_str);
 
   g_object_get (tensor_trainer, "model-save-path", &get_str, NULL);
-  EXPECT_STREQ (get_str, "model.bin");
+  EXPECT_STREQ (get_str, "new_model.bin");
+  g_free (get_str);
+
+  g_object_get (tensor_trainer, "model-load-path", &get_str, NULL);
+  EXPECT_STREQ (get_str, "old_model.bin");
+  g_free (get_str);
+
+  /* set nullable param */
+  g_object_set (GST_OBJECT (tensor_trainer), "model-load-path", NULL, NULL);
+
+  g_object_get (tensor_trainer, "model-load-path", &get_str, NULL);
+  EXPECT_STREQ (get_str, NULL);
+  g_free (get_str);
 
   g_object_get (tensor_trainer, "num-inputs", &get_value, NULL);
   ASSERT_EQ (get_value, 1U);


### PR DESCRIPTION
- Add model_load_path to load an existing model to use for training a new model
- Add model_load_path property to tensor_trainer

Related PR : (No dependency) https://github.com/nnstreamer/nntrainer/pull/2258 (review please)

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped