### PR TITLE
[Filter/cpp] invalid header include

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
+++ b/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
@@ -37,9 +37,7 @@
 #ifdef __cplusplus
 
 #include <assert.h>
-#include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api_filter.h>
-#include <nnstreamer_util.h>
 #include <stdexcept>
 #include <stdint.h>
 #include <string.h>
@@ -185,12 +183,10 @@ class tensor_filter_subplugin
   virtual void invoke_dynamic (GstTensorFilterProperties *prop,
       const GstTensorMemory *input, GstTensorMemory *output)
   {
-    UNUSED (prop);
-    UNUSED (input);
-    UNUSED (output);
-
-    nns_loge ("Dynamic invoke is not supported with this subplugin.");
-    assert (0);
+    assert (prop && prop->invoke_dynamic);
+    assert (input);
+    assert (output);
+    assert (0 && "Dynamic invoke is not supported with this subplugin.");
   }
   /**< Optional. Invoke with dynamic output.
    * Must set proper output info in prop.


### PR DESCRIPTION
The log util in nnstreamer is not exported, remove invalid header include.
