### PR TITLE
[Documentation] Add libjson-glib-dev package dependency

### DIFF
--- a/Documentation/getting-started-meson-build.md
+++ b/Documentation/getting-started-meson-build.md
@@ -54,7 +54,7 @@ $ git clone https://github.com/nnstreamer/nnstreamer
 ```
 $ sudo add-apt-repository ppa:nnstreamer/ppa
 $ sudo apt-get update
-$ sudo apt-get install libedgetpu-dev libflatbuffers-dev libgrpc-dev openvino-dev libpaho-mqtt-dev libprotobuf-dev pytorch tensorflow-c-dev tensorflow-lite-dev tensorflow2-lite-dev tvm-runtime-dev
+$ sudo apt-get install libedgetpu-dev libflatbuffers-dev libgrpc-dev openvino-dev libpaho-mqtt-dev libprotobuf-dev pytorch tensorflow2-lite-dev tvm-runtime-dev
 ```
 
 *Option B*: Build & install your own frameworks and provide corresponding pkg-config files.

--- a/Documentation/getting-started-meson-build.md
+++ b/Documentation/getting-started-meson-build.md
@@ -29,7 +29,7 @@ The following dependencies are needed to compile/build/run.
 
 The minimal requirement to build nnstreamer with default configuration is
 ```bash
-$ sudo apt-get install meson ninja-build gcc g++ libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+$ sudo apt-get install meson ninja-build gcc g++ libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libjson-glib-dev
 ```
 
 Optional utilities:

--- a/gst/datarepo/meson.build
+++ b/gst/datarepo/meson.build
@@ -4,8 +4,6 @@ repo_sources = [
   'gstdatareposink.c'
 ]
 
-json_glib_dep = dependency('json-glib-1.0')
-
 gstdatarepo_shared = shared_library('gstdatarepo',
   repo_sources,
   dependencies: [nnstreamer_dep, json_glib_dep],

--- a/gst/meson.build
+++ b/gst/meson.build
@@ -8,5 +8,7 @@ endif
 subdir('nnstreamer')
 
 if get_option('enable-datarepo')
+  json_glib_dep = dependency('json-glib-1.0', required : true, \
+      not_found_message : 'json-glib-1.0 package should be installed to build the datarepo elements.')
   subdir('datarepo')
 endif


### PR DESCRIPTION
 If there is no libjson-glib-dev package, occur meson build error below:
```
$ meson build
...
 Program sh found: YES (/usr/bin/sh)
 Run-time dependency json-glib-1.0 found: NO (tried pkgconfig and cmake)
 gst/datarepo/meson.build:7:0: ERROR: Dependency "json-glib-1.0" not found, tried pkgconfig and cmake
```

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped