### PR TITLE
[prod/tizen-8.0] Disable snpe subplugin build for mv_prj temporarily

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -139,6 +139,9 @@
 %define		tvm_support 0
 %define		trix_engine_support 0
 %define		onnxruntime_support 0
+# Disable snpe build temporarily
+# TODO: Enable snpe build after fixing the snpe package
+%define		snpe_support 0
 %endif
 
 # DA requested to remove unnecessary module builds


### PR DESCRIPTION
- Disable snpe build. There is problem in platform's snpe package.
- This should be reverted when the snpe package is fixed.


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


