### PR TITLE
Test LLVM/Clang build in github-action

### DIFF
--- a/.github/workflows/ubuntu_clean_llvm_build.yml
+++ b/.github/workflows/ubuntu_clean_llvm_build.yml
@@ -1,0 +1,28 @@
+name: Minimal meson build in Ubuntu with LLVM/clang
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04 ]
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v1
+    - name: install minimal requirements
+      run: |
+          sudo apt-get update && \
+          sudo apt-get install -y libglib2.0-dev libjson-glib-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev googletest \
+            gstreamer1.0-plugins-good clang meson ninja-build
+    - name: meson build with llvm/clang
+      run: |
+          CC=clang CXX=clang++ meson build && \
+          ninja test -C build

--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,10 @@ warning_flags = [
   '-Wvla',
   '-Wpointer-arith'
 ]
+if cxx.get_id() == 'clang'
+  # For the usage of GstTensorFilterFramework in tensor_filter_support_cc.cc
+  warning_flags += '-Wno-c99-designator'
+endif
 
 warning_c_flags = [
   '-Wmissing-declarations',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -50,7 +50,16 @@ endif
 # gtest
 gtest_dep = dependency('gtest', required: false)
 if gtest_dep.found()
-  lesser_code_quality_accepted_for_unittest_code = declare_dependency(compile_args: ['-Wno-unused-parameter', '-Wno-missing-field-initializers', '-Wno-maybe-uninitialized'])
+  gtest_compile_args = ['-Wno-unused-parameter', '-Wno-missing-field-initializers', '-Wno-format-nonliteral']
+  if cc.get_id() == 'clang' and cxx.get_id() == 'clang'
+    gtest_compile_args += '-Wno-uninitialized'
+    gtest_compile_args += '-Wno-format-nonliteral'
+    gtest_compile_args += '-Wno-deprecated-copy'
+  else
+    gtest_compile_args += '-Wno-maybe-uninitialized'
+  endif
+
+  lesser_code_quality_accepted_for_unittest_code = declare_dependency(compile_args: gtest_compile_args)
 
   nnstreamer_unittest_deps = [
     unittest_util_dep,

--- a/tests/nnstreamer_filter_reload/tensor_filter_reload_test.c
+++ b/tests/nnstreamer_filter_reload/tensor_filter_reload_test.c
@@ -209,7 +209,7 @@ main (int argc, char *argv[])
           &second_model_path,
           "The path of second model file",
         "e.g., models/mobilenet_v2_1.0_224_quant.tflite"},
-    {NULL}
+    {0}
   };
 
   /* parse options */

--- a/tools/development/parser/toplevel.c
+++ b/tools/development/parser/toplevel.c
@@ -31,7 +31,7 @@ static GOptionEntry entries[] = {
         "From pbtxt to gst pipeline", NULL},
   {"verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose, "Enable verbose messages",
         NULL},
-  {NULL}
+  {0}
 };
 
 /** @brief Get input string for parsing */


### PR DESCRIPTION
This fixes #3979 (CC @wooksong )

1st commit:

commit 3fe9ae56a19aff98a77d24862a2a3dbc756dfa7d
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Fri Oct 13 18:16:58 2023 +0900

    Support clang/clang++
    
    Fix clang's complaints.
    Addressing #3979
    
    To build w/ LLVM, do
    $ CC=clang CXX=clang++ meson ...
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


2nd commit:

commit 9d27be517d23d14ab097af0c954ac0d7f28ad024
Date:   Fri Oct 13 18:55:48 2023 +0900

    github-action: ubuntu-llvm/clang build test
    
    Add llvm/clang build test.
    Fixes #3979
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
