### PR TITLE
[Draft] Initial implementation of executorch tensor filter

### DIFF
--- a/ext/nnstreamer/tensor_filter/README.md
+++ b/ext/nnstreamer/tensor_filter/README.md
@@ -38,6 +38,8 @@ title: NNStreamer tensor\_filter default subplugin manual
 - subplugin name: 'tensorflow2-lite-custom'
 ## ncnn
 - subplugin name: 'ncnn'
+## ExecuTorch
+- subplugin name: 'executorch'
 
 ### How to use custom tensorflow-lite binaries
 

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -795,6 +795,19 @@ if ncnn_support_is_available
   )
 endif
 
+if executorch_support_is_available
+  filter_sub_executorch_sources = ['tensor_filter_executorch.cc']
+
+  nnstreamer_filter_executorch_deps = [executorch_support_deps, glib_dep, nnstreamer_single_dep]
+
+  static_library('nnstreamer_filter_executorch',
+    filter_sub_executorch_sources,
+    dependencies: nnstreamer_filter_executorch_deps,
+    install: true,
+    install_dir: nnstreamer_libdir
+  )
+endif
+
 if onnxruntime_support_is_available
   filter_sub_onnxruntime_sources = ['tensor_filter_onnxruntime.cc']
 

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -795,6 +795,26 @@ if ncnn_support_is_available
   )
 endif
 
+if executorch_support_is_available
+  filter_sub_executorch_sources = ['tensor_filter_executorch.cc']
+
+  nnstreamer_filter_executorch_deps = [executorch_support_deps, glib_dep, nnstreamer_single_dep]
+
+  shared_library('nnstreamer_filter_executorch',
+    filter_sub_executorch_sources,
+    dependencies: nnstreamer_filter_executorch_deps,
+    install: true,
+    install_dir: filter_subplugin_install_dir
+  )
+
+  static_library('nnstreamer_filter_executorch',
+    filter_sub_executorch_sources,
+    dependencies: nnstreamer_filter_executorch_deps,
+    install: true,
+    install_dir: filter_subplugin_install_dir
+  )
+endif
+
 if onnxruntime_support_is_available
   filter_sub_onnxruntime_sources = ['tensor_filter_onnxruntime.cc']
 

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -795,19 +795,6 @@ if ncnn_support_is_available
   )
 endif
 
-if executorch_support_is_available
-  filter_sub_executorch_sources = ['tensor_filter_executorch.cc']
-
-  nnstreamer_filter_executorch_deps = [executorch_support_deps, glib_dep, nnstreamer_single_dep]
-
-  static_library('nnstreamer_filter_executorch',
-    filter_sub_executorch_sources,
-    dependencies: nnstreamer_filter_executorch_deps,
-    install: true,
-    install_dir: nnstreamer_libdir
-  )
-endif
-
 if onnxruntime_support_is_available
   filter_sub_onnxruntime_sources = ['tensor_filter_onnxruntime.cc']
 

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -798,6 +798,9 @@ endif
 if executorch_support_is_available
   filter_sub_executorch_sources = ['tensor_filter_executorch.cc']
 
