### PR TITLE
[build] Remove unnecessary BuildRequires @open sesame 1/5 20:43

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -184,7 +184,9 @@ if tflite2_support_is_available
   )
   message('TensorFlow2-lite version: ' + tflite2_ver)
 
-  if not cxx.check_header('flatbuffers/flatbuffers.h')
+  # check flatbuffers header
+  ## Note that tizen tflite package has its own flatbuffers header internally.
+  if build_platform != 'tizen' and not cxx.check_header('flatbuffers/flatbuffers.h')
     error('flatbuffers header files are required to build tensorflow2-lite subplugin. Please install compatible version for tensorflow-lite library. Or disable tflite2-support in meson_options.txt')
   endif
 

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -207,7 +207,6 @@ BuildRequires: tensorflow-lite-devel
 %if 0%{?tensorflow2_lite_support}
 # for tensorflow2-lite
 BuildRequires: tensorflow2-lite-devel
-BuildRequires: flatbuffers-devel
 # tensorflow2-lite-custom requires scripts for rpm >= 4.9
 BuildRequires:  rpm >= 4.9
 %global __requires_exclude ^libtensorflow2-lite-custom.*$


### PR DESCRIPTION
- The latest tflite2 tizen package has its own flatbuffers header internally. Let's remove the `BuildRequires: flatbuffers-debvel`
- Let meson check the header when build_platform is not tizen

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
