### PR TITLE
[build] Check flatbuffers header files before build tflite subplugin

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -184,6 +184,10 @@ if tflite2_support_is_available
   )
   message('TensorFlow2-lite version: ' + tflite2_ver)
 
+  if not cxx.check_header('flatbuffers/flatbuffers.h')
+    error('flatbuffers header files are required to build tensorflow2-lite subplugin. Please install compatible version for tensorflow-lite library. Or disable tflite2-support in meson_options.txt')
+  endif
+
   filter_sub_tflite2_sources = ['tensor_filter_tensorflow_lite.cc']
 
   nnstreamer_filter_tflite2_deps = tflite2_support_deps + [thread_dep, libdl_dep, nnstreamer_single_dep]

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -207,6 +207,7 @@ BuildRequires: tensorflow-lite-devel
 %if 0%{?tensorflow2_lite_support}
 # for tensorflow2-lite
 BuildRequires: tensorflow2-lite-devel
+BuildRequires: flatbuffers-devel
 # tensorflow2-lite-custom requires scripts for rpm >= 4.9
 BuildRequires:  rpm >= 4.9
 %global __requires_exclude ^libtensorflow2-lite-custom.*$


### PR DESCRIPTION
- TFLite API requires flatbuffers header. Let meson check required header
- Add `BuildRequires` flatbuffers-devel explicitly in spec

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped


