### PR TITLE
[Filter] [Experimental] Add support for dali pipeline.

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -857,3 +857,23 @@ if onnxruntime_support_is_available
     install_dir: nnstreamer_libdir
   )
 endif
+
+if dali_support_is_available
+  filter_sub_dali_sources = ['tensor_filter_dali.cc']
+
+  nnstreamer_filter_dali_deps = [glib_dep, nnstreamer_single_dep, cuda_dep, cudart_dep, dali_support_deps]
+
+  shared_library('nnstreamer_filter_dali',
+    filter_sub_dali_sources,
+    dependencies: nnstreamer_filter_dali_deps,
+    install: true,
+    install_dir: filter_subplugin_install_dir
+  )
+
+  static_library('nnstreamer_filter_dali',
+    filter_sub_dali_sources,
+    dependencies: nnstreamer_filter_dali_deps,
+    install: true,
+    install_dir: nnstreamer_libdir
+  )
+endif

--- a/ext/nnstreamer/tensor_filter/tensor_filter_dali.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_dali.cc
@@ -1,0 +1,516 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * NNStreamer tensor_filter, sub-plugin for dali
+ * Copyright (C) 2024 Bram Veldhoen
+ */
+/**
+ * @file        tensor_filter_dali.cc
+ * @date        Jun 2024
+ * @brief       NNStreamer tensor-filter sub-plugin for dali
+ * @see         http://github.com/nnstreamer/nnstreamer
+ * @see         https://github.com/NVIDIA/DALI
+ * @author      Bram Veldhoen
+ * @bug         No known bugs except for NYI items
+ *
+ * This is the per-NN-framework plugin (dali) for tensor_filter.
+ *
+ * This plugin uses a dali pipeline, which can be created and serialized with
+ * c++. (see for instance tests/nnstreamer_filter_dali/main.cpp).
+ * In order to support batch_size > 1, the dali pipeline always expects an
+ * explicit batch size. Therefore, the dimensions specified for the dali
+ * input/output should always include the batch size (even if it's 1). For
+ * example, for batch_size 4:
+ * @code
+ * tensor_filter framework=dali model=dali_pipeline_4_3_640_640.txt
+ * inputname=input0 input=3:2560:1440:4 inputtype=uint8 output=640:640:3:4
+ * outputtype=float32
+ * @endcode
+ * This approach implies some specific requirements to the dali pipeline:
+ * - The pipeline ctor parameter max_batch_size must be 1.
+ * - The ExternalSource argument "batch" should be false.
+ * - The ExternalSource argument "ndim" must match the number of dimensions
+ * specified for the tensor_filter inputtype. For example:
+ * @code
+ * // Create the pipeline
+ * Pipeline pipe(
+ *   1, // max_batch_size
+ *   ...
+ * );
+ *
+ * // Add pipeline operators
+ * // Input: (4, 1440, 2560, 3), Output: (4, 1440, 2560, 3)
+ * pipe.AddOperator(
+ *   OpSpec("ExternalSource")
+ *   .AddArg("batch", false)
+ *   .AddArg("device", "cpu")
+ *   .AddArg("dtype", DALIDataType::DALI_UINT8)
+ *   .AddArg("name", "input0")
+ *   .AddArg("ndim", 4)
+ *   .AddOutput("input0", "cpu"),
+ *   "input0"
+ * );
+ * ... (add other operators) ...
+ * // Build the pipeline
+ * std::vector<std::pair<std::string, std::string>> outputs = {{"output0",
+ * "gpu"}}; pipe.Build(outputs);
+ *
+ * // Serialize the pipeline
+ * auto serialized_pipe_str = pipe.SerializeToProtobuf();
+ *
+ * // Save to file
+ * std::ofstream serialized_pipe_out(serialized_pipe_filename);
+ * serialized_pipe_out << serialized_pipe_str;
+ * serialized_pipe_out.close();
+ * @endcode
+ *
+ * @todo
+ *  - Support multiple inputs/outputs.
+ *  - Support for input/output devices ("cpu" or "gpu"). Currently only dali
+ * input device = "cpu", outputdevice = "gpu" is supported.
+ */
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <glib.h>
+#include <nnstreamer_cppplugin_api_filter.hh>
+#include <nnstreamer_log.h>
+#include <nnstreamer_plugin_api_util.h>
+#include <nnstreamer_util.h>
+
+#include <dali/c_api.h>
+#include <dali/operators.h>
+#include <dali/pipeline/data/types.h>
+
+
+namespace
+{
+
+template <typename T>
+inline std::string
+to_string (const std::vector<T> &vec, const char sep = ',')
+{
+  std::stringstream ss;
+  ss << "(";
+  for (std::size_t index = 0; index < vec.size (); ++index) {
+    const T &item = vec[index];
+    if (index) {
+      ss << sep << " ";
+    }
+    ss << item;
+  }
+  ss << ")";
+  return ss.str ();
+}
+
+} // namespace
+namespace nnstreamer
+{
+namespace tensor_filter_dali
+{
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+void _init_filter_dali (void) __attribute__ ((constructor));
+void _fini_filter_dali (void) __attribute__ ((destructor));
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+/** @brief tensor-filter-subplugin concrete class for dali */
+class dali_subplugin final : public tensor_filter_subplugin
+{
+  public:
+  static void init_filter_dali ();
+  static void fini_filter_dali ();
+
+  dali_subplugin ();
+  ~dali_subplugin ();
+
+  tensor_filter_subplugin &getEmptyInstance ();
+  void configure_instance (const GstTensorFilterProperties *prop);
+  void invoke (const GstTensorMemory *input, GstTensorMemory *output);
+  void getFrameworkInfo (GstTensorFilterFrameworkInfo &info);
+  int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info);
+  int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data);
+
+  private:
+  bool configured{};
+  int _device_id{}; /**< Device id of the gpu to use. */
+
+  static const char *name;
+  static const accl_hw hw_list[];
+  static const int num_hw{};
+  static dali_subplugin *registeredRepresentation;
+
+  GstTensorsInfo _inputTensorMeta{};
+  GstTensorsInfo _outputTensorMeta{};
+
+  daliPipelineHandle _pipeline_handle{}; /**< The dali c_api handle to the pipeline. */
+
+  // We currently use only the first input and first output of the dali pipeline.
+  std::size_t _input_index{}; /** The index of the dali and nns input (i.e., 0) */
+  std::size_t _output_index{}; /** The index of the dali and nns output (i.e., 0) */
+
+  gchar *_pipeline_path{}; /**< pipeline file path */
+  const char *_nns_input_name{}; /**< Name of the first input of the dali pipeline */
+  std::vector<std::int64_t> _nns_input_shape{}; /**< The reversed shape of the nns input */
+  dali_data_type_t _nns_input_dali_data_type{}; /**< The dali type of the nns input */
+  const char *_nns_output_name{}; /**< Name of the first output of the dali pipeline */
+  std::vector<std::int64_t> _nns_output_shape{}; /**< The reversed shape of the nns output */
+  dali_data_type_t _nns_output_dali_data_type{}; /**< The dali type of the nns output */
+  gsize _nns_output_tensor_element_size{}; /**< The element size of the dali output, i.e. the number of uint8's or float32's. */
+
+  void cleanup ();
+  void loadPipeline ();
+  std::vector<std::int64_t> getDaliOutputShape ();
+  std::vector<std::int64_t> convertShape (const GstTensorInfo &tensor_info) const;
+  dali_data_type_t getDaliDataType (tensor_type nns_tensor_type) const;
+};
+
+const char *dali_subplugin::name = "dali";
+const accl_hw dali_subplugin::hw_list[] = {};
+
+/**
+ * @brief Constructor for dali_subplugin.
+ */
+dali_subplugin::dali_subplugin ()
+{
+  ml_logi ("dali_subplugin::dali_subplugin");
+  gst_tensors_info_init (&_inputTensorMeta);
+  gst_tensors_info_init (&_outputTensorMeta);
+}
+
+/**
+ * @brief Destructor for dali_subplugin.
+ */
+dali_subplugin::~dali_subplugin ()
+{
+  ml_logi ("dali_subplugin::~dali_subplugin");
+  cleanup ();
+}
+
+/** @brief cleanup resources used by dali subplugin */
+void
+dali_subplugin::cleanup ()
+{
+  if (!configured) {
+    return;
+  }
+
+  if (_pipeline_handle) {
+    daliDeletePipeline (&_pipeline_handle);
+    _pipeline_handle = nullptr;
+  }
+
+  gst_tensors_info_free (&_inputTensorMeta);
+  gst_tensors_info_free (&_outputTensorMeta);
+
+  configured = false;
+}
+
+/**
+ * @brief Method to get empty object.
+ */
+tensor_filter_subplugin &
+dali_subplugin::getEmptyInstance ()
+{
+  ml_logi ("dali_subplugin::getEmptyInstance");
+  return *(new dali_subplugin ());
+}
+
+/**
+ * @brief Method to prepare/configure dali instance.
+ */
+void
+dali_subplugin::configure_instance (const GstTensorFilterProperties *prop)
+{
+  ml_logi ("dali_subplugin::configure_instance");
+  g_assert (prop != nullptr);
+
+  gst_tensors_info_copy (
+      std::addressof (_inputTensorMeta), std::addressof (prop->input_meta));
+  gst_tensors_info_copy (
+      std::addressof (_outputTensorMeta), std::addressof (prop->output_meta));
+
+  // Get dali input datatype
+  GstTensorInfo *input_tensor_info = gst_tensors_info_get_nth_info (
+      std::addressof (_inputTensorMeta), _input_index);
+  _nns_input_name = input_tensor_info->name;
+  _nns_input_dali_data_type = getDaliDataType (input_tensor_info->type);
+  _nns_input_shape = convertShape (*input_tensor_info);
+
+  // Get dali output datatype
+  GstTensorInfo *output_tensor_info = gst_tensors_info_get_nth_info (
+      std::addressof (_outputTensorMeta), _output_index);
+  _nns_output_name = output_tensor_info->name;
+  _nns_output_dali_data_type = getDaliDataType (output_tensor_info->type);
+  _nns_output_tensor_element_size
+      = gst_tensor_get_element_size (output_tensor_info->type);
+  _nns_output_shape = convertShape (*output_tensor_info);
+
+  ml_logi ("input_shape: %s, output shape: %s",
+      to_string (_nns_input_shape).data (), to_string (_nns_output_shape).data ());
+
+  /* Set pipeline path */
+  if (prop->num_models != 1 || !prop->model_files[0]) {
+    ml_loge ("dali filter requires one pipeline file.");
+    throw std::invalid_argument ("The pipeline file is not given.");
+  }
+  _pipeline_path = g_strdup (prop->model_files[0]);
+  g_assert (_pipeline_path != nullptr);
+
+  loadPipeline ();
+}
+
+/**
+ * @brief Loads the pipeline file and makes a member object to be used for execution.
+ */
+void
+dali_subplugin::loadPipeline ()
+{
+  std::filesystem::path pipeline_fs_path (_pipeline_path);
+
+  std::ifstream file (pipeline_fs_path, std::ios::binary | std::ios::ate);
+  std::streamsize size = file.tellg ();
+  if (size < 0) {
+    ml_loge ("Unable to open pipeline file %s", std::string (pipeline_fs_path).data ());
+    throw std::runtime_error ("Unable to open pipeline file");
+  }
+
+  file.seekg (0, std::ios::beg);
+  ml_logi ("Loading pipeline from file: %s with buffer size: %" G_GUINT64_FORMAT,
+      std::string (pipeline_fs_path).data (), size);
+
+  std::stringstream serialized_pipeline;
+  serialized_pipeline << file.rdbuf ();
+  auto serialized_pipeline_str = serialized_pipeline.str ();
+
+  daliDeserializeDefault (&_pipeline_handle, serialized_pipeline_str.c_str (),
+      serialized_pipeline_str.size ());
+
+  configured = true;
+}
+
+/**
+ * @brief Method to execute the dali pipeline.
+ */
+void
+dali_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
+{
+  try {
+    ml_logd ("dali_subplugin::invoke on device_id: %d", _device_id);
+    g_assert (configured);
+
+    daliSetExternalInputBatchSize (&_pipeline_handle, _nns_input_name, 1);
+
+    device_type_t device_type = CPU;
+    auto data_ptr = input[_input_index].data;
+    auto sample_dim = _nns_input_shape.size ();
+    const char *layout_str = nullptr;
+    unsigned int flags{ DALI_ext_default };
+    ml_logd ("dali_subplugin::invoke; copy data");
+    daliSetExternalInput (&_pipeline_handle, _nns_input_name, device_type,
+        data_ptr, _nns_input_dali_data_type, _nns_input_shape.data (),
+        sample_dim, layout_str, flags);
+    ml_logd ("dali_subplugin::invoke; copied data");
+
+    ml_logd ("dali_subplugin::invoke; execute pipeline");
+    daliRun (&_pipeline_handle);
+    ml_logd ("dali_subplugin::invoke; executed pipeline");
+
+    // Collect outputs
+    daliOutput (&_pipeline_handle);
+    g_assert (daliGetNumOutput (&_pipeline_handle) == 1);
+
+    bool has_uniform_shape = daliOutputHasUniformShape (&_pipeline_handle, _output_index);
+    g_assert (has_uniform_shape);
+
+    auto dali_output_data_type = daliTypeAt (&_pipeline_handle, _output_index);
+    auto nns_output_num_elements = output[_output_index].size / _nns_output_tensor_element_size;
+    auto dali_output_num_elements = daliNumElements (&_pipeline_handle, _output_index);
+    auto dali_output_shape = getDaliOutputShape ();
+
+    ml_logd ("nnstreamer output num_elements: %" G_GINT64_FORMAT
+             "; dali output num_elements: %" G_GINT64_FORMAT "; dali output shape: %s",
+        nns_output_num_elements, dali_output_num_elements,
+        to_string (dali_output_shape).data ());
+
+    g_assert (dali_output_data_type == _nns_output_dali_data_type);
+    g_assert (nns_output_num_elements == dali_output_num_elements);
+    g_assert (_nns_output_shape == dali_output_shape);
+
+    ml_logd ("dali_subplugin::invoke; copying output");
+    daliOutputCopy (&_pipeline_handle, output[_output_index].data,
+        _output_index, device_type, 0, flags);
+    ml_logd ("dali_subplugin::invoke; copied output");
+
+  } catch (const std::exception &exc) {
+    ml_loge ("ERROR running dali pipeline: %s", exc.what ());
+    const std::string err_msg
+        = "ERROR running dali pipeline: " + (std::string) exc.what ();
+    throw std::runtime_error (err_msg);
+  }
+}
+
+/**
+ * @brief Method to get the information of dali subplugin.
+ */
+void
+dali_subplugin::getFrameworkInfo (GstTensorFilterFrameworkInfo &info)
+{
+  ml_logi ("dali_subplugin::getFrameworkInfo");
+
+  info.name = name;
+  info.allow_in_place = FALSE;
+  info.allocate_in_invoke = FALSE;
+  info.run_without_model = FALSE;
+  info.verify_model_path = TRUE;
+  info.hw_list = hw_list;
+  info.num_hw = num_hw;
+}
+
+/**
+ * @brief Method to get the model information.
+ */
+int
+dali_subplugin::getModelInfo (
+    model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info)
+{
+  ml_logi ("dali_subplugin::getModelInfo");
+
+  if (ops != GET_IN_OUT_INFO) {
+    return -ENOENT;
+  }
+
+  gst_tensors_info_copy (std::addressof (in_info), std::addressof (_inputTensorMeta));
+  gst_tensors_info_copy (std::addressof (out_info), std::addressof (_outputTensorMeta));
+
+  return 0;
+}
+
+/**
+ * @brief Method to handle events.
+ */
+int
+dali_subplugin::eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data)
+{
+  ml_logi ("dali_subplugin::eventHandler");
+
+  UNUSED (ops);
+  UNUSED (data);
+  return 0;
+}
+
+std::vector<std::int64_t>
+dali_subplugin::convertShape (const GstTensorInfo &tensor_info) const
+{
+  std::vector<std::int64_t> shape;
+
+  // Set dali shape in reverse order
+  int dim_index = 0;
+  while (tensor_info.dimension[dim_index] != 0) {
+    shape.push_back (tensor_info.dimension[dim_index++]);
+  }
+  std::reverse (shape.begin (), shape.end ());
+
+  return shape;
+}
+
+std::vector<std::int64_t>
+dali_subplugin::getDaliOutputShape ()
+{
+  std::vector<std::int64_t> dali_output_shape;
+
+  auto custom_deleter = [] (std::int64_t *t) noexcept { free (t); };
+  auto dali_output_shape_ptr = std::unique_ptr<int64_t, decltype (custom_deleter)> (
+      daliShapeAt (&_pipeline_handle, _output_index), custom_deleter);
+
+  // The dali output has an additional dimension with value 1 at index 0, i.e. (1, 4, 3, 640, 640) instead of (4, 3, 640, 640).
+  //  We can safely ignore this additional dimension and remove it. Therefore start index at 1.
+  std::size_t shape_index = 1;
+  while (dali_output_shape_ptr.get ()[shape_index] != 0) {
+    dali_output_shape.push_back (dali_output_shape_ptr.get ()[shape_index++]);
+  }
+
+  return dali_output_shape;
+}
+
+dali_data_type_t
+dali_subplugin::getDaliDataType (tensor_type nns_tensor_type) const
+{
+  switch (nns_tensor_type) {
+    case _NNS_INT32:
+      return DALI_INT32;
+    case _NNS_UINT32:
+      return DALI_UINT32;
+    case _NNS_INT16:
+      return DALI_INT16;
+    case _NNS_UINT16:
+      return DALI_UINT16;
+    case _NNS_INT8:
+      return DALI_INT8;
+    case _NNS_UINT8:
+      return DALI_UINT8;
+    case _NNS_FLOAT64:
+      return DALI_FLOAT64;
+    case _NNS_FLOAT32:
+      return DALI_FLOAT;
+    case _NNS_INT64:
+      return DALI_INT64;
+    case _NNS_UINT64:
+      return DALI_UINT64;
+    case _NNS_FLOAT16:
+      return DALI_FLOAT16;
+    case _NNS_END:
+    default:
+      throw std::runtime_error ("tensor_type not supported.");
+  }
+}
+
+dali_subplugin *dali_subplugin::registeredRepresentation = nullptr;
+
+/** @brief Initialize this object for tensor_filter subplugin runtime register. */
+void
+dali_subplugin::init_filter_dali ()
+{
+  ml_logi ("dali_subplugin::init_filter_dali");
+
+  dali::InitOperatorsLib ();
+  daliInitialize ();
+
+  registeredRepresentation
+      = tensor_filter_subplugin::register_subplugin<dali_subplugin> ();
+}
+
+/** @brief Destruct the sub-plugin for dali. */
+void
+dali_subplugin::fini_filter_dali ()
+{
+  ml_logi ("dali_subplugin::fini_filter_dali");
+
+  g_assert (registeredRepresentation != nullptr);
+  tensor_filter_subplugin::unregister_subplugin (registeredRepresentation);
+}
+
+/** @brief initializer */
+void
+_init_filter_dali ()
+{
+  dali_subplugin::init_filter_dali ();
+}
+
+/** @brief finalizer */
+void
+_fini_filter_dali ()
+{
+  dali_subplugin::fini_filter_dali ();
+}
+
+} /* namespace tensor_filter_dali */
+} /* namespace nnstreamer */

