### PR TITLE
[Ubuntu/1804] Check pytorch version @open sesame 08/31 14:16

### DIFF
--- a/debian/control.ubuntu.ppa
+++ b/debian/control.ubuntu.ppa
@@ -9,7 +9,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev,
  python3, python3-dev, python3-numpy,
  nnfw-dev [amd64] | gcc, tensorflow2-lite-dev,
- pytorch, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
+ pytorch (>= 3.10) | gcc, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
  openvino-dev, openvino-cpu-mkldnn [amd64], libflatbuffers-dev, flatbuffers-compiler,
  protobuf-compiler (>=3.12), libprotobuf-dev [amd64 arm64 armhf],
  libpaho-mqtt-dev, flex, bison, tvm-runtime-dev

--- a/debian/rules
+++ b/debian/rules
@@ -58,6 +58,8 @@ override_dh_auto_build:
 	ninja -C ${BUILDDIR}
 	# A few modules are not avaiable in Ubuntu 22.04. Don't try to create them if not available.
 	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_nnfw.so' ]; then echo "NNFW exists" ; else rm debian/nnstreamer-nnfw.install; fi
+	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_pytorch.so' ]; then echo "pytorch exists" ; else rm debian/nnstreamer-pytorch.install; fi
+	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_caffe2.so' ]; then echo "caffe2 exists" ; else rm debian/nnstreamer-caffe2.install; fi
 
 override_dh_auto_test:
 	./packaging/run_unittests_binaries.sh ./tests


### PR DESCRIPTION
Check pytorch version to fix ubuntu 18.04 build failure
 - Fix incompatibility of protobuf and caffe2 of ubuntu 18.04.


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

