### PR TITLE
[build] Rename ..._snpe.cc to ..._snpe_v1.cc and let meson check SNPE version

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -639,7 +639,7 @@ if get_option('enable-mediapipe')
 endif
 
 if snpe_support_is_available
-  filter_sub_snpe_sources = ['tensor_filter_snpe.cc']
+  filter_sub_snpe_sources = ['tensor_filter_snpe_v1.cc']
   nnstreamer_filter_snpe_deps = [glib_dep, nnstreamer_single_dep, snpe_support_deps, declare_dependency(compile_args: ['-Wno-deprecated-declarations'])]
 
   shared_library('nnstreamer_filter_snpe',

--- a/ext/nnstreamer/tensor_filter/tensor_filter_snpe_v1.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_snpe_v1.cc
@@ -4,7 +4,7 @@
  * Copyright (C) 2020 Yongjoo Ahn <yongjoo1.ahn@samsung.com>
  */
 /**
- * @file	tensor_filter_snpe.cc
+ * @file	tensor_filter_snpe_v1.cc
  * @date	24 Apr 2020
  * @brief	NNStreamer tensor-filter sub-plugin for SNPE (Qualcomm Neural Processing SDK)
  * @see		http://github.com/nnstreamer/nnstreamer
@@ -13,10 +13,6 @@
  * @bug		No known bugs except for NYI items
  *
  * This is the per-NN-framework plugin (SNPE) for tensor_filter.
- *
- * @todo This supports only ITensor for input. Do support IUserBuffer.
- * @todo This supports float32 input output only. Do support Tf8 using IUserBuffer.
- * @todo This supports only CPU runtime on linux-x86_64. Do support others.
  */
 
 #include <iostream>

--- a/meson.build
+++ b/meson.build
@@ -201,6 +201,7 @@ endif
 
 # snpe
 snpe_dep = dependency('', required: false)
+snpe_api_version = 0 # Check whether the snpe api version is 1 or 2
 if not get_option('snpe-support').disabled()
   # Check whether the platform supports snpe
   snpe_dep = dependency('snpe', required: false)
@@ -226,13 +227,40 @@ if not get_option('snpe-support').disabled()
           required: true
         )
 
-        snpe_incdir = include_directories(join_paths(SNPE_ROOT, 'include', 'zdl'))
+        # SNPE 1 and 2 has different include paths
+        # Use this to check which version of snpe is provided
+        snpe_include_path = ''
+        snpe_1_include_path = join_paths(SNPE_ROOT, 'include', 'zdl')
+        if run_command('[', '-d', snpe_1_include_path, ']', check : false).returncode() == 0
+          snpe_api_version = 1
+          snpe_include_path = snpe_1_include_path
+        endif
+
+        snpe_2_include_path = join_paths(SNPE_ROOT, 'include', 'SNPE')
+        if run_command('[', '-d', snpe_2_include_path, ']', check : false).returncode() == 0
+          snpe_api_version = 2
+          snpe_include_path = snpe_2_include_path
+        endif
+
+        if snpe_include_path == ''
+          error('SNPE header files are not found in your $SNPE_ROOT path')
+        endif
+
+        snpe_incdir = include_directories(snpe_include_path)
 
         snpe_dep = declare_dependency(
           dependencies: snpe_lib,
           include_directories: snpe_incdir
         )
+      else
+        message('If you want to build SNPE tensor_filter, provide $SNPE_ROOT as the path of SNPE SDK')
       endif
+    endif
+  else # snpe found via pkg-config or cmake
+    if snpe_dep.version().version_compare('>=2.0')
+      snpe_api_version = 2
+    else
+      snpe_api_version = 1
     endif
   endif
 endif
@@ -432,7 +460,7 @@ features = {
   },
   'snpe-support': {
     'extra_deps': [ snpe_dep ],
-    'project_args': { 'ENABLE_SNPE' : 1 },
+    'project_args': { 'ENABLE_SNPE' : 1, 'SNPE_VERSION_MAJOR' : snpe_api_version },
   },
   'flatbuf-support': {
     'extra_deps': [ flatc_dep, flatbuf_dep, flatbuf_version_check_dep ],


### PR DESCRIPTION
- Rename tensor_filter_snpe.cc to tensor_filter_snpe_v1.cc
  - Current source code targets SNPE version 1.
- Let meson.build check SNPE API version.
- Added compile flag `SNPE_VERSION_MAJOR` would be used in future commits targeting SNPE v2.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped


