### PR TITLE
[Query] Release edge handle when stoping the playing

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_server.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.h
@@ -19,10 +19,9 @@
 #include "tensor_meta.h"
 
 G_BEGIN_DECLS
-
 #define DEFAULT_SERVER_ID 0
 #define DEFAULT_QUERY_INFO_TIMEOUT 5
-typedef void * edge_server_handle;
+typedef void *edge_server_handle;
 
 /**
  * @brief GstTensorQueryServer internal info data structure.
@@ -40,45 +39,44 @@ typedef struct
 /**
  * @brief Get nnstreamer edge server handle.
  */
-edge_server_handle
-gst_tensor_query_server_get_handle (const char *id);
+edge_server_handle gst_tensor_query_server_get_handle (const char *id);
 
 /**
  * @brief Add GstTensorQueryServer.
  */
-edge_server_handle
-gst_tensor_query_server_add_data (const char *id, nns_edge_connect_type_e connect_type);
+edge_server_handle gst_tensor_query_server_add_data (const char *id);
 
 /**
  * @brief Remove GstTensorQueryServer.
  */
-void
-gst_tensor_query_server_remove_data (edge_server_handle server_h);
+void gst_tensor_query_server_remove_data (edge_server_handle server_h);
 
 /**
  * @brief Wait until the sink is configured and get server info handle.
  */
-gboolean
-gst_tensor_query_server_wait_sink (edge_server_handle server_h);
+gboolean gst_tensor_query_server_wait_sink (edge_server_handle server_h);
 
 /**
- * @brief Get edge handle from server data.
+ * @brief Get nnstreamer edge handle of query server.
  */
-nns_edge_h
-gst_tensor_query_server_get_edge_handle (edge_server_handle server_h);
+nns_edge_h gst_tensor_query_server_get_edge_handle (const char *id, nns_edge_connect_type_e connect_type);
 
 /**
  * @brief set query server sink configured.
  */
-void
-gst_tensor_query_server_set_configured (edge_server_handle server_h);
+void gst_tensor_query_server_set_configured (edge_server_handle server_h);
 
 /**
  * @brief set query server caps.
  */
 void
-gst_tensor_query_server_set_caps (edge_server_handle server_h, const char *caps_str);
+gst_tensor_query_server_set_caps (edge_server_handle server_h,
+    const char *caps_str);
+
+/**
+ * @brief Release nnstreamer edge handle of query server.
+ */
+void gst_tensor_query_server_release_edge_handle (edge_server_handle server_h);
 
 G_END_DECLS
-
 #endif /* __GST_TENSOR_QUERY_CLIENT_H__ */

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.h
@@ -20,7 +20,6 @@
 #include "tensor_query_server.h"
 #include "tensor_query_common.h"
 G_BEGIN_DECLS
-
 #define GST_TYPE_TENSOR_QUERY_SERVERSINK \
   (gst_tensor_query_serversink_get_type())
 #define GST_TENSOR_QUERY_SERVERSINK(obj) \
@@ -32,7 +31,6 @@ G_BEGIN_DECLS
 #define GST_IS_TENSOR_QUERY_SERVERSINK_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_QUERY_SERVERSINK))
 #define GST_TENSOR_QUERY_SERVERSINK_CAST(obj) ((GstTensorQueryServerSink *)(obj))
-
 typedef struct _GstTensorQueryServerSink GstTensorQueryServerSink;
 typedef struct _GstTensorQueryServerSinkClass GstTensorQueryServerSinkClass;
 

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
@@ -19,7 +19,6 @@
 #include "tensor_query_server.h"
 
 G_BEGIN_DECLS
-
 #define GST_TYPE_TENSOR_QUERY_SERVERSRC \
   (gst_tensor_query_serversrc_get_type())
 #define GST_TENSOR_QUERY_SERVERSRC(obj) \
@@ -31,7 +30,6 @@ G_BEGIN_DECLS
 #define GST_IS_TENSOR_QUERY_SERVERSRC_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_QUERY_SERVERSRC))
 #define GST_TENSOR_QUERY_SERVERSRC_CAST(obj) ((GstTensorQueryServerSrc *)(obj))
-
 typedef struct _GstTensorQueryServerSrc GstTensorQueryServerSrc;
 typedef struct _GstTensorQueryServerSrcClass GstTensorQueryServerSrcClass;
 
@@ -57,6 +55,7 @@ struct _GstTensorQueryServerSrc
   edge_server_handle server_h;
   nns_edge_h edge_h;
   GAsyncQueue *msg_queue;
+  gboolean playing;
 };
 
 /**

--- a/tests/nnstreamer_edge/query/unittest_query.cc
+++ b/tests/nnstreamer_edge/query/unittest_query.cc
@@ -230,10 +230,17 @@ TEST (tensorQuery, serverRun)
   EXPECT_NE (gstpipe, nullptr);
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
-
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PAUSED, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_READY, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_READY, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PAUSED, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_READY, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PAUSED, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
   gst_object_unref (gstpipe);
   g_free (pipeline);


### PR DESCRIPTION
Problem: When state changes from PAUSED to NULL,the tensor_query_serversrc cannot switch to NULL state because it keeps waiting for data pop.

Solution: Change the creation and destruction of server data and edge handle to be managed according to the state.

 READY->PAUSED: Create query server common data
 PAUSED->PLAYING: Create nns-edge handle
 PLAYING->PAUSED: Release nns-edge handle
 PAUSED->READY: Destruct query server common data

Releated issue: https://github.com/nnstreamer/api/issues/487


**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [* ]Passed [ ]Failed []Skipped


