### PR TITLE
[tensor_trainer] Add stop function to GstTensorTrainerFramework

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -57,6 +57,7 @@ struct _GstTensorTrainer
   gboolean fw_created;
   gboolean is_training_complete;
   gboolean is_epoch_complete;
+  gboolean ready_to_complete_training;
   unsigned int input_ranks[NNS_TENSOR_SIZE_LIMIT];
   unsigned int output_ranks[NNS_TENSOR_SIZE_LIMIT];
   GstTensorsInfo output_meta;

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_trainer.h
@@ -125,6 +125,14 @@ struct _GstTensorTrainerFramework
    * @return 0 if ok. < 0 if error.
    */
 
+  int (*stop) (const GstTensorTrainerFramework * self,
+      const GstTensorTrainerProperties * prop, void **private_data);
+  /**< tensor_trainer call this to stop training the model
+   * @param[in] prop read-only property values
+   * @param[in/out] private_data, a subplugin may save its internal private data here.
+   * @return 0 if ok. < 0 if error.
+   */ 
+
   int (*push_data) (const GstTensorTrainerFramework * self,
       const GstTensorTrainerProperties * prop,
       void *private_data, const GstTensorMemory * input);


### PR DESCRIPTION
tensor_trainer calls this to stop model training being performed in a sub-plugin,
currently running epoch is finished to the end and sub-plugin saves the model
    
- Add function to stop model training
- Add ready-to-complete property to tensor_trainer
  User should set when the training is ready to be completed and saved.



Ref: sub-plugin (https://github.com/nnstreamer/nntrainer/pull/2271/commits/6f5f4fcbc0698d140ed6af50ac8e0b6264c3518a)

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
