### PR TITLE
test/datareposink: timing error in test case

### DIFF
--- a/tests/nnstreamer_datarepo/unittest_datareposink.cc
+++ b/tests/nnstreamer_datarepo/unittest_datareposink.cc
@@ -557,6 +557,7 @@ TEST (datareposink, writeFlexibleTensors_n)
 
   setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT);
   g_main_loop_run (loop);
+  g_usleep (100000); /** wait 0.1 sec before forcing stop */
 
   setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT);
   gst_object_unref (pipeline);


### PR DESCRIPTION
Occasionally, in github-action CI, datareposink.writeFlexibleTensors_n fails due to synchronization errors:

```
[ RUN      ] datareposink.writeFlexibleTensors_n
../tests/nnstreamer_datarepo/unittest_datareposink.cc:570: Failure
Expected: (file_info) != (nullptr), actual: NULL vs (nullptr)
[  FAILED  ] datareposink.writeFlexibleTensors_n (173 ms)
```

It happens when the pipeline is set NULL before the file 'flexible.data' is writtn within the pipeline.
Allow some time (0.1s) before setting it NULL.

