### PR TITLE
[Build] dependency to gstreamer

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -53,21 +53,21 @@ Description: NNStreamer Single-shot
 Package: nnstreamer-tensorflow2-lite
 Architecture: any
 Multi-Arch: same
-Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
+Depends: nnstreamer-single, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer TensorFlow Lite 2.x Support
  This package allows nnstreamer to support tensorflow-lite 2.x.
 
 Package: nnstreamer-pytorch
 Architecture: any
 Multi-Arch: same
-Depends: nnstreamer, pytorch, ${shlibs:Depends}, ${misc:Depends}
+Depends: nnstreamer-single, pytorch, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer Pytorch Support
  This package allows nnstreamer to support pytorch.
 
 Package: nnstreamer-caffe2
 Architecture: any
 Multi-Arch: same
-Depends: nnstreamer, pytorch, ${shlibs:Depends}, ${misc:Depends}
+Depends: nnstreamer-single, pytorch, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer Caffe2 Support
  This package allows nnstreamer to support caffe2.
 
@@ -81,21 +81,21 @@ Description: NNStreamer Python Custom Filter Support (3.x)
 Package: nnstreamer-edgetpu
 Architecture: any
 Multi-Arch: same
-Depends: nnstreamer, libedgetpu1-std, ${shlibs:Depends}, ${misc:Depends}
+Depends: nnstreamer-single, libedgetpu1-std, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer Edge TPU support
  This package allows nnstreamer to support Edge TPU.
 
 Package: nnstreamer-openvino
 Architecture: any
 Multi-Arch: same
-Depends: nnstreamer, openvino, ${shlibs:Depends}, ${misc:Depends}
+Depends: nnstreamer-single, openvino, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer OpenVino support
  This package allows nnstreamer to support OpenVino.
 
 Package: nnstreamer-nnfw
 Architecture: amd64
 Multi-Arch: same
-Depends: nnstreamer, nnfw, ${shlibs:Depends}, ${misc:Depends}
+Depends: nnstreamer-single, nnfw, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer NNFW (ONE) support
  This package allows nnstreamer to support NNFW (ONE, On-Device Neural Engine).
 

--- a/ext/nnstreamer/extra/meson.build
+++ b/ext/nnstreamer/extra/meson.build
@@ -61,7 +61,7 @@ if grpc_support_is_available
 endif
 
 if have_python3
