### PR TITLE
DataRepo/Src: Add missing null check to the finalize function

### DIFF
--- a/gst/datarepo/gstdatareposrc.c
+++ b/gst/datarepo/gstdatareposrc.c
@@ -281,7 +281,8 @@ gst_data_repo_src_finalize (GObject * object)
     src->fd = 0;
   }
 
-  g_object_unref (src->parser);
+  if (src->parser)
+    g_object_unref (src->parser);
 
   if (src->shuffled_index_array)
     g_array_free (src->shuffled_index_array, TRUE);


### PR DESCRIPTION
Since a null check is omitted in the finalize function, g_object_unref complains about it in some cases as follows:

(unittest_datareposrc:19927): GLib-GObject-CRITICAL **: 10:46:26.793: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

This patch fixes it.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

#### Before this patch
```bash
26/27 unittest_datareposrc                        OK               7.91s
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
stdout:
[==========] Running 22 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 22 tests from datareposrc
[ RUN      ] datareposrc.readImageFiles
[       OK ] datareposrc.readImageFiles (192 ms)
[ RUN      ] datareposrc.readVideoRaw
[       OK ] datareposrc.readVideoRaw (336 ms)
[ RUN      ] datareposrc.readAudioRaw
[       OK ] datareposrc.readAudioRaw (1005 ms)
[ RUN      ] datareposrc.invalidJsonPath0_n
[       OK ] datareposrc.invalidJsonPath0_n (0 ms)
[ RUN      ] datareposrc.invalidJsonPath1_n
[       OK ] datareposrc.invalidJsonPath1_n (0 ms)
[ RUN      ] datareposrc.invalidFilePath0_n
[       OK ] datareposrc.invalidFilePath0_n (0 ms)
[ RUN      ] datareposrc.invalidFilePath1_n
[       OK ] datareposrc.invalidFilePath1_n (0 ms)
[ RUN      ] datareposrc.invalidCapsWithoutJSON_n
[       OK ] datareposrc.invalidCapsWithoutJSON_n (0 ms)
[ RUN      ] datareposrc.readTensors
[       OK ] datareposrc.readTensors (0 ms)
[ RUN      ] datareposrc.readFlexibleTensors
[       OK ] datareposrc.readFlexibleTensors (1009 ms)
[ RUN      ] datareposrc.fps30ReadFlexibleTensors
Elapsed time: 0.988310 second
Elapsed time: 0.004492 second
Elapsed time: 1.001086 second
[       OK ] datareposrc.fps30ReadFlexibleTensors (2336 ms)
[ RUN      ] datareposrc.readSparseTensors
[       OK ] datareposrc.readSparseTensors (3 ms)
[ RUN      ] datareposrc.readTensorsNoJSONWithCapsParam
[       OK ] datareposrc.readTensorsNoJSONWithCapsParam (0 ms)
[ RUN      ] datareposrc.invalidStartSampleIndex0_n
[       OK ] datareposrc.invalidStartSampleIndex0_n (0 ms)
[ RUN      ] datareposrc.invalidStartSampleIndex1_n
[       OK ] datareposrc.invalidStartSampleIndex1_n (0 ms)
[ RUN      ] datareposrc.invalidStopSampleIndex0_n
[       OK ] datareposrc.invalidStopSampleIndex0_n (0 ms)
[ RUN      ] datareposrc.invalidStopSampleIndex1_n
[       OK ] datareposrc.invalidStopSampleIndex1_n (0 ms)
[ RUN      ] datareposrc.invalidEpochs0_n
[       OK ] datareposrc.invalidEpochs0_n (0 ms)
[ RUN      ] datareposrc.invalidEpochs1_n
[       OK ] datareposrc.invalidEpochs1_n (0 ms)
[ RUN      ] datareposrc.invalidTensorsSequence0_n
[       OK ] datareposrc.invalidTensorsSequence0_n (0 ms)
[ RUN      ] datareposrc.readInvalidFlexibleTensors_n
[       OK ] datareposrc.readInvalidFlexibleTensors_n (2006 ms)
[ RUN      ] datareposrc.readInvalidSparseTensors_n
[       OK ] datareposrc.readInvalidSparseTensors_n (1002 ms)
[----------] 22 tests from datareposrc (7895 ms total)

[----------] Global test environment tear-down
[==========] 22 tests from 1 test suite ran. (7895 ms total)
[  PASSED  ] 22 tests.
stderr:

(unittest_datareposrc:19927): GStreamer-CRITICAL **: 10:46:26.791: gst_value_get_fraction_numerator: assertion 'GST_VALUE_HOLDS_FRACTION (value)' failed

(unittest_datareposrc:19927): GStreamer-CRITICAL **: 10:46:26.791: gst_value_get_fraction_denominator: assertion 'GST_VALUE_HOLDS_FRACTION (value)' failed

** (unittest_datareposrc:19927): CRITICAL **: 10:46:26.793: gst_data_repo_src_read_json_file: assertion 'src->json_filename != NULL' failed

(unittest_datareposrc:19927): GLib-GObject-CRITICAL **: 10:46:26.793: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(unittest_datareposrc:19927): GLib-GObject-CRITICAL **: 10:46:26.794: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(unittest_datareposrc:19927): GLib-GObject-CRITICAL **: 10:46:26.794: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(unittest_datareposrc:19927): GLib-GObject-CRITICAL **: 10:46:26.794: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(unittest_datareposrc:19927): GLib-GObject-CRITICAL **: 10:46:26.794: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(unittest_datareposrc:19927): GLib-GObject-CRITICAL **: 10:46:30.144: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(unittest_datareposrc:19927): GLib-GObject-WARNING **: 10:46:30.144: value "4294967295" of type 'guint' is invalid or out of range for property 'start-sample-index' of type 'guint'

(unittest_datareposrc:19927): GLib-GObject-WARNING **: 10:46:30.145: value "4294967295" of type 'guint' is invalid or out of range for property 'stop-sample-index' of type 'guint'

(unittest_datareposrc:19927): GLib-GObject-WARNING **: 10:46:30.145: value "4294967295" of type 'guint' is invalid or out of range for property 'epochs' of type 'guint'
```

