### PR TITLE
[build] Halt meson setup when compiler is not GCC and pytorch is enabled

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -346,30 +346,30 @@ else # no tflite2
 endif
 
 if pytorch_support_is_available
-  if cxx.get_id() == 'gcc'
-    filter_sub_torch_sources = ['tensor_filter_pytorch.cc']
-    # pytorch sources contain unused parameters
-    ignore_unused_params = declare_dependency(compile_args: ['-Wno-unused-parameter'])
-    pytorch_support_deps += ignore_unused_params
+  if cxx.get_id() != 'gcc'
+    error('Pytorch headers (Array.h and reverse_iterator.h) require GCC for license issues. Use GCC or disable pytorch with -Dpytorch-support=disabled.')
+  endif
+
+  filter_sub_torch_sources = ['tensor_filter_pytorch.cc']
+  # pytorch sources contain unused parameters
+  ignore_unused_params = declare_dependency(compile_args: ['-Wno-unused-parameter'])
+  pytorch_support_deps += ignore_unused_params
 
     nnstreamer_filter_torch_deps = [pytorch_support_deps, nnstreamer_single_dep]
 
-    shared_library('nnstreamer_filter_pytorch',
-      filter_sub_torch_sources,
-      dependencies: nnstreamer_filter_torch_deps,
-      install: true,
-      install_dir: filter_subplugin_install_dir
-    )
+  shared_library('nnstreamer_filter_pytorch',
+    filter_sub_torch_sources,
+    dependencies: nnstreamer_filter_torch_deps,
+    install: true,
+    install_dir: filter_subplugin_install_dir
+  )
 
-    static_library('nnstreamer_filter_pytorch',
-      filter_sub_torch_sources,
-      dependencies: nnstreamer_filter_torch_deps,
-      install: true,
-      install_dir: nnstreamer_libdir
-    )
-  else # Compilers is not gcc
-    warning('There are a few headers (Array.h and reverse_iterator.h) that require gcc for license issues. Disabling pytorch subplugin build')
-  endif
+  static_library('nnstreamer_filter_pytorch',
+    filter_sub_torch_sources,
+    dependencies: nnstreamer_filter_torch_deps,
+    install: true,
+    install_dir: nnstreamer_libdir
+  )
 endif
 
 if caffe2_support_is_available

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -33,11 +33,7 @@ if nnfw_runtime_support_is_available
 endif
 
 if pytorch_support_is_available
-  if cxx.get_id() == 'gcc'
-    extensions += [['pytorch', 'torch', nnstreamer_filter_torch_deps, 'pytorch_lenet5.pt', 'pytorch']]
-  else # Compilers is not gcc
-    warning('There are a few headers (Array.h and reverse_iterator.h) that require gcc for license issues. Disabling pytorch subplugin build')
-  endif
+  extensions += [['pytorch', 'torch', nnstreamer_filter_torch_deps, 'pytorch_lenet5.pt', 'pytorch']]
 endif
 
 if caffe2_support_is_available


### PR DESCRIPTION
- Halt meson setup procedure when given compiler is not GCC and pytorch-support is enabled. Rather than warning and go.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [*]Skipped
2. Run test: [X]Passed [ ]Failed [*]Skipped
