### PR TITLE
[Common] unref memory when appending tensor buffer

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_demux.c
+++ b/gst/nnstreamer/elements/gsttensor_demux.c
@@ -525,7 +525,6 @@ gst_tensor_demux_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
             idx);
         mem = gst_tensor_buffer_get_nth_memory (buf, idx);
         if (!gst_tensor_buffer_append_memory (outbuf, mem, _info)) {
-          gst_memory_unref (mem);
           gst_buffer_unref (outbuf);
           res = GST_FLOW_ERROR;
           goto error;
@@ -538,7 +537,6 @@ gst_tensor_demux_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
           gst_tensors_info_get_nth_info (&tensor_demux->tensors_config.info, i);
       mem = gst_tensor_buffer_get_nth_memory (buf, i);
       if (!gst_tensor_buffer_append_memory (outbuf, mem, _info)) {
-        gst_memory_unref (mem);
         gst_buffer_unref (outbuf);
         res = GST_FLOW_ERROR;
         goto error;

--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -130,7 +130,7 @@ gst_tensor_buffer_get_nth_memory (GstBuffer * buffer, const guint index);
 /**
  * @brief Append @a memory to given @a buffer.
  * @param[in/out] buffer GstBuffer to be appended.
- * @param[in] memory GstMemory to append. This function will take ownership of this.
+ * @param[in] memory GstMemory to append. This function takes ownership of this, even if it returns failure.
  * @param[in] info GstTensorInfo of given @a memory.
  * @return TRUE if successfully appended, otherwise FALSE.
  */


### PR DESCRIPTION
Fix util function to take gst-memory if failed to append it.
