### PR TITLE
memleak fix: decoder/bounding-box

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -1978,7 +1978,7 @@ bb_decode (void **pdata, const GstTensorsConfig * config,
 
     /* Already checked with getOutCaps. Thus, this is an internal bug */
     g_assert (num_tensors >= MP_PALM_DETECTION_MAX_TENSORS);
-    results = g_array_sized_new (FALSE, TRUE, sizeof (detectedObject), 100);
+    /* results will be allocated by _get_objects_mp_palm_detection_ */
 
     boxes = &input[0];
     detections = &input[1];


### PR DESCRIPTION
"results" is allocated in ```_get_objects_mp_palm_detection_``` macro. Do not allocate it before calling it.

Fixes #4185

