### PR TITLE
[Test/decoder] Add test cases for direct video decoer @open sesame 09/24 20:41

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
@@ -190,12 +190,10 @@ dv_getOutCaps (void **pdata, const GstTensorsConfig * config)
         format = GST_VIDEO_FORMAT_GRAY16_LE;
         break;
       case DIRECT_VIDEO_FORMAT_UNKNOWN:
+      default:
         GST_WARNING ("Default format has been applied: GRAY8");
         format = GST_VIDEO_FORMAT_GRAY8;
         break;
-      default:
-        GST_ERROR ("Invalid format. Please check the video format");
-        return NULL;
     }
   } else if (channel == 3) {
     switch (ddata->format) {
@@ -206,12 +204,9 @@ dv_getOutCaps (void **pdata, const GstTensorsConfig * config)
         format = GST_VIDEO_FORMAT_BGR;
         break;
       case DIRECT_VIDEO_FORMAT_UNKNOWN:
+      default:
         GST_WARNING ("Default format has been applied: RGB");
         format = GST_VIDEO_FORMAT_RGB;
-        break;
-      default:
-        GST_ERROR ("Invalid format. Please check the video format");
-        return NULL;
     }
   } else if (channel == 4) {
     switch (ddata->format) {
@@ -240,12 +235,10 @@ dv_getOutCaps (void **pdata, const GstTensorsConfig * config)
         format = GST_VIDEO_FORMAT_ABGR;
         break;
       case DIRECT_VIDEO_FORMAT_UNKNOWN:
+      default:
         GST_WARNING ("Default format has been applied: BGRx");
         format = GST_VIDEO_FORMAT_BGRx;
         break;
-      default:
-        GST_ERROR ("Invalid format. Please check the video format");
-        return NULL;
     }
   } else {
     GST_ERROR ("%d channel is not supported", channel);

--- a/tests/nnstreamer_decoder/runTest.sh
+++ b/tests/nnstreamer_decoder/runTest.sh
@@ -103,6 +103,20 @@ callCompareTest testcase7_origin.raw testcase7_dv.raw 7 "Compare for case 7" 0 0
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! videoconvert ! videoscale ! video/x-raw, width=160, height=120, framerate=5/1,format=GRAY16_LE ! tee name =t t. ! queue ! tensor_converter ! tensor_decoder mode=direct_video option1=GRAY16_LE ! filesink location=\"testcase8_dv.raw\" sync=true t. ! queue ! filesink location=\"testcase8_origin.raw\" sync=true" 8 0 0 $PERFORMANCE
 callCompareTest testcase8_origin.raw testcase8_dv.raw 8 "Compare for case 8" 0 0
 
+# Test all supported video formats of direct video
+function video_format_test() {
+    gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! videoconvert ! videoscale ! video/x-raw,format=${1},width=640,height=480,framerate=0/1 ! filesink location=\"testcase09_${1}.golden.raw\" sync=true" "Generate golden test for ${1}" 0 0 $PERFORMANCE
+
+    gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! videoconvert ! videoscale ! video/x-raw,format=${1},width=640,height=480,framerate=0/1 ! tensor_converter ! tensor_decoder mode=direct_video option1=${1} ! filesink location=\"testcase09_${1}.log\" sync=true" "direct video conversion result ${1}" 0 0 $PERFORMANCE
+
+    callCompareTest testcase09_${1}.golden.raw testcase09_${1}.log 1 "Test ${1} comparison" 0 0
+}
+
+VIDEO_FORMAT=("GRAY8" "GRAY16_LE" "GRAY16_BE" "RGB" "BGR" "RGBx" "BGRx" "xRGB" "xBGR" "RGBA" "BGRA" "ARGB" "ABGR")
+for FORMAT in ${VIDEO_FORMAT[@]}; do
+    video_format_test ${FORMAT}
+done
+
 rm *.log *.bmp *.png *.golden *.raw
 
 report


### PR DESCRIPTION
Add test cases of all supported video format of the direct video decoder.

**Self evaluation:**
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped

