### PR TITLE
MLAgent: Unref JsonParser variable using g_object_unref

### DIFF
--- a/gst/nnstreamer/ml_agent.c
+++ b/gst/nnstreamer/ml_agent.c
@@ -87,7 +87,7 @@ mlagent_get_model_path_from (const GValue * val)
       g_autofree gchar *name = g_strdup (parts[MODEL_PART_IDX_NAME]);
       guint version = strtoul (parts[MODEL_PART_IDX_VERSION], NULL, 10);
       g_autofree gchar *stringfied_json = NULL;
-      g_autoptr (JsonParser) json_parser = NULL;
+      JsonParser *json_parser = NULL;
       gint rcode;
 
       /**
@@ -146,12 +146,16 @@ mlagent_get_model_path_from (const GValue * val)
               "Invalid value for the key, %s", JSON_KEY_MODEL_PATH);
           goto fallback;
         }
+        if (json_parser)
+          g_object_unref (json_parser);
         return g_strdup (path);
       }
     }
   }
 
 fallback:
+  if (json_parser)
+    g_object_unref (json_parser);
   g_clear_error (&err);
   g_strfreev (parts);
 


### PR DESCRIPTION
 This patch transforms the JsonParser variable generated by the function
 json_parser_new() by using g_object_unref() to release memory.

 The g_autoptr variable is released at the end of the scope by g_autofree(),
 but should not be released if there is still a reference.

 It should be released only when there is no reference through
 the management using the reference count.

 reference url:
  https://www.manpagez.com/html/json-glib/json-glib-1.2.8/JsonParser.php#json-parser-new

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