--- a/meson.build
+++ b/meson.build
@@ -271,49 +271,63 @@ cuda_major = 0
 cuda_minor = 0
 cuda_dep = dependency('', required: false)
 cudart_dep = dependency('', required: false)
-if not get_option('tensorrt-support').disabled() or not get_option('tensorrt10-support').disabled()
+if not get_option('tensorrt-support').disabled() or \
+  not get_option('tensorrt10-support').disabled() or \
+  not get_option('dali-support').disabled()
   nvcc = find_program('nvcc', required: false)
   if nvcc.found()
-    cuda_version_str = run_command(find_program('tools/cuda-version.sh'), check: true).stdout().strip()
-    message('$cuda_version_str: @0@'.format(cuda_version_str))
+    cuda_version_cmd = run_command(find_program('tools/cuda-version.sh'), check: false)
+    if cuda_version_cmd.returncode() != 0
+      message('ERROR: tools/cuda-version.sh exited with exit code: @0@, tensorrt10-support and/or dali-support will be disabled.'.format(cuda_version_cmd.returncode()))
+    else
+      cuda_version_str = cuda_version_cmd.stdout().strip()
+      message('$cuda_version_str: @0@'.format(cuda_version_str))
 
-    cuda_versions = cuda_version_str.split('.')
-    cuda_major = cuda_versions[0].to_int()
-    cuda_minor = cuda_versions[1].to_int()
+      cuda_versions = cuda_version_str.split('.')
+      cuda_major = cuda_versions[0].to_int()
+      cuda_minor = cuda_versions[1].to_int()
 
-    cuda_dep = dependency('cuda-' + cuda_version_str, required: false)
-    cudart_dep = dependency('cudart-' + cuda_version_str, required: false)
+      cuda_dep = dependency('cuda-' + cuda_version_str, required: false)
+      cudart_dep = dependency('cudart-' + cuda_version_str, required: false)
+    endif
   endif
 endif
 
 # tensorrt
-tensorrt_version_str = run_command(find_program('tools/tensorrt-version.sh'), check: true).stdout().strip()
+tensorrt_version_str = ''
 tensorrt_major = 0
 tensorrt_minor = 0
 nvinfer_dep = dependency('', required: false)
 nvuffparsers_dep = dependency('', required: false)
 nvonnxparser_dep = dependency('', required: false)
-if tensorrt_version_str != '' and cuda_major > 0 and (not get_option('tensorrt-support').disabled() or not get_option('tensorrt10-support').disabled())
-  message('$tensorrt_version_str: @0@'.format(tensorrt_version_str))
+if cuda_major > 0 and (not get_option('tensorrt-support').disabled() or not get_option('tensorrt10-support').disabled())
 
-  tensorrt_versions = tensorrt_version_str.split('.')
-  tensorrt_major = tensorrt_versions[0].to_int()
-  tensorrt_minor = tensorrt_versions[1].to_int()
+  tensorrt_version_cmd = run_command(find_program('tools/tensorrt-version.sh'), check: false)
+  if tensorrt_version_cmd.returncode() != 0
+    message('ERROR: tools/tensorrt-version.sh exited with exit code: @0@, tensorrt10-support will be disabled.'.format(tensorrt_version_cmd.returncode()))
+  else
+    tensorrt_version_str = tensorrt_version_cmd.stdout().strip()
+    message('$tensorrt_version_str: @0@'.format(tensorrt_version_str))
 
