### PR TITLE
datareposink unittest fix: g_file_query_info error return handling

### DIFF
--- a/tests/nnstreamer_datarepo/unittest_datareposink.cc
+++ b/tests/nnstreamer_datarepo/unittest_datareposink.cc
@@ -626,7 +626,7 @@ TEST (datareposink, writeSparseTensors_n)
   ASSERT_NE (file, nullptr);
   file_info = g_file_query_info (
       file, G_FILE_ATTRIBUTE_STANDARD_SIZE, G_FILE_QUERY_INFO_NONE, NULL, NULL);
-  ASSERT_NE (file_info, nullptr);
+  ASSERT_NE (file_info, NULL); /** this returns NULL, not nullptr */
   size = g_file_info_get_size (file_info);
   ASSERT_EQ (size, 0);
   g_object_unref (file_info);


### PR DESCRIPTION
https://developer-old.gnome.org/gio/unstable/GFile.html#g-file-query-info states that g_file_query_info returns NULL on error. Recent compilers regard NULL and nullptr differently:

Ubuntu 22.04/latest:
```
[ RUN      ] datareposink.writeSparseTensors_n
../tests/nnstreamer_datarepo/unittest_datareposink.cc:629: Failure
Expected: (file_info) != (nullptr), actual: NULL vs (nullptr)
[  FAILED  ] datareposink.writeSparseTensors_n (174 ms)
```
