### PR TITLE
[filter] Add custom prop `OutputTensor`, `OutputType`, and `InputType` for snpe 

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_snpe.cc
@@ -250,7 +250,7 @@ snpe_subplugin::configure_instance (const GstTensorFilterProperties *prop)
 
     /* assign user_buffermap */
     size_t bufsize = gst_tensor_info_get_size (info);
-    Snpe_UserBufferEncoding_Handle_t ube_h;
+    Snpe_UserBufferEncoding_Handle_t ube_h = NULL;
     if (type == SNPE_USERBUFFERENCODING_ELEMENTTYPE_TF8) {
       Snpe_IBufferAttributes_Handle_t bufferAttributesOpt
           = Snpe_SNPE_GetInputOutputBufferAttributes (snpe_h, tensorName);


### PR DESCRIPTION
[prop `OutputTensor`]
- Let snpe subplugin set output tensor names provided by `OutputTensor`
  custom property.
- Each name should be sepearted by `;` (if OutputTensor is plural)
- Example usage:
  ... model=model.dlc custom=OutputTensor:"output_0;output_1" ...

[prop `InputType` and `OutputType`]
- Let snpe subplugin set types for input/output tensors.
- The value should be one of {"FLOAT32", "TF8"}
- Each value should be seperated by `;` (if plural)
- The order should follow the order of input/output tensors in the model.
- Example usage:
  ... custom=InputType:TF8,OutputType:"FLOAT32,FLOAT32" ...
- If type is not specified, use default type of the given model.
  - quanitzed model can use both float32 and tf8,
    non-quantized model can only use float32.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
