### PR TITLE
[Query] Add max-request prop to query client @open sesame 11/22 10:40

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_client.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_client.c
@@ -685,7 +685,7 @@ gst_tensor_query_client_chain (GstPad * pad,
   nns_edge_data_set_info (data_h, "client_id", val);
   g_free (val);
 
-  if (self->requested_num > self->max_request) {
+  if (self->max_request > 0 && self->requested_num > self->max_request) {
     nns_logi
         ("the processing speed of the query server is too slow. Drop the input buffer.");
   } else {

--- a/gst/nnstreamer/tensor_query/tensor_query_client.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_client.h
@@ -59,6 +59,9 @@ struct _GstTensorQueryClient
   nns_edge_connect_type_e connect_type;
   nns_edge_h edge_h;
   GAsyncQueue *msg_queue;
+
+  guint max_request;
+  guint requested_num;
 };
 
 /**


### PR DESCRIPTION
Currently, the query client sends all input buffers to the query server.
If the processing speed of the server is slower than the client, the result time of the server is gradually different from the input time.
To prevent this, the server processes only limited number of buffers, and drop the remaining input buffers.

Signed-off-by: gichan2-jang <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

