### PR TITLE
[tensor] Increase NNS_TENSOR_RANK_LIMIT to 16

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_trainer.c
+++ b/gst/nnstreamer/elements/gsttensor_trainer.c
@@ -1267,15 +1267,20 @@ gst_tensor_trainer_output_dimension (GstTensorTrainer * trainer)
 {
   GstTensorsInfo *info;
   int i = 0;
-  int value[8] = { 1, 1, 4, 1, 1, 1, 1, 1 };  /** loss, accuracy, val_loss, val_accuracy */
+
   g_return_if_fail (trainer != NULL);
 
   info = &trainer->output_meta;
   trainer->output_ranks[0] = 4;
   trainer->output_configured = TRUE;
 
-  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
-    info->info[0].dimension[i] = value[i];
+  info->info[0].dimension[0] = 1;
+  info->info[0].dimension[1] = 1;
+  info->info[0].dimension[2] = 4; /** loss, accuracy, val_loss, val_accuracy */
+  info->info[0].dimension[3] = 1;
+
+  for (i = 4; i < NNS_TENSOR_RANK_LIMIT; i++)
+    info->info[0].dimension[i] = 0;
 
   info->num_tensors = 1;
 }

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -67,7 +67,7 @@
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_transform_debug);
 #define GST_CAT_DEFAULT gst_tensor_transform_debug
 #define CAPS_STRING GST_TENSOR_CAP_DEFAULT ";" GST_TENSORS_CAP_MAKE ("{ static, flexible }")
-#define REGEX_DIMCHG_OPTION "^([0-7]):([0-7])$"
+#define REGEX_DIMCHG_OPTION "^([0-9]|1[0-5]):([0-9]|1[0-5])$"
 #define REGEX_TYPECAST_OPTION "(^[u]?int(8|16|32|64)$|^float(16|32|64)$)"
 #define REGEX_TRANSPOSE_OPTION "^(?:([0-2]):(?!.*\\1)){3}3$"
 #define REGEX_STAND_OPTION "^(default|dc-average)(:([u]?int(8|16|32|64)|float(16|32|64)))?(,per-channel:(true|false))?$"
@@ -180,7 +180,7 @@ gst_tensor_transform_mode_get_type (void)
     static GEnumValue mode_types[] = {
       {GTT_DIMCHG, "Mode for changing tensor dimensions, "
             "option=FROM_DIM:TO_DIM (with a regex, " REGEX_DIMCHG_OPTION
-            ", where NNS_TENSOR_RANK_LIMIT is 8)",
+            ", where NNS_TENSOR_RANK_LIMIT is 16)",
           "dimchg"},
       {GTT_TYPECAST, "Mode for casting type of tensor, "
             "option=" REGEX_TYPECAST_OPTION, "typecast"},

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -31,7 +31,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define NNS_TENSOR_RANK_LIMIT	(8)
+#define NNS_TENSOR_RANK_LIMIT	(16)
 #define NNS_TENSOR_RANK_LIMIT_PREV (4)
 #define NNS_TENSOR_SIZE_LIMIT	(16)
 #define NNS_TENSOR_SIZE_LIMIT_STR	"16"

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -1692,27 +1692,6 @@ TEST (commonMetaInfo, convertMetaInvalidParam02_n)
 }
 
 /**
- * @brief Test for tensor meta info (dimension rank mismatched).
- */
-TEST (commonMetaInfo, convertMetaInvalidParam03_n)
-{
-  GstTensorMetaInfo meta;
-  GstTensorInfo info;
-  guint i;
-  gboolean ret;
-
-  gst_tensor_meta_info_init (&meta);
-  meta.type = _NNS_UINT16;
-  meta.format = _NNS_TENSOR_FORMAT_STATIC;
-  /* rank > NNS_TENSOR_RANK_LIMIT */
-  for (i = 0; i < NNS_TENSOR_RANK_LIMIT + 3; i++)
-    meta.dimension[i] = 2;
-
-  ret = gst_tensor_meta_info_convert (&meta, &info);
-  EXPECT_FALSE (ret);
-}
-
-/**
  * @brief Test for aggregation utils (clear data).
  */
 TEST (commonAggregationUtil, clearData)

--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
@@ -315,7 +315,7 @@ TEST (nnstreamer@EXT_ABBRV@BasicFunctions, setDimension)
     set.num_tensors = 1;
     set.info[0].type = _NNS_INT8;
     for (i = 0; i < NNS_TENSOR_RANK_LIMIT; ++i) {
-      set.info[0].dimension[i] = 10-i;
+      set.info[0].dimension[i] = (NNS_TENSOR_RANK_LIMIT * 2) - i;
     }
   }
 

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -295,8 +295,8 @@ TEST (testTensorTransform, dimchgProperties0_n)
   h = gst_harness_new ("tensor_transform");
   ASSERT_TRUE (NULL != h);
 
-  /* It should be in the form of ^([0-3]):([0-3]) */
-  g_object_set (h->element, "mode", GTT_DIMCHG, "option", "10:11", NULL);
+  /* It should be in the form of ^([0-9]|1[0-5]):([0-9]|1[0-5]) */
+  g_object_set (h->element, "mode", GTT_DIMCHG, "option", "20:21", NULL);
 
   g_object_get (h->element, "option", &str, NULL);
   EXPECT_TRUE (str == NULL);
@@ -315,7 +315,7 @@ TEST (testTensorTransform, dimchgProperties1_n)
   h = gst_harness_new ("tensor_transform");
   ASSERT_TRUE (NULL != h);
 
-  /* It should be in the form of ^([0-3]):([0-3]) */
+  /* It should be in the form of ^([0-9]|1[0-5]):([0-9]|1[0-5]) */
   g_object_set (h->element, "mode", GTT_DIMCHG, "option", "1,2", NULL);
 
   g_object_get (h->element, "option", &str, NULL);
@@ -355,7 +355,7 @@ TEST (testTensorTransform, dimchgProperties3_n)
   h = gst_harness_new ("tensor_transform");
   ASSERT_TRUE (NULL != h);
 
-  /* It should be in the form of ^([0-3]):([0-3]) */
+  /* It should be in the form of ^([0-9]|1[0-5]):([0-9]|1[0-5]) */
   g_object_set (h->element, "mode", GTT_DIMCHG, "option", "0:2,1:3", NULL);
 
   g_object_get (h->element, "option", &str, NULL);


### PR DESCRIPTION
This patch Increase NNS_TENSOR_RANK_LIMIT
- Increase NNS_TENSOR_RANK_LIMIT to 16 from 8
- Delete convertMetaInvalidParam03_n, since NNS_TENSOR_RANK_LIMIT and NNS_TENSOR_META_RANK_LIMIT are now same.
- Fix some values in tests.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
