### PR TITLE
[spec] Disable mlops-agent on VD Cosmos infra

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -119,6 +119,7 @@
 %define		trix_engine_support 0
 %define		onnxruntime_support 0
 %define		nnstreamer_edge_support 0
+%define		ml_agent_support 0
 %endif
 
 # Disable a few features for movable device


### PR DESCRIPTION
This patch disables the mlops-agent on VD Cosmos infra.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped


Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

