### PR TITLE
[build] Let meson test work with python3 support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -741,6 +741,13 @@ if get_option('enable-test')
   testenv.set('NNSTREAMER_TRAINERS', path_nns_plugin_trainers)
   testenv.set('NNSTREAMER_SOURCE_ROOT_PATH', meson.source_root())
   testenv.set('NNSTREAMER_BUILD_ROOT_PATH', meson.build_root())
+  if have_python3
+    py3_module_path = join_paths(meson.current_build_dir(), 'ext/nnstreamer/extra')
+    run_command('ln', '-s',
+        py3_module_path + '/nnstreamer_python3.' + so_ext,
+        py3_module_path + '/nnstreamer_python.' + so_ext, check : true)
+    testenv.set('PYTHONPATH', py3_module_path)
+  endif
 
   subdir('tests')
 endif

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -87,23 +87,5 @@ foreach ext : extensions
     install_dir: unittest_install_dir
   )
 
-  filter_ext_common_testenv = environment()
-  filter_ext_common_testenv.set('GST_PLUGIN_PATH', path_gst_plugin)
-  filter_ext_common_testenv.set('NNSTREAMER_CONF', path_nns_conf)
-  filter_ext_common_testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
-  filter_ext_common_testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
-  filter_ext_common_testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
-  filter_ext_common_testenv.set('NNSTREAMER_SOURCE_ROOT_PATH', meson.source_root())
-
-  if ext[0] == 'python3'
-    py3_module_path = join_paths(meson.build_root(), 'tests/' + ext[0] + '_module')
-    run_command('rm', '-rf', py3_module_path, check : true)
-    run_command('mkdir', '-p', py3_module_path, check : true)
-    run_command('ln', '-sf',
-        join_paths(meson.build_root(), 'ext/nnstreamer/extra/nnstreamer_python3.' + so_ext),
-        py3_module_path + '/nnstreamer_python.' + so_ext, check : true)
-    filter_ext_common_testenv.set('PYTHONPATH', py3_module_path)
-  endif
-
-  test(ext_test_template_prefix + ext[4], exec, env: filter_ext_common_testenv)
+  test(ext_test_template_prefix + ext[4], exec, env: testenv)
 endforeach


### PR DESCRIPTION
- Set proper symbolic link and PYTHONPATH env variable to testenv to make `meson test` works with python module tests.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
