### PR TITLE
[action] Let gbs action cache 'GBS-ROOT/local/cache'

### DIFF
--- a/.github/workflows/gbs_x64.yml
+++ b/.github/workflows/gbs_x64.yml
@@ -20,6 +20,16 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y gbs
     - name: configure GBS
       run: cp .github/workflows/tizen.gbs.conf ~/.gbs.conf
+    - name: make cache key
+      id: make-key
+      run: echo "cache_key=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: cache gbs cache
+      id: cache-gbs-root
+      uses: actions/cache@v3
+      with:
+        path: ~/GBS-ROOT/local/cache
+        key: ${{ steps.make-key.outputs.cache_key }}
     - name: run GBS
       run: gbs build
     - name: get nntrainer

--- a/.github/workflows/gbs_x64.yml
+++ b/.github/workflows/gbs_x64.yml
@@ -31,11 +31,11 @@ jobs:
         path: ~/GBS-ROOT/local/cache
         key: ${{ steps.make-key.outputs.cache_key }}
     - name: run GBS
-      run: gbs build
+      run: gbs build --skip-srcrpm --define "_skip_debug_rpm 1"
     - name: get nntrainer
       uses: actions/checkout@v3
       with:
         repository: nnstreamer/nntrainer
         path: nntrainer
     - name: run nntrainer GBS build
-      run: pushd nntrainer && gbs build --define "unit_test 1" && popd
+      run: pushd nntrainer && gbs build --skip-srcrpm --define "unit_test 1" --define "_skip_debug_rpm 1" && popd


### PR DESCRIPTION
- Let github action cache the directory. Speed gbs build up by removing package downloads.
- The cache key is the date. The very first run each day will make new cache.

Gbs build with _skip_debug_rpm and --skip-srcrpm
- Let gbs build do not make debug rpms and skip srcrpm
- This will save extra seconds..

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped
