### PR TITLE
[Test/Edge] fix mem leak

### DIFF
--- a/tests/nnstreamer_edge/nnstreamer-edge-custom-test.c
+++ b/tests/nnstreamer_edge/nnstreamer-edge-custom-test.c
@@ -109,12 +109,13 @@ nns_edge_custom_connect (void *priv)
   custom_h = (nns_edge_custom_test_s *) priv;
   custom_h->is_connected = 1;
 
-  /* Push dummy buffers to launch GstBaseSRc */
+  /* Push dummy buffer to launch GstBaseSrc */
   nns_edge_data_create (&data_h);
   raw_data = g_strdup ("Dummy data");
   nns_edge_data_add (data_h, raw_data, strlen (raw_data) + 1, g_free);
   nns_edge_event_invoke_callback (custom_h->event_cb, custom_h->user_data,
       NNS_EDGE_EVENT_NEW_DATA_RECEIVED, data_h, sizeof (nns_edge_data_h), NULL);
+  nns_edge_data_destroy (data_h);
 
   return NNS_EDGE_ERROR_NONE;
 }


### PR DESCRIPTION
Code clean, fix mem leak case when invoking event callback with data.
