### PR TITLE
[build] Fix recent meson usage

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -279,7 +279,7 @@ if tflite2_support_is_available
     ]
     filepath = ''
     foreach file : filepaths
-      if run_command('bash', '-c', '[ -f "' + file + '" ]').returncode() == 0
+      if run_command('bash', '-c', '[ -f "' + file + '" ]', check : false).returncode() == 0
         message('Found: ' + file)
         filepath = file
         configure_file (
@@ -302,8 +302,8 @@ if tflite2_support_is_available
           join_paths(meson.current_source_dir(), 'libtensorflow2-lite.a',)]
 
       foreach file : filepaths
-        if run_command('bash', '-c', '[ -f "'+ file + '" ]').returncode() == 0
-          somake = run_command('gcc', '-shared', '-o', 'libtensorflow2-lite-custom.so', '-Wl,--whole-archive', file, '-Wl,--no-whole-archive')
+        if run_command('bash', '-c', '[ -f "'+ file + '" ]', check : false).returncode() == 0
+          somake = run_command('gcc', '-shared', '-o', 'libtensorflow2-lite-custom.so', '-Wl,--whole-archive', file, '-Wl,--no-whole-archive', check : false)
           if somake.returncode() == 0
             message('Successfully created libtensorflow2-lite-custom.so from archive: ' + file)
             configure_file (

--- a/meson.build
+++ b/meson.build
@@ -215,7 +215,7 @@ if not get_option('snpe-support').disabled()
           error('@0@ does not exists'.format(SNPE_ROOT))
         endif
 
-        snpe_lib = cxx.find_library('libSNPE',
+        snpe_lib = cxx.find_library('SNPE',
           dirs: join_paths(SNPE_ROOT, 'lib', 'x86_64-linux-clang'),
           required: true
         )


### PR DESCRIPTION
- meson may change the default value of `run_command`'s `check` arg (false -> true). Set `check : false` in omitted lines.
- meson complains as `starting in "lib" only works by accident and is not portable`. Change `libSNPE` to `SNPE`.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped
