### PR TITLE
[Edge] Fix memory leak when finalize sync

### DIFF
--- a/gst/edge/edge_sink.c
+++ b/gst/edge/edge_sink.c
@@ -256,10 +256,15 @@ static void
 gst_edgesink_finalize (GObject * object)
 {
   GstEdgeSink *self = GST_EDGESINK (object);
-  if (self->host) {
-    g_free (self->host);
-    self->host = NULL;
-  }
+
+  g_free (self->host);
+  self->host = NULL;
+
+  g_free (self->dest_host);
+  self->dest_host = NULL;
+
+  g_free (self->topic);
+  self->topic = NULL;
 
   if (self->edge_h) {
     nns_edge_release_handle (self->edge_h);

--- a/gst/edge/edge_src.c
+++ b/gst/edge/edge_src.c
@@ -228,20 +228,14 @@ gst_edgesrc_class_finalize (GObject * object)
   GstEdgeSrc *self = GST_EDGESRC (object);
   nns_edge_data_h data_h;
 
-  if (self->host) {
-    g_free (self->host);
-    self->host = NULL;
-  }
+  g_free (self->host);
+  self->host = NULL;
 
-  if (self->dest_host) {
-    g_free (self->dest_host);
-    self->dest_host = NULL;
-  }
+  g_free (self->dest_host);
+  self->dest_host = NULL;
 
-  if (self->topic) {
-    g_free (self->topic);
-    self->topic = NULL;
-  }
+  g_free (self->topic);
+  self->topic = NULL;
 
   if (self->msg_queue) {
     while ((data_h = g_async_queue_try_pop (self->msg_queue))) {


### PR DESCRIPTION
 Free dest_host, topic variable memory in GstEdgeSink
 when call finalize method to clear GstEdgeSink memory

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

