### PR TITLE
tensor_query: nnstreamer-edge dependency fix

### DIFF
--- a/gst/edge/edge_common.h
+++ b/gst/edge/edge_common.h
@@ -15,7 +15,7 @@
 
 #include <glib.h>
 #include <gst/gst.h>
-#include "nnstreamer-edge.h"
+#include <nnstreamer-edge.h>
 
 #ifndef GST_EDGE_PACKAGE
 #define GST_EDGE_PACKAGE "GStreamer Edge Plugins"

--- a/gst/edge/edge_sink.h
+++ b/gst/edge/edge_sink.h
@@ -16,7 +16,7 @@
 #include <gst/gst.h>
 #include <gst/base/gstbasesink.h>
 #include "edge_common.h"
-#include "nnstreamer-edge.h"
+#include <nnstreamer-edge.h>
 #include "../nnstreamer/nnstreamer_log.h"
 #include "tensor_typedef.h"
 

--- a/gst/edge/edge_src.h
+++ b/gst/edge/edge_src.h
@@ -16,7 +16,7 @@
 #include <gst/gst.h>
 #include <gst/base/gstbasesrc.h>
 #include "edge_common.h"
-#include "nnstreamer-edge.h"
+#include <nnstreamer-edge.h>
 #include "nnstreamer_util.h"
 #include "../nnstreamer/nnstreamer_log.h"
 

--- a/gst/edge/meson.build
+++ b/gst/edge/meson.build
@@ -5,7 +5,7 @@ edge_srcs = [
     'edge_src.c',
 ]
 
