### PR TITLE
[fix] Resolve CodeQL alerts

### DIFF
--- a/gst/datarepo/gstdatareposrc.c
+++ b/gst/datarepo/gstdatareposrc.c
@@ -339,7 +339,7 @@ gst_data_repo_src_parse_caps (GstDataRepoSrc * src, GstCaps * caps)
       channel = GST_AUDIO_INFO_CHANNELS (&audio_info);
       depth = GST_AUDIO_INFO_DEPTH (&audio_info);
 
-      src->sample_size = channel * (depth / 8) * rate;
+      src->sample_size = (gsize) channel * (depth / 8) * rate;
 
       GST_DEBUG_OBJECT (src,
           "format(%s), depth(%d), rate(%d), channel(%d): %zd bps",

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -1767,9 +1767,9 @@ gst_tensor_transform_padding (GstTensorTransform * filter,
   guint i, j, k, left, top, front, loop_limit = 1;
   element_size = gst_tensor_get_element_size (in_info->type);
 
-  in_loop_size = in_info->dimension[2] * in_info->dimension[1]
+  in_loop_size = (gsize) in_info->dimension[2] * in_info->dimension[1]
       * in_info->dimension[0] * element_size;
-  out_loop_size = out_info->dimension[2] * out_info->dimension[1]
+  out_loop_size =(gsize) out_info->dimension[2] * out_info->dimension[1]
       * out_info->dimension[0] * element_size;
   copy_block_size = in_info->dimension[0] * element_size;
 

--- a/tests/get_available_port.py
+++ b/tests/get_available_port.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
     # Bind to any available port
-    s.bind(('', 0))
+    s.bind(('127.0.0.1', 0))
     addr = s.getsockname()
     s.close()
 


### PR DESCRIPTION
This resolves some CodeQL alerts
- Binding test socket to a address
- Converting to larger type

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