#### After this patch
```bash
26/27 unittest_datareposrc                        OK               7.90s
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
stdout:
[==========] Running 22 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 22 tests from datareposrc
[ RUN      ] datareposrc.readImageFiles
[       OK ] datareposrc.readImageFiles (188 ms)
[ RUN      ] datareposrc.readVideoRaw
[       OK ] datareposrc.readVideoRaw (337 ms)
[ RUN      ] datareposrc.readAudioRaw
[       OK ] datareposrc.readAudioRaw (1004 ms)
[ RUN      ] datareposrc.invalidJsonPath0_n
[       OK ] datareposrc.invalidJsonPath0_n (0 ms)
[ RUN      ] datareposrc.invalidJsonPath1_n
[       OK ] datareposrc.invalidJsonPath1_n (0 ms)
[ RUN      ] datareposrc.invalidFilePath0_n
[       OK ] datareposrc.invalidFilePath0_n (0 ms)
[ RUN      ] datareposrc.invalidFilePath1_n
[       OK ] datareposrc.invalidFilePath1_n (0 ms)
[ RUN      ] datareposrc.invalidCapsWithoutJSON_n
[       OK ] datareposrc.invalidCapsWithoutJSON_n (0 ms)
[ RUN      ] datareposrc.readTensors
[       OK ] datareposrc.readTensors (0 ms)
[ RUN      ] datareposrc.readFlexibleTensors
[       OK ] datareposrc.readFlexibleTensors (1011 ms)
[ RUN      ] datareposrc.fps30ReadFlexibleTensors
Elapsed time: 0.987812 second
Elapsed time: 0.005436 second
Elapsed time: 1.000884 second
[       OK ] datareposrc.fps30ReadFlexibleTensors (2335 ms)
[ RUN      ] datareposrc.readSparseTensors
[       OK ] datareposrc.readSparseTensors (2 ms)
[ RUN      ] datareposrc.readTensorsNoJSONWithCapsParam
[       OK ] datareposrc.readTensorsNoJSONWithCapsParam (0 ms)
[ RUN      ] datareposrc.invalidStartSampleIndex0_n
[       OK ] datareposrc.invalidStartSampleIndex0_n (0 ms)
[ RUN      ] datareposrc.invalidStartSampleIndex1_n
[       OK ] datareposrc.invalidStartSampleIndex1_n (0 ms)
[ RUN      ] datareposrc.invalidStopSampleIndex0_n
[       OK ] datareposrc.invalidStopSampleIndex0_n (0 ms)
[ RUN      ] datareposrc.invalidStopSampleIndex1_n
[       OK ] datareposrc.invalidStopSampleIndex1_n (0 ms)
[ RUN      ] datareposrc.invalidEpochs0_n
[       OK ] datareposrc.invalidEpochs0_n (0 ms)
[ RUN      ] datareposrc.invalidEpochs1_n
[       OK ] datareposrc.invalidEpochs1_n (0 ms)
[ RUN      ] datareposrc.invalidTensorsSequence0_n
[       OK ] datareposrc.invalidTensorsSequence0_n (0 ms)
[ RUN      ] datareposrc.readInvalidFlexibleTensors_n
[       OK ] datareposrc.readInvalidFlexibleTensors_n (2005 ms)
[ RUN      ] datareposrc.readInvalidSparseTensors_n
[       OK ] datareposrc.readInvalidSparseTensors_n (1001 ms)
[----------] 22 tests from datareposrc (7890 ms total)

[----------] Global test environment tear-down
[==========] 22 tests from 1 test suite ran. (7890 ms total)
[  PASSED  ] 22 tests.
stderr:

(unittest_datareposrc:32106): GStreamer-CRITICAL **: 11:07:52.712: gst_value_get_fraction_numerator: assertion 'GST_VALUE_HOLDS_FRACTION (value)' failed

(unittest_datareposrc:32106): GStreamer-CRITICAL **: 11:07:52.712: gst_value_get_fraction_denominator: assertion 'GST_VALUE_HOLDS_FRACTION (value)' failed

** (unittest_datareposrc:32106): CRITICAL **: 11:07:52.714: gst_data_repo_src_read_json_file: assertion 'src->json_filename != NULL' failed

(unittest_datareposrc:32106): GLib-GObject-WARNING **: 11:07:56.066: value "4294967295" of type 'guint' is invalid or out of range for property 'start-sample-index' of type 'guint'

(unittest_datareposrc:32106): GLib-GObject-WARNING **: 11:07:56.066: value "4294967295" of type 'guint' is invalid or out of range for property 'stop-sample-index' of type 'guint'

(unittest_datareposrc:32106): GLib-GObject-WARNING **: 11:07:56.066: value "4294967295" of type 'guint' is invalid or out of range for property 'epochs' of type 'guint'
```