### PR TITLE
[pytorch] Fix load model with use_gpu option with recent pytorch

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -353,11 +353,6 @@ if pytorch_support_is_available
 
     nnstreamer_filter_torch_deps = pytorch_support_deps + [nnstreamer_single_dep]
 
-    # pytorch version
-    if pytorch_support_deps[0].version().version_compare('>=1.2.0')
-      nnstreamer_filter_torch_deps += declare_dependency(compile_args: ['-DPYTORCH_VER_ATLEAST_1_2_0=1'])
-    endif
-
     shared_library('nnstreamer_filter_pytorch',
       filter_sub_torch_sources,
       dependencies: nnstreamer_filter_torch_deps,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -202,11 +202,7 @@ TorchCore::loadModel ()
 #endif
 
   try {
-#ifdef PYTORCH_VER_ATLEAST_1_2_0
     model = std::make_shared<torch::jit::script::Module> (torch::jit::load (model_path));
-#else
-    model = torch::jit::load (model_path);
-#endif
   } catch (const std::invalid_argument &ia) {
     ml_loge ("Invalid argument while loading the model: %s", ia.what ());
     return -1;
@@ -470,15 +466,10 @@ TorchCore::serializeOutput (const torch::jit::IValue &value,
         return -2;
       }
     }
-#ifdef PYTORCH_VER_ATLEAST_1_2_0
   } else if (value.isList ()) {
     c10::ArrayRef<torch::jit::IValue> output_ref_list = value.toListRef ();
     std::vector<torch::jit::IValue> output_list (
         output_ref_list.begin (), output_ref_list.end ());
-#else
-  } else if (value.isGenericList ()) {
-    c10::ArrayRef<torch::jit::IValue> output_list = value.toGenericListRef ();
-#endif
     for (auto &element : output_list) {
       if (serializeOutput (element, output, idx, limit_idx)) {
         ml_loge ("Failed to process a tensor list. Output Tensor Information is not valid at index %d",

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -202,7 +202,10 @@ TorchCore::loadModel ()
 #endif
 
   try {
-    model = std::make_shared<torch::jit::script::Module> (torch::jit::load (model_path));
+    torch::Device device
+        = use_gpu ? torch::Device (torch::kCUDA) : torch::Device (torch::kCPU);
+    model = std::make_shared<torch::jit::script::Module> (
+        torch::jit::load (model_path, device));
   } catch (const std::invalid_argument &ia) {
     ml_loge ("Invalid argument while loading the model: %s", ia.what ());
     return -1;
@@ -217,10 +220,6 @@ TorchCore::loadModel ()
   if (model == nullptr) {
     ml_loge ("Failed to read graph.");
     return -1;
-  }
-
-  if (use_gpu) {
-    model->to (at::kCUDA);
   }
 
   /** set the model to evaluation mode */


### PR DESCRIPTION
 - Drop pytorch support for version less than 1.2.0 
- In the recent pytorch, `model->to (device)` does not work properly.
- Use `torch::jit::load (model, torch::Device)` instead.

Tested with yolov8 torchscript model with pytorch v2.0.1

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped