### PR TITLE
[Action] Fix action job name

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  generate_github.io:
+  generate_hotdoc:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Fix invalid action job name
```
[Invalid workflow file: .github/workflows/publish_docs.yml#L11](https://github.com/nnstreamer/nnstreamer/actions/runs/10409426056/workflow)
The workflow is not valid. .github/workflows/publish_docs.yml (Line: 11, Col: 3): The identifier 'generate_github.io' is invalid. IDs may only contain alphanumeric characters, '_', and '-'. IDs must start with a letter or '_' and and must be less than 100 characters.
```
@todo: Remove gen doc from TAOS-CI

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped



