### PR TITLE
Meson: Append force option to 'ln' creating python sub-plugin @open sesame 9/20 17:15

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -743,7 +743,7 @@ if get_option('enable-test')
   testenv.set('NNSTREAMER_BUILD_ROOT_PATH', meson.build_root())
   if have_python3
     py3_module_path = join_paths(meson.current_build_dir(), 'ext/nnstreamer/extra')
-    run_command('ln', '-s',
+    run_command('ln', '-sf',
         py3_module_path + '/nnstreamer_python3.' + so_ext,
         py3_module_path + '/nnstreamer_python.' + so_ext, check : true)
     testenv.set('PYTHONPATH', py3_module_path)


### PR DESCRIPTION
Since the ln command returns an error when the target already exists, 'meson build --reconfigure' fails as follows:

meson.build:746:4: ERROR: Command "/usr/bin/ln -s nnstreamer/build/ext/nnstreamer/extra/nnstreamer_python3.so
    nnstreamer/build/ext/nnstreamer/extra/nnstreamer_python.so" failed with status 1.

To fix it, this patch appends the -f, (--force) option to the ln command that creates a soft link file for the python3 sub-plugin.

Signed-off-by: Wook Song <wook16.song@samsung.com>