### PR TITLE
[Documentation] Fix tizen reference link

### DIFF
--- a/Documentation/getting-started-tizen.md
+++ b/Documentation/getting-started-tizen.md
@@ -8,9 +8,9 @@ title: Tizen GBS
 
 * If you are a Tizen application developer, you may still use GBS to build your customized nnstreamer for your own Tizen devices. However, you won't be able to publish Tizen application that depends on your modification. You need to upstream your modifications to github.com/nnstreamer/nnstreamer and wait for next Tizen updates.
 
-[How to install GBS](https://source.tizen.org/documentation/developer-guide/getting-started-guide/installing-development-tools)
+[How to install GBS](https://docs.tizen.org/platform/developing/installing/)
 
-[How to build with GBS](https://source.tizen.org/documentation/reference/git-build-system/usage/gbs-build)
+[How to build with GBS](https://docs.tizen.org/platform/developing/building/)
 
 
 ### Build without options


### PR DESCRIPTION
Tizen reference link has been changed and updated with the latest link.

 - How to install GBS : https://docs.tizen.org/platform/developing/installing/
 - How to build with GBS : https://docs.tizen.org/platform/developing/building/

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
```

