### PR TITLE
[Fix] Resolve memory leaks detected by valgrind

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.cc
@@ -174,7 +174,7 @@ gst_tensor_converter_protobuf (GstBuffer *in_buf, GstTensorsConfig *config, void
     mem_data = _g_memdup (tensor->data ().c_str (), mem_size);
 
     out_mem = gst_memory_new_wrapped (
-        (GstMemoryFlags) 0, mem_data, mem_size, 0, mem_size, NULL, NULL);
+        (GstMemoryFlags) 0, mem_data, mem_size, 0, mem_size, mem_data, g_free);
 
     gst_tensor_buffer_append_memory (out_buf, out_mem, _info);
   }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -1200,19 +1200,19 @@ TFLiteCore::reloadModel (const char *_model_path)
    */
   if (interpreter_sub->loadModel (num_threads, delegate) != 0) {
     ml_loge ("Failed to load model %s\n", _model_path);
-    return -EINVAL;
+    goto error;
   }
   if (interpreter_sub->setInputTensorProp () != 0) {
     ml_loge ("Failed to initialize input tensor\n");
-    return -EINVAL;
+    goto error;
   }
   if (interpreter_sub->setOutputTensorProp () != 0) {
     ml_loge ("Failed to initialize output tensor\n");
-    return -EINVAL;
+    goto error;
   }
   if (interpreter_sub->cacheInOutTensorPtr () != 0) {
     ml_loge ("Failed to cache input and output tensors storage\n");
-    return -EINVAL;
+    goto error;
   }
 
   if (shared_tensor_filter_key) {
@@ -1222,12 +1222,16 @@ TFLiteCore::reloadModel (const char *_model_path)
   } else {
     if (reloadInterpreter (interpreter_sub) != 0) {
       ml_loge ("Failed replace interpreter\n");
-      return -EINVAL;
+      goto error;
     }
     delete interpreter_temp;
   }
 
   return 0;
+
+error:
+  delete interpreter_sub;
+  return -EINVAL;
 }
 
 /**

--- a/gst/nnstreamer/elements/gsttensor_if.c
+++ b/gst/nnstreamer/elements/gsttensor_if.c
@@ -332,6 +332,8 @@ gst_tensor_if_set_property_glist (const GValue * value, GList ** prop_list,
   const gchar *param = g_value_get_string (value);
   gchar **strv = g_strsplit_set (param, delimiters, -1);
   gint i, num = g_strv_length (strv);
+
+  g_list_free (*prop_list);
   *prop_list = NULL;
 
   for (i = 0; i < num; i++) {
@@ -388,6 +390,7 @@ gst_tensor_if_set_property_cv_option (const GValue * value, GList ** prop_list)
     *prop_list = g_list_append (*prop_list, GINT_TO_POINTER (val));
   }
   g_strfreev (strv);
+  g_value_reset (&tmp);
 }
 
 /**

--- a/tests/nnstreamer_filter_single/unittest_filter_single.cc
+++ b/tests/nnstreamer_filter_single/unittest_filter_single.cc
@@ -172,6 +172,7 @@ TEST_F (NNSFilterSingleTest, setInvalidInfo_n)
   in_info.info[0].type = _NNS_UINT8;
   gst_tensor_parse_dimension ("3:224:224:1", in_info.info[0].dimension);
   EXPECT_TRUE (klass->set_input_info (single, &in_info, &out_info) == 0);
+  gst_tensors_info_free (&out_info);
 
   /* request to set invalid tensor info */
   gst_tensor_parse_dimension ("1:1:1:1", in_info.info[0].dimension);
@@ -317,6 +318,7 @@ TEST_F (NNSFilterSingleTestExtended, setInvalidInfo_n)
   in_info.info[1].type = _NNS_FLOAT32;
   gst_tensor_parse_dimension ("4:4:4:4:4", in_info.info[1].dimension);
   EXPECT_TRUE (klass->set_input_info (single, &in_info, &out_info) == 0);
+  gst_tensors_info_free (&out_info);
 
   /* request to set invalid tensor info */
   in_info.num_tensors = 1U;

--- a/tests/nnstreamer_latency/unittest_latency.cc
+++ b/tests/nnstreamer_latency/unittest_latency.cc
@@ -269,6 +269,8 @@ main (int argc, char **argv)
     g_clear_error (&error);
   }
 
+  g_option_context_free (optionctx);
+
   try {
     result = RUN_ALL_TESTS ();
   } catch (...) {

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -3232,6 +3232,8 @@ TEST (testTensorConverter, bytesToMultiInvalidType03_n)
   EXPECT_DEATH (gst_harness_push (h, in_buf), "");
 
   EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_buffer_unref (in_buf);
   gst_harness_teardown (h);
 }
 
@@ -3272,6 +3274,8 @@ TEST (testTensorConverter, bytesToMultiInvalidSize_n)
   EXPECT_DEATH (gst_harness_push (h, in_buf), "");
 
   EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_buffer_unref (in_buf);
   gst_harness_teardown (h);
 }
 


### PR DESCRIPTION
- Call `g_option_context_free` in unittest_latency
- Unref memory properly during unittests.
- Free g_list and GValue in tensor_if
- Fix memory leak when reload tflite model
- Fix memory leak in nnstreamer_protobuf

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
