### PR TITLE
[datarepo] fix a bug that datarepo could not be used in Tizen App after reinstalling rpm @open sesame 09/19 17:05

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -38,7 +38,7 @@
 %define		trix_engine_support 1
 # Support AI offloading (tensor_query) using nnstreamer-edge interface
 %define		nnstreamer_edge_support 1
-%define         datarepo_support 1
+%define		datarepo_support 1
 
 %define		check_test 1
 %define		release_test 1
@@ -1279,6 +1279,9 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 
 %if 0%{?datarepo_support}
 %files datarepo
+%manifest nnstreamer.manifest
+%defattr(-,root,root,-)
+%license LICENSE
 %{gstlibdir}/libgstdatarepo.so
 %endif
 


### PR DESCRIPTION
The datarepo installed on the platform image can be used in the app, but if we reinstall the datarepo rpm after pushing by sdb, it cannot be used in the app.
-Add %license, %manifest, and %defattr(-,root,root,-) to spec

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped