### PR TITLE
[GitHub Action] Fix macOS build failure

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -14,9 +14,11 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v1
     - name: homebrew
-      run: brew install cask
+      run: |
+          brew update
+          brew install cask
     - name: install minimal requirements
-      run: brew install meson ninja pkg-config cmake libffi glib gstreamer gst-plugins-base gst-plugins-good numpy json-glib
+      run: brew install meson ninja pkg-config cmake libffi glib gstreamer numpy json-glib
     - uses: BSFishy/meson-build@v1.0.3
       with:
         action: build


### PR DESCRIPTION
Don't install gstreamer-plugins.

Warning messages:
```
Warning: Formula gst-plugins-base was renamed to gstreamer.
Warning: Formula gst-plugins-good was renamed to gstreamer.
```

Related issue: https://github.com/Homebrew/brew/issues/15488
Bug report from the issue:  "There is technically a bug here in that the dependency collector doesn't recognise multiple renames into one formula as being a single formula, so it tries to install gstreamer multiple times."


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
