### PR TITLE
test/datarepo_src: scope error

### DIFF
--- a/tests/nnstreamer_filter_reload/tensor_filter_reload_test.c
+++ b/tests/nnstreamer_filter_reload/tensor_filter_reload_test.c
@@ -32,7 +32,6 @@ static gchar *input_img_path = NULL;
 static gchar *first_model_path = NULL;
 static gchar *second_model_path = NULL;
 
-static GMainLoop *loop = NULL;
 static gint return_val = 0;
 
 /**
@@ -41,8 +40,8 @@ static gint return_val = 0;
 static gboolean
 bus_callback (GstBus * bus, GstMessage * message, gpointer data)
 {
+  GMainLoop *loop = data;
   UNUSED (bus);
-  UNUSED (data);
   _print_log ("Got %s message\n", GST_MESSAGE_TYPE_NAME (message));
 
   switch (GST_MESSAGE_TYPE (message)) {
@@ -272,7 +271,7 @@ main (int argc, char *argv[])
       tensor_converter, tensor_filter, appsink, NULL);
 
   bus = gst_pipeline_get_bus (GST_PIPELINE (pipeline));
-  gst_bus_add_watch (bus, bus_callback, NULL);
+  gst_bus_add_watch (bus, bus_callback, loop);
   gst_object_unref (bus);
 
   gst_element_set_state (pipeline, GST_STATE_PLAYING);


### PR DESCRIPTION
The bus_callback was using a global variable, loop, while its registerers (e.g., TEST (datareposrc, fps30ReadFlexibleTensors) ) has loop local variable.

Therefore, the callback has been using uninitialied and unrelated global variable, loop, which often causes unit test errors:

```
[  316s] [ RUN      ] datareposrc.fps30ReadFlexibleTensors
[  317s] Elapsed time: 0.687305 second
[  317s] ../tests/nnstreamer_datarepo/unittest_datareposrc.cc:686: Failure
[  317s] Expected: (0.8) < (elapsed_time), actual: 0.8 vs 0.687305
[  317s] Elapsed time: 0.003219 second
[  318s] Elapsed time: 1.001501 second
[  318s] [  FAILED  ] datareposrc.fps30ReadFlexibleTensors (2045 ms)
```

by exiting from g_main_loop too early.

