### PR TITLE
[Query] util function using integer id

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_server.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.c
@@ -42,105 +42,228 @@ _release_server_data (gpointer data)
   if (!_data)
     return;
 
+  g_mutex_lock (&_data->lock);
   if (_data->edge_h) {
     nns_edge_release_handle (_data->edge_h);
     _data->edge_h = NULL;
   }
+  g_mutex_unlock (&_data->lock);
 
   g_mutex_clear (&_data->lock);
   g_cond_clear (&_data->cond);
-  g_free (_data->id);
+
   g_free (_data);
 }
 
 /**
  * @brief Get nnstreamer edge server handle.
  */
-edge_server_handle
-gst_tensor_query_server_get_handle (const char *id)
+static GstTensorQueryServer *
+gst_tensor_query_server_get_handle (const guint id)
 {
-  edge_server_handle p;
+  GstTensorQueryServer *data;
 
   G_LOCK (query_server_table);
-  p = g_hash_table_lookup (_qs_table, id);
-  G_UNLOCK (query_server_table);
-
-  return p;
-}
-
-/**
- * @brief Add nnstreamer edge server handle into hash table.
- */
-edge_server_handle
-gst_tensor_query_server_add_data (const char *id)
-{
-  GstTensorQueryServer *data = NULL;
-
-  data = gst_tensor_query_server_get_handle (id);
-
-  if (NULL != data) {
-    return data;
-  }
-
-  data = g_try_new0 (GstTensorQueryServer, 1);
-  if (NULL == data) {
-    GST_ERROR ("Failed to allocate memory for tensor query server data.");
-    return NULL;
-  }
-
-  g_mutex_init (&data->lock);
-  g_cond_init (&data->cond);
-  data->id = g_strdup (id);
-  data->configured = FALSE;
-
-  G_LOCK (query_server_table);
-  g_hash_table_insert (_qs_table, g_strdup (id), data);
+  data = g_hash_table_lookup (_qs_table, GUINT_TO_POINTER (id));
   G_UNLOCK (query_server_table);
 
   return data;
 }
 
 /**
- * @brief Get nnstreamer edge handle of query server.
+ * @brief Add nnstreamer edge server handle into hash table.
  */
-nns_edge_h
-gst_tensor_query_server_get_edge_handle (const char *id,
-    nns_edge_connect_type_e connect_type)
+gboolean
+gst_tensor_query_server_add_data (const guint id)
 {
-  GstTensorQueryServer *data = NULL;
+  GstTensorQueryServer *data;
+
+  data = gst_tensor_query_server_get_handle (id);
+
+  if (NULL != data) {
+    return TRUE;
+  }
+
+  data = g_try_new0 (GstTensorQueryServer, 1);
+  if (NULL == data) {
+    nns_loge ("Failed to allocate memory for tensor query server data.");
+    return FALSE;
+  }
+
+  g_mutex_init (&data->lock);
+  g_cond_init (&data->cond);
+  data->id = id;
+  data->configured = FALSE;
+
+  G_LOCK (query_server_table);
+  g_hash_table_insert (_qs_table, GUINT_TO_POINTER (id), data);
+  G_UNLOCK (query_server_table);
+
+  return TRUE;
+}
+
+/**
+ * @brief Prepare edge connection and its handle.
+ */
+gboolean
+gst_tensor_query_server_prepare (const guint id,
+    nns_edge_connect_type_e connect_type, GstTensorQueryEdgeInfo * edge_info)
+{
+  GstTensorQueryServer *data;
+  gchar *port_str, *id_str;
+  gboolean prepared = FALSE;
   int ret;
 
   data = gst_tensor_query_server_get_handle (id);
-  if (!data)
-    return NULL;
+  if (NULL == data) {
+    return FALSE;
+  }
+
+  id_str = g_strdup_printf ("%u", id);
 
   g_mutex_lock (&data->lock);
-  if (data->edge_h) {
-    goto done;
+  if (data->edge_h == NULL) {
+    ret = nns_edge_create_handle (id_str, connect_type,
+        NNS_EDGE_NODE_TYPE_QUERY_SERVER, &data->edge_h);
+    if (NNS_EDGE_ERROR_NONE != ret) {
+      GST_ERROR ("Failed to get nnstreamer edge handle.");
+      goto done;
+    }
   }
 
-  ret = nns_edge_create_handle (id, connect_type,
-      NNS_EDGE_NODE_TYPE_QUERY_SERVER, &data->edge_h);
-  if (NNS_EDGE_ERROR_NONE != ret) {
-    GST_ERROR ("Failed to get nnstreamer edge handle.");
+  if (edge_info) {
+    if (edge_info->host) {
+      nns_edge_set_info (data->edge_h, "HOST", edge_info->host);
+    }
+    if (edge_info->port > 0) {
+      port_str = g_strdup_printf ("%u", edge_info->port);
+      nns_edge_set_info (data->edge_h, "PORT", port_str);
+      g_free (port_str);
+    }
+    if (edge_info->dest_host) {
+      nns_edge_set_info (data->edge_h, "DEST_HOST", edge_info->dest_host);
+    }
+    if (edge_info->dest_port > 0) {
+      port_str = g_strdup_printf ("%u", edge_info->dest_port);
+      nns_edge_set_info (data->edge_h, "DEST_PORT", port_str);
+      g_free (port_str);
+    }
+    if (edge_info->topic) {
+      nns_edge_set_info (data->edge_h, "TOPIC", edge_info->topic);
+    }
+
+    nns_edge_set_event_callback (data->edge_h, edge_info->cb, edge_info->pdata);
+
+    ret = nns_edge_start (data->edge_h);
+    if (NNS_EDGE_ERROR_NONE != ret) {
+      nns_loge
+          ("Failed to start NNStreamer-edge. Please check server IP and port.");
+      goto done;
+    }
   }
+
+  prepared = TRUE;
 
 done:
   g_mutex_unlock (&data->lock);
-  return data->edge_h;
+  g_free (id_str);
+  return prepared;
+}
+
+/**
+ * @brief Send buffer to connected edge device.
+ */
+gboolean
+gst_tensor_query_server_send_buffer (const guint id, GstBuffer * buffer)
+{
+  GstTensorQueryServer *data;
+  GstMetaQuery *meta_query;
+  nns_edge_data_h data_h;
+  guint i, num_tensors = 0;
+  gint ret = NNS_EDGE_ERROR_NONE;
+  GstMemory *mem[NNS_TENSOR_SIZE_LIMIT];
+  GstMapInfo map[NNS_TENSOR_SIZE_LIMIT];
+  gchar *val;
+  gboolean sent = FALSE;
+
+  data = gst_tensor_query_server_get_handle (id);
+
+  if (NULL == data) {
+    nns_loge ("Failed to send buffer, server handle is null.");
+    return FALSE;
+  }
+
+  meta_query = gst_buffer_get_meta_query (buffer);
+  if (!meta_query) {
+    nns_loge ("Failed to send buffer, cannot get tensor query meta.");
+    return FALSE;
+  }
+
+  ret = nns_edge_data_create (&data_h);
+  if (ret != NNS_EDGE_ERROR_NONE) {
+    nns_loge ("Failed to create edge data handle in query server.");
+    return FALSE;
+  }
+
+  num_tensors = gst_tensor_buffer_get_count (buffer);
+  for (i = 0; i < num_tensors; i++) {
+    mem[i] = gst_tensor_buffer_get_nth_memory (buffer, i);
+
+    if (!gst_memory_map (mem[i], &map[i], GST_MAP_READ)) {
+      ml_loge ("Cannot map the %uth memory in gst-buffer.", i);
+      gst_memory_unref (mem[i]);
+      num_tensors = i;
+      goto done;
+    }
+
+    nns_edge_data_add (data_h, map[i].data, map[i].size, NULL);
+  }
+
+  val = g_strdup_printf ("%lld", (long long) meta_query->client_id);
+  nns_edge_data_set_info (data_h, "client_id", val);
+  g_free (val);
+
+  g_mutex_lock (&data->lock);
+  ret = nns_edge_send (data->edge_h, data_h);
+  g_mutex_unlock (&data->lock);
+
+  if (ret != NNS_EDGE_ERROR_NONE) {
+    nns_loge ("Failed to send edge data handle in query server.");
+    goto done;
+  }
+
+  sent = TRUE;
+
+done:
+  for (i = 0; i < num_tensors; i++) {
+    gst_memory_unmap (mem[i], &map[i]);
+    gst_memory_unref (mem[i]);
+  }
+
+  nns_edge_data_destroy (data_h);
+
+  return sent;
 }
 
 /**
  * @brief Release nnstreamer edge handle of query server.
  */
 void
-gst_tensor_query_server_release_edge_handle (edge_server_handle server_h)
+gst_tensor_query_server_release_edge_handle (const guint id)
 {
-  GstTensorQueryServer *data = (GstTensorQueryServer *) server_h;
+  GstTensorQueryServer *data;
+
+  data = gst_tensor_query_server_get_handle (id);
+
+  if (NULL == data) {
+    return;
+  }
 
   g_mutex_lock (&data->lock);
-  nns_edge_release_handle (data->edge_h);
-  data->edge_h = NULL;
+  if (data->edge_h) {
+    nns_edge_release_handle (data->edge_h);
+    data->edge_h = NULL;
+  }
   g_mutex_unlock (&data->lock);
 }
 
@@ -148,17 +271,11 @@ gst_tensor_query_server_release_edge_handle (edge_server_handle server_h)
  * @brief Remove GstTensorQueryServer.
  */
 void
-gst_tensor_query_server_remove_data (edge_server_handle server_h)
+gst_tensor_query_server_remove_data (const guint id)
 {
-  GstTensorQueryServer *data = (GstTensorQueryServer *) server_h;
-
-  if (NULL == data) {
-    return;
-  }
-
   G_LOCK (query_server_table);
-  if (g_hash_table_lookup (_qs_table, data->id))
-    g_hash_table_remove (_qs_table, data->id);
+  if (g_hash_table_lookup (_qs_table, GUINT_TO_POINTER (id)))
+    g_hash_table_remove (_qs_table, GUINT_TO_POINTER (id));
   G_UNLOCK (query_server_table);
 }
 
@@ -166,10 +283,12 @@ gst_tensor_query_server_remove_data (edge_server_handle server_h)
  * @brief Wait until the sink is configured and get server info handle.
  */
 gboolean
-gst_tensor_query_server_wait_sink (edge_server_handle server_h)
+gst_tensor_query_server_wait_sink (const guint id)
 {
   gint64 end_time;
-  GstTensorQueryServer *data = (GstTensorQueryServer *) server_h;
+  GstTensorQueryServer *data;
+
+  data = gst_tensor_query_server_get_handle (id);
 
   if (NULL == data) {
     return FALSE;
@@ -194,12 +313,16 @@ gst_tensor_query_server_wait_sink (edge_server_handle server_h)
  * @brief set query server sink configured.
  */
 void
-gst_tensor_query_server_set_configured (edge_server_handle server_h)
+gst_tensor_query_server_set_configured (const guint id)
 {
-  GstTensorQueryServer *data = (GstTensorQueryServer *) server_h;
+  GstTensorQueryServer *data;
+
+  data = gst_tensor_query_server_get_handle (id);
+
   if (NULL == data) {
     return;
   }
+
   g_mutex_lock (&data->lock);
   data->configured = TRUE;
   g_cond_broadcast (&data->cond);
@@ -210,17 +333,20 @@ gst_tensor_query_server_set_configured (edge_server_handle server_h)
  * @brief set query server caps.
  */
 void
-gst_tensor_query_server_set_caps (edge_server_handle server_h,
-    const char *caps_str)
+gst_tensor_query_server_set_caps (const guint id, const gchar * caps_str)
 {
-  GstTensorQueryServer *data = (GstTensorQueryServer *) server_h;
-  gchar *prev_caps_str = NULL, *new_caps_str;
+  GstTensorQueryServer *data;
+  gchar *prev_caps_str, *new_caps_str;
+
+  data = gst_tensor_query_server_get_handle (id);
 
   if (NULL == data) {
     return;
   }
+
   g_mutex_lock (&data->lock);
 
+  prev_caps_str = new_caps_str = NULL;
   nns_edge_get_info (data->edge_h, "CAPS", &prev_caps_str);
   if (!prev_caps_str)
     prev_caps_str = g_strdup ("");
@@ -241,7 +367,7 @@ init_queryserver (void)
 {
   G_LOCK (query_server_table);
   g_assert (NULL == _qs_table); /** Internal error (duplicated init call?) */
-  _qs_table = g_hash_table_new_full (g_str_hash, g_str_equal, g_free,
+  _qs_table = g_hash_table_new_full (g_direct_hash, g_direct_equal, NULL,
       _release_server_data);
   G_UNLOCK (query_server_table);
 }

--- a/gst/nnstreamer/tensor_query/tensor_query_server.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_server.h
@@ -21,14 +21,29 @@
 G_BEGIN_DECLS
 #define DEFAULT_SERVER_ID 0
 #define DEFAULT_QUERY_INFO_TIMEOUT 5
-typedef void *edge_server_handle;
+
+/**
+ * @brief Internal data structure for nns-edge info to prepare edge connection.
+ */
+typedef struct
+{
+  gchar *host;
+  guint16 port;
+  gchar *dest_host;
+  guint16 dest_port;
+  gchar *topic;
+
+  /* nns-edge callback info */
+  nns_edge_event_cb cb;
+  void *pdata;
+} GstTensorQueryEdgeInfo;
 
 /**
  * @brief GstTensorQueryServer internal info data structure.
  */
 typedef struct
 {
-  char *id;
+  guint id;
   gboolean configured;
   GMutex lock;
   GCond cond;
@@ -37,46 +52,45 @@ typedef struct
 } GstTensorQueryServer;
 
 /**
- * @brief Get nnstreamer edge server handle.
- */
-edge_server_handle gst_tensor_query_server_get_handle (const char *id);
-
-/**
  * @brief Add GstTensorQueryServer.
  */
-edge_server_handle gst_tensor_query_server_add_data (const char *id);
+gboolean gst_tensor_query_server_add_data (const guint id);
+
+/**
+ * @brief Prepare edge connection and its handle.
+ */
+gboolean gst_tensor_query_server_prepare (const guint id,
+    nns_edge_connect_type_e connect_type, GstTensorQueryEdgeInfo *edge_info);
 
 /**
  * @brief Remove GstTensorQueryServer.
  */
-void gst_tensor_query_server_remove_data (edge_server_handle server_h);
+void gst_tensor_query_server_remove_data (const guint id);
 
 /**
  * @brief Wait until the sink is configured and get server info handle.
  */
-gboolean gst_tensor_query_server_wait_sink (edge_server_handle server_h);
+gboolean gst_tensor_query_server_wait_sink (const guint id);
 
 /**
- * @brief Get nnstreamer edge handle of query server.
+ * @brief Send buffer to connected edge device.
  */
-nns_edge_h gst_tensor_query_server_get_edge_handle (const char *id, nns_edge_connect_type_e connect_type);
+gboolean gst_tensor_query_server_send_buffer (const guint id, GstBuffer *buffer);
 
 /**
  * @brief set query server sink configured.
  */
-void gst_tensor_query_server_set_configured (edge_server_handle server_h);
+void gst_tensor_query_server_set_configured (const guint id);
 
 /**
  * @brief set query server caps.
  */
-void
-gst_tensor_query_server_set_caps (edge_server_handle server_h,
-    const char *caps_str);
+void gst_tensor_query_server_set_caps (const guint id, const gchar *caps_str);
 
 /**
  * @brief Release nnstreamer edge handle of query server.
  */
-void gst_tensor_query_server_release_edge_handle (edge_server_handle server_h);
+void gst_tensor_query_server_release_edge_handle (const guint id);
 
 G_END_DECLS
 #endif /* __GST_TENSOR_QUERY_CLIENT_H__ */

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.h
@@ -47,8 +47,6 @@ struct _GstTensorQueryServerSink
   gint metaless_frame_count;
 
   nns_edge_connect_type_e connect_type;
-  edge_server_handle server_h;
-  nns_edge_h edge_h;
 };
 
 /**

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
@@ -52,8 +52,6 @@ struct _GstTensorQueryServerSrc
   gchar *topic; /**< Main operation such as 'object_detection' or 'image_segmentation' */
 
   nns_edge_connect_type_e connect_type;
-  edge_server_handle server_h;
-  nns_edge_h edge_h;
   GAsyncQueue *msg_queue;
   gboolean playing;
 };


### PR DESCRIPTION
To prevent double free case, remove query handle and use integer id.
Also, add util function to hide edge handle in query elements and fix null ptr case.