+  ignore_sign_compare = declare_dependency(compile_args: ['-Wno-sign-compare'])
+  executorch_support_deps+= ignore_sign_compare
+
   nnstreamer_filter_executorch_deps = [executorch_support_deps, glib_dep, nnstreamer_single_dep]
 
   shared_library('nnstreamer_filter_executorch',

--- a/ext/nnstreamer/tensor_filter/tensor_filter_executorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_executorch.cc
@@ -4,14 +4,14 @@
  * @file    tensor_filter_executorch.cc
  * @date    26 Apr 2024
  * @brief   NNStreamer tensor-filter sub-plugin for ExecuTorch
- * @author  
+ * @author
  * @see     http://github.com/nnstreamer/nnstreamer
  * @bug     No known bugs.
  *
  * This is the executorch plugin for tensor_filter.
  *
  * @note Currently only skeleton
- * 
+ *
  **/
 
 
@@ -23,6 +23,7 @@
 
 #include <iostream>
 #include <memory>
+#include <vector>
 
 #include <executorch/extension/data_loader/file_data_loader.h>
 #include <executorch/extension/evalue_util/print_evalue.h>
@@ -32,52 +33,314 @@
 #include <executorch/runtime/platform/log.h>
 #include <executorch/runtime/platform/runtime.h>
 
-// static uint8_t method_allocator_pool[4 * 1024U * 1024U]; // 4 MB
-
-// DEFINE_string(
-//     model_path,
-//     "model.pte",
-//     "Model serialized in flatbuffer format.");
+static uint8_t method_allocator_pool[4 * 1024U * 1024U]; // 4 MB
 
 using namespace torch::executor;
 using torch::executor::util::FileDataLoader;
 
 namespace nnstreamer
 {
-namespace tensorfilter_executorch
+namespace tensor_filter_executorch
 {
 
-G_BEGIN_DECLS
-
+extern "C" {
 void init_filter_executorch (void) __attribute__ ((constructor));
 void fini_filter_executorch (void) __attribute__ ((destructor));
-
-G_END_DECLS
+}
 
 /**
- * @brief Class for executorch subplugin (skeleton)
+ * @brief tensor-filter-subplugin concrete class for ExecuTorch
  */
 
-class executorch_subplugin final: public tensor_filter_subplugin
+class executorch_subplugin final : public tensor_filter_subplugin
 {
-    public:
-    static void init_filter_executorch (); /**< Dynamic library contstructor helper */
-    static void fini_filter_executorch (); /**< Dynamic library desctructor helper */
+  private:
+  static executorch_subplugin *registeredRepresentation;
+  static const GstTensorFilterFrameworkInfo framework_info;
 
-    executorch_subplugin ();
-    ~executorch_subplugin ();
+  bool configured;
+  char *model_path; /**< The model *.pte file */
+  void cleanup (); /**< cleanup function */
+  GstTensorsInfo inputInfo; /**< Input tensors metadata */
+  GstTensorsInfo outputInfo; /**< Output tensors metadata */
 
-    /**< Implementations of ncnn tensor_filter_subplugin */
-    tensor_filter_subplugin &getEmptyInstance ();
-    void configure_instance (const GstTensorFilterProperties *prop);
-    void invoke (const GstTensorMemory *input, GstTensorMemory *output);
-    void getFrameworkInfo (GstTensorFilterFrameworkInfo &info);
-    int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info);
-    int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data);
+  /** executorch method*/
+  std::unique_ptr<Result<Method>> method;
+  const char *method_name;
 
-    private:
-    bool empty_model; /**< Empty (not initialized) model flag */
+  public:
+  static void init_filter_executorch ();
+  static void fini_filter_executorch ();
+
+  executorch_subplugin ();
+  ~executorch_subplugin ();
+
+  tensor_filter_subplugin &getEmptyInstance ();
+  void configure_instance (const GstTensorFilterProperties *prop);
+  void invoke (const GstTensorMemory *input, GstTensorMemory *output);
+  void getFrameworkInfo (GstTensorFilterFrameworkInfo &info);
+  int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info);
+  int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data);
 };
 
+/**
+ * @brief Describe framework information.
+ */
+const GstTensorFilterFrameworkInfo executorch_subplugin::framework_info = { .name = "executorch",
+  .allow_in_place = FALSE,
+  .allocate_in_invoke = FALSE,
+  .run_without_model = FALSE,
+  .verify_model_path = TRUE,
+  .hw_list = (const accl_hw[]){ ACCL_CPU },
+  .num_hw = 1,
+  .accl_auto = ACCL_CPU,
+  .accl_default = ACCL_CPU,
+  .statistics = nullptr };
+
+/**
+ * @brief Constructor for executorch subplugin.
+ */
+executorch_subplugin::executorch_subplugin ()
+    : tensor_filter_subplugin (), configured (false), model_path (nullptr),
+      method_name (nullptr)
+{
+  gst_tensors_info_init (std::addressof (inputInfo));
+  gst_tensors_info_init (std::addressof (outputInfo));
 }
