### PR TITLE
github-action/macos build fix

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -21,7 +21,9 @@ jobs:
         rebuild=`bash .github/workflows/check_if_rebuild_requires.sh ${tmpfile} rebuild | grep "REBUILD=YES" | wc -l`
         echo "Rebuild required: ${rebuild}"
         echo "rebuild=${rebuild}" >> "$GITHUB_ENV"
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
     - name: homebrew
       if: env.rebuild == '1'
       run: |


### PR DESCRIPTION
Github-action macos build started spitting:
```
Run actions/setup-python@v1
  with:
    python-version: 3.x
    architecture: x64
  env:
    changed_file_list: /var/folders/3m/p59k4qdj0f17st0gn2cmj3640000gn/T/tmp.b0uhtmFUzp
    rebuild:        1
Error: Version 3.x with arch x64 not found
Available versions:
```
Similar with https://github.com/actions/setup-python/issues/162

