### PR TITLE
[Spec] Enable protobuf filter for Movable project

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -127,7 +127,6 @@
 %define		grpc_support 0
 %define		check_test 0
 %define		edgetpu_support 0
-%define		protobuf_support 0
 %define		python3_support 0
 %define		mvncsdk2_support 0
 %define		openvino_support 0


### PR DESCRIPTION
This patch enables the protobuf filter for Movable project.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
