### PR TITLE
memleak fix: filter/lua null check

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_lua.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_lua.cc
@@ -487,6 +487,11 @@ lua_subplugin::configure_instance (const GstTensorFilterProperties *prop)
 void
 lua_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
 {
+  if (!input)
+    throw std::runtime_error ("Invalid input buffer, it is NULL.");
+  if (!output)
+    throw std::runtime_error ("Invalid output buffer, it is NULL.");
+
   for (uint i = 0; i < inputInfo.num_tensors; ++i) {
     input_lua_tensors[i].type = inputInfo.info[i].type;
     input_lua_tensors[i].data = input[i].data;

--- a/tests/nnstreamer_filter_lua/unittest_filter_lua.cc
+++ b/tests/nnstreamer_filter_lua/unittest_filter_lua.cc
@@ -485,9 +485,9 @@ TEST (nnstreamerFilterLua, invoke01_n)
   output.data = g_malloc (output.size);
   ((float *) input.data)[0] = 10.0;
 
-  /* catching assertion error */
-  EXPECT_DEATH (sp->invoke (NULL, NULL, data, NULL, &output), "");
-  EXPECT_DEATH (sp->invoke (NULL, NULL, data, &input, NULL), "");
+  /* catching exception */
+  EXPECT_NE (sp->invoke (NULL, NULL, data, NULL, &output), 0);
+  EXPECT_NE (sp->invoke (NULL, NULL, data, &input, NULL), 0);
 
   g_free (input.data);
   g_free (output.data);


### PR DESCRIPTION
It may access a struct of null pointer:
```
==32601== 1 errors in context 1 of 5:
==32601== Invalid read of size 8
==32601==    at 0x81659BA: nnstreamer::tensorfilter_lua::lua_subplugin::invoke(GstTensorMemory const*, GstTensorMemory*) (tensor_filter_lua.cc:498)
==32601==    by 0x8393D7B: nnstreamer::tensor_filter_subplugin::cpp_invoke(_GstTensorFilterFramework const*, _GstTensorFilterProperties*, void*, GstTensorMemory const*, GstTensorMemory*) (tensor_filter_support_cc.cc:168)
==32601==    by 0x16FCDC: nnstreamerFilterLua_invoke01_n_Test::TestBody() (unittest_filter_lua.cc:490)
==32601==    by 0x1A8F0B: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2402)
==32601==    by 0x1A274A: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2438)
==32601==    by 0x185943: testing::Test::Run() (gtest.cc:2474)
==32601==    by 0x1862B9: testing::TestInfo::Run() (gtest.cc:2656)
==32601==    by 0x18694A: testing::TestCase::Run() (gtest.cc:2776)
==32601==    by 0x18D9FE: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:4651)
==32601==    by 0x1AA27E: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2402)
==32601==    by 0x1A36D0: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2438)
==32601==    by 0x18C5F2: testing::UnitTest::Run() (gtest.cc:4259)
==32601==    by 0x178659: RUN_ALL_TESTS() (gtest.h:2233)
==32601==    by 0x176CA7: main (unittest_filter_lua.cc:1069)
==32601==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
```

