### PR TITLE
[filter] Support TFLite QNN Delegate

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -89,6 +89,14 @@
 #endif
 #endif
 
+#ifdef TFLITE_QNN_DELEGATE_SUPPORTED
+#include <QNN/TFLiteDelegate/QnnTFLiteDelegate.h>
+#endif
+
+#if defined(__ANDROID__)
+#include <jni.h>
+#endif
+
 #if !defined(TFLITE_SUBPLUGIN_NAME)
 #warning "The sub-plugin name for tensorflow-lite is not defined."
 #define TFLITE_SUBPLUGIN_NAME "tensorflow-lite"
@@ -276,7 +284,11 @@ class TFLiteCore
 };
 
 extern "C" {
+#if defined(__ANDROID__)
+void init_filter_tflite (JNIEnv *env, jobject context);
+#else
 void init_filter_tflite (void) __attribute__ ((constructor));
+#endif
 void fini_filter_tflite (void) __attribute__ ((destructor));
 }
 
@@ -1656,20 +1668,153 @@ static GstTensorFilterFramework NNS_support_tensorflow_lite
               .allocateInInvoke = nullptr,
           } } };
 
-/** @brief Initialize this object for tensor_filter subplugin runtime register */
-void
-init_filter_tflite (void)
+/**
+ * @brief Internal function to register the filter.
+ */
+static void
+_nns_filter_register_tflite (void)
 {
   nnstreamer_filter_probe (&NNS_support_tensorflow_lite);
   nnstreamer_filter_set_custom_property_desc (NNS_support_tensorflow_lite.v0.name,
       "NumThreads", "Number of threads. Set 0 for default behaviors.", "Delegate",
-      "TF-Lite delegation options: {'NNAPI', 'GPU', 'XNNPACK', 'External'}."
+      "TF-Lite delegation options: {'NNAPI', 'GPU', 'XNNPACK', 'External', 'QNN'}."
       " Do not specify to disable delegation.",
       "ExtDelegateLib", "Path to external delegate shared library", "ExtDelegateKeyVal",
       "key/values pairs optional parameters for delegate."
       " Format ExtDelegateKeyVal=key1#value1;key2#value2...",
       NULL);
 }
+
+#if defined(__ANDROID__)
+/**
+ * @brief Set additional environment for qnn delegate
+ */
+static gboolean
+_tflite_set_env_qnn_android (JNIEnv *env, jobject context)
+{
+  gboolean tflite_failed = TRUE;
+  jclass context_class = NULL;
+  jmethodID get_application_info_method_id = NULL;
+  jobject application_info_object = NULL;
+  jclass application_info_object_class = NULL;
+  jfieldID native_library_dir_field_id = NULL;
+  jstring native_library_dir_path = NULL;
+
+  const gchar *native_library_dir_path_str;
+  gchar *new_path;
+
+  g_return_val_if_fail (env != NULL, FALSE);
+  g_return_val_if_fail (context != NULL, FALSE);
+
+  context_class = env->GetObjectClass (context);
+  if (!context_class) {
+    nns_loge ("Failed to get context class.");
+    goto done;
+  }
+
+  get_application_info_method_id = env->GetMethodID (context_class,
+      "getApplicationInfo", "()Landroid/content/pm/ApplicationInfo;");
+  if (!get_application_info_method_id) {
+    nns_loge ("Failed to get method ID for `ApplicationInfo()`.");
+    goto done;
+  }
+
+  application_info_object = env->CallObjectMethod (context, get_application_info_method_id);
+  if (env->ExceptionCheck ()) {
+    env->ExceptionDescribe ();
+    env->ExceptionClear ();
+    nns_loge ("Failed to call method `ApplicationInfo()`.");
+    goto done;
+  }
+
+  application_info_object_class = env->GetObjectClass (application_info_object);
+  if (!application_info_object_class) {
+    nns_loge ("Failed to get `ApplicationInfo` object class");
+    goto done;
+  }
+
+  native_library_dir_field_id = env->GetFieldID (
+      application_info_object_class, "nativeLibraryDir", "Ljava/lang/String;");
+  if (!native_library_dir_field_id) {
+    nns_loge ("Failed to get field ID for `nativeLibraryDir`.");
+    goto done;
+  }
+
+  native_library_dir_path = static_cast<jstring> (
+      env->GetObjectField (application_info_object, native_library_dir_field_id));
+  if (!native_library_dir_path) {
+    nns_loge ("Failed to get field `nativeLibraryDir`.");
+    goto done;
+  }
+  gchar *ls_cmd;
+
+  native_library_dir_path_str = env->GetStringUTFChars (native_library_dir_path, NULL);
+  if (env->ExceptionCheck ()) {
+    env->ExceptionDescribe ();
+    env->ExceptionClear ();
+    nns_loge ("Failed to get string `nativeLibraryDir`");
+    goto done;
+  }
+
+  new_path = g_strconcat (native_library_dir_path_str,
+      ";/system/lib/rfsa/adsp;/system/vendor/lib/rfsa/adsp;/dsp", NULL);
+
+  /**
+   * See https://docs.qualcomm.com/bundle/publicresource/topics/80-63442-2/dsp_runtime.html for details
+   */
+  nns_logi ("Set env ADSP_LIBRARY_PATH for TFLite QNN Delegate: %s", new_path);
+  g_setenv ("ADSP_LIBRARY_PATH", new_path, TRUE);
+
+  g_free (new_path);
+  env->ReleaseStringUTFChars (native_library_dir_path, native_library_dir_path_str);
+
+  tflite_failed = FALSE;
+
+done:
+
+  if (native_library_dir_path) {
+    env->DeleteLocalRef (native_library_dir_path);
+  }
+
+  if (application_info_object_class) {
+    env->DeleteLocalRef (application_info_object_class);
+  }
+
+  if (application_info_object) {
+    env->DeleteLocalRef (application_info_object);
+  }
+
+  if (context_class) {
+    env->DeleteLocalRef (context_class);
+  }
+
+  return !(tflite_failed);
+}
+
+/**
+ * @brief Register the sub-plugin for tflite in Android.
+ */
+void
+init_filter_tflite (JNIEnv *env, jobject context)
+{
+
+#if defined(TFLITE_QNN_DELEGATE_SUPPORTED)
+  if (!_tflite_set_env_qnn_android (env, context)) {
+    nns_loge ("Failed to set extra env for qnn delegate");
+    return;
+  }
+#endif /* defined(TFLITE_QNN_DELEGATE_SUPPORTED) */
+
+  _nns_filter_register_tflite ();
+}
+#else
+/** @brief Initialize this object for tensor_filter subplugin runtime register */
+void
+init_filter_tflite (void)
+{
+  _nns_filter_register_tflite ();
+}
+#endif /* defined(__ANDROID__) */
 
 /** @brief Destruct the subplugin */
 void


### PR DESCRIPTION
- Import QNN delegate header.
- For Android, set certain environment variables for DSP/HTP runtimes.
- Add custom option for QNN Delegate.
- Add custom option for QNN backend and performance mode.
- User can use this in pipeline:
`... custom=Delegate:QNN,QNNBackend:DSP,QNNPerformanceMode:highperformance ...`

Disclaimer: This only be tested in Android.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