-  nnstreamer_python3_deps = [python3_dep, libdl_dep, glib_dep, gst_dep, nnstreamer_dep]
+  nnstreamer_python3_deps = [python3_dep, libdl_dep, glib_dep, nnstreamer_single_dep]
   nnstreamer_python3_src = ['nnstreamer_python3_helper.cc']
 
   nnstreamer_python3_helper = shared_library('nnstreamer_python3',

--- a/ext/nnstreamer/extra/nnstreamer_python3_helper.h
+++ b/ext/nnstreamer/extra/nnstreamer_python3_helper.h
@@ -22,7 +22,7 @@
 #include <numpy/arrayobject.h>
 #include <structmember.h>
 #include <nnstreamer_log.h>
-#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_util.h>
 #include <stdexcept>
 #include <string>
 

--- a/ext/nnstreamer/tensor_converter/meson.build
+++ b/ext/nnstreamer/tensor_converter/meson.build
@@ -47,14 +47,14 @@ if have_python3
 
   shared_library('nnstreamer_converter_python3',
     converter_sub_python3_sources,
-    dependencies: nnstreamer_python3_helper_dep,
+    dependencies: [nnstreamer_dep, nnstreamer_python3_helper_dep],
     install: true,
     install_dir: converter_subplugin_install_dir
   )
 
   static_library('nnstreamer_converter_python3',
     converter_sub_python3_sources,
-    dependencies: nnstreamer_python3_helper_dep,
+    dependencies: [nnstreamer_dep, nnstreamer_python3_helper_dep],
     install: true,
     install_dir: nnstreamer_libdir
   )

--- a/ext/nnstreamer/tensor_converter/tensor_converter_python3.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_python3.cc
@@ -13,6 +13,7 @@
  * @bug		python converter with Python3.9.10 is stucked during Py_Finalize().
  */
 
+#include <nnstreamer_plugin_api.h>
 #include <nnstreamer_plugin_api_converter.h>
 #include <nnstreamer_util.h>
 #include "nnstreamer_python3_helper.h"

--- a/ext/nnstreamer/tensor_decoder/meson.build
+++ b/ext/nnstreamer/tensor_decoder/meson.build
@@ -165,14 +165,14 @@ if have_python3
 
   shared_library('nnstreamer_decoder_python3',
     decoder_sub_python3_sources,
-    dependencies: nnstreamer_python3_helper_dep,
+    dependencies: [nnstreamer_dep, nnstreamer_python3_helper_dep],
     install: true,
     install_dir: decoder_subplugin_install_dir
   )
 
   static_library('nnstreamer_decoder_python3',
     decoder_sub_python3_sources,
-    dependencies: nnstreamer_python3_helper_dep,
+    dependencies: [nnstreamer_dep, nnstreamer_python3_helper_dep],
     install: true,
     install_dir: nnstreamer_libdir
   )

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -1,7 +1,7 @@
 if nnfw_runtime_support_is_available
   filter_sub_nnfw_sources = ['tensor_filter_nnfw.c']
 
-  nnstreamer_filter_nnfw_deps = nnfw_runtime_support_deps + [nnstreamer_single_dep]
+  nnstreamer_filter_nnfw_deps = [nnfw_runtime_support_deps, nnstreamer_single_dep]
 
   # Check old function (@todo remove this definition later, nnfw ver >= 1.6.0)
   if not cc.has_header_symbol('nnfw/nnfw.h', 'nnfw_set_input_tensorinfo', dependencies: nnfw_dep)
@@ -43,7 +43,7 @@ if armnn_support_is_available
     message('ARMNN subplugin is built with TFLite parser.')
   endif
 
-  nnstreamer_filter_armnn_deps = armnn_support_deps + [glib_dep, gst_dep, nnstreamer_dep ]
+  nnstreamer_filter_armnn_deps = [armnn_support_deps, glib_dep, nnstreamer_single_dep]
 
   armnn_plugin_lib = shared_library('nnstreamer_filter_armnn',
     filter_sub_armnn_sources,
@@ -81,7 +81,7 @@ if tf_support_is_available
 
   filter_sub_tf_sources = ['tensor_filter_tensorflow.cc']
 
-  nnstreamer_filter_tf_deps = tf_support_deps + [nnstreamer_single_dep]
+  nnstreamer_filter_tf_deps = [tf_support_deps, nnstreamer_single_dep]
   nnstreamer_filter_tf_deps += tf_ver_dep
 
   shared_library('nnstreamer_filter_tensorflow',
@@ -123,7 +123,7 @@ if tflite_support_is_available
 
   filter_sub_tflite_sources = ['tensor_filter_tensorflow_lite.cc']
 
-  nnstreamer_filter_tflite_deps = tflite_support_deps + [thread_dep, libdl_dep, glib_dep, nnstreamer_single_dep]
+  nnstreamer_filter_tflite_deps = [tflite_support_deps, thread_dep, libdl_dep, glib_dep, nnstreamer_single_dep]
 
   # Since tf-1.13, tflite has moved from contrib to core
   tflite_h_prefix='#include <tensorflow/lite/model.h>'
@@ -190,7 +190,7 @@ if tflite2_support_is_available
 
   filter_sub_tflite2_sources = ['tensor_filter_tensorflow_lite.cc']
 
-  nnstreamer_filter_tflite2_deps = tflite2_support_deps + [thread_dep, libdl_dep, nnstreamer_single_dep]
+  nnstreamer_filter_tflite2_deps = [tflite2_support_deps, thread_dep, libdl_dep, nnstreamer_single_dep]
 
   tflite2_compile_args = []
   tflite2_compile_args += '-DTFLITE_INT8=1'
@@ -355,7 +355,7 @@ if pytorch_support_is_available
     ignore_unused_params = declare_dependency(compile_args: ['-Wno-unused-parameter'])
     pytorch_support_deps += ignore_unused_params
 
-    nnstreamer_filter_torch_deps = pytorch_support_deps + [nnstreamer_single_dep]
+    nnstreamer_filter_torch_deps = [pytorch_support_deps, nnstreamer_single_dep]
 
     shared_library('nnstreamer_filter_pytorch',
       filter_sub_torch_sources,
@@ -378,7 +378,7 @@ endif
 if caffe2_support_is_available
   filter_sub_caffe2_sources = ['tensor_filter_caffe2.cc']
 
-  nnstreamer_filter_caffe2_deps = caffe2_support_deps + [protobuf_dep, glib_dep, nnstreamer_single_dep]
+  nnstreamer_filter_caffe2_deps = [caffe2_support_deps, protobuf_dep, glib_dep, nnstreamer_single_dep]
 
   shared_library('nnstreamer_filter_caffe2',
     filter_sub_caffe2_sources,
@@ -396,7 +396,7 @@ if caffe2_support_is_available
 endif
 
 if deepview_rt_support_is_available
-  nnstreamer_filter_deepview_rt_deps = deepview_rt_support_deps + [glib_dep, gst_dep, nnstreamer_dep]
+  nnstreamer_filter_deepview_rt_deps = [deepview_rt_support_deps, glib_dep, nnstreamer_single_dep]
 
   filter_sub_deepview_rt_sources = ['tensor_filter_deepview_rt.cc']
 
@@ -438,7 +438,7 @@ if mvncsdk2_support_is_available
     'tensor_filter_movidius_ncsdk2.c'
   ]
 
-  nnstreamer_filter_mvncsdk2_deps = mvncsdk2_support_deps + [glib_dep, gst_dep, nnstreamer_dep]
+  nnstreamer_filter_mvncsdk2_deps = [mvncsdk2_support_deps, glib_dep, nnstreamer_single_dep]
 
   shared_library('nnstreamer_filter_movidius-ncsdk2',
     filter_sub_mvncsdk2_sources,
@@ -496,7 +496,7 @@ if get_option('enable-edgetpu')
     endif
   endif
 
-  nnstreamer_filter_edgetpu_deps = [glib_dep, gst_dep, nnstreamer_dep, edgetpu_dep, libdl_dep]
+  nnstreamer_filter_edgetpu_deps = [glib_dep, nnstreamer_single_dep, edgetpu_dep, libdl_dep]
 
   if tflite2_support_is_available
     nnstreamer_filter_edgetpu_deps += [tflite2_support_deps, tflite2_ver_dep]
@@ -544,7 +544,7 @@ if get_option('enable-openvino')
   endif
   filter_sub_openvino_sources = ['tensor_filter_openvino.cc']
 
-  nnstreamer_filter_openvino_deps = [glib_dep, gst_dep, nnstreamer_dep, openvino_deps]
+  nnstreamer_filter_openvino_deps = [glib_dep, nnstreamer_single_dep, openvino_deps]
 
   nnstreamer_filter_openvino_so_lib = shared_library('nnstreamer_filter_openvino',
     filter_sub_openvino_sources,
@@ -615,8 +615,7 @@ if get_option('enable-mediapipe')
 
   nnstreamer_filter_mediapipe_deps = [
     glib_dep,
-    gst_dep,
-    nnstreamer_dep,
+    nnstreamer_single_dep,
     opencv_core_dep,
     opencv_video_dep,
     opencv_imgcodecs_dep,
@@ -642,7 +641,7 @@ endif
 
 if snpe_support_is_available
   filter_sub_snpe_sources = ['tensor_filter_snpe.cc']
-  nnstreamer_filter_snpe_deps = [glib_dep, gst_dep, nnstreamer_dep, snpe_support_deps, declare_dependency(compile_args: ['-Wno-deprecated-declarations'])]
+  nnstreamer_filter_snpe_deps = [glib_dep, nnstreamer_single_dep, snpe_support_deps, declare_dependency(compile_args: ['-Wno-deprecated-declarations'])]
 
   shared_library('nnstreamer_filter_snpe',
     filter_sub_snpe_sources,
@@ -662,7 +661,7 @@ endif
 if tensorrt_support_is_available
   filter_sub_tensorrt_sources = ['tensor_filter_tensorrt.cc']
 
-  nnstreamer_filter_tensorrt_deps = [glib_dep, gst_dep, nnstreamer_dep, tensorrt_support_deps]
+  nnstreamer_filter_tensorrt_deps = [glib_dep, nnstreamer_single_dep, tensorrt_support_deps]
 
   shared_library('nnstreamer_filter_tensorrt',
     filter_sub_tensorrt_sources,
@@ -689,7 +688,7 @@ endif
 if lua_support_is_available
   filter_sub_lua_sources = ['tensor_filter_lua.cc']
 
-  nnstreamer_filter_lua_deps = [glib_dep, gst_dep, nnstreamer_dep, lua_support_deps]
+  nnstreamer_filter_lua_deps = [glib_dep, nnstreamer_single_dep, lua_support_deps]
 
   shared_library('nnstreamer_filter_lua',
     filter_sub_lua_sources,
@@ -707,7 +706,7 @@ if lua_support_is_available
 endif
 
 if tvm_support_is_available
-  nnstreamer_filter_tvm_deps = tvm_support_deps + [glib_dep, gst_dep, nnstreamer_dep]
+  nnstreamer_filter_tvm_deps = [tvm_support_deps, glib_dep, nnstreamer_dep]
 
   filter_sub_tvm_sources = ['tensor_filter_tvm.cc']
 
@@ -727,7 +726,7 @@ if tvm_support_is_available
 endif
 
 if trix_engine_support_is_available
-  nnstreamer_filter_trix_engine_deps = trix_engine_support_deps + [glib_dep, gst_dep, nnstreamer_dep]
+  nnstreamer_filter_trix_engine_deps = [trix_engine_support_deps, glib_dep, nnstreamer_single_dep]
 
   filter_sub_trix_engine_sources = ['tensor_filter_trix_engine.cc']
 
@@ -755,7 +754,7 @@ if mxnet_support_is_available
     'tensor_filter_mxnet.cc'
   ]
 
-  nnstreamer_filter_mxnet_deps = mxnet_support_deps + [glib_dep, gst_dep, nnstreamer_dep, libdl_dep]
+  nnstreamer_filter_mxnet_deps = [mxnet_support_deps, glib_dep, nnstreamer_single_dep, libdl_dep]
 
   nnstreamer_filter_mxnet_so_lib = shared_library('nnstreamer_filter_mxnet',
     filter_sub_mxnet_sources,
@@ -774,7 +773,7 @@ endif
 if ncnn_support_is_available
   filter_sub_ncnn_sources = ['tensor_filter_ncnn.cc']
 
-  nnstreamer_filter_ncnn_deps = ncnn_support_deps + [glib_dep, gst_dep, nnstreamer_dep]
+  nnstreamer_filter_ncnn_deps = [ncnn_support_deps, glib_dep, nnstreamer_single_dep]
 
   shared_library('nnstreamer_filter_ncnn',
     filter_sub_ncnn_sources,
@@ -794,7 +793,7 @@ endif
 if onnxruntime_support_is_available
   filter_sub_onnxruntime_sources = ['tensor_filter_onnxruntime.cc']
 
-  nnstreamer_filter_onnxruntime_deps = [glib_dep, gst_dep, nnstreamer_dep, onnxruntime_support_deps]
+  nnstreamer_filter_onnxruntime_deps = [glib_dep, nnstreamer_single_dep, onnxruntime_support_deps]
 
   shared_library('nnstreamer_filter_onnxruntime',
     filter_sub_onnxruntime_sources,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -48,7 +48,7 @@
 #include <nnstreamer_plugin_api_filter.h>
 #undef NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_conf.h>
-#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
 
 static const gchar *armnn_accl_support[]

--- a/ext/nnstreamer/tensor_filter/tensor_filter_deepview_rt.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_deepview_rt.cc
@@ -32,8 +32,8 @@
 #include <glib.h>
 #include <nnstreamer_cppplugin_api_filter.hh>
 #include <nnstreamer_log.h>
+#include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
-#include <tensor_common.h>
 
 #include <deepview_rt.h>
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
@@ -28,8 +28,8 @@
 #include <glib.h>
 #include <nnstreamer_cppplugin_api_filter.hh>
 #include <nnstreamer_log.h>
+#include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
-#include <tensor_common.h>
 
 #include <edgetpu.h>
 #include <tensorflow/lite/builtin_op_data.h>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_lua.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_lua.cc
@@ -81,10 +81,9 @@ extern "C" {
 #include <memory>
 #include <nnstreamer_cppplugin_api_filter.hh>
 #include <nnstreamer_log.h>
+#include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
 #include <string>
-#include <tensor_common.h>
-
 
 namespace nnstreamer
 {

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mediapipe.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mediapipe.cc
@@ -19,7 +19,7 @@
 #include <string>
 
 #include <nnstreamer_cppplugin_api_filter.hh>
-#include <tensor_common.h>
+#include <nnstreamer_plugin_api_util.h>
 
 #include <mediapipe/framework/calculator_framework.h>
 #include <mediapipe/framework/formats/image_frame.h>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
@@ -29,7 +29,6 @@
 #include <fcntl.h>
 #include <glib.h>
 #include <glib/gstdio.h>
-#include <gst/gst.h>
 #include <mvnc2/mvnc.h>
 #include <nnstreamer_log.h>
 #include <nnstreamer_util.h>
@@ -152,8 +151,8 @@ _mvncsdk2_open (const GstTensorFilterProperties * prop, void **private_data)
       idx_dev = i;
       break;
     } else {
-      GST_WARNING ("Failed to create device handle at index %d: "
-          "%d is returned\n", i, ret_code);
+      nns_logw ("Failed to create device handle at index %d: %d is returned\n",
+          i, ret_code);
     }
   }
   if ((ret_code != NC_OK) && (i == NNS_MVNCSDK2_SUPPORT_MAX_NUMS_DEVICES)) {

--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -81,7 +81,7 @@
  *                custom=input_rank=4:1
  */
 #include <nnstreamer_cppplugin_api_filter.hh>
-#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
 #include <stdexcept>
 #include <unistd.h>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_ncnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_ncnn.cc
@@ -47,9 +47,8 @@
 #include <glib.h>
 #include <nnstreamer_cppplugin_api_filter.hh>
 #include <nnstreamer_log.h>
-#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
-#include <tensor_common.h>
 #include <thread>
 
 #include <ncnn/net.h>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_onnxruntime.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_onnxruntime.cc
@@ -23,8 +23,8 @@
 #include <glib.h>
 #include <nnstreamer_cppplugin_api_filter.hh>
 #include <nnstreamer_log.h>
+#include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
-#include <tensor_common.h>
 
 #include <onnxruntime_cxx_api.h>
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
@@ -29,7 +29,7 @@
 #define NO_ANONYMOUS_NESTED_STRUCT
 #include <nnstreamer_plugin_api_filter.h>
 #undef NO_ANONYMOUS_NESTED_STRUCT
-#include <tensor_common.h>
+#include <nnstreamer_plugin_api_util.h>
 #ifdef __OPENVINO_CPU_EXT__
 #include <ext_list.hpp>
 #endif /* __OPENVINO_CPU_EXT__ */
@@ -240,6 +240,15 @@ TensorFilterOpenvino::loadModel (accl_hw hw)
   this->_inferRequest = this->_executableNet.CreateInferRequest ();
 
   return RetSuccess;
+}
+
+/**
+ * @brief Check the neural network model is loaded.
+ */
+bool
+TensorFilterOpenvino::isModelLoaded ()
+{
+  return _isLoaded;
 }
 
 /**

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.hh
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.hh
@@ -35,7 +35,6 @@
 
 #include <glib.h>
 #include <nnstreamer_plugin_api_filter.h>
-#include <tensor_common.h>
 #ifdef __OPENVINO_CPU_EXT__
 #include <ext_list.hpp>
 #endif /* __OPENVINO_CPU_EXT__ */
@@ -44,6 +43,9 @@
 #include <string>
 #include <vector>
 
+/**
+ * @brief Wrapper class for OpenVino.
+ */
 class TensorFilterOpenvino
 {
   public:
@@ -66,11 +68,7 @@ class TensorFilterOpenvino
 
   /** @todo Need to support other acceleration devices */
   int loadModel (accl_hw hw);
-  bool isModelLoaded ()
-  {
-    return _isLoaded;
-  }
-
+  bool isModelLoaded ();
   int getInputTensorDim (GstTensorsInfo *info);
   int getOutputTensorDim (GstTensorsInfo *info);
   int invoke (const GstTensorFilterProperties *prop,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_snap.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_snap.cc
@@ -27,7 +27,7 @@
 #include <android/log.h>
 
 #include <nnstreamer_cppplugin_api_filter.hh>
-#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_util.h>
 #include <snap_sdk_interface.h>
 
 #define TAG "NNStreamer-SNAP"

--- a/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
@@ -25,8 +25,8 @@
 #include <glib.h>
 #include <nnstreamer_cppplugin_api_filter.hh>
 #include <nnstreamer_log.h>
+#include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
-#include <tensor_common.h>
 
 #include <DlContainer/IDlContainer.hpp>
 #include <DlSystem/ITensorFactory.hpp>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt.cc
@@ -21,8 +21,8 @@
 #include <vector>
 
 #include <nnstreamer_cppplugin_api_filter.hh>
+#include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
-#include <tensor_common.h>
 
 #include <NvInfer.h>
 #include <NvUffParser.h>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_trix_engine.hh
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_trix_engine.hh
@@ -22,7 +22,7 @@
 /* nnstreamer plugin api headers */
 #include <nnstreamer_cppplugin_api_filter.hh>
 #include <nnstreamer_log.h>
-#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
 
 namespace nnstreamer

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tvm.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tvm.cc
@@ -17,7 +17,6 @@
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api.h>
 #include <nnstreamer_util.h>
-#include <tensor_common.h>
 
 #include <dlpack/dlpack.h>
 #include <tvm/runtime/module.h>

--- a/ext/nnstreamer/tensor_filter/vivante/meson.build
+++ b/ext/nnstreamer/tensor_filter/vivante/meson.build
@@ -8,14 +8,14 @@ libdl_dep = cc.find_library('dl') # dl library
 base_deps = [
   glib_dep,
   gobject_dep,
-  nnstreamer_dep
+  nnstreamer_single_dep
 ]
 
 sources = [
-  'tensor_filter_subplugin.c'
+  'tensor_filter_vivante.c'
 ]
 
-# TODO: This header files are specified to support Tizen. 
+# TODO: This header files are specified to support Tizen.
 # If you use VIM3/Ubuntu18.04(aarch64) board,
 # you need to update the below header folders.
 # - '/usr/include/vivante', '/usr/include/VX'

--- a/ext/nnstreamer/tensor_filter/vivante/tensor_filter_vivante.c
+++ b/ext/nnstreamer/tensor_filter/vivante/tensor_filter_vivante.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @file	tensor_filter_subplugin.c
+ * @file	tensor_filter_vivante.c
  * @date	28 Jan 2020
  * @brief	NNStreamer tensor-filter subplugin template
  * @see		http://github.com/nnsuite/nnstreamer

--- a/gst/nnstreamer/tensor_filter/meson.build
+++ b/gst/nnstreamer/tensor_filter/meson.build
@@ -10,6 +10,6 @@ nnstreamer_headers += files('tensor_filter_single.h')
 nnstreamer_sources += files('tensor_filter.c')
 
 if get_option('enable-filter-cpp-class')
-  nnstreamer_sources += files('tensor_filter_support_cc.cc')
+  nnstreamer_single_sources += files('tensor_filter_support_cc.cc')
 endif
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
@@ -42,7 +42,6 @@
 
 #include <nnstreamer_cppplugin_api_filter.hh>
 #include <nnstreamer_util.h>
-#include <tensor_common.h>
 
 namespace nnstreamer
 {

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -362,7 +362,7 @@ NNStreamer's global configuration setup for the end user.
 %if 0%{?tensorflow_support}
 %package tensorflow
 Summary:	NNStreamer TensorFlow Support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 Requires:	tensorflow
 %description tensorflow
 NNStreamer's tensor_filter subplugin of TensorFlow.
@@ -375,7 +375,7 @@ Tensorflow used for building this package.
 %if 0%{?tensorflow_lite_support}
 %package tensorflow-lite
 Summary:	NNStreamer TensorFlow Lite Support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 # tensorflow-lite provides .a file and it's embedded into the subplugin. No dep to tflite.
 %description tensorflow-lite
 NNStreamer's tensor_filter subplugin of TensorFlow Lite.
@@ -385,7 +385,7 @@ NNStreamer's tensor_filter subplugin of TensorFlow Lite.
 %if 0%{?tensorflow2_lite_support}
 %package tensorflow2-lite
 Summary:	NNStreamer TensorFlow2 Lite Support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 # tensorflow2-lite provides .a file and it's embedded into the subplugin. No dep to tflite.
 %description tensorflow2-lite
 NNStreamer's tensor_filter subplugin of TensorFlow2 Lite.
@@ -402,7 +402,7 @@ NNStreamer's tensor_filter subplugin of Python3.
 %if 0%{?armnn_support}
 %package armnn
 Summary:	NNStreamer Arm NN support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 Requires:	armnn
 %description armnn
 NNStreamer's tensor_filter subplugin of Arm NN Inference Engine.
@@ -412,7 +412,7 @@ NNStreamer's tensor_filter subplugin of Arm NN Inference Engine.
 %if 0%{?vivante_support}
 %package vivante
 Summary:    NNStreamer subplugin for Verisilicon's Vivante
-Requires:   nnstreamer = %{version}-%{release}
+Requires:   nnstreamer-single = %{version}-%{release}
 %description vivante
 NNStreamer filter subplugin for Verisilicon Vivante.
 %define enable_vivante -Denable-vivante=true
@@ -447,7 +447,7 @@ NNStreamer's tensor_converter and decoder subplugin of flatbuf.
 %if 0%{?pytorch_support}
 %package pytorch
 Summary:	NNStreamer PyTorch Support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 Requires:	pytorch
 %description pytorch
 NNStreamer's tensor_filter subplugin of pytorch
@@ -457,7 +457,7 @@ NNStreamer's tensor_filter subplugin of pytorch
 %if 0%{?caffe2_support}
 %package caffe2
 Summary:	NNStreamer caffe2 Support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 Requires:	pytorch
 %description caffe2
 NNStreamer's tensor_filter subplugin of caffe2
@@ -467,7 +467,7 @@ NNStreamer's tensor_filter subplugin of caffe2
 %if 0%{?lua_support}
 %package lua
 Summary:	NNStreamer lua Support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 Requires:	lua
 %description lua
 NNStreamer's tensor_filter subplugin of lua
@@ -486,7 +486,7 @@ NNStreamer's tensor_filter subplugin of tvm
 %if 0%{?snpe_support}
 %package snpe
 Summary:	NNStreamer snpe Support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 Requires:	snpe
 %description snpe
 NNStreamer's tensor_filter subplugin of snpe
@@ -496,7 +496,7 @@ NNStreamer's tensor_filter subplugin of snpe
 %if 0%{?trix_engine_support}
 %package trix-engine
 Summary:	NNStreamer TRIx-Engine support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 Requires:	trix-engine
 %description trix-engine
 NNStreamer's tensor_filter subplugin of trix-engine
@@ -506,7 +506,7 @@ NNStreamer's tensor_filter subplugin of trix-engine
 %if 0%{?onnxruntime_support}
 %package onnxruntime
 Summary:	NNStreamer onnxruntime Support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 %description onnxruntime
 NNStreamer's tensor_filter subplugin of onnxruntime
 %endif
@@ -571,7 +571,7 @@ HTML pages of lcov results of NNStreamer generated during rpmbuild
 %if 0%{?nnfw_support}
 %package nnfw
 Summary:	NNStreamer Tizen-nnfw runtime support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 Requires:	nnfw
 %description nnfw
 NNStreamer's tensor_filter subplugin of Tizen-NNFW Runtime. (5.5 M2 +)
@@ -580,7 +580,7 @@ NNStreamer's tensor_filter subplugin of Tizen-NNFW Runtime. (5.5 M2 +)
 %if 0%{?mvncsdk2_support}
 %package	ncsdk2
 Summary:	NNStreamer Intel Movidius NCSDK2 support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 Group:		Machine Learning/ML Framework
 %description	ncsdk2
 NNStreamer's tensor_filter subplugin of Intel Movidius Neural Compute stick SDK2.
@@ -589,7 +589,7 @@ NNStreamer's tensor_filter subplugin of Intel Movidius Neural Compute stick SDK2
 %if 0%{openvino_support}
 %package	openvino
 Summary:	NNStreamer OpenVino support
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 Requires:	openvino
 Group:		Machine Learning/ML Framework
 %description	openvino
@@ -641,7 +641,7 @@ NNStreamer's gRPC IDL support for flatbuf
 %package edgetpu
 Summary:	NNStreamer plugin for Google-Coral Edge TPU
 Requires:	libedgetpu1
-Requires:	nnstreamer = %{version}-%{release}
+Requires:	nnstreamer-single = %{version}-%{release}
 %description edgetpu
 You may enable this package to use Google Edge TPU with NNStreamer and Tizen ML APIs.
 %endif


### PR DESCRIPTION
Remove unnecessary dependency of gstreamer when building subplugins. 
(e.g., we should support filter-subplugin for single-shot, without gst.)