+
+/**
+ * @brief Destructor for executorch subplugin.
+ */
+executorch_subplugin::~executorch_subplugin ()
+{
+  cleanup ();
 }
+
+/**
+ * @brief Method to get empty object.
+ */
+tensor_filter_subplugin &
+executorch_subplugin::getEmptyInstance ()
+{
+  return *(new executorch_subplugin ());
+}
+
+/**
+ * @brief Method to cleanup executorch subplugin.
+ */
+void
+executorch_subplugin::cleanup ()
+{
+  g_free (model_path);
+  model_path = nullptr;
+
+  if (!configured)
+    return;
+
+  gst_tensors_info_free (std::addressof (inputInfo));
+  gst_tensors_info_free (std::addressof (outputInfo));
+
+  method_name = nullptr;
+  configured = false;
+}
+
+/**
+ * @brief Method to prepare/configure ExecuTorch instance.
+ */
+void
+executorch_subplugin::configure_instance (const GstTensorFilterProperties *prop)
+{
+  /* Already configured */
+  if (configured)
+    cleanup ();
+
+  try {
+    /* Load network (.pte file) */
+    if (!g_file_test (prop->model_files[0], G_FILE_TEST_IS_REGULAR)) {
+      const std::string err_msg
+          = "Given file " + (std::string) prop->model_files[0] + " is not valid";
+      throw std::invalid_argument (err_msg);
+    }
+
+    model_path = g_strdup (prop->model_files[0]);
+
+    // Create a loader to get the data of the program file.
+    Result<FileDataLoader> loader = FileDataLoader::from (model_path);
+    ET_CHECK_MSG (loader.ok (), "FileDataLoader::from() failed: 0x%" PRIx32,
+        (uint32_t) loader.error ());
+
+    // Parse the program file.
+    Result<Program> program = Program::load (&loader.get ());
+    if (!program.ok ()) {
+      ET_LOG (Error, "Failed to parse model file %s", model_path);
+      return;
+    }
+    ET_LOG (Info, "Model file %s is loaded.", model_path);
+
+    // Use the first method in the program.
+    const auto method_name_result = program->get_method_name (0);
+    ET_CHECK_MSG (method_name_result.ok (), "Program has no methods");
+    method_name = *method_name_result;
+    ET_LOG (Info, "Using method %s", method_name);
+
+    // MethodMeta describes the memory requirements of the method.
+    Result<MethodMeta> method_meta = program->method_meta (method_name);
+    ET_CHECK_MSG (method_meta.ok (), "Failed to get method_meta for %s: 0x%" PRIx32,
+        method_name, (uint32_t) method_meta.error ());
+
+    MemoryAllocator method_allocator{ MemoryAllocator (
+        sizeof (method_allocator_pool), method_allocator_pool) };
+
+    std::vector<std::unique_ptr<uint8_t[]>> planned_buffers; // Owns the memory
+    std::vector<Span<uint8_t>> planned_spans; // Passed to the allocator
+    size_t num_memory_planned_buffers = method_meta->num_memory_planned_buffers ();
+    for (size_t id = 0; id < num_memory_planned_buffers; ++id) {
+      // .get() will always succeed because id < num_memory_planned_buffers.
+      size_t buffer_size = static_cast<size_t> (
+          method_meta->memory_planned_buffer_size (id).get ());
+      ET_LOG (Info, "Setting up planned buffer %zu, size %zu.", id, buffer_size);
+      planned_buffers.push_back (std::make_unique<uint8_t[]> (buffer_size));
+      planned_spans.push_back ({ planned_buffers.back ().get (), buffer_size });
+    }
+    HierarchicalAllocator planned_memory ({ planned_spans.data (), planned_spans.size () });
+
+    // Assemble all of the allocators into the MemoryManager that the Executor
+    // will use.
+    MemoryManager memory_manager (&method_allocator, &planned_memory);
+
+    //
+    // Load the method from the program, using the provided allocators. Running
+    // the method can mutate the memory-planned buffers, so the method should
+    // only be used by a single thread at at time, but it can be reused.
+    //
+
+    method = std::make_unique<Result<Method>> (
+        program->load_method (method_name, &memory_manager));
+    ET_CHECK_MSG (method->ok (), "Loading of method %s failed with status 0x%" PRIx32,
+        method_name, (uint32_t) method->error ());
+    ET_LOG (Info, "Method loaded.");
+
+    configured = true;
+  } catch (const std::exception &e) {
+    cleanup ();
+    /* throw exception upward */
+    throw;
+  }
+}
+
+/**
+ * @brief Method to execute the model.
+ */
+void
+executorch_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
+{
+  if (!input)
+    throw std::runtime_error ("Invalid input buffer, it is NULL.");
+  if (!output)
+    throw std::runtime_error ("Invalid output buffer, it is NULL.");
+
+  if (!method->ok ()) {
+    throw std::runtime_error ("Method is not properly initialized.");
+  }
+
+  Method &method_ref = method->get ();
+
+  // Set inputs
+  for (unsigned int i = 0; i < inputInfo.num_tensors; i++) {
+    GstTensorInfo *info = gst_tensors_info_get_nth_info (std::addressof (inputInfo), i);
+    EValue input_value ((const char *) input[i].data, info->type);
+    Error set_input_error = method_ref.set_input (input_value, i);
+    assert (set_input_error == Error::Ok);
+  }
+
+  // Execute the method
+  Error status = method_ref.execute ();
+  ET_CHECK_MSG (status == Error::Ok, "Execution of method %s failed with status 0x%" PRIx32,
+      method_name, (uint32_t) status);
+  ET_LOG (Info, "Model executed successfully.");
+
+  // Get outputs
+  for (unsigned int i = 0; i < outputInfo.num_tensors; i++) {
+    auto output_value = method_ref.get_output (i);
+    Error set_output_error
+        = method_ref.set_output_data_ptr (output[i].data, sizeof (output[i].data), i);
+    assert (set_output_error == Error::Ok);
+  }
+}
+
+/**
+ * @brief Method to get the information of ExecuTorch subplugin.
+ */
+void
+executorch_subplugin::getFrameworkInfo (GstTensorFilterFrameworkInfo &info)
+{
+  info = framework_info;
+}
+
+/**
+ * @brief Method to get the model information.
+ */
+int
+executorch_subplugin::getModelInfo (
+    model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info)
+{
+  if (ops == GET_IN_OUT_INFO) {
+    gst_tensors_info_copy (std::addressof (in_info), std::addressof (inputInfo));
+    gst_tensors_info_copy (std::addressof (out_info), std::addressof (outputInfo));
+    return 0;
+  }
+
+  return -ENOENT;
+}
+
+/**
+ * @brief Method to handle events.
+ */
+int
+executorch_subplugin::eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data)
+{
+  UNUSED (ops);
+  UNUSED (data);
+
+  return -ENOENT;
+}
+
+executorch_subplugin *executorch_subplugin::registeredRepresentation = nullptr;
+
+/** @brief Initialize this object for tensor_filter subplugin runtime register */
+void
+executorch_subplugin::init_filter_executorch (void)
+{
+  registeredRepresentation
+      = tensor_filter_subplugin::register_subplugin<executorch_subplugin> ();
+}
+
+/** @brief Destruct the subplugin */
+void
+executorch_subplugin::fini_filter_executorch (void)
+{
+  assert (registeredRepresentation != nullptr);
+  tensor_filter_subplugin::unregister_subplugin (registeredRepresentation);
+}
+
+/**
+ * @brief Register the sub-plugin for ExecuTorch.
+ */
+void
+init_filter_executorch ()
+{
+  executorch_subplugin::init_filter_executorch ();
+}
+
+/**
+ * @brief Destruct the sub-plugin for ExecuTorch.
+ */
+void
+fini_filter_executorch ()
+{
+  executorch_subplugin::fini_filter_executorch ();
+}
+
+
+} // namespace tensor_filter_executorch
+} // namespace nnstreamer

