### PR TITLE
[CodeClean] invalid function to handle mem block

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_protobuf.cc
+++ b/ext/nnstreamer/extra/nnstreamer_protobuf.cc
@@ -118,7 +118,7 @@ gst_tensor_decoder_protobuf (const GstTensorsConfig *config,
   if (outbuf_size == 0)
     gst_buffer_append_memory (outbuf, out_mem);
   else
-    gst_memory_unref (out_mem);
+    gst_buffer_replace_all_memory (outbuf, out_mem);
 
   return GST_FLOW_OK;
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
@@ -932,7 +932,7 @@ BoundingBox::decode (const GstTensorsConfig *config,
   if (need_output_alloc)
     gst_buffer_append_memory (outbuf, out_mem);
   else
-    gst_memory_unref (out_mem);
+    gst_buffer_replace_all_memory (outbuf, out_mem);
 
   return GST_FLOW_OK;
 

--- a/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
@@ -371,7 +371,7 @@ dv_decode (void **pdata, const GstTensorsConfig * config,
   if (gst_buffer_get_size (outbuf) == 0)
     gst_buffer_append_memory (outbuf, out_mem);
   else
-    gst_memory_unref (out_mem);
+    gst_buffer_replace_all_memory (outbuf, out_mem);
 
   /** @todo Caller of dv_decode in tensordec.c should call gst_memory_unmap to inbuf */
 

--- a/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flatbuf.cc
@@ -172,7 +172,7 @@ fbd_decode (void **pdata, const GstTensorsConfig *config,
   if (gst_buffer_get_size (outbuf) == 0)
     gst_buffer_append_memory (outbuf, out_mem);
   else
-    gst_memory_unref (out_mem);
+    gst_buffer_replace_all_memory (outbuf, out_mem);
 
   return GST_FLOW_OK;
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-flexbuf.cc
@@ -197,7 +197,7 @@ flxd_decode (void **pdata, const GstTensorsConfig *config,
   if (need_alloc)
     gst_buffer_append_memory (outbuf, out_mem);
   else
-    gst_memory_unref (out_mem);
+    gst_buffer_replace_all_memory (outbuf, out_mem);
 
   return GST_FLOW_OK;
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
@@ -238,7 +238,7 @@ il_decode (void **pdata, const GstTensorsConfig * config,
   if (gst_buffer_get_size (outbuf) == 0)
     gst_buffer_append_memory (outbuf, out_mem);
   else
-    gst_memory_unref (out_mem);
+    gst_buffer_replace_all_memory (outbuf, out_mem);
 
   return GST_FLOW_OK;
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
@@ -620,7 +620,7 @@ is_decode (void **pdata, const GstTensorsConfig * config,
   if (need_output_alloc)
     gst_buffer_append_memory (outbuf, out_mem);
   else
-    gst_memory_unref (out_mem);
+    gst_buffer_replace_all_memory (outbuf, out_mem);
 
   return GST_FLOW_OK;
 

--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -815,7 +815,7 @@ pose_decode (void **pdata, const GstTensorsConfig * config,
   if (gst_buffer_get_size (outbuf) == 0)
     gst_buffer_append_memory (outbuf, out_mem);
   else
-    gst_memory_unref (out_mem);
+    gst_buffer_replace_all_memory (outbuf, out_mem);
 
   return GST_FLOW_OK;
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-python3.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-python3.cc
@@ -187,7 +187,7 @@ PYDecoderCore::decode (const GstTensorsConfig *config,
     if (need_alloc)
       gst_buffer_append_memory (outbuf, out_mem);
     else
-      gst_memory_unref (out_mem);
+      gst_buffer_replace_all_memory (outbuf, out_mem);
 
     Py_SAFEDECREF (output);
   } else {

--- a/tests/nnstreamer_decoder/unittest_decoder.cc
+++ b/tests/nnstreamer_decoder/unittest_decoder.cc
@@ -90,7 +90,7 @@ tensor_decoder_custom_cb (const GstTensorMemory *input,
   if (need_alloc)
     gst_buffer_append_memory (out_buf, out_mem);
   else
-    gst_memory_unref (out_mem);
+    gst_buffer_replace_all_memory (out_buf, out_mem);
 
   return GST_FLOW_OK;
 }


### PR DESCRIPTION
If gst-buffer has multiple mem blocks, memory from get-all-memory function does not update original data.
Update function - replace old memory.
