### PR TITLE
[spec] Suppress ORC log level

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -917,6 +917,9 @@ export NNSTREAMER_DECODERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_d
 export NNSTREAMER_CONVERTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_converter
 export NNSTREAMER_TRAINERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_trainer
 
+# Suppress ORC logs during unittests (showing WARNING or higher)
+export ORC_DEBUG=2
+
 %define test_script $(pwd)/packaging/run_unittests_binaries.sh
 
 # if it's tizen && non-TV, run unittest even if "unit_test"==0 for build-time sanity checks.


### PR DESCRIPTION
- Suppress ORC logs as showing WARNING or higher logs to reduce too many them during gbs unittests.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