-  nvinfer_lib = cxx.find_library('nvinfer', required: false)
-  if nvinfer_lib.found() and cxx.has_header('NvInfer.h')
-    nvinfer_dep = declare_dependency(dependencies: nvinfer_lib)
-  endif
+    tensorrt_versions = tensorrt_version_str.split('.')
+    tensorrt_major = tensorrt_versions[0].to_int()
+    tensorrt_minor = tensorrt_versions[1].to_int()
 
-  if tensorrt_major < 10 and not get_option('tensorrt-support').disabled()
-    nvuffparsers_lib = cxx.find_library('nvuffparsers', required: false)
-    if nvuffparsers_lib.found() and cxx.has_header('NvUffParser.h')
-      nvuffparsers_dep = declare_dependency(dependencies: nvuffparsers_lib)
+    nvinfer_lib = cxx.find_library('nvinfer', required: false)
+    if nvinfer_lib.found() and cxx.has_header('NvInfer.h')
+      nvinfer_dep = declare_dependency(dependencies: nvinfer_lib)
     endif
-  elif tensorrt_major >= 10 and not get_option('tensorrt10-support').disabled()
-    nvonnxparser_lib = cxx.find_library('nvonnxparser', required: false)
-    if nvonnxparser_lib.found() and cxx.has_header('NvOnnxParser.h')
-      nvonnxparser_dep = declare_dependency(dependencies: nvonnxparser_lib)
+
+    if tensorrt_major < 10 and not get_option('tensorrt-support').disabled()
+      nvuffparsers_lib = cxx.find_library('nvuffparsers', required: false)
+      if nvuffparsers_lib.found() and cxx.has_header('NvUffParser.h')
+        nvuffparsers_dep = declare_dependency(dependencies: nvuffparsers_lib)
+      endif
+    elif tensorrt_major >= 10 and not get_option('tensorrt10-support').disabled()
+      nvonnxparser_lib = cxx.find_library('nvonnxparser', required: false)
+      if nvonnxparser_lib.found() and cxx.has_header('NvOnnxParser.h')
+        nvonnxparser_dep = declare_dependency(dependencies: nvonnxparser_lib)
+      endif
     endif
   endif
 endif
