### PR TITLE
[snpe] Remove excessive asserts and fix test

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
@@ -419,8 +419,6 @@ snpe_subplugin::configure_instance (const GstTensorFilterProperties *prop)
     throw std::invalid_argument (err_msg);
   }
 
-  assert (model_path == nullptr);
-
   model_path = g_strdup (prop->model_files[0]);
 
   container = zdl::DlContainer::IDlContainer::open (model_path);
@@ -485,13 +483,15 @@ snpe_subplugin::configure_instance (const GstTensorFilterProperties *prop)
 void
 snpe_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
 {
-  assert (!empty_model);
-  assert (snpe);
-
 #if (DBG)
   gint64 start_time = g_get_real_time ();
 #endif
   GstTensorInfo *_info;
+
+  if (!input)
+    throw std::runtime_error ("Invalid input buffer, it is NULL.");
+  if (!output)
+    throw std::runtime_error ("Invalid output buffer, it is NULL.");
 
   if (use_user_buffer) {
     for (unsigned int i = 0; i < inputInfo.num_tensors; ++i) {

--- a/tests/nnstreamer_filter_snpe/unittest_filter_snpe.cc
+++ b/tests/nnstreamer_filter_snpe/unittest_filter_snpe.cc
@@ -80,18 +80,17 @@ TEST (nnstreamerFilterSnpe, getModelInfo00)
   EXPECT_EQ (ret, 0);
 
   EXPECT_EQ (in_info.num_tensors, 1U);
-  EXPECT_EQ (in_info.info[0].dimension[0], 1U);
-  EXPECT_EQ (in_info.info[0].dimension[1], 1U);
-  EXPECT_EQ (in_info.info[0].dimension[2], 1U);
-  EXPECT_EQ (in_info.info[0].dimension[3], 1U);
   EXPECT_EQ (in_info.info[0].type, _NNS_FLOAT32);
+  EXPECT_EQ (in_info.info[0].dimension[0], 1U);
+  for (int i = 1; i < NNS_TENSOR_RANK_LIMIT; ++i)
+    EXPECT_EQ (in_info.info[0].dimension[i], 0U);
 
   EXPECT_EQ (out_info.num_tensors, 1U);
-  EXPECT_EQ (out_info.info[0].dimension[0], 1U);
-  EXPECT_EQ (out_info.info[0].dimension[1], 1U);
-  EXPECT_EQ (out_info.info[0].dimension[2], 1U);
-  EXPECT_EQ (out_info.info[0].dimension[3], 1U);
   EXPECT_EQ (out_info.info[0].type, _NNS_FLOAT32);
+  EXPECT_EQ (out_info.info[0].dimension[0], 1U);
+  for (int i = 1; i < NNS_TENSOR_RANK_LIMIT; ++i)
+    EXPECT_EQ (out_info.info[0].dimension[i], 0U);
+
 
   sp->close (&prop, &data);
   gst_tensors_info_free (&in_info);

--- a/tests/nnstreamer_filter_snpe/unittest_filter_snpe.cc
+++ b/tests/nnstreamer_filter_snpe/unittest_filter_snpe.cc
@@ -433,6 +433,7 @@ TEST (nnstreamerFilterSnpe, launch04_n)
   ASSERT_TRUE (gstpipe != nullptr);
 
   EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  g_usleep (100000);
 
   gst_object_unref (gstpipe);
   g_free (pipeline);

--- a/tests/nnstreamer_filter_snpe/unittest_filter_snpe.cc
+++ b/tests/nnstreamer_filter_snpe/unittest_filter_snpe.cc
@@ -288,9 +288,9 @@ TEST (nnstreamerFilterSnpe, invoke01_n)
   ret = sp->open (&prop, &data);
   EXPECT_EQ (ret, 0);
 
-  /* catching assertion error */
-  EXPECT_DEATH (sp->invoke (NULL, NULL, data, NULL, &output), "");
-  EXPECT_DEATH (sp->invoke (NULL, NULL, data, &input, NULL), "");
+  /* catching exception */
+  EXPECT_NE (sp->invoke (NULL, NULL, data, NULL, &output), 0);
+  EXPECT_NE (sp->invoke (NULL, NULL, data, &input, NULL), 0);
 
   g_free (input.data);
   g_free (output.data);


### PR DESCRIPTION
[filter]
- Remove excessive asserts. Throw exception when input or output buffer is NULL in invoke method instead.

[test]
- Sleep a while when the negative pipeline test exits.
- Deal with the recent rank update in nnstreamer.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped