### PR TITLE
[build] Set cpp_std=c++17 (changed from c++14)

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -638,7 +638,7 @@ endif
 
 if snpe_support_is_available
   filter_sub_snpe_sources = ['tensor_filter_snpe.cc']
-  nnstreamer_filter_snpe_deps = [glib_dep, gst_dep, nnstreamer_dep, snpe_support_deps]
+  nnstreamer_filter_snpe_deps = [glib_dep, gst_dep, nnstreamer_dep, snpe_support_deps, declare_dependency(compile_args: ['-Wno-deprecated-declarations'])]
 
   shared_library('nnstreamer_filter_snpe',
     filter_sub_snpe_sources,

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ project('nnstreamer', 'c', 'cpp',
     'werror=true',
     'warning_level=2',
     'c_std=gnu89',
-    'cpp_std=c++14'
+    'cpp_std=c++17'
   ]
 )
 


### PR DESCRIPTION
- Recent neural network frameworks needs c++17 standards to use its APIs
- Let nnstreamer be built with c++17.
- Add a Wno flag to snpe filter.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped