### PR TITLE
[Filter/Decoder] function to get property

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_decoder.c
+++ b/gst/nnstreamer/elements/gsttensor_decoder.c
@@ -361,7 +361,7 @@ gst_tensordec_class_init (GstTensorDecoderClass * klass)
 
   g_object_class_install_property (gobject_class, PROP_CONFIG,
       g_param_spec_string ("config-file", "Configuration-file",
-          "sets config file path which contains plugins properties", "",
+          "Path to configuraion file which contains plugins properties", "",
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   gst_element_class_set_details_simple (gstelement_class,
@@ -413,6 +413,7 @@ gst_tensordec_init (GstTensorDecoder * self)
   self->is_custom = FALSE;
   self->custom.func = NULL;
   self->custom.data = NULL;
+  self->config_path = NULL;
   for (i = 0; i < TensorDecMaxOpNum; i++)
     self->option[i] = NULL;
 
@@ -515,8 +516,9 @@ gst_tensordec_set_property (GObject * object, guint prop_id,
     }
     case PROP_CONFIG:
     {
-      const gchar *config_path = g_value_get_string (value);
-      gst_tensor_parse_config_file (config_path, object);
+      g_free (self->config_path);
+      self->config_path = g_strdup (g_value_get_string (value));
+      gst_tensor_parse_config_file (self->config_path, object);
       break;
     }
       PROP_MODE_OPTION (1);
@@ -588,6 +590,9 @@ gst_tensordec_get_property (GObject * object, guint prop_id,
       }
       break;
     }
+    case PROP_CONFIG:
+      g_value_set_string (value, self->config_path ? self->config_path : "");
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -607,6 +612,7 @@ gst_tensordec_class_finalize (GObject * object)
 
   gst_tensor_decoder_clean_plugin (self);
 
+  g_free (self->config_path);
   for (i = 0; i < TensorDecMaxOpNum; ++i) {
     g_free (self->option[i]);
   }

--- a/gst/nnstreamer/elements/gsttensor_decoder.h
+++ b/gst/nnstreamer/elements/gsttensor_decoder.h
@@ -71,6 +71,7 @@ struct _GstTensorDecoder
   /** For transformer */
   gboolean negotiated; /**< TRUE if tensor metadata is set */
   gboolean silent; /**< True if logging is minimized */
+  gchar *config_path; /**< Path to configuration file */
   gchar *option[TensorDecMaxOpNum]; /**< Assume we have two options */
 
   /** For Tensor */

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -291,12 +291,14 @@ gst_tensor_filter_set_property (GObject * object, guint prop_id,
   silent_debug (self, "Setting property for prop %d.\n", prop_id);
 
   if (prop_id == PROP_CONFIG) {
-    const gchar *config_path = g_value_get_string (value);
-    gst_tensor_parse_config_file (config_path, object);
-  } else if (!gst_tensor_filter_common_set_property (priv, prop_id, value,
-          pspec)) {
-    G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    g_free (priv->config_path);
+    priv->config_path = g_strdup (g_value_get_string (value));
+    gst_tensor_parse_config_file (priv->config_path, object);
+    return;
   }
+
+  if (!gst_tensor_filter_common_set_property (priv, prop_id, value, pspec))
+    G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 }
 
 /**
@@ -313,6 +315,11 @@ gst_tensor_filter_get_property (GObject * object, guint prop_id,
   priv = &self->priv;
 
   silent_debug (self, "Getting property for prop %d.\n", prop_id);
+
+  if (prop_id == PROP_CONFIG) {
+    g_value_set_string (value, priv->config_path ? priv->config_path : "");
+    return;
+  }
 
   if (!gst_tensor_filter_common_get_property (priv, prop_id, value, pspec))
     G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -893,8 +893,8 @@ gst_tensor_filter_install_properties (GObjectClass * gobject_class)
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_INPUT,
       g_param_spec_string ("input", "Input dimension",
-          "Input tensor dimension from inner array, up to 4 dimensions ?", "",
-          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+          "Input tensor dimension from inner array (Max rank #NNS_TENSOR_RANK_LIMIT)",
+          "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_INPUTNAME,
       g_param_spec_string ("inputname", "Name of Input Tensor",
           "The Name of Input Tensor", "",
@@ -918,8 +918,8 @@ gst_tensor_filter_install_properties (GObjectClass * gobject_class)
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_OUTPUT,
       g_param_spec_string ("output", "Output dimension",
-          "Output tensor dimension from inner array, up to 4 dimensions ?", "",
-          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+          "Output tensor dimension from inner array (Max rank #NNS_TENSOR_RANK_LIMIT)",
+          "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_OUTPUTTYPE,
       g_param_spec_string ("outputtype", "Output tensor element type",
           "Type of each element of the output tensor ?", "",
@@ -1000,7 +1000,7 @@ gst_tensor_filter_install_properties (GObjectClass * gobject_class)
           FALSE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_CONFIG,
       g_param_spec_string ("config-file", "Configuration-file",
-          "sets config file path which contains plugins properties", "",
+          "Path to configuraion file which contains plugins properties", "",
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 }
 
@@ -1051,6 +1051,7 @@ gst_tensor_filter_common_free_property (GstTensorFilterPrivate * priv)
 
   gst_tensors_config_free (&priv->in_config);
   gst_tensors_config_free (&priv->out_config);
+  g_free (priv->config_path);
 
   g_list_free (priv->combi.in_combi);
   g_list_free (priv->combi.out_combi_i);

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -159,6 +159,7 @@ typedef struct _GstTensorFilterPrivate
   gboolean silent; /**< Verbose mode if FALSE. int instead of gboolean for non-glib custom plugins */
   gboolean configured; /**< True if already successfully configured tensor metadata */
   gboolean is_updatable; /**<  a given model to the filter is updatable if TRUE */
+  gchar *config_path; /**< Path to configuration file */
   GstTensorsConfig in_config; /**< input tensor info */
   GstTensorsConfig out_config; /**< output tensor info */
 


### PR DESCRIPTION
Fix warning on gst-inspect cmd,
1. add config-path to read plugin properties.
2. update invalid description.