@@ -414,6 +428,79 @@ if not get_option('datarepo-support').disabled() and not json_glib_dep.found()
   message('datarepo-support is off because json-glib-1.0 is not available.')
 endif
 
+# Python3
+have_python3 = false
+if not get_option('python3-support').disabled()
+  # Check python 3.x
+  python3_dep = dependency('python3', required: false)
+  if python3_dep.found() and python3_dep.version().version_compare('>= 3.8')
+    # The name of .pc file provides C/CXX/LD_FLAGS for Python C API has been changed since v3.8
+    python3_dep = dependency('python3-embed', required: false)
+  endif
+
+  if python3_dep.found()
+    pg_pkgconfig = find_program('pkg-config')
+
+    python3_inc_args = []
+    python3_inc_args += run_command(pg_pkgconfig, ['python3', '--cflags'], check : true).stdout().strip().split()
+    python3_inc_args += run_command('python3', ['-c', 'import site\nfor i in site.getsitepackages(): print("-I" + i + "/numpy/core/include")'], check : true).stdout().strip().split()
+    r = run_command('python3', ['-m', 'site', '--user-site'], check : false)
+    if r.returncode() == 0
+      python3_inc_args += '-I' + r.stdout().strip() + '/numpy/core/include'
+    endif
+    python3_inc_valid_args = []
+
+    foreach python3_inc_arg : python3_inc_args
+      if cxx.has_argument(python3_inc_arg) and \
+          cxx.check_header('numpy/arrayobject.h', args : python3_inc_arg, dependencies : python3_dep)
+        python3_inc_valid_args += python3_inc_arg
+        have_python3 = true
+        break
+      endif
+    endforeach
+
+    if have_python3
+      python3_dep = declare_dependency(dependencies: python3_dep,
+          compile_args : python3_inc_valid_args)
+    else
+      warning('Found python3, but failed to find numpy.')
+      warning('Disable nnstreamer-python3.')
+      python3_dep = disabler()
+    endif
+  endif
+
+  if get_option('python3-support').enabled() and not have_python3
+    error('Cannot find python3 with numpy support')
+  endif
+endif
+
+# dali
+dali_dep = dependency('', required: false)
+if not get_option('dali-support').disabled() and have_python3
+  # Read include folder, lib folder, compile args
+  dali_config_cmd = run_command(find_program('tools/dali-config.sh'), check: false)
+  if dali_config_cmd.returncode() != 0
+    message('ERROR: tools/dali-config.sh exited with exit code: @0@, dali-support will be disabled.'.format(dali_config_cmd.returncode()))
+  else
+    dali_config = dali_config_cmd.stdout().split()
+    dali_inc_folder = dali_config[0]
+    dali_lib_folder = dali_config[1]
+    dali_compile_args = dali_config[2]
+    dali_lib = cxx.find_library('dali', required: false, dirs: [dali_lib_folder])
+    dali_core_lib = cxx.find_library('dali_core', required: false, dirs: [dali_lib_folder])
+    dali_kernels_lib = cxx.find_library('dali_kernels', required: false, dirs: [dali_lib_folder])
+    dali_operators_lib = cxx.find_library('dali_operators', required: false, dirs: [dali_lib_folder])
+    if (dali_lib.found() and dali_core_lib.found() and dali_kernels_lib.found() and dali_operators_lib.found() and cxx.has_header(dali_inc_folder + '/dali/c_api.h'))
+      dali_inc = include_directories(dali_inc_folder, is_system: true)
+      dali_dep = declare_dependency(
+        dependencies: [ dali_lib, dali_core_lib, dali_kernels_lib, dali_operators_lib ],
+        include_directories: [ dali_inc ],
+        compile_args: [ dali_compile_args ]
+      )
+    endif
+  endif
+endif
+
 # features registration to be controlled
 #
 # register feature as follows
@@ -490,6 +577,10 @@ features = {
   'tensorrt10-support': {
     'extra_deps': [ nvinfer_dep, nvonnxparser_dep, cuda_dep, cudart_dep ],
     'project_args': { 'ENABLE_TENSORRT10': 1 }
+  },
+  'dali-support': {
+    'extra_deps': [ dali_dep, cuda_dep, cudart_dep ],
+    'project_args': { 'ENABLE_DALI': 1 }
   },
   'grpc-support': {
     'extra_deps': [ grpc_dep, gpr_dep, grpcpp_dep ],
@@ -616,52 +707,6 @@ if not (pytorch_support_is_available or caffe2_support_is_available)
   endif
   if cxx.has_argument (redundant_decls_flag)
     add_project_arguments([redundant_decls_flag], language: 'cpp')
-  endif
-endif
-
-# Python3
-have_python3 = false
-if not get_option('python3-support').disabled()
-  # Check python 3.x
-  python3_dep = dependency('python3', required: false)
-  if python3_dep.found() and python3_dep.version().version_compare('>= 3.8')
-    # The name of .pc file provides C/CXX/LD_FLAGS for Python C API has been changed since v3.8
-    python3_dep = dependency('python3-embed', required: false)
-  endif
-
-  if python3_dep.found()
-    pg_pkgconfig = find_program('pkg-config')
-
-    python3_inc_args = []
-    python3_inc_args += run_command(pg_pkgconfig, ['python3', '--cflags'], check : true).stdout().strip().split()
-    python3_inc_args += run_command('python3', ['-c', 'import site\nfor i in site.getsitepackages(): print("-I" + i + "/numpy/core/include")'], check : true).stdout().strip().split()
-    r = run_command('python3', ['-m', 'site', '--user-site'], check : false)
-    if r.returncode() == 0
-      python3_inc_args += '-I' + r.stdout().strip() + '/numpy/core/include'
-    endif
-    python3_inc_valid_args = []
-
-    foreach python3_inc_arg : python3_inc_args
-      if cxx.has_argument(python3_inc_arg) and \
-          cxx.check_header('numpy/arrayobject.h', args : python3_inc_arg, dependencies : python3_dep)
-        python3_inc_valid_args += python3_inc_arg
-        have_python3 = true
-        break
-      endif
-    endforeach
-
-    if have_python3
-      python3_dep = declare_dependency(dependencies: python3_dep,
-          compile_args : python3_inc_valid_args)
-    else
-      warning('Found python3, but failed to find numpy.')
-      warning('Disable nnstreamer-python3.')
-      python3_dep = disabler()
-    endif
-  endif
-
-  if get_option('python3-support').enabled() and not have_python3
-    error('Cannot find python3 with numpy support')
   endif
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -32,6 +32,7 @@ option('parser-support', type: 'feature', value: 'auto') # gstreamer pipeline de
 option('datarepo-support', type: 'feature', value: 'auto', description: 'Data repository sink/src for in-pipeline training') # this required json-glib-1.0.
 option('ml-agent-support', type: 'feature', value: 'auto')
 option('onnxruntime-support', type: 'feature', value: 'auto')
+option('dali-support', type: 'feature', value: 'auto')
 
 # booleans & other options
 option('enable-test', type: 'boolean', value: true)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -492,4 +492,13 @@ if get_option('install-test')
   install_subdir('transform_stand', install_dir: unittest_install_dir)
   install_subdir('transform_transpose', install_dir: unittest_install_dir)
   install_subdir('transform_typecast', install_dir: unittest_install_dir)
+  if dali_support_is_available
+    install_subdir('nnstreamer_filter_dali', install_dir: unittest_install_dir)
+    create_dali_pipeline = executable('create_dali_pipeline',
+      join_paths('nnstreamer_filter_dali', 'create_dali_pipeline.cc'),
+      dependencies: [dali_dep, cuda_dep, cudart_dep],
+      install: get_option('install-test'),
+      install_dir: join_paths(unittest_install_dir, 'nnstreamer_filter_dali'),
+    )
+  endif
 endif

--- a/tests/nnstreamer_filter_dali/create_dali_pipeline.cc
+++ b/tests/nnstreamer_filter_dali/create_dali_pipeline.cc
@@ -1,0 +1,167 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Tool to create a dali pipeline for testing purposes.
+ * Copyright (C) 2024 Bram Veldhoen
+ */
+/**
+ * @file        create_dali_pipeline.cc
+ * @date        Jun 2024
+ * @brief       Tool to create a dali pipeline for testing purposes.
+ * @see         http://github.com/nnstreamer/nnstreamer
+ * @see         https://github.com/NVIDIA/DALI
+ * @author      Bram Veldhoen
+ * @bug         No known bugs except for NYI items
+ *
+ * Tool to create a dali pipeline for testing purposes.
+ *
+ */
+
+#define _GLIBCXX_USE_CXX11_ABI 0
+
+#include <dali/pipeline/pipeline.h>
+#include <dali/pipeline/workspace/workspace.h>
+#include "dali/operators.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+using namespace dali;
+
+void
+usage ()
+{
+  std::cout << "Usage: create_dali_pipeline <output_folder> [<H> [<W> [<C>]]]" << std::endl;
+  std::cout << "  output_folder: Folder in which to store the created pipeline binary file."
+            << std::endl;
+  std::cout << "  H: Output height of the preprocessed image." << std::endl;
+  std::cout << "  W: Output width of the preprocessed image." << std::endl;
+  std::cout << "  C: Number of channels of the preprocessed image." << std::endl;
+}
+
+int
+main (int argc, char *argv[])
+{
+  if ((argc < 2) || (argc > 5)) {
+    usage ();
+    return EXIT_FAILURE;
+  }
+
+  std::filesystem::path output_folder{ argv[1] };
+  if (!std::filesystem::exists (output_folder)) {
+    std::cerr << "Specified output path does not exist: " << argv[1] << std::endl
+              << std::endl;
+    usage ();
+    return EXIT_FAILURE;
+  }
+
+  int H_out{ 320 };
+  int W_out{ 320 };
+  int C{ 3 };
+  if (argc >= 3) {
+    H_out = atoi (argv[2]);
+    if (H_out == 0) {
+      std::cerr << "Specified H_out invalid: " << argv[2] << std::endl
+                << std::endl;
+      usage ();
+      return EXIT_FAILURE;
+    }
+  }
+  if (argc >= 4) {
+    W_out = atoi (argv[3]);
+    if (W_out == 0) {
+      std::cerr << "Specified W_out invalid: " << argv[3] << std::endl
+                << std::endl;
+      usage ();
+      return EXIT_FAILURE;
+    }
+  }
+  if (argc >= 5) {
+    C = atoi (argv[4]);
+    if (C == 0) {
+      std::cerr << "Specified C invalid: " << argv[4] << std::endl << std::endl;
+      usage ();
+      return EXIT_FAILURE;
+    }
+  }
+
+  InitOperatorsLib ();
+
+  int max_batch_size{ 1 };
+  int num_threads{ 1 };
+  int device_id{ 0 };
+  int seed = { -1 };
+  bool pipelined_execution{ true };
+  int prefetch_queue_depth{ 1 };
+  bool async_execution{ true };
+
+  std::string serialized_pipe_filename ("dali_pipeline_N_" + std::to_string (C)
+                                        + "_" + std::to_string (H_out) + "_"
+                                        + std::to_string (W_out) + ".bin");
+  auto output_path = output_folder / serialized_pipe_filename;
+
+  // Create the pipeline
+  Pipeline pipe (max_batch_size, num_threads, device_id, seed,
+      pipelined_execution, prefetch_queue_depth, async_execution);
+
+  // Add pipeline operators
+  // Input: (N, H, W, C), dtype=uint8, Output: (N, H, W, C), dtype=uint8
+  pipe.AddOperator (OpSpec ("ExternalSource")
+                        .AddArg ("batch", false)
+                        .AddArg ("device", "cpu")
+                        .AddArg ("dtype", DALIDataType::DALI_UINT8)
+                        .AddArg ("name", "input0")
+                        .AddArg ("ndim", 4)
+                        .AddOutput ("input0", "cpu"),
+      "input0");
+  // Input: (N, H, W, C), dtype=uint8, Output: (N, H, W, C), dtype=uint8
+  pipe.AddOperator (OpSpec ("MakeContiguous")
+                        .AddArg ("device", "mixed")
+                        .AddInput ("input0", "cpu")
+                        .AddOutput ("input0_gpu", "gpu"));
+  // Input: (N, H, W, C), dtype=uint8, Output: (N, W_out, H_out, C), dtype=uint8
+  pipe.AddOperator (OpSpec ("Resize")
+                        .AddArg ("antialias", false)
+                        .AddArg ("device", "gpu")
+                        .AddArg ("dtype", DALIDataType::DALI_UINT8)
+                        .AddArg ("interp_type", DALIInterpType::DALI_INTERP_LINEAR)
+                        .AddArg ("resize_x", static_cast<float> (W_out))
+                        .AddArg ("resize_y", static_cast<float> (H_out))
+                        .AddInput ("input0_gpu", "gpu")
+                        .AddOutput ("resized", "gpu"));
+  // Input: (N, W_out, H_out, C), dtype=uint8, Output: (N, W_out, H_out, C), dtype=float32
+  pipe.AddOperator (OpSpec ("ArithmeticGenericOp")
+                        .AddArg ("device", "gpu")
+                        .AddArg ("expression_desc", "fdiv(&0 $0:int32)")
+                        .AddArg ("integer_constants", std::vector<int>{ 255 })
+                        .AddInput ("resized", "gpu")
+                        .AddOutput ("normalized", "gpu"));
+  // Input: (N, W_out, H_out, C), dtype=float32, Output: (N, C, W_out, H_out), dtype=float32
+  std::vector<int> perm{ 0, 3, 1, 2 };
+  pipe.AddOperator (OpSpec ("Transpose")
+                        .AddArg ("device", "gpu")
+                        .AddArg ("output_layout", "FCHW")
+                        .AddArg ("perm", perm)
+                        .AddInput ("normalized", "gpu")
+                        .AddOutput ("output0", "gpu"));
+
+  // Build the pipeline
+  std::vector<std::pair<std::string, std::string>> outputs = { { "output0", "gpu" } };
+  pipe.Build (outputs);
+
+  // Serialize the pipeline
+  auto serialized_pipe_str = pipe.SerializeToProtobuf ();
+
+  // Save to file
+  std::ofstream serialized_pipe_out (output_path);
+  serialized_pipe_out << serialized_pipe_str;
+  serialized_pipe_out.close ();
+
+  // Deserialize the pipeline
+  Pipeline pipe2 (serialized_pipe_str);
+  pipe2.Build ();
+
+  return 0;
+}

--- a/tests/nnstreamer_filter_dali/runTest.sh
+++ b/tests/nnstreamer_filter_dali/runTest.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
+## @file runTest.sh
+## @author Bram Veldhoen
+## @date Jun 2024
+## @brief SSAT Test Cases for NNStreamer
+##
+
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}"
+fi
+
+# This is compatible with SSAT (https://github.com/myungjoo/SSAT)
+testInit $1
+
+# NNStreamer and plugins path for test
+PATH_TO_PLUGIN="../../build"
+
+if [[ -d $PATH_TO_PLUGIN ]]; then
+    ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
+    if [[ -d ${ini_path} ]]; then
+        check=$(ls ${ini_path} | grep dali.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find dali shared lib"
+            report
+            exit
+        fi
+    else
+        echo "Cannot find ${ini_path}"
+    fi
+else
+    ini_file="/etc/nnstreamer.ini"
+    if [[ -f ${ini_file} ]]; then
+        path=$(grep "^filters" ${ini_file})
+        key=${path%=*}
+        value=${path##*=}
+
+        if [[ $key != "filters" ]]; then
+            echo "String Error"
+            report
+            exit
+        fi
+
+        if [[ -d ${value} ]]; then
+            check=$(ls ${value} | grep dali.so)
+            if [[ ! $check ]]; then
+                echo "Cannot find dali lib"
+                report
+                exit
+            fi
+        else
+            echo "Cannot find ${value}"
+            report
+            exit
+        fi
+    else
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
+    fi
+fi
+
+# Create the dali pipeline
+./create_dali_pipeline ./ 320 320 3
+
+PATH_TO_PIPELINE="dali_pipeline_N_3_320_320.bin"
+PATH_TO_IMAGE="../test_models/data/orange.png"
+PATH_TO_LOG="dali_result_%1d.log"
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+    filesrc location=${PATH_TO_IMAGE} ! \
+    pngdec ! \
+    videoscale ! \
+    imagefreeze ! \
+    videoconvert ! \
+    capsfilter caps=video/x-raw,width=1000,height=1000,format=RGB,framerate=0/1 ! \
+    tensor_converter ! \
+    capsfilter caps=other/tensors,num_tensors=1,types=uint8,dimensions=3:1000:1000:1,format=static ! \
+    tensor_filter framework=dali model=${PATH_TO_PIPELINE} inputname=input0 input=3:1000:1000:1 inputtype=uint8 output=320:320:3:1 outputtype=float32 ! \
+    capsfilter caps=other/tensors,num_tensors=1,types=float32,dimensions=320:320:3:1,format=static ! \
+    filesink location=${PATH_TO_LOG} " \
+    1 0 0 $PERFORMANCE
+
+# Cleanup
+rm dali_result_*.log*
+
+report

--- a/tools/cuda-version.sh
+++ b/tools/cuda-version.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+set -e
 nvcc --version | grep release | awk '{print $5}' | tr ',' ' '

--- a/tools/dali-config.sh
+++ b/tools/dali-config.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+python3 -c "import nvidia.dali as dali; print(dali.sysconfig.get_include_dir()); print(dali.sysconfig.get_lib_dir()); print(\" \".join(dali.sysconfig.get_compile_flags()))"

--- a/tools/tensorrt-version.sh
+++ b/tools/tensorrt-version.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 NV_INFER_VERSION_H=$(find /usr/include -iname "NvInferVersion.h")
 if [ -z ${NV_INFER_VERSION_H} ]; then
   exit


### PR DESCRIPTION
This PR adds a tensor_filter for dali pipelines. See also https://github.com/NVIDIA/DALI. Only dali pipeline operators implemented in C++ are supported. The tensor_filter_dali uses the DALI c_api (which may be subject to change). By using the dali pipeline GPU operators, the preprocessing steps can be executed leveraging cuda acceleration.

The dali pipeline used for testing purposes is created using tests/nnstreamer_filter_dali/create_dali_pipeline.cpp. The created binary file (dali_pipeline_N_3_320_320.bin) contains the protobuf binary serialized representation of the dali pipeline.