### PR TITLE
[QueryClient] handle tensor buffer

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_client.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_client.h
@@ -46,7 +46,8 @@ struct _GstTensorQueryClient
 
   gboolean silent; /**< True if logging is minimized */
   gchar *in_caps_str;
-
+  gboolean is_tensor;
+  GstTensorsConfig config;
   guint timeout; /**< timeout value (in ms) to wait message from server */
 
   /* Query-hybrid feature */


### PR DESCRIPTION
1. Decrease the ref count of incoming buffer if an error occurs.
2. Check the number of requested buffer before creating edge-data handle, and try to get the output from query-server.
3. Append gst-buffer using util function if current caps is tensor stream.
