### PR TITLE
Filter/MLAgent: Replace MLAgentd with MLAgent @open saseme 10/13 16:30

### DIFF
--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -49,7 +49,7 @@ nnstreamer_single_sources = [
 
 if ml_agent_support_is_available
   nnstreamer_single_sources += files('ml_agent.c')
-  nnstreamer_single_deps += ml_agentd_dep
+  nnstreamer_single_deps += ml_agent_dep
 endif
 
 # Add nnstreamer registerer and common sources

--- a/gst/nnstreamer/ml_agent.c
+++ b/gst/nnstreamer/ml_agent.c
@@ -12,7 +12,7 @@
  * @bug     No known bugs except for NYI items
  */
 
-#include <ml-agentd/ml-agent-dbus-interface.h>
+#include <ml-agent-interface.h>
 
 #include "ml_agent.h"
 
@@ -86,9 +86,7 @@ mlagent_parse_uri_string (const GValue * val)
        * @todo The specification of the data layout filled in the third
        *       argument (i.e., stringfied_json) by the callee is not fully decided.
        */
-      rcode =
-          ml_agent_dbus_interface_model_get (name, version, stringfied_json,
-          &err);
+      rcode = ml_agent_model_get (name, version, stringfied_json, &err);
       g_clear_error (&err);
 
       if (rcode != 0)

--- a/gst/nnstreamer/ml_agent.h
+++ b/gst/nnstreamer/ml_agent.h
@@ -17,7 +17,7 @@
 
 #include <glib-object.h>
 
-#ifdef ENABLE_ML_AGENTD
+#ifdef ENABLE_ML_AGENT
 /**
  * @brief Parse the given URI into the valid file path string
  */

--- a/meson.build
+++ b/meson.build
@@ -354,13 +354,13 @@ endif
 if not get_option('datarepo-support').disabled() and not json_glib_dep.found()
   message('datarepo-support is off because json-glib-1.0 is not available.')
 endif
-# ml-agentd
-ml_agentd_dep = dependency('', required: false)
+# ml-agent
+ml_agent_dep = dependency('', required: false)
 if not get_option('ml-agent-support').disabled()
-  ml_agentd_dep = dependency('ml-agentd', required: false)
-  if not ml_agentd_dep.found()
-    if cc.check_header('ml-agentd/ml-agent-dbus-interface.h', dependencies: [glib_dep], required: get_option('ml-agent-support'))
-      ml_agentd_dep = cc.find_library('ml-agentd', required: true)
+  ml_agent_dep = dependency('ml-agent', required: false)
+  if not ml_agent_dep.found()
+    if cc.check_header('ml-agent/ml-agent-interface.h', dependencies: [glib_dep], required: get_option('ml-agent-support'))
+      ml_agent_dep = cc.find_library('ml-agent', required: true)
     endif
   endif
 endif
@@ -472,8 +472,8 @@ features = {
     'extra_deps': [ json_glib_dep ],
   },
   'ml-agent-support': {
-    'extra_deps': [ ml_agentd_dep ],
-    'project_args': { 'ENABLE_ML_AGENTD' : 1 }
+    'extra_deps': [ ml_agent_dep ],
+    'project_args': { 'ENABLE_ML_AGENT' : 1 }
   }
 }
 


### PR DESCRIPTION
Since MLAgentd would no longer be used interchangeably with MLAgent, this patch applies those changes. 

Signed-off-by: Wook Song <wook16.song@samsung.com>

See also: https://github.com/nnstreamer/api/pull/407

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped