### PR TITLE
workaround: brew error in github action.

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -15,7 +15,8 @@ jobs:
     - uses: actions/setup-python@v1
     - name: homebrew
       run: |
-          brew update
+          # temporarily disabled, because it always fails these days.
+          # brew update
           brew install cask
     - name: install minimal requirements
       run: brew install meson ninja pkg-config cmake libffi glib gstreamer numpy json-glib


### PR DESCRIPTION
Fix the error:
```
==> Pouring python@3.11--3.11.5.monterey.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3
Target /usr/local/bin/2to3
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3'
```

Reference: https://github.com/universal-ctags/ctags/pull/3759
    
This is a workaround. When homebrew resumes working in github-action,
we need to revert this.

