### PR TITLE
JNI/NDK: Add llama2.c sources to nnstreamer.mk

### DIFF
--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -127,6 +127,10 @@ NNSTREAMER_FILTER_SNAP_SRCS := \
 NNSTREAMER_FILTER_MXNET_SRCS := \
     $(NNSTREAMER_EXT_HOME)/tensor_filter/tensor_filter_mxnet.cc
 
+# filter llama2.c
+NNSTREAMER_FILTER_LLAMA2C_SRCS := \
+    $(NNSTREAMER_EXT_HOME)/tensor_filter/tensor_filter_llama2.cc
+
 # converter flatbuffers
 NNSTREAMER_CONVERTER_FLATBUF_SRCS := \
     $(NNSTREAMER_EXT_HOME)/tensor_converter/tensor_converter_util.c \


### PR DESCRIPTION
This patch modifies nnstreamer.mk to import TensorFilter sub-plugin for llama2.c into NNStreamer's Android NDK build chain.

Signed-off-by: Wook Song <wook16.song@samsung.com>