### PR TITLE
test: don't wait for 10000sec. wait 10sec.

### DIFF
--- a/tests/nnstreamer_filter_custom/unittest_filter_custom.cc
+++ b/tests/nnstreamer_filter_custom/unittest_filter_custom.cc
@@ -129,7 +129,7 @@ TEST (tensorFilterCustom, flexibleInvoke_p)
   sink_received = 0;
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
-  EXPECT_TRUE (wait_pipeline_process_buffers (&sink_received, 6, TEST_TIMEOUT_LIMIT));
+  EXPECT_TRUE (wait_pipeline_process_buffers (&sink_received, 6, TEST_TIMEOUT_LIMIT_MS));
   g_usleep (1000000);
 
   /** cleanup registered custom_easy filter */
@@ -183,7 +183,7 @@ TEST (tensorFilterCustom, staticFlexibleInvoke_p)
   sink_received = 0;
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
-  EXPECT_TRUE (wait_pipeline_process_buffers (&sink_received, 6, TEST_TIMEOUT_LIMIT));
+  EXPECT_TRUE (wait_pipeline_process_buffers (&sink_received, 6, TEST_TIMEOUT_LIMIT_MS));
   g_usleep (1000000);
 
   /** cleanup registered custom_easy filter */

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -31,6 +31,7 @@ extern "C" {
 #define UNITTEST_STATECHANGE_TIMEOUT (2000U)
 #define TEST_DEFAULT_SLEEP_TIME (10000U)
 #define TEST_TIMEOUT_LIMIT (10000000U) /* 10 secs */
+#define TEST_TIMEOUT_LIMIT_MS (10000U) /* 10 secs */
 
 /**
  * @brief Set pipeline state, wait until it's done.


### PR DESCRIPTION
wait_pipeline_process_buffers accepts timeout in ms, not us.
