### PR TITLE
tizen: remove armcl dependency with Tizen 8+

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -270,8 +270,10 @@ BuildRequires:	capi-system-sensor-devel
 # As of 2019-09-24, unfortunately, nnfw does not support pkg-config
 BuildRequires:  nnfw-devel
 %ifarch %arm aarch64
+%if 0%{tizen_version_major} <= 7
 BuildRequires:  libarmcl
 BuildConflicts: libarmcl-release
+%endif
 %endif
 %endif
 


### PR DESCRIPTION
ARMCL is no longer required by nnfw.
