### PR TITLE
[Tizen] Fix gcov build error

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -1030,9 +1030,9 @@ find . -name "CMakeCCompilerId*.gcda" -delete
 find . -name "CMakeCXXCompilerId*.gcda" -delete
 #find . -path "/%{builddir}/*.j
 # Generate report
-lcov -t 'NNStreamer Unit Test Coverage' -o unittest.info -c -d . -b %{builddir} --no-external
+lcov -t 'NNStreamer Unit Test Coverage' -o unittest.info -c -d . -b %{builddir} --no-external --ignore-errors mismatch
 # Exclude generated files (e.g., Orc, Protobuf) and device-dependent filters.
-lcov -r unittest.info "*/*-orc.*" "*/tests/*" "*/tools/*" "*/meson*/*" "*/*@sha/*" "*/*_openvino*" "*/*_edgetpu*" "*/*_movidius_ncsdk2*" "*/*.so.p/*" -o unittest-filtered.info
+lcov -r unittest.info "*/*-orc.*" "*/tests/*" "*/tools/*" "*/meson*/*" "*/*@sha/*" "*/*_openvino*" "*/*_edgetpu*" "*/*_movidius_ncsdk2*" "*/*.so.p/*" -o unittest-filtered.info --ignore-errors graph,unused
 # Visualize the report
 genhtml -o result unittest-filtered.info -t "nnstreamer %{version}-%{release} ${VCS}" --ignore-errors source -p ${RPM_BUILD_DIR}
 


### PR DESCRIPTION
Due to the lcov 2.0 upgrade, the warning is changed to error so the gcov build fails. Ignore this case. (Tizen PM guide)


**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed [ ]Skipped
2. Run test: [* ]Passed [ ]Failed [ ]Skipped

