### PR TITLE
[Converter/decoder] Support GRAY16 format

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_converter.c
+++ b/gst/nnstreamer/elements/gsttensor_converter.c
@@ -1465,6 +1465,11 @@ gst_tensor_converter_parse_video (GstTensorConverter * self,
       config->info.info[0].type = _NNS_UINT8;
       config->info.info[0].dimension[0] = 1;
       break;
+    case GST_VIDEO_FORMAT_GRAY16_BE:
+    case GST_VIDEO_FORMAT_GRAY16_LE:
+      config->info.info[0].type = _NNS_UINT16;
+      config->info.info[0].dimension[0] = 1;
+      break;
     case GST_VIDEO_FORMAT_RGB:
     case GST_VIDEO_FORMAT_BGR:
       config->info.info[0].type = _NNS_UINT8;
@@ -1483,7 +1488,7 @@ gst_tensor_converter_parse_video (GstTensorConverter * self,
       break;
     default:
       GST_WARNING_OBJECT (self,
-          "The given video caps with format \"%s\" is not supported. Please use GRAY8, RGB, BGR, RGBx, BGRx, xRGB, xBGR, RGBA, BGRA, ARGB, or ABGR.\n",
+          "The given video caps with format \"%s\" is not supported. Please use GRAY8, GRAY16_LE, GRAY16_BE, RGB, BGR, RGBx, BGRx, xRGB, xBGR, RGBA, BGRA, ARGB, or ABGR.\n",
           GST_STR_NULL (gst_video_format_to_string (format)));
       break;
   }
@@ -1937,8 +1942,7 @@ gst_tensor_converter_get_possible_media_caps (GstTensorConverter * self)
       switch (type) {
         case _NNS_VIDEO:
           /* video caps from tensor info */
-          if (is_video_supported (self)
-              && config.info.info[0].type == _NNS_UINT8) {
+          if (is_video_supported (self)) {
             GValue supported_formats = G_VALUE_INIT;
             gint colorspace, width, height;
 
@@ -1946,7 +1950,7 @@ gst_tensor_converter_get_possible_media_caps (GstTensorConverter * self)
             switch (colorspace) {
               case 1:
                 gst_tensor_converter_get_format_list (&supported_formats,
-                    "GRAY8", NULL);
+                    "GRAY8", "GRAY16_BE", "GRAY16_LE", NULL);
                 break;
               case 3:
                 gst_tensor_converter_get_format_list (&supported_formats,

--- a/gst/nnstreamer/elements/gsttensor_converter_media_info_video.h
+++ b/gst/nnstreamer/elements/gsttensor_converter_media_info_video.h
@@ -26,7 +26,7 @@
  * @brief Caps string for supported video format
  */
 #define VIDEO_CAPS_STR \
-    GST_VIDEO_CAPS_MAKE ("{ RGB, BGR, RGBx, BGRx, xRGB, xBGR, RGBA, BGRA, ARGB, ABGR, GRAY8 }") \
+    GST_VIDEO_CAPS_MAKE ("{ RGB, BGR, RGBx, BGRx, xRGB, xBGR, RGBA, BGRA, ARGB, ABGR, GRAY8, GRAY16_BE, GRAY16_LE }") \
     ", interlace-mode = (string) progressive"
 
 #define append_video_caps_template(caps) \

--- a/gst/nnstreamer/elements/gsttensor_converter_media_no_video.h
+++ b/gst/nnstreamer/elements/gsttensor_converter_media_no_video.h
@@ -38,7 +38,9 @@ typedef enum {
   GST_VIDEO_FORMAT_BGRA,
   GST_VIDEO_FORMAT_ARGB,
   GST_VIDEO_FORMAT_ABGR,
-  GST_VIDEO_FORMAT_I420
+  GST_VIDEO_FORMAT_I420,
+  GST_VIDEO_FORMAT_GRAY16_BE,
+  GST_VIDEO_FORMAT_GRAY16_LE
 } GstVideoFormat;
 
 #define gst_video_info_init(i) memset (i, 0, sizeof (GstVideoInfo))

--- a/tests/nnstreamer_decoder/runTest.sh
+++ b/tests/nnstreamer_decoder/runTest.sh
@@ -94,6 +94,15 @@ else
     callCompareTest test_06_raw_2.log test_06_decoded_2.log 6-3 "Compare for case 6-3" 1 0
 fi
 
+
+# Test for GRAY16_BE
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! videoconvert ! videoscale ! video/x-raw, width=160, height=120, framerate=5/1,format=GRAY16_BE ! tee name =t t. ! queue ! tensor_converter ! tensor_decoder mode=direct_video option1=GRAY16_BE ! filesink location=\"testcase7_dv.raw\" sync=true t. ! queue ! filesink location=\"testcase7_origin.raw\" sync=true" 7 0 0 $PERFORMANCE
+callCompareTest testcase7_origin.raw testcase7_dv.raw 7 "Compare for case 7" 0 0
+
+# Test for GRAY16_LE
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! videoconvert ! videoscale ! video/x-raw, width=160, height=120, framerate=5/1,format=GRAY16_LE ! tee name =t t. ! queue ! tensor_converter ! tensor_decoder mode=direct_video option1=GRAY16_LE ! filesink location=\"testcase8_dv.raw\" sync=true t. ! queue ! filesink location=\"testcase8_origin.raw\" sync=true" 8 0 0 $PERFORMANCE
+callCompareTest testcase8_origin.raw testcase8_dv.raw 8 "Compare for case 8" 0 0
+
 rm *.log *.bmp *.png *.golden *.raw
 
 report


### PR DESCRIPTION
Support GRAY16 video format for tnesor_converter and tensor_decoder::direct_video.

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed [ ]Skipped
2. Run test: [* ]Passed [ ]Failed [ ]Skipped

