### PR TITLE
[doc] fix broken link in github.io

### DIFF
--- a/Documentation/hotdoc/gen-hotdoc.sh
+++ b/Documentation/hotdoc/gen-hotdoc.sh
@@ -42,3 +42,8 @@ rm *.png
 cp tmp_doc/*.md .
 rm -r tmp_doc
 rm -rf Documentation/nnst-exam
+
+# github.com uses .md and github.io uses .html
+find . -type f -name "*.html" -exec sed -i -E 's+<li>(.*)<a href="/gst(.*).md+<li>\1<a href="gst\2.html+' {} \;
+find . -type f -name "*.html" -exec sed -i -E 's+<li>(.*)<a href="/Documentation/(.*).md+<li>\1<a href="\2.html+' {} \;
+

--- a/gst/nnstreamer/elements/README.md
+++ b/gst/nnstreamer/elements/README.md
@@ -6,17 +6,17 @@ title: tensor_element
 NNStreamer elements are the basic building blocks for managing neural network pipelines and running neural network models. It provides neural network developers with various elements for easy and efficient development. The name of NNStreamer elements starts with `GstTensor` prefix.
 
 ## NNStreamer element list
-* [Tensor Aggregator](./gsttensor_aggregator.md)
-* [Tensor Converter](./gsttensor_converter.md)
+* [Tensor Aggregator](/gst/nnstreamer/elements/gsttensor_aggregator.md)
+* [Tensor Converter](/gst/nnstreamer/elements/gsttensor_converter.md)
 * Tensor Crop
-* [Tensor Decoder](./gsttensor_decoder.md)
-* [Tensor If](./gsttensor_if.md)
+* [Tensor Decoder](/gst/nnstreamer/elements/gsttensor_decoder.md)
+* [Tensor If](/gst/nnstreamer/elements/gsttensor_if.md)
 * Tensor Mux / Demux
 * Tensor Merge
 * Tensor Rate
 * Tensor Repo
-* [Tensor Sink](./gsttensor_sink.md)
+* [Tensor Sink](/gst/nnstreamer/elements/gsttensor_sink.md)
 * Tensor Sparse
 * Tensor Split
-* [Tensor Source](./gsttensor_src.md)
-* [Tensor Transform](./gsttensor_transform.md)
+* [Tensor Source](/gst/nnstreamer/elements/gsttensor_src.md)
+* [Tensor Transform](/gst/nnstreamer/elements/gsttensor_transform.md)


### PR DESCRIPTION
This patch fixes broken link in github.io.

- Tensor * in https://nnstreamer.github.io/gst/nnstreamer/elements/README.html 
- Links in https://nnstreamer.github.io/gst/nnstreamer/tensor_query/README.html

github.com uses .md file and github.io uses .html file for link. 
So conversion is required.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
