### PR TITLE
[CodeClean] util to get nth info

### DIFF
--- a/ext/nnstreamer/tensor_decoder/box_properties/ovdetection.cc
+++ b/ext/nnstreamer/tensor_decoder/box_properties/ovdetection.cc
@@ -116,6 +116,7 @@ OVDetection::checkCompatible (const GstTensorsConfig *config)
 {
   const guint *dim;
   int i;
+  GstTensorInfo *info = nullptr;
   UNUSED (total_labels);
 
   if (!check_tensors (config, DEFAULT_MAX_TENSORS))
@@ -125,7 +126,8 @@ OVDetection::checkCompatible (const GstTensorsConfig *config)
    * The shape of the output tensor is [7, N, 1, 1], where N is the maximum
    * number (i.e., 200) of detected bounding boxes.
    */
-  dim = config->info.info[0].dimension;
+  info = gst_tensors_info_get_nth_info ((GstTensorsInfo *) &config->info, 0);
+  dim = info->dimension;
   g_return_val_if_fail (dim[0] == DEFAULT_SIZE_DETECTION_DESC, FALSE);
   g_return_val_if_fail (dim[1] == DETECTION_MAX, FALSE);
   for (i = 2; i < NNS_TENSOR_RANK_LIMIT; ++i)
@@ -144,12 +146,14 @@ OVDetection::decode (const GstTensorsConfig *config, const GstTensorMemory *inpu
 {
   GArray *results = NULL;
   const guint num_tensors = config->info.num_tensors;
+  GstTensorInfo *info = nullptr;
 
   /* Already checked with getOutCaps. Thus, this is an internal bug */
   g_assert (num_tensors >= DEFAULT_MAX_TENSORS);
 
   results = g_array_sized_new (FALSE, TRUE, sizeof (detectedObject), DETECTION_MAX);
-  switch (config->info.info[0].type) {
+  info = gst_tensors_info_get_nth_info ((GstTensorsInfo *) &config->info, 0);
+  switch (info->type) {
     _get_persons_ov (uint8_t, input[0].data, _NNS_UINT8, results);
     _get_persons_ov (int8_t, input[0].data, _NNS_INT8, results);
     _get_persons_ov (uint16_t, input[0].data, _NNS_UINT16, results);

--- a/ext/nnstreamer/tensor_decoder/box_properties/yolo.cc
+++ b/ext/nnstreamer/tensor_decoder/box_properties/yolo.cc
@@ -121,9 +121,12 @@ YoloV5::setOptionInternal (const char *param)
 int
 YoloV5::checkCompatible (const GstTensorsConfig *config)
 {
-  const guint *dim = config->info.info[0].dimension;
+  GstTensorInfo *info = nullptr;
+  const guint *dim;
   int i;
 
+  info = gst_tensors_info_get_nth_info ((GstTensorsInfo *) &config->info, 0);
+  dim = info->dimension;
   if (!check_tensors (config, 1U))
     return FALSE;
 
@@ -152,6 +155,7 @@ YoloV5::decode (const GstTensorsConfig *config, const GstTensorMemory *input)
   int cIdx, numTotalClass, cStartIdx, cIdxMax;
   float *boxinput;
   int is_output_scaled = scaled_output;
+  GstTensorInfo *info = nullptr;
 
   numTotalBox = max_detection;
   numTotalClass = total_labels;
@@ -162,7 +166,9 @@ YoloV5::decode (const GstTensorsConfig *config, const GstTensorMemory *input)
   boxinput = (float *) input[0].data;
 
   /** Only support for float type model */
-  g_assert (config->info.info[0].type == _NNS_FLOAT32);
+
+  info = gst_tensors_info_get_nth_info ((GstTensorsInfo *) &config->info, 0);
+  g_assert (info->type == _NNS_FLOAT32);
 
   results = g_array_sized_new (FALSE, TRUE, sizeof (detectedObject), numTotalBox);
   for (bIdx = 0; bIdx < numTotalBox; ++bIdx) {

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
@@ -385,7 +385,11 @@ check_tensors (const GstTensorsConfig *config, const unsigned int limit)
 
   /* tensor-type of the tensors should be the same */
   for (i = 1; i < config->info.num_tensors; ++i) {
-    g_return_val_if_fail (config->info.info[i - 1].type == config->info.info[i].type, FALSE);
+    g_return_val_if_fail (
+        gst_tensors_info_get_nth_info ((GstTensorsInfo *) &config->info, i - 1)->type
+            == gst_tensors_info_get_nth_info ((GstTensorsInfo *) &config->info, i)
+                   ->type,
+        FALSE);
   }
   return TRUE;
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.h
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.h
@@ -109,6 +109,7 @@
 #include <math.h> /* expf */
 #include <nnstreamer_log.h>
 #include <nnstreamer_util.h>
+#include <nnstreamer_plugin_api_util.h>
 #include "tensordecutil.h"
 
 #define PIXEL_VALUE (0xFF0000FF) /* RED 100% in RGBA */

--- a/tests/nnstreamer_decoder_boundingbox/runTest.sh
+++ b/tests/nnstreamer_decoder_boundingbox/runTest.sh
@@ -118,6 +118,10 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=yolov8_decode
 
 callCompareTest yolov8_result_golden.raw yolov8_result_0.log "8 diff" "yolov8 golden" 0
 
+# negative case for box properties
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=10 ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! videoconvert ! tensor_converter ! tensor_decoder mode=bounding_boxes option1=wrong_mode_name ! fakesink " 9_n 0 1
+
 rm yolov*.log
 
 report


### PR DESCRIPTION
This patch use util to get nth info in tensor_decoder bounding box and add test case.

https://github.com/nnstreamer/nnstreamer/pull/4427#issuecomment-2114713513

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

