### PR TITLE
[common] Fix mem leak in gst_tensor_buffer_append_memory @open sesame 2/6 13:59

### DIFF
--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -1776,6 +1776,8 @@ gst_tensor_buffer_append_memory (GstBuffer * buffer, GstMemory * memory,
       incoming_memory_map.data, incoming_memory_map.size);
 
   gst_memory_unmap (memory, &incoming_memory_map);
+  gst_memory_unmap (last_memory, &last_memory_map);
+  last_memory = NULL;
 
   gst_buffer_replace_memory (buffer, num_mems - 1, new_memory);
   appended = TRUE;


### PR DESCRIPTION
- last_memory should be released before calling `gst_buffer_replace_memory`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped