### PR TITLE
[ncnn] Use g_message for accl log

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_ncnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_ncnn.cc
@@ -180,7 +180,7 @@ ncnn_subplugin::configure_instance (const GstTensorFilterProperties *prop)
   if (std::find (prop->hw_list, prop->hw_list + prop->num_hw, ACCL_GPU)
       != (prop->hw_list + prop->num_hw)) {
     net.opt.use_vulkan_compute = true;
-    nns_logi ("accl = gpu\n");
+    g_message ("accl = gpu\n");
   } else {
     net.opt.use_vulkan_compute = false;
   }


### PR DESCRIPTION
This patch makes ssat test (grep "accl = gpu" string) works.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped