### PR TITLE
Fix typos

### DIFF
--- a/ext/nnstreamer/include/nnstreamer.fbs
+++ b/ext/nnstreamer/include/nnstreamer.fbs
@@ -25,7 +25,7 @@ enum Tensor_type : int {
   }
 
 enum Tensor_format : int {
-  NNS_TENSOR_FORAMT_STATIC = 0,
+  NNS_TENSOR_FORMAT_STATIC = 0,
   NNS_TENSOR_FORMAT_FLEXIBLE,
   NNS_TENSOR_FORMAT_SPARSE,
 
@@ -48,7 +48,7 @@ table Tensors {
   num_tensor : int;
   fr : frame_rate;
   tensor : [Tensor]; // tensor size is limited to 16
-  format : Tensor_format = NNS_TENSOR_FORAMT_STATIC;
+  format : Tensor_format = NNS_TENSOR_FORMAT_STATIC;
 }
 
 root_type Tensors;

--- a/ext/nnstreamer/include/nnstreamer.proto
+++ b/ext/nnstreamer/include/nnstreamer.proto
@@ -34,7 +34,7 @@ message Tensors {
   frame_rate fr = 2;
   repeated Tensor tensor = 3;
   enum Tensor_format {
-    NNS_TENSOR_FORAMT_STATIC = 0;
+    NNS_TENSOR_FORMAT_STATIC = 0;
     NNS_TENSOR_FORMAT_FLEXIBLE = 1;
     NNS_TENSOR_FORMAT_SPARSE = 2;
   }


### PR DESCRIPTION
Fix typos in flatbuf and protobuf schema file.
Since tensor type are managed as enum value from the generated header, there is no problem changing tensor type name .


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


