### PR TITLE
[filter] Fix qnn context config

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_qnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_qnn.cc
@@ -294,6 +294,7 @@ QnnManager::init (const char *model_path, const char *backend_path)
 
   /* Create Context */
   QnnContext_Config_t qnn_context_config = QNN_CONTEXT_CONFIG_INIT;
+  qnn_context_config.option = QNN_CONTEXT_CONFIG_OPTION_PRIORITY;
   qnn_context_config.priority = QNN_PRIORITY_NORMAL;
   const QnnContext_Config_t *context_configs[] = { &qnn_context_config, nullptr };
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -614,7 +614,7 @@ _gst_tensor_filter_transform_validate (GstBaseTransform * trans,
     return GST_FLOW_ERROR;
   }
 
-  silent_debug (self, "Invoking %s with %s model\n", priv->fw->name,
+  silent_debug (self, "Invoking %s with %s model\n", prop->fwname,
       GST_STR_NULL (prop->model_files[0]));
 
   /* skip input data when throttling delay is set */


### PR DESCRIPTION
- Set proper option to context_config.
-  Fix log of filter subplugin's name 

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
