### PR TITLE
[Spec] Remove flatbuf-python dependency

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -431,9 +431,6 @@ NNStreamer's tensor_converter and decoder subplugin of Protobuf.
 Summary:	NNStreamer Flatbuf Support
 Requires:	nnstreamer = %{version}-%{release}
 Requires:	flatbuffers
-%if "%{?profile}" != "tv"
-Recommends: flatbuffers-python
-%endif
 %description flatbuf
 NNStreamer's tensor_converter and decoder subplugin of flatbuf.
 %endif


### PR DESCRIPTION
Remove flatbuf-python dependency from all Tizen profile.

* This patch is backported from https://github.com/nnstreamer/nnstreamer/commit/28bb054acae2d29a902694b12f9684fcef203884

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

