### PR TITLE
[Fix] Fix memory leaks found by CI valgrind check

### DIFF
--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -1768,6 +1768,12 @@ gst_tensor_buffer_append_memory (GstBuffer * buffer, GstMemory * memory,
   /* Copy tensor info into extra. */
   if (is_static) {
     gst_tensor_info_copy (&extra_info->infos[new_mem_index], info);
+
+    /**
+     * Free the name string, cause it does not freed by gstreamer.
+     * @todo Make custom gst_allocator later?
+     */
+    g_free (extra_info->infos[new_mem_index].name);
   } else {
     gst_tensor_meta_info_convert (&meta, &extra_info->infos[new_mem_index]);
   }

--- a/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
+++ b/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
@@ -110,6 +110,9 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
   }
 
   EXPECT_EQ (max_idx, 951U);
+
+  gst_memory_unmap (mem_res, &info_res);
+  gst_memory_unref (mem_res);
 }
 
 /**
@@ -194,6 +197,7 @@ TEST (nnstreamerFilterTensorFlow2Lite, quantModelResult)
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
+  gst_object_unref (sink_handle);
   gst_object_unref (gstpipe);
   g_free (pipeline);
   g_free (model_file);


### PR DESCRIPTION
- Extra tensor names stored in GstMemory leaks. Let the extra tensor do not store names.
- Fix mem leak in tflite unittest
- Fix memory leak in tensor_region
  - mem argument of `gst_tensor_meta_info_append_header` should be freed.
  - Properly free old memory after the call and replace the buffer with new memory

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped