### PR TITLE
[actions] Fix gh actions

### DIFF
--- a/.github/workflows/gbs_build.yml
+++ b/.github/workflows/gbs_build.yml
@@ -22,7 +22,7 @@ jobs:
           - gbs_build_arch: "aarch64"
             gbs_build_option: "--define \"unit_test 0\""
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
     - name: prepare GBS
       if: env.rebuild == '1'
       run: |
-        echo "deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_20.04/ /" | sudo tee /etc/apt/sources.list.d/tizen.list
+        echo "deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_22.04/ /" | sudo tee /etc/apt/sources.list.d/tizen.list
         sudo apt-get update && sudo apt-get install -y gbs
         cp .github/workflows/tizen.gbs.conf ~/.gbs.conf
 

--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -60,6 +60,11 @@ jobs:
       ## prevent permission error
       run: sudo mkdir --mode a=rwx --parents /var/cache/pbuilder
 
+    - name: get date
+      id: get-date
+      run: |
+        echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
     - name: restore pbuilder cache
       id: restore-pbuilder-cache
       if: env.rebuild == '1'
@@ -68,8 +73,9 @@ jobs:
         path: |
           /var/cache/pbuilder/aptcache
           /var/cache/pbuilder/base.tgz
-        key: pbuilder-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('**/debian/control') }}
+        key: pbuilder-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('**/debian/control') }}-${{ steps.get-date.outputs.date }}
         restore-keys: |
+          pbuilder-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('**/debian/control') }}-
           pbuilder-cache-${{ matrix.os }}-${{ matrix.arch }}-
 
     - name: prepare pdebuild

--- a/.github/workflows/update_gbs_cache.yml
+++ b/.github/workflows/update_gbs_cache.yml
@@ -14,14 +14,14 @@ jobs:
       matrix:
         gbs_build_arch: [x86_64, i586, armv7l, aarch64]
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v1
 
     - name: prepare deb sources for GBS
-      run: echo "deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_20.04/ /" | sudo tee /etc/apt/sources.list.d/tizen.list
+      run: echo "deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_22.04/ /" | sudo tee /etc/apt/sources.list.d/tizen.list
 
     - name: install GBS
       run: sudo apt-get update && sudo apt-get install -y gbs

--- a/.github/workflows/update_pbuilder_cache.yml
+++ b/.github/workflows/update_pbuilder_cache.yml
@@ -39,6 +39,11 @@ jobs:
           sudo mkdir -p /root/
           sudo ln -s ~/.pbuilderrc /root/
 
+      - name: get date
+        id: get-date
+        run: |
+          echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
       - name: make pbuilder base.tgz
         run: |
           echo "=== pbuilder create"
@@ -64,4 +69,4 @@ jobs:
           path: |
             /var/cache/pbuilder/aptcache
             /var/cache/pbuilder/base.tgz
-          key: pbuilder-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('**/debian/control') }}
+          key: pbuilder-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('**/debian/control') }}-${{ steps.get-date.outputs.date }}


### PR DESCRIPTION
- Since Ubuntu 22.04 supports gbs from this year, let's switch to it.
- This patch makes the daily pdebuild workflow save the cache key with date postfix and outdate previous cache. Then the pdebuild.yml workflow can use the fresh cache.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
