### PR TITLE
[edge] Deprecate port and host property of edgesrc and update description for port property

### DIFF
--- a/gst/edge/edge_sink.c
+++ b/gst/edge/edge_sink.c
@@ -95,7 +95,9 @@ gst_edgesink_class_init (GstEdgeSinkClass * klass)
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_PORT,
       g_param_spec_uint ("port", "Port",
-          "A self port address to accept connection from edgesrc.",
+          "A self port address to accept connection from edgesrc. "
+          "If the port is set to 0 then the available port is allocated. "
+          "If the connect-type is AITT then the port setting is not required.",
           0, 65535, DEFAULT_PORT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_CONNECT_TYPE,
       g_param_spec_enum ("connect-type", "Connect Type",

--- a/gst/edge/edge_src.h
+++ b/gst/edge/edge_src.h
@@ -42,8 +42,6 @@ struct _GstEdgeSrc
 {
   GstBaseSrc element;
 
-  gchar *host;
-  guint16 port;
   gchar *dest_host;
   guint16 dest_port;
   gchar *topic;

--- a/tests/nnstreamer_edge/edge/unittest_edge.cc
+++ b/tests/nnstreamer_edge/edge/unittest_edge.cc
@@ -107,7 +107,7 @@ TEST (edgeSrc, properties0)
   gchar *str_val;
 
   /* Create a nnstreamer pipeline */
-  pipeline = g_strdup_printf ("gst-launch-1.0 edgesrc port=0 name=srcx ! "
+  pipeline = g_strdup_printf ("gst-launch-1.0 edgesrc name=srcx ! "
                               "other/tensors,num_tensors=1,dimensions=3:320:240:1,types=uint8,format=static,framerate=30/1 ! "
                               "tensor_sink");
   gstpipe = gst_parse_launch (pipeline, NULL);
@@ -117,15 +117,6 @@ TEST (edgeSrc, properties0)
   EXPECT_NE (edge_handle, nullptr);
 
   /* Set/Get properties of edgesrc */
-  g_object_set (edge_handle, "host", "127.0.0.2", NULL);
-  g_object_get (edge_handle, "host", &str_val, NULL);
-  EXPECT_STREQ ("127.0.0.2", str_val);
-  g_free (str_val);
-
-  g_object_set (edge_handle, "port", 5001U, NULL);
-  g_object_get (edge_handle, "port", &uint_val, NULL);
-  EXPECT_EQ (5001U, uint_val);
-
   g_object_set (edge_handle, "dest-host", "127.0.0.2", NULL);
   g_object_get (edge_handle, "dest-host", &str_val, NULL);
   EXPECT_STREQ ("127.0.0.2", str_val);


### PR DESCRIPTION
    - Add a description of deprecated for port and host property of edgesrc.
      In the case of edgesrc, port and host settings are not required.
    - Update description of port property of edgesink

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
