### PR TITLE
[Protobuf] missing tensor type

### DIFF
--- a/ext/nnstreamer/include/nnstreamer.fbs
+++ b/ext/nnstreamer/include/nnstreamer.fbs
@@ -20,7 +20,7 @@ enum Tensor_type : int {
   NNS_FLOAT32,
   NNS_INT64,
   NNS_UINT64,
-
+  NNS_FLOAT16,
   NNS_END
   }
 

--- a/ext/nnstreamer/include/nnstreamer.proto
+++ b/ext/nnstreamer/include/nnstreamer.proto
@@ -17,6 +17,7 @@ message Tensor {
     NNS_FLOAT32 = 7;
     NNS_INT64 = 8;
     NNS_UINT64 = 9;
+    NNS_FLOAT16 = 10;
   }
   Tensor_type type = 2;
   repeated uint32 dimension = 3;

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -133,6 +133,7 @@
 
 /**
  * @brief Possible data element types of other/tensor.
+ * @note When changing tensor type, you shoud update related type in ML-API and protobuf/flatbuf schema also.
  */
 typedef enum _nns_tensor_type
 {


### PR DESCRIPTION
Add missing tensor type 'float16' when generating protobuf and flatbuf code.
