### PR TITLE
[action] Check yocto/meta-neural-network build per PR

### DIFF
--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -1,13 +1,16 @@
-name: Build test/ Yocto 4.0.15
+name: Build test / Yocto-5.0.3 (scarthgap-5.0.3)
 
 on:
   pull_request:
     branches: [ main ]
 
+  # Allow manually triggering the workflow
+  workflow_dispatch:
+
 jobs:
   build:
-    name: Build with Yocto devtool on Ubuntu
-    runs-on: ubuntu-20.04
+    name: Build with Yocto / meta-neural-network on Ubuntu
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -17,39 +20,69 @@ jobs:
       uses: ./.github/actions/check-rebuild
       with:
         mode: build
-    ## @todo Make cache works (daily update cache on main branch / restore the cache on each PR (not saving))
-    - name: Prepare build
-      if: env.rebuild == '1'
+
+    - name: make cache dir for yocto
+      ## prevent permission error
+      run: sudo mkdir --mode a=rwx --parents /var/cache/yocto
+
+    - name: restore yocto sstate and downloads cache
+      if: github.ref == 'refs/heads/main' || env.rebuild == '1'
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          /var/cache/yocto/downloads
+          /var/cache/yocto/sstate-cache
+          /var/cache/yocto/persistent
+        key: yocto-cache-yocto-5.0.3
+
+    - name: build
+      if: github.ref == 'refs/heads/main' || env.rebuild == '1'
       run: |
         echo "::group::apt-get install"
         sudo apt-get update
-        sudo apt-get install sudo curl diffstat python2.7 locales bash-completion qemu gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint3 xterm python3-subunit mesa-common-dev gzip libglib2.0-dev libjson-glib-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev googletest liborc-0.4-dev flex bison libopencv-dev pkg-config python3-dev python3-numpy git
-        sudo ln -sf python2.7 /usr/bin/python
+        sudo apt install gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 python3-subunit zstd liblz4-tool file locales libacl1
+        pip install websockets
+        sudo locale-gen en_US.UTF-8
         echo "::endgroup::"
-        echo "::group::Locale Setup"
-        sudo dpkg-reconfigure locales
-        sudo locale-gen "en_US.UTF-8"
-        sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-        export LC_ALL=en_US.UTF-8
-        export LANG=en_US.UTF-8
-        export LANGUAGE=en_US:en
-        locale
+
+        echo "::group::Prepare poky and meta-neural-network"
+        git clone git://git.yoctoproject.org/poky -b yocto-5.0.3 && cd poky
+        git clone https://github.com/nnstreamer/meta-neural-network -b scarthgap
+        echo 'SRC_URI = "git://${{ github.workspace }};protocol=file;usehead=1"' >> meta-neural-network/recipes-nnstreamer/nnstreamer/nnstreamer_%.bbappend
+        source oe-init-build-env
+        bitbake-layers add-layer ../meta-neural-network
         echo "::endgroup::"
-        echo "::group::eSDK install"
-        ## @todo Find a way to cache this.
-        if [[ -f ~/poky_sdk/environment-setup-cortexa57-poky-linux ]]; then
-          echo "There is a cached eSDK. Skip installing and reset previous builds"
-          . ~/poky_sdk/environment-setup-cortexa57-poky-linux
-          devtool reset -a -r
-        else
-          wget -nv https://downloads.yoctoproject.org/releases/yocto/yocto-4.0.15/toolchain/x86_64/poky-glibc-x86_64-core-image-minimal-cortexa57-qemuarm64-toolchain-ext-4.0.15.sh
-          sh poky-glibc-x86_64-core-image-minimal-cortexa57-qemuarm64-toolchain-ext-4.0.15.sh -d ~/poky_sdk
-        fi
+
+        echo "::group::Set local.conf"
+        echo 'DL_DIR = "/var/cache/yocto/downloads"' >> conf/local.conf
+        echo 'BB_GENERATE_MIRROR_TARBALLS = "1"' >> conf/local.conf
+        echo 'SSTATE_DIR = "/var/cache/yocto/sstate-cache"' >> conf/local.conf
+        echo 'BB_SIGNATURE_HANDLER = "OEEquivHash"' >> conf/local.conf
+        echo 'BB_HASHSERVE = "auto"' >> conf/local.conf
+        echo 'BB_HASHSERVE_UPSTREAM = "wss://hashserv.yoctoproject.org/ws"' >> conf/local.conf
+        echo 'SSTATE_MIRRORS ?= "file://.* http://cdn.jsdelivr.net/yocto/sstate/all/PATH;downloadfilename=PATH"' >> conf/local.conf
+        echo 'PERSISTENT_DIR="/var/cache/yocto/persistent"' >> conf/local.conf
         echo "::endgroup::"
-    - name: Build
-      if: env.rebuild == '1'
-      run: |
-        # Get meta-nerual-network
-        . ~/poky_sdk/environment-setup-cortexa57-poky-linux
-        devtool add metaneuralnetwork http://github.com/nnstreamer/meta-neural-network.git
-        devtool build metaneuralnetwork
+
+        echo "::group::Do setscene-only task and disregard its error"
+        bitbake --setscene-only nnstreamer || true
+        echo "::endgroup::"
+
+        echo "::group::Build nnstreamer"
+        bitbake --skip-setscene nnstreamer
+        echo "::endgroup::"
+
+        echo "::group::Cat build log"
+        cat tmp/work/core2-64-poky-linux/nnstreamer/*/temp/log.do_configure || true
+        cat tmp/work/core2-64-poky-linux/nnstreamer/*/temp/log.do_compile || true
+        echo "::endgroup::"
+
+    - name: save yocto cache (main branch only)
+      uses: actions/cache/save@v4
+      if: always() && github.ref == 'refs/heads/main'
+      with:
+        path: |
+          /var/cache/yocto/downloads
+          /var/cache/yocto/sstate-cache
+          /var/cache/yocto/persistent
+        key: yocto-cache-yocto-5.0.3


### PR DESCRIPTION
- Existing yocto workflow technically does not build nnstreamer.
  This fixes the worfklow to handle yocto cache and build nnstreamer.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

