### PR TITLE
[datareposrc] Bugfix: Fixed removing JSON file before unittest @open sesame 11/24 12:50

### DIFF
--- a/gst/datarepo/gstdatareposrc.c
+++ b/gst/datarepo/gstdatareposrc.c
@@ -1122,7 +1122,7 @@ gst_data_repo_src_start (GstDataRepoSrc * src)
 
   /* record if it's a regular (hence seekable and lengthable) file */
   if (!S_ISREG (stat_results.st_mode))
-    goto error_close;;
+    goto error_close;
 
   src->read_position = 0;
 


### PR DESCRIPTION
- The Filename is changed for each TC because sometimes the JSON file of unittest(fps30ReadFlexibleTensors) is deleted by g_remove() in the previous unittest


**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
