### PR TITLE
[action] Disable meaningless cache and action

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,18 +25,7 @@ jobs:
         rebuild=`bash .github/workflows/check_if_rebuild_requires.sh ${tmpfile} android | grep "REBUILD=YES" | wc -l`
         echo "Rebuild required: ${rebuild}"
         echo "rebuild=${rebuild}" >> "$GITHUB_ENV"
-    - name: make cache key
-      if: env.rebuild == '1'
-      id: make-key
-      run: echo "cache_key=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: cache GST root
-      id: cache-gbs-root
-      if: env.rebuild == '1'
-      uses: actions/cache@v3
-      with:
-        path: ~/android
-        key: ${{ steps.make-key.outputs.cache_key }}
+    ## @todo Make cache works (daily update cache on main branch / restore the cache on each PR (w/o saving))
     - name: Prepare Build
       if: env.rebuild == '1'
       run: |

--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -55,23 +55,7 @@ jobs:
         echo "Rebuild required: ${rebuild}"
         echo "rebuild=${rebuild}" >> "$GITHUB_ENV"
     - uses: actions/setup-python@v1
-    - name: make cache dir for pbuilder
-      ## prevent permission error
-      run: sudo mkdir --mode a=rwx --parents /var/cache/pbuilder
-    - name: make cache key
-      if: env.rebuild == '1'
-      id: make-key
-      run: echo "cache_key=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: cache pbuilder cache
-      id: cache-pbuilder
-      if: env.rebuild == '1'
-      uses: actions/cache@v3
-      with:
-        path: |
-          /var/cache/pbuilder/aptcache
-          /var/cache/pbuilder/base.tgz
-        key: ${{ steps.make-key.outputs.cache_key }}
+    ## @todo Make cache works (daily update cache on main branch / restore the cache on each PR (w/o saving))
     - name: prepare pdebuild
       if: env.rebuild == '1'
       run: |
@@ -86,7 +70,6 @@ jobs:
         sudo mkdir -p /root/
         sudo ln -s ~/.pbuilderrc /root/
     - name: make pbuilder base.tgz
-      if: steps.cache-pbuilder.outputs.cache-hit != 'true'
       run: |
         echo "=== pbuilder create"
         echo "::group::pbuilder create --allow-untrusted"

--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -30,7 +30,10 @@ jobs:
         # E: End of debootstrap.log
         # W: Aborting with an error
         os: [ ubuntu-22.04 ]
-        arch: [ amd64, arm64 ]
+        #arch: [ amd64, arm64 ]
+        ## pdebuild with `--architecture arm64` is meaningless
+        ## pbuilder create --architecture arm64 currently fails
+        arch: [ amd64 ]
         include:
           - distroname: jammy
             os: ubuntu-22.04

--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -22,18 +22,7 @@ jobs:
         rebuild=`bash .github/workflows/check_if_rebuild_requires.sh ${tmpfile} build | grep "REBUILD=YES" | wc -l`
         echo "Rebuild required: ${rebuild}"
         echo "rebuild=${rebuild}" >> "$GITHUB_ENV"
-    - name: make cache key
-      if: env.rebuild == '1'
-      id: make-key
-      run: echo "cache_key=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: cache Yocto SDK
-      id: cache-gbs-root
-      if: env.rebuild == '1'
-      uses: actions/cache@v3
-      with:
-        path: ~/poky_sdk/
-        key: ${{ steps.make-key.outputs.cache_key }}
+    ## @todo Make cache works (daily update cache on main branch / restore the cache on each PR (not saving))
     - name: Prepare build
       if: env.rebuild == '1'
       run: |


### PR DESCRIPTION
- Currently `pdebuild --architecture arm64` is equivalent as `pdebuild --architecture amd64`. Drop arm64 build.
- Saving cache in each PR consumes too much space.
- To utilize the cache, we need to update each cache in main branch periodically.
  Before introducing such action, disable cache for a while.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
