### PR TITLE
[prod/tizen-7.0][spec] Enable vivante for specific profile

### DIFF
--- a/ext/nnstreamer/tensor_filter/vivante/meson.build
+++ b/ext/nnstreamer/tensor_filter/vivante/meson.build
@@ -2,8 +2,6 @@
 cc = meson.get_compiler('c')
 
 libovx_dep = cc.find_library('ovxlib') # ovxlib library
-libdl_dep = cc.find_library('dl') # dl library
-
 
 base_deps = [
   glib_dep,
@@ -23,7 +21,6 @@ sources = [
 # - https://dl.khadas.com/repos/vim3/ (Ubuntu 18.04, aarch64, Bionic)
 vivante_todo_incs = []
 vivante_todo_incs += include_directories(
-  '/usr/include/dann',
   '/usr/include/ovx',
   '/usr/include/amlogic-vsi-npu-sdk'
 )

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -131,6 +131,12 @@
 %define		tvm_support 0
 %define		trix_engine_support 0
 %define		onnxruntime_support 0
+
+# Enable subplugins for specific profiles
+%if 0%{?_with_meson64}
+%define		vivante_support 1
+%endif
+
 %endif
 
 # Release unit test suite as a subpackage only if check_test is enabled.
@@ -253,10 +259,7 @@ BuildRequires:	pkgconfig(openvino)
 %endif
 
 # for Vivante
-# TODO: dann and opencv will be removed in the near future.
 %if 0%{?vivante_support}
-BuildRequires:  pkgconfig(opencv)
-BuildRequires:  pkgconfig(dann)
 BuildRequires:  pkgconfig(ovxlib)
 BuildRequires:  pkgconfig(amlogic-vsi-npu-sdk)
 %endif


### PR DESCRIPTION
- Build vivante subplugin for some targets.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped
