### PR TITLE
Clean up build scripts for datarepo

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -45,6 +45,7 @@ override_dh_auto_configure:
 ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo yes), yes)
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
 	-Denable-edgetpu=true -Denable-openvino=true -Dgrpc-support=disabled -Dmqtt-support=enabled \
+        -Denable-datarepo=true \
 	-Denable-tizen=false -Denable-test=true -Dinstall-test=true -Dsubplugindir=/usr/lib/nnstreamer $(FLOAT16) ${BUILDDIR}
 else
 	# Debian has less packages ready.

--- a/gst/meson.build
+++ b/gst/meson.build
@@ -7,8 +7,6 @@ if mqtt_support_is_available
 endif
 subdir('nnstreamer')
 
-if get_option('enable-datarepo')
-  json_glib_dep = dependency('json-glib-1.0', required : true, \
-      not_found_message : 'json-glib-1.0 package should be installed to build the datarepo elements.')
+if datarepo_support_is_available
   subdir('datarepo')
 endif

--- a/meson.build
+++ b/meson.build
@@ -344,6 +344,15 @@ if get_option('nnstreamer-edge-support').enabled()
 endif
 ## Without the explicit method designation, it fails to find cflags in older Meson
 
+# datarepo requires json-glib-1.0 in the name of json_glib_dep
+json_glib_dep = dependency('json-glib-1.0', required: false)
+if get_option('datarepo-support').enabled() and not json_glib_dep.found()
+  error('json-glib-1.0 is required for datarepo-support option.')
+endif
+if not get_option('datarepo-support').disabled() and not json_glib_dep.found()
+  message('datarepo-support is off because json-glib-1.0 is not available.')
+endif
+
 # features registration to be controlled
 #
 # register feature as follows
@@ -446,7 +455,10 @@ features = {
   'mxnet-support': {
     'extra_deps': [ mxnet_dep ],
     'project_args': { 'ENABLE_MXNET' : 1 }
-  }
+  },
+  'datarepo-support': {
+    'extra_deps': [ json_glib_dep ],
+  },
 }
 
 project_args = {}

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,6 +26,7 @@ option('trix-engine-support', type: 'feature', value: 'auto')
 option('nnstreamer-edge-support', type: 'feature', value: 'auto')
 option('mxnet-support', type: 'feature', value: 'auto')
 option('parser-support', type: 'feature', value: 'auto') # gstreamer pipeline description <--> pbtxt pipeline
+option('datarepo-support', type: 'feature', value: 'auto', description: 'Data repository sink/src for in-pipeline training') # this required json-glib-1.0.
 
 # booleans & other options
 option('enable-test', type: 'boolean', value: true)
@@ -50,7 +51,6 @@ option('framework-priority-bin', type: 'string', value: '', description: 'A comm
 option('skip-tflite-flatbuf-check', type: 'boolean', value: false, description: 'Do not check the availability of flatbuf for tensorflow-lite build. In some systems, flatbuffers\' dependency cannot be found with meson.')
 option('trix-engine-alias', type: 'string', value: 'srnpu', description: 'The alias name list of trix-engine sub-plugin. This option provides backward compatibility of the previous framework name.')
 option('enable-float16', type: 'boolean', value: false, description: 'Support float16 streams with GCC extensions')
-option('enable-datarepo', type: 'boolean', value: true, description: 'Data repository sink/src for in-pipeline training')
 
 # Utilities
 option('enable-nnstreamer-check', type: 'boolean', value: true)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -38,6 +38,7 @@
 %define		trix_engine_support 1
 # Support AI offloading (tensor_query) using nnstreamer-edge interface
 %define		nnstreamer_edge_support 1
+%define         datarepo_support 1
 
 %define		check_test 1
 %define		release_test 1
@@ -309,7 +310,9 @@ BuildRequires:	flex
 BuildRequires:	bison
 
 # For datarepo
+%if 0%{?datarepo_support}
 BuildRequires: pkgconfig(json-glib-1.0)
+%endif
 
 # Note that debug packages generate an additional build and storage cost.
 # If you do not need debug packages, run '$ gbs -c .TAOS-CI/.gbs.conf build ... --define "_skip_debug_rpm 1"'.
@@ -648,10 +651,15 @@ BuildRequires:	pkgconfig(paho-mqtt-c)
 %description misc
 Provides additional gstreamer plugins for nnstreamer pipelines
 
+%if 0%{?datarepo_support}
 %package datarepo
 Summary: NNStreamer MLOps Data Repository plugin packages
 %description datarepo
 NNStreamer's datareposrc/sink plugins for reading and writing files in MLOps Data Repository
+%define enable_datarepo -Ddatarepo-support=enabled
+%else
+%define enable_datarepo -Ddatarepo-support=disabled
+%endif
 
 ## Define build options ##
 %define enable_tizen -Denable-tizen=false
@@ -853,7 +861,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir
 	%{enable_tizen} %{element_restriction} %{fw_priority} -Denable-env-var=false -Denable-symbolic-link=false \
 	%{enable_tf_lite} %{enable_tf2_lite} %{enable_tf} %{enable_pytorch} %{enable_caffe2} %{enable_python3} \
 	%{enable_nnfw_runtime} %{enable_mvncsdk2} %{enable_openvino} %{enable_armnn} %{enable_edgetpu}  %{enable_vivante} \
-	%{enable_flatbuf} %{enable_trix_engine} \
+	%{enable_flatbuf} %{enable_trix_engine} %{enable_datarepo} \
 	%{enable_tizen_sensor} %{enable_mqtt} %{enable_lua} %{enable_tvm} %{enable_test} %{enable_test_coverage} %{install_test} \
         %{fp16_support} \
 	%{builddir}
@@ -886,7 +894,9 @@ export NNSTREAMER_TRAINERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_t
     bash %{test_script} ./tests
     bash %{test_script} ./tests/cpp_methods
     bash %{test_script} ./tests/nnstreamer_filter_extensions_common
+%if 0%{?datarepo_support}
     bash %{test_script} ./tests/nnstreamer_datarepo
+%endif
 %if 0%{?nnstreamer_edge_support}
     bash %{test_script} ./tests/nnstreamer_edge
 %endif
@@ -1261,8 +1271,10 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{gstlibdir}/libgstmqtt.so
 %endif
 
+%if 0%{?datarepo_support}
 %files datarepo
 %{gstlibdir}/libgstdatarepo.so
+%endif
 
 %if 0%{?release_test}
 %files test-devel

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -342,7 +342,7 @@ if gtest_dep.found()
     test('unittest_filter_shared_model', unittest_filter_shared_model, timeout: 30, env: testenv)
   endif
 
-  if get_option('enable-datarepo')
+  if datarepo_support_is_available
     subdir('nnstreamer_datarepo')
   endif
 


### PR DESCRIPTION
1. Make it 'feature' so that it can be resolved automatically.
2. Because it has an additional dependency, don't make it default true.
3. Force enable datarepo for Ubuntu/Tizen


CC: @songgot 
