### PR TITLE
[filter] Support invoke-dynamic for cpp subplugins

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
+++ b/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
@@ -37,7 +37,9 @@
 #ifdef __cplusplus
 
 #include <assert.h>
+#include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api_filter.h>
+#include <nnstreamer_util.h>
 #include <stdexcept>
 #include <stdint.h>
 #include <string.h>
@@ -178,6 +180,20 @@ class tensor_filter_subplugin
   /**< Mandatory virtual method.  Invoke NN.
 
        Possible exceptions: ... @todo describe them!
+   */
+
+  virtual void invoke_dynamic (GstTensorFilterProperties *prop,
+      const GstTensorMemory *input, GstTensorMemory *output)
+  {
+    UNUSED (prop);
+    UNUSED (input);
+    UNUSED (output);
+
+    nns_loge ("Dynamic invoke is not supported with this subplugin.");
+    assert (0);
+  }
+  /**< Optional. Invoke with dynamic output.
+   * Must set proper output info in prop.
    */
 
   virtual void getFrameworkInfo (GstTensorFilterFrameworkInfo &info) = 0;

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
@@ -161,10 +161,13 @@ tensor_filter_subplugin::cpp_invoke (const GstTensorFilterFramework *tf,
 
   GET_TFSP_WITH_CHECKS (obj, private_data);
   UNUSED (tf);
-  UNUSED (prop);
 
   try {
-    obj->invoke (input, output);
+    if (prop && prop->invoke_dynamic) {
+      obj->invoke_dynamic (prop, input, output);
+    } else {
+      obj->invoke (input, output);
+    }
   } catch (const std::invalid_argument &e) {
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
   } catch (const std::system_error &e) {


### PR DESCRIPTION
- Let cpp-class based subplugins do `invoke_dynamic`.
- If subplugin overrides `invoke_dynamic` filter would call it, otherwise asserts.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
