### PR TITLE
[mlagent] Fix fallback case and unittest_mlagent @open sesame 1/9 16:24

### DIFF
--- a/gst/nnstreamer/ml_agent.c
+++ b/gst/nnstreamer/ml_agent.c
@@ -146,6 +146,8 @@ mlagent_get_model_path_from (const GValue * val)
               "Invalid value for the key, %s", JSON_KEY_MODEL_PATH);
           goto fallback;
         }
+
+        g_strfreev (parts);
         return g_strdup (path);
       }
     }
@@ -155,5 +157,5 @@ fallback:
   g_clear_error (&err);
   g_strfreev (parts);
 
-  return uri;
+  return g_strdup (uri);
 }

--- a/tests/unittest_mlagent/mock_mlagent.h
+++ b/tests/unittest_mlagent/mock_mlagent.h
@@ -15,6 +15,7 @@
 
 #include <unordered_map>
 #include <vector>
+#include <utility>
 
 struct MockModel;
 

--- a/tests/unittest_mlagent/unittest_mlagent.cc
+++ b/tests/unittest_mlagent/unittest_mlagent.cc
@@ -94,7 +94,8 @@ TEST (testMLAgent, GetModelInvalidURIFormats_n)
 
     path = mlagent_get_model_path_from (&val);
 
-    /* In the case that invalid URIs are given, mlagent_get_model_path_from () returns
+    /**
+     * In the case that invalid URIs are given, mlagent_get_model_path_from () returns
      * the given URI as it is so that it is handled by the fallback procedure (i.e., regarding it as a file path).
      */
     EXPECT_STREQ (uri, path);
@@ -123,7 +124,8 @@ TEST (testMLAgent, GetModelInvalidModel_n)
 
   path = mlagent_get_model_path_from (&val);
 
-  /* In the case that invalid URIs are given, mlagent_get_model_path_from () returns
+  /**
+   * In the case that invalid URIs are given, mlagent_get_model_path_from () returns
    * the given URI as it is so that it is handled by the fallback procedure (i.e., regarding it as a file path).
    */
   EXPECT_STREQ (uri, path);

--- a/tests/unittest_mlagent/unittest_mlagent.cc
+++ b/tests/unittest_mlagent/unittest_mlagent.cc
@@ -127,6 +127,8 @@ TEST (testMLAgent, GetModelInvalidModel_n)
    * the given URI as it is so that it is handled by the fallback procedure (i.e., regarding it as a file path).
    */
   EXPECT_STREQ (uri, path);
+
+  g_value_reset (&val);
 }
 
 /**


### PR DESCRIPTION
- Let `mlagent_get_model_path_from` returns uri in fallback case
- Fix memleak (g_strfreev).
- Fix memleak in a testcase.
- Add a missing header <utility> in mock_mlagent.h
  - It declares `std::exchange`
- Fix multiline comments in unittest_mlagent.cc to satisfy CI (doxygen)

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
