### PR TITLE
[tensor_trainer] bugfix: Add exception handling for a non-existent model config file

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_trainer.c
+++ b/gst/nnstreamer/elements/gsttensor_trainer.c
@@ -478,6 +478,13 @@ gst_tensor_trainer_check_invalid_param (GstTensorTrainer * trainer)
     return FALSE;
   }
 
+  if (!g_file_test (trainer->prop.model_config,
+          (G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR))) {
+    GST_ERROR_OBJECT (trainer, "Model config file does not exist. [%s]",
+        trainer->prop.model_config);
+    return FALSE;
+  }
+
   return TRUE;
 }
 


### PR DESCRIPTION
Added exception handling for a non-existent model config file

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
