### PR TITLE
Filter/MLAgent: Update build dependency on MLOps Agent

### DIFF
--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -49,7 +49,7 @@ nnstreamer_single_sources = [
 
 if ml_agent_support_is_available
   nnstreamer_single_sources += files('ml_agent.c')
-  nnstreamer_single_deps += [ml_agent_dep, json_glib_dep]
+  nnstreamer_single_deps += [ml_agent_support_deps, json_glib_dep]
 endif
 
 # Add nnstreamer registerer and common sources

--- a/gst/nnstreamer/ml_agent.c
+++ b/gst/nnstreamer/ml_agent.c
@@ -14,7 +14,7 @@
 
 #include <json-glib/json-glib.h>
 #include <nnstreamer_log.h>
-#include <ml-agent-interface.h>
+#include <mlops-agent-interface.h>
 
 #include "ml_agent.h"
 
@@ -91,14 +91,12 @@ mlagent_get_model_path_from (const GValue * val)
        * @todo The specification of the data layout filled in the third
        *       argument (i.e., stringified_json) by the callee is not fully decided.
        */
-      rcode = ml_agent_model_get (name, version, &stringified_json, &err);
+      rcode = ml_agent_model_get (name, version, &stringified_json);
       if (rcode != 0) {
         nns_loge
-            ("Failed to get the stringied JSON using the given URI(%s): %s",
-            uri, (err ? err->message : "unknown reason"));
+            ("Failed to get the stringied JSON using the given URI(%s)", uri);
         goto fallback;
       }
-      g_clear_error (&err);
 
       json_parser = json_parser_new ();
       /** @todo Parse stringified_json to get the model's path */

--- a/meson.build
+++ b/meson.build
@@ -390,17 +390,6 @@ if not get_option('datarepo-support').disabled() and not json_glib_dep.found()
   message('datarepo-support is off because json-glib-1.0 is not available.')
 endif
 
-# ml-agent
-ml_agent_dep = dependency('', required: false)
-if not get_option('ml-agent-support').disabled()
-  ml_agent_dep = dependency('ml-agent', required: false)
-  if not ml_agent_dep.found()
-    if cc.check_header('ml-agent/ml-agent-interface.h', dependencies: [glib_dep], required: get_option('ml-agent-support'))
-      ml_agent_dep = cc.find_library('ml-agent', required: true)
-    endif
-  endif
-endif
-
 # features registration to be controlled
 #
 # register feature as follows
@@ -512,7 +501,7 @@ features = {
     'extra_deps': [ json_glib_dep ],
   },
   'ml-agent-support': {
-    'extra_deps': [ ml_agent_dep ],
+    'target': 'mlops-agent',
     'project_args': { 'ENABLE_ML_AGENT' : 1 }
   },
   'onnxruntime-support': {

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -324,7 +324,7 @@ BuildRequires: pkgconfig(json-glib-1.0)
 
 # For ml-agent
 %if 0%{?ml_agent_support}
-BuildRequires: pkgconfig(ml-agent)
+BuildRequires: pkgconfig(mlops-agent)
 %endif
 
 # Note that debug packages generate an additional build and storage cost.


### PR DESCRIPTION
This patch updates build dependency on MLOps Agent. Note that MLAgent has been renamed to MLOps Agent and provided from a new repository separated from the API repository.

See also: https://github.com/nnstreamer/api/pull/455

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>