### PR TITLE
[Query] case when change pipe state

### DIFF
--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.c
@@ -181,6 +181,10 @@ gst_tensor_query_serversink_change_state (GstElement * element,
         nns_loge ("Failed to change state from PAUSED to PLAYING.");
         return GST_STATE_CHANGE_FAILURE;
       }
+
+      caps = gst_pad_peer_query_caps (GST_BASE_SINK_PAD (bsink), NULL);
+      gst_tensor_query_serversink_set_caps (bsink, caps);
+      gst_caps_unref (caps);
       break;
     case GST_STATE_CHANGE_READY_TO_PAUSED:
       if (!_gst_tensor_query_serversink_start (sink)) {
@@ -201,10 +205,6 @@ gst_tensor_query_serversink_change_state (GstElement * element,
   switch (transition) {
     case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
       gst_tensor_query_server_release_edge_handle (sink->sink_id);
-      break;
-    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
-      caps = gst_pad_peer_query_caps (GST_BASE_SINK_PAD (bsink), NULL);
-      gst_tensor_query_serversink_set_caps(bsink, caps);
       break;
     default:
       break;

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.c
@@ -286,6 +286,11 @@ gst_tensor_query_serversrc_change_state (GstElement * element,
         nns_loge ("Failed to change state from PAUSED to PLAYING.");
         return GST_STATE_CHANGE_FAILURE;
       }
+
+      caps = gst_pad_peer_query_caps (GST_BASE_SRC_PAD (bsrc), NULL);
+      gst_tensor_query_serversrc_set_caps (bsrc, caps);
+      gst_caps_unref (caps);
+
       src->playing = TRUE;
       break;
     case GST_STATE_CHANGE_READY_TO_PAUSED:
@@ -311,10 +316,6 @@ gst_tensor_query_serversrc_change_state (GstElement * element,
       break;
     case GST_STATE_CHANGE_PAUSED_TO_READY:
       gst_tensor_query_server_remove_data (src->src_id);
-      break;
-    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
-      caps = gst_pad_peer_query_caps (GST_BASE_SRC_PAD (bsrc), NULL);
-      gst_tensor_query_serversrc_set_caps (bsrc, caps);
       break;
     default:
       break;


### PR DESCRIPTION
Set caps in edge handle before calling change-state callback.
