### PR TITLE
[Doc/API] Clarify GstMemory ownership of gst_tensor_meta_info_append_header

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -108,6 +108,10 @@ gst_tensor_meta_info_parse_memory (GstTensorMetaInfo * meta, GstMemory * mem);
  * @param[in] meta tensor meta structure
  * @param[in] mem pointer to GstMemory
  * @return Newly allocated GstMemory (Caller should free returned memory using gst_memory_unref())
+ * @note This does not take the ownership of @a mem; its content is copied into
+ *       the returned memory. If the caller owns a reference of @a mem (e.g., the
+ *       memory acquired by gst_tensor_buffer_get_nth_memory ()), the caller
+ *       should unref @a mem as well as the returned memory.
  */
 extern GstMemory *
 gst_tensor_meta_info_append_header (GstTensorMetaInfo * meta, GstMemory * mem);

--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -1633,6 +1633,10 @@ gst_tensor_meta_info_parse_memory (GstTensorMetaInfo * meta, GstMemory * mem)
  * @param[in] meta tensor meta structure
  * @param[in] mem pointer to GstMemory
  * @return Newly allocated GstMemory (Caller should free returned memory using gst_memory_unref())
+ * @note This does not take the ownership of @a mem; its content is copied into
+ *       the returned memory. If the caller owns a reference of @a mem (e.g., the
+ *       memory acquired by gst_tensor_buffer_get_nth_memory ()), the caller
+ *       should unref @a mem as well as the returned memory.
  */
 GstMemory *
 gst_tensor_meta_info_append_header (GstTensorMetaInfo * meta, GstMemory * mem)


### PR DESCRIPTION
## What this PR is now

This PR has been reduced to **documentation only**.

`gst_tensor_meta_info_append_header()` copies the content of the given `GstMemory` into a newly allocated one and never takes ownership of the input. The doc comment said only that the *returned* memory must be unref'ed, leaving the fate of the *input* memory ambiguous. That ambiguity is what produced a series of leaks in the converter / mux / transform / filter flexible-tensor paths.

This adds an `@note` to both the implementation (`nnstreamer_plugin_api_impl.c`) and the public header (`nnstreamer_plugin_api.h`, which is what API consumers actually read) stating that the input memory is not consumed and remains the caller's responsibility.

No functional change.

## Why the original code changes were dropped

The original 2023 version of this PR fixed the actual leaks by rewriting the flexible-tensor paths to mutate buffers in place. Every one of those leaks has since been fixed on `main` by the other resolution — keep building a fresh output buffer and simply `gst_memory_unref()` the memory passed to `gst_tensor_meta_info_append_header()`:

| original target | current `main` |
|---|---|
| `gsttensor_converter.c` flex tensor | `gst_memory_unref (mem);` after `append_header` |
| `gsttensor_mux.c` flex tensor | same pattern |
| `gsttensor_transform.c` | literally the `old` / temp-variable pattern this PR proposed |
| `tensor_filter.c` | unref'ed in both the `invoke_dynamic` and `allocate_in_invoke` flexible paths |
| `nnstreamer_plugin_api_impl.c` caller | `gst_memory_unref (in_mem[i]);` |

The second motivation in the original description — `collect_pad->buf` becoming dangling after buffer replacement — no longer applies either. `gst_tensor_mux_collected()` now passes a locally allocated `gst_buffer_new()` filled by `gst_tensor_mux_collect_buffer()`, not a `GstCollectData` buffer, so replacing the buffer instance is safe.

Rebasing the original in-place-mutation diff would therefore re-litigate an already-merged fix with a larger, riskier change. Only the piece that is still genuinely missing — the ownership note — is kept here.
