### PR TITLE
don't assert on PyIsInitialized.

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_python3_helper.cc
+++ b/ext/nnstreamer/extra/nnstreamer_python3_helper.cc
@@ -584,7 +584,10 @@ nnstreamer_python_status_check ()
     return -EINVAL;
   }
 
-  assert (Py_IsInitialized ());
+  if (!Py_IsInitialized ()) {
+    fprintf (stderr, "Py_IsInitialized () is FALSE. If nnstreamer is called by python context, please ignore this error.");
+    return -EINVAL;
+  }
   return 0;
 }
 


### PR DESCRIPTION
It is possible that python-status-check is called
when PyIsInitialized is false (refer to #4523)

Trying to fix #4523

CC: @liuhao-97
