### PR TITLE
[tensor_trainer] Add a function that generates dummy data

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_trainer.h
+++ b/gst/nnstreamer/elements/gsttensor_trainer.h
@@ -60,10 +60,13 @@ struct _GstTensorTrainer
   gboolean ready_to_complete_training;
   unsigned int input_ranks[NNS_TENSOR_SIZE_LIMIT];
   unsigned int output_ranks[NNS_TENSOR_SIZE_LIMIT];
+
+  GstTensorMemory push_tensors[NNS_TENSOR_SIZE_LIMIT];
   GstTensorsInfo output_meta;
   GstTensorsConfig out_config;
   GstTensorsConfig in_config;
 
+  guint required_sample;
   guint cur_epoch_data_cnt;      /**< number of total push data in one eposh */
 
   void *privateData; /**< NNFW plugin's private data is stored here */
@@ -75,6 +78,8 @@ struct _GstTensorTrainer
   GCond training_completion_cond;
   GMutex epoch_completion_lock;
   GCond epoch_completion_cond;
+
+  GThread *dummy_data_thread; /**< Dummy data generation thread */
 };
 
 /**


### PR DESCRIPTION
When the pipeline stops and no data is input, the necessary data for the current epoch is generated for the normal termination of nntrainer. The data generation callback of nntrainer is no longer called until all the necessary data for the current epoch are received.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped
