### PR TITLE
[Filter] Typecast using G_TENSOR_FILTER_SINGLE_PRIV macro

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_single.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_single.c
@@ -119,7 +119,7 @@ g_tensor_filter_single_init (GTensorFilterSingle * self)
 
   self->priv = g_type_instance_get_private ((GTypeInstance *) self,
       G_TYPE_TENSOR_FILTER_SINGLE);
-  spriv = (GTensorFilterSinglePrivate *) self->priv;
+  spriv = G_TENSOR_FILTER_SINGLE_PRIV (self);
   priv = &spriv->filter_priv;
 
   gst_tensor_filter_common_init_property (priv);


### PR DESCRIPTION
Changed to use a macro when converting a pointer to the GstTensorFilterSinglePrivate type. 
Through this, the type conversion method is unified in other functions to maintain consistency and ensure stability.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped


