### PR TITLE
[Edge] Fix memory leak

### DIFF
--- a/gst/edge/edge_src.c
+++ b/gst/edge/edge_src.c
@@ -228,9 +228,19 @@ gst_edgesrc_class_finalize (GObject * object)
   GstEdgeSrc *self = GST_EDGESRC (object);
   nns_edge_data_h data_h;
 
+  if (self->host) {
+    g_free (self->host);
+    self->host = NULL;
+  }
+
   if (self->dest_host) {
     g_free (self->dest_host);
     self->dest_host = NULL;
+  }
+
+  if (self->topic) {
+    g_free (self->topic);
+    self->topic = NULL;
   }
 
   if (self->msg_queue) {


### PR DESCRIPTION
 Free host, topic variable memory in GstEdgeSrc when call finalize method to clear GstEdgeSrc memory


**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


