### PR TITLE
[lts][build] Disable some testcases in tizen-7.0

### DIFF
--- a/tests/nnstreamer_filter_single/unittest_filter_single.cc
+++ b/tests/nnstreamer_filter_single/unittest_filter_single.cc
@@ -279,7 +279,7 @@ class NNSFilterSingleTestExtended : public ::testing::Test
 /**
  * @brief Test to invoke tf-lite model.
  */
-TEST_F (NNSFilterSingleTestExtended, invoke_p)
+TEST_F (NNSFilterSingleTestExtended, DISABLED_invoke_p)
 {
   guint i, length = 4 * 4 * 4 * 4 * 4;
   ASSERT_TRUE (this->loaded);
@@ -301,7 +301,7 @@ TEST_F (NNSFilterSingleTestExtended, invoke_p)
 /**
  * @brief Test to set invalid info.
  */
-TEST_F (NNSFilterSingleTestExtended, setInvalidInfo_n)
+TEST_F (NNSFilterSingleTestExtended, DISABLED_setInvalidInfo_n)
 {
   GstTensorsInfo in_info, out_info;
   gst_tensors_info_init (&in_info);


### PR DESCRIPTION
- Those testcases requires recent tflite version (2.11.0), whose version is lower in tizen 7.0. skip it.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped