### PR TITLE
[TEST] increase timeout for state change

### DIFF
--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 #define _print_log(...) do { if (DBG) g_message (__VA_ARGS__); } while (0)
 
-#define UNITTEST_STATECHANGE_TIMEOUT (2000U)
+#define UNITTEST_STATECHANGE_TIMEOUT (10000U) /* 10 secs */
 #define TEST_DEFAULT_SLEEP_TIME (10000U)
 #define TEST_TIMEOUT_LIMIT (10000000U) /* 10 secs */
 #define TEST_TIMEOUT_LIMIT_MS (10000U) /* 10 secs */


### PR DESCRIPTION
State change tests in the armv7l architecture is too long. Let's increase the timeout limit.

```
[  638s] [ RUN      ] nnstreamerFilterSharedModel.tfliteSharedReload
[  638s] ** Message: 09:59:55.720: accl = cpu
[  638s] ** Message: 09:59:55.725: accl = cpu
[  640s] ../tests/nnstreamer_filter_shared_model/unittest_filter_shared_model.cc:174: Failure
[  640s] Expected equality of these values:
[  640s]   setPipelineStateSync (pipeline, GST_STATE_PLAYING, (2000U))
[  640s]     Which is: -62
[  640s]   0
[  640s]
[  641s] ../tests/nnstreamer_filter_shared_model/unittest_filter_shared_model.cc:180: Failure
[  641s] Expected: (res[0]) != (0U), actual: 0 vs 0
[  641s]
[  643s] [  FAILED  ] nnstreamerFilterSharedModel.tfliteSharedReload (4570 ms)
```


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
