### PR TITLE
[query] Set tensor query caps when state changes from PAUSED to PLAYING

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.c
@@ -171,7 +171,9 @@ gst_tensor_query_serversink_change_state (GstElement * element,
     GstStateChange transition)
 {
   GstTensorQueryServerSink *sink = GST_TENSOR_QUERY_SERVERSINK (element);
+  GstBaseSink *bsink = GST_BASE_SINK (element);
   GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+  GstCaps *caps;
 
   switch (transition) {
     case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
@@ -199,6 +201,10 @@ gst_tensor_query_serversink_change_state (GstElement * element,
   switch (transition) {
     case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
       gst_tensor_query_server_release_edge_handle (sink->sink_id);
+      break;
+    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
+      caps = gst_pad_peer_query_caps (GST_BASE_SINK_PAD (bsink), NULL);
+      gst_tensor_query_serversink_set_caps(bsink, caps);
       break;
     default:
       break;


### PR DESCRIPTION
This patch makes to set tensor query caps, when state changes from PAUSED to PLAYING.
When the tensor_query_server is stopped, edge_handle is released.
So we need to set caps again when restarted.
If caps are not set, client connection is not possible after restart tensor_query_server.
This PR fixes https://github.com/nnstreamer/nnstreamer-android/pull/35#issuecomment-2164310115

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