--- a/ext/nnstreamer/tensor_filter/tensor_filter_executorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_executorch.cc
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+
+/**
+ * @file    tensor_filter_executorch.cc
+ * @date    26 Apr 2024
+ * @brief   NNStreamer tensor-filter sub-plugin for ExecuTorch
+ * @author  
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @bug     No known bugs.
+ *
+ * This is the executorch plugin for tensor_filter.
+ *
+ * @note Currently only skeleton
+ * 
+ **/
+
+#include <functional>
+#include <glib.h>
+#include <nnstreamer_cppplugin_api_filter.hh>
+#include <nnstreamer_log.h>
+#include <nnstreamer_plugin_api_util.h>
+#include <nnstreamer_util.h>
+#include <thread>
+
+
+namespace nnstreamer
+{
+namespace tensorfilter_executorch
+{
+
+G_BEGIN_DECLS
+
+void init_filter_executorch (void) __attribute__ ((constructor));
+void fini_filter_executorch (void) __attribute__ ((destructor));
+
+G_END_DECLS
+
+/**
+ * @brief Class for executorch subplugin (skeleton)
+ */
+
+class executorch_subplugin final: public tensor_filter_subplugin
+{
+    public:
+    static void init_filter_executorch (); /**< Dynamic library contstructor helper */
+    static void fini_filter_executorch (); /**< Dynamic library desctructor helper */
+
+    executorch_subplugin ();
+    ~executorch_subplugin ();
+
+    /**< Implementations of ncnn tensor_filter_subplugin */
+    tensor_filter_subplugin &getEmptyInstance ();
+    void configure_instance (const GstTensorFilterProperties *prop);
+    void invoke (const GstTensorMemory *input, GstTensorMemory *output);
+    void getFrameworkInfo (GstTensorFilterFrameworkInfo &info);
+    int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info);
+    int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data);
+
+    private:
+    bool empty_model; /**< Empty (not initialized) model flag */
+}
+
+}
+}

