### PR TITLE
[android] Let api-android build QNN tensor_filter

### DIFF
--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -115,6 +115,10 @@ NNSTREAMER_FILTER_SNPE_SRCS := \
     $(NNSTREAMER_EXT_HOME)/tensor_filter/tensor_filter_snpe_v1.cc
 endif
 
+# filter qnn
+NNSTREAMER_FILTER_QNN_SRCS := \
+    $(NNSTREAMER_EXT_HOME)/tensor_filter/tensor_filter_qnn.cc
+
 # filter snap
 NNSTREAMER_FILTER_SNAP_SRCS := \
     $(NNSTREAMER_EXT_HOME)/tensor_filter/tensor_filter_snap.cc


### PR DESCRIPTION
- Expose the source code in `jni/nnstreamer.mk` so that api/android build can use it.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

