### PR TITLE
[Edge] Remove re-connect from nnstreamer element

### DIFF
--- a/gst/edge/edge_src.h
+++ b/gst/edge/edge_src.h
@@ -49,6 +49,8 @@ struct _GstEdgeSrc
   nns_edge_connect_type_e connect_type;
   nns_edge_h edge_h;
   GAsyncQueue *msg_queue;
+
+  gboolean playing;
 };
 
 /**


### PR DESCRIPTION
 - Since the reconnection has been changed to be done inside the nns-edge, nns_edge_connect for reconnection is deleted from the nnstreamer element.
 - Add state change function and set `playing` prop.


**Self evaluation:**
1. Build test: [O]Passed [ ]Failed [ ]Skipped
2. Run test: [O]Passed [ ]Failed [ ]Skipped