--- a/ext/nnstreamer/tensor_filter/tensor_filter_executorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_executorch.cc
@@ -25,7 +25,7 @@
 #include <memory>
 #include <vector>
 
-#include <executorch/cmake-out/kernels/portable/RegisterCodegenUnboxedKernelsEverything.cpp>
+#include <executorch/cmake-out/kernels/portable/portable_ops_lib/RegisterCodegenUnboxedKernelsEverything.cpp>
 #include <executorch/extension/data_loader/file_data_loader.h>
 #include <executorch/extension/evalue_util/print_evalue.h>
 #include <executorch/extension/runner_util/inputs.h>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_executorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_executorch.cc
@@ -14,14 +14,33 @@
  * 
  **/
 
-#include <functional>
+
 #include <glib.h>
 #include <nnstreamer_cppplugin_api_filter.hh>
 #include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
-#include <thread>
 
+#include <iostream>
+#include <memory>
+
+#include <executorch/extension/data_loader/file_data_loader.h>
+#include <executorch/extension/evalue_util/print_evalue.h>
+#include <executorch/extension/runner_util/inputs.h>
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/program.h>
+#include <executorch/runtime/platform/log.h>
+#include <executorch/runtime/platform/runtime.h>
+
+// static uint8_t method_allocator_pool[4 * 1024U * 1024U]; // 4 MB
+
+// DEFINE_string(
+//     model_path,
+//     "model.pte",
+//     "Model serialized in flatbuffer format.");
+
+using namespace torch::executor;
+using torch::executor::util::FileDataLoader;
 
 namespace nnstreamer
 {
@@ -58,7 +77,7 @@ class executorch_subplugin final: public tensor_filter_subplugin
 
     private:
     bool empty_model; /**< Empty (not initialized) model flag */
-}
+};
 
 }
 }

--- a/meson.build
+++ b/meson.build
@@ -381,6 +381,18 @@ if not get_option('ncnn-support').disabled()
   endif
 endif
 
+# executorch
+executorch_dep = dependency('', required: false)
+if not get_option('executorch-support').disabled()
+  executorch_dep = dependency('executorch', required: false)
+  if (not executorch_dep.found())
+    executorch_lib = cxx.find_library('executorch', required: false)
+    if (executorch_lib.found() and cxx.check_header('executorch/runtime/platform/runtime.h'))
+      executorch_dep = declare_dependency(dependencies: [ executorch_lib ])
+    endif
+  endif
+endif
+
 # datarepo requires json-glib-1.0 in the name of json_glib_dep
 json_glib_dep = dependency('json-glib-1.0', required: false)
 if get_option('datarepo-support').enabled() and not json_glib_dep.found()
@@ -496,6 +508,10 @@ features = {
   'ncnn-support': {
     'extra_deps': [ ncnn_dep ],
     'project_args': { 'ENABLE_NCNN' : 1 }
+  },
+  'executorch-support': {
+    'extra_deps': [ executorch_dep ],
+    'project_args': { 'ENABLE_EXECUTORCH' : 1 }
   },
   'datarepo-support': {
     'extra_deps': [ json_glib_dep ],

--- a/meson.build
+++ b/meson.build
@@ -381,18 +381,6 @@ if not get_option('ncnn-support').disabled()
   endif
 endif
 
-# executorch
-executorch_dep = dependency('', required: false)
-if not get_option('executorch-support').disabled()
-  executorch_dep = dependency('executorch', required: false)
-  if (not executorch_dep.found())
-    executorch_lib = cxx.find_library('executorch', required: false)
-    if (executorch_lib.found() and cxx.check_header('executorch/runtime/platform/runtime.h'))
-      executorch_dep = declare_dependency(dependencies: [ executorch_lib ])
-    endif
-  endif
-endif
-
 # datarepo requires json-glib-1.0 in the name of json_glib_dep
 json_glib_dep = dependency('json-glib-1.0', required: false)
 if get_option('datarepo-support').enabled() and not json_glib_dep.found()
@@ -510,7 +498,7 @@ features = {
     'project_args': { 'ENABLE_NCNN' : 1 }
   },
   'executorch-support': {
-    'extra_deps': [ executorch_dep ],
+    'target': 'executorch',
     'project_args': { 'ENABLE_EXECUTORCH' : 1 }
   },
   'datarepo-support': {

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,6 +26,7 @@ option('trix-engine-support', type: 'feature', value: 'auto')
 option('nnstreamer-edge-support', type: 'feature', value: 'auto')
 option('mxnet-support', type: 'feature', value: 'auto')
 option('ncnn-support', type: 'feature', value: 'auto')
+option('executorch-support', type: 'feature', value: 'auto')
 option('parser-support', type: 'feature', value: 'auto') # gstreamer pipeline description <--> pbtxt pipeline
 option('datarepo-support', type: 'feature', value: 'auto', description: 'Data repository sink/src for in-pipeline training') # this required json-glib-1.0.
 option('ml-agent-support', type: 'feature', value: 'auto')


### PR DESCRIPTION
## Future Work and Implementation
This draft pull request lays the groundwork for integrating the executorch tensor filter into nnstreamer. Although the current implementation is not yet complete and might have some errors or inefficiencies, we believe it can serve as a valuable starting point and reference for future work on this feature.

## Build and Performance Considerations
During the development of this draft PR, we encountered significant performance issues with the current stable branch of executorch (v0.2.1). Despite our efforts to investigate and resolve these issues, we were unable to identify the root cause of the performance degradation.

As a result, we made the decision to build the executorch main branch instead of the stable v0.2.1 branch. While we acknowledge that using the main branch may introduce instability and potential compatibility issues, we found that it provided better performance compared to the stable branch.

#### Building ExecuTorch:
```
# Assume conda is installed

# Create and activate a conda environment named "executorch"
conda create -yn executorch python=3.10.0
conda activate executorch

# Clone the ExecuTorch repo from GitHub
git clone https://github.com/pytorch/executorch.git
cd executorch

# Update and pull submodules
git submodule sync
git submodule update --init

# Install ExecuTorch pip package and its dependencies, as well as
# development tools like CMake.
# If developing on a Mac, make sure to install the Xcode Command Line Tools first.
./install_requirements.sh

rm -rf cmake-out
mkdir cmake-out

# Configure cmake
cmake \
    -DCMAKE_INSTALL_PREFIX=cmake-out \
    -DCMAKE_BUILD_TYPE=Release \
    -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
    -DEXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL=ON \
    -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
    -DEXECUTORCH_ENABLE_LOGGING=ON \
    -DPYTHON_EXECUTABLE=python \
    -Bcmake-out .

cmake --build cmake-out -j9 --target install --config Release
```
#### Integrating ExecuTorch to NNStreamer:
1. **Create executorch.pc in /usr/lib/pkgconfig**
```
includedir=/home/<username>
libdir=${includedir}/executorch/cmake-out/lib

Name: executorch
Description: Executorch
Version: 0.2.0
Libs: -L${libdir} -lexecutorch_no_prim_ops -lexecutorch -lextension_data_loader -lextension_module -lextension_module_static -lextension_runner_util -lportable_kernels -lportable_ops_lib
Cflags: -I${includedir}
```
2. **Manually reslove naming conflicts between two files below.** 
(NEED FUTURE IMPROVEMENT: We could not find out a nice way to register kernels when using executorch runtime in nnstreamer)
```
#include <executorch/cmake-out/kernels/portable/portable_ops_lib/RegisterCodegenUnboxedKernelsEverything.cpp>
#include <executorch/kernels/prim_ops/register_prim_ops.cpp>
```
3. **Build and install nnstreamer**
ref. https://github.com/nnstreamer/nnstreamer/blob/main/Documentation/getting-started-meson-build.md

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**Example Image classfication test script:**
```
gst-launch-1.0 \
    textoverlay name=overlay font-desc=Sans,24 ! videoconvert ! ximagesink name=img_test \
    v4l2src name=cam_src ! videoconvert ! videoscale ! video/x-raw,width=640,height=480,format=RGB ! tee name=t_raw \
    t_raw. ! queue ! overlay.video_sink \
    t_raw. ! queue leaky=2 max-size-buffers=2 ! videoconvert ! videoscale ! video/x-raw,width=224,height=224,format=RGB ! tensor_converter ! \
    tensor_transform mode=arithmetic option=typecast:float32,per-channel:true@2,div:255.0,add:-0.485@0,add:-0.456@1,add:-0.406@2,div:0.229@0,div:0.224@1,div:0.225@2 ! \
    tensor_transform mode=dimchg option=0:2 ! \
    tensor_filter framework=executorch model=executorch_model/mobilenetv3_large.pte input=224:224:3 inputtype=float32 output=1000:1 outputtype=float32 ! \
    tensor_decoder mode=image_labeling option1=executorch_model/imagenet_classes.txt ! \
    overlay.text_sink
```