### PR TITLE
[action] Do not run github workflows on every push event

### DIFF
--- a/.github/workflows/gbs_x64.yml
+++ b/.github/workflows/gbs_x64.yml
@@ -1,8 +1,6 @@
 name: GBS Tizen build for x64 from Ubuntu
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,8 +1,6 @@
 name: macos
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/risc-v.yml
+++ b/.github/workflows/risc-v.yml
@@ -1,8 +1,6 @@
 name: Test on RISCV64 Ubuntu 20.04
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/ubuntu_clean_llvm_build.yml
+++ b/.github/workflows/ubuntu_clean_llvm_build.yml
@@ -1,8 +1,6 @@
 name: Minimal meson build in Ubuntu with LLVM/clang
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -1,8 +1,6 @@
 name: Minimal meson build in Ubuntu
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/update_gbs_cache.yml
+++ b/.github/workflows/update_gbs_cache.yml
@@ -1,0 +1,33 @@
+name: Update GBS cache once a day
+
+on:
+  schedule:
+    - cron: '58 15 * * 0,1,2,3,4' # every weekday at 00:58 (KST)
+
+  # Allow manually triggering the workflow
+  workflow_dispatch:
+
+jobs:
+  cache_gbs:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v1
+    - name: prepare deb sources for GBS
+      run: echo "deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_20.04/ /" | sudo tee /etc/apt/sources.list.d/tizen.list
+    - name: install GBS
+      run: sudo apt-get update && sudo apt-get install -y gbs
+    - name: configure GBS
+      run: cp .github/workflows/tizen.gbs.conf ~/.gbs.conf
+    - name: make cache key
+      id: make-key
+      run: echo "cache_key=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: cache gbs cache
+      id: cache-gbs-root
+      uses: actions/cache@v3
+      with:
+        path: ~/GBS-ROOT/local/cache
+        key: ${{ steps.make-key.outputs.cache_key }}
+    - name: run GBS
+      run: gbs build --skip-srcrpm --define "_skip_debug_rpm 1"


### PR DESCRIPTION
- Doing every workflows on each push is not necessary as each
  pull request already checks it.
- Do not run those to save the earth!


[action] Cache gbs once every weekday
- Let the new workflow cache gbs every weekday.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