-edge_dep = [
+edge_deps = [
     glib_dep,
     gst_base_dep,
     gst_dep,
@@ -13,14 +13,14 @@ edge_dep = [
 ]
 
 if build_platform == 'tizen'
-  edge_dep += dlog_dep
+  edge_deps += dlog_dep
 elif cc.has_header_symbol('android/log.h', '__android_log_print')
-  edge_dep += cc.find_library('log')
+  edge_deps += cc.find_library('log')
 endif
 
 gstedge_shared = shared_library('gstedge',
   edge_srcs,
-  dependencies: edge_dep,
+  dependencies: edge_deps,
   install: true,
   include_directories: include_directories('../nnstreamer/include'),
   install_dir: plugins_install_dir
@@ -28,6 +28,6 @@ gstedge_shared = shared_library('gstedge',
 
 gstedge_dep = declare_dependency(
     link_with: gstedge_shared,
-    dependencies: edge_dep,
+    dependencies: edge_deps,
     include_directories: include_directories('.')
 )

--- a/gst/edge/meson.build
+++ b/gst/edge/meson.build
@@ -9,7 +9,7 @@ edge_dep = [
     glib_dep,
     gst_base_dep,
     gst_dep,
-    nnstreamer_edge_support_deps
+    nnstreamer_edge_dep,
 ]
 
 if build_platform == 'tizen'

--- a/gst/nnstreamer/tensor_query/tensor_query_client.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_client.h
@@ -16,7 +16,7 @@
 #include <gst/gst.h>
 #include <gio/gio.h>
 #include <tensor_common.h>
-#include "nnstreamer-edge.h"
+#include <nnstreamer-edge.h>
 
 G_BEGIN_DECLS
 

--- a/gst/nnstreamer/tensor_query/tensor_query_common.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_common.h
@@ -16,7 +16,7 @@
 #include "tensor_typedef.h"
 #include "tensor_common.h"
 #include "tensor_meta.h"
-#include "nnstreamer-edge.h"
+#include <nnstreamer-edge.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/gst/nnstreamer/tensor_query/tensor_query_server.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.h
@@ -15,7 +15,7 @@
 
 #include <gst/gst.h>
 #include <tensor_common.h>
-#include "nnstreamer-edge.h"
+#include <nnstreamer-edge.h>
 #include "tensor_meta.h"
 
 G_BEGIN_DECLS

--- a/meson.build
+++ b/meson.build
@@ -325,6 +325,15 @@ if not get_option('mxnet-support').disabled()
   endif
 endif
 
+# nnstreamer-edge
+nnstreamer_edge_dep = dependency('nnstreamer-edge', method : 'pkg-config', required: false)
+if get_option('nnstreamer-edge-support').enabled()
+  if not nnstreamer_edge_dep.found()
+    error('nnstreamer-edge not found whilt it is enabled.')
+  endif
+endif
+## Without the explicit method designation, it fails to find cflags in older Meson
+
 # features registration to be controlled
 #
 # register feature as follows
@@ -421,7 +430,7 @@ features = {
     'project_args': { 'ENABLE_TRIX_ENGINE' : 1 }
   },
   'nnstreamer-edge-support': {
-    'target': 'nnstreamer-edge',
+    'extra_deps': [ nnstreamer_edge_dep ],
     'project_args': { 'ENABLE_NNSTREAMER_EDGE': 1 }
   },
   'mxnet-support': {

--- a/meson.build
+++ b/meson.build
@@ -157,6 +157,7 @@ protobuf_dep = dependency('protobuf', version: '>= 3.6.1', required: false)
 flatc = find_program('flatc', required : get_option('flatbuf-support'))
 flatbuf_dep = disabler()
 flatbuf_version_check_dep = disabler()
+flatc_dep = disabler()
 if flatc.found()
   # TODO: After bumping up meson version to 0.62.0, we can use flatc.version()
   # Please refer https://mesonbuild.com/Reference-manual_returned_external_program.html#external_programversion
@@ -165,13 +166,22 @@ if flatc.found()
       required : get_option('flatbuf-support'))
   flatbuf_version_check_dep = dependency('flatbuffers', version: '>=2.0.0',
       required : get_option('flatbuf-support'))
+  flatc_dep = declare_dependency()
 endif
 
 # Protobuf compiler
 pb_comp = find_program('protoc', required: get_option('protobuf-support'))
+pb_comp_dep = disabler()
+if (pb_comp.found())
+  pb_comp_dep = declare_dependency()
+endif
 
 #orc
 pg_orcc = find_program('orcc', required: get_option('orcc-support'))
+pg_orcc_dep = disabler()
+if (pg_orcc.found())
+  pg_orcc_dep = declare_dependency()
+endif
 orc_dep = dependency('orc-0.4', version: '>= 0.4.17', required: get_option('orcc-support'))
 
 ## nnfw
@@ -386,7 +396,7 @@ features = {
     'project_args': { 'ENABLE_ARMNN': 1 }
   },
   'orcc-support': {
-    'extra_deps': [ orc_dep, pg_orcc ],
+    'extra_deps': [ orc_dep, pg_orcc_dep ],
     'project_args': {'HAVE_ORC': 1},
     'project_args_disabled': { 'DISABLE_ORC': 1 },
     'extra_args': {'orcc_args': [pg_orcc, '--include', 'glib.h'] }
@@ -396,11 +406,11 @@ features = {
     'project_args': { 'ENABLE_SNPE' : 1 },
   },
   'flatbuf-support': {
-    'extra_deps': [ flatc, flatbuf_dep, flatbuf_version_check_dep ],
+    'extra_deps': [ flatc_dep, flatbuf_dep, flatbuf_version_check_dep ],
     'project_args': { 'ENABLE_FLATBUF': 1 }
   },
   'protobuf-support': {
-    'extra_deps': [ pb_comp, protobuf_dep ],
+    'extra_deps': [ pb_comp_dep, protobuf_dep ],
     'project_args': { 'ENABLE_PROTOBUF': 1 }
   },
   'tensorrt-support': {


### PR DESCRIPTION
1. nnstreamer-edge.h is from another package. Use #include appropriately.
2. dependency on nnstreamer-edge is not expressed proprely in meson.

Potential issue: Android build w/ nnstreamer-edge might need further care in /jni
