### PR TITLE
decoder: add detailed descriptions for a few subplugins.

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
@@ -373,6 +373,10 @@ void
 init_dv (void)
 {
   nnstreamer_decoder_probe (&directVideo);
+  nnstreamer_decoder_set_custom_property_desc (decoder_subplugin_direct_video,
+      "option1",
+      "The output video format. If this is unspecified, it is 'GRAY8' (dim[0]/channel == 1), 'RGB' (dim[0]/channel == 3), or 'BGRx' (dim[0]/channel == 4). Available options are: { GRAY8, RGB, BGR, RGBx, BGRx, xRGB, xBGR, RGBA, BGRA, ARGB, ABGR, GRAY16_BE, GRAY16_LE }.",
+      NULL);
 }
 
 /** @brief Destruct this object for tensordec-plugin */

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
@@ -261,6 +261,9 @@ void
 init_il (void)
 {
   nnstreamer_decoder_probe (&imageLabeling);
+  nnstreamer_decoder_set_custom_property_desc (
+      decoder_subplugin_image_labeling, "option1", "The path to the label file",
+      NULL);
 }
 
 /** @brief Destruct this object for tensordec-plugin */

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
@@ -650,6 +650,11 @@ void
 init_is (void)
 {
   nnstreamer_decoder_probe (&imageSegment);
+  nnstreamer_decoder_set_custom_property_desc ( decoder_subplugin_image_segment,
+      "option1",
+      "Mode of image segmentation. { tflite-deeplab (input: #labels x width x height (float32, label probability). e.g., deeplabv3_257_mv_gpu.tflite), snpe-deeplab (input: width x height x 1 (float32, label index) e.g., deeplabv3_mnv2_pascal_train_aug.dlc), snpe-depth (input: 1 x width x height (float32, grayscale) e.g., .dlc snpe models producing grayscale images) }",
+      "option2", "Maximum number of labels. 20 is applied if not specified.",
+      NULL);
 }
 
 /** @brief Destruct this object for tensordec-plugin */


### PR DESCRIPTION
As #3903 requests, we need descriptions for subplugin users.

@wooksong, @yeonykim2, @niley7464 (or anyone who's capable), please populate such info for more decoder, converter, filter subplugins. (then, close #3903 )
@songgot : Please apply similar changes to tensor_trainer subplugins.