### PR TITLE
[util] Let `gst_tensors_info_to_string` handle tensor_format

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_llama2.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_llama2.cc
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <nnstreamer_cppplugin_api_filter.hh>
+#include <nnstreamer_log.h>
 #include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
 

--- a/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
@@ -511,6 +511,9 @@ gst_tensors_info_copy (GstTensorsInfo * dest, const GstTensorsInfo * src)
   num = dest->num_tensors = src->num_tensors;
   dest->format = src->format;
 
+  if (src->format != _NNS_TENSOR_FORMAT_STATIC)
+    return;
+
   for (i = 0; i < num; i++) {
     _dest = gst_tensors_info_get_nth_info (dest, i);
     _src = gst_tensors_info_get_nth_info ((GstTensorsInfo *) src, i);

--- a/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
@@ -787,31 +787,37 @@ gst_tensors_info_to_string (const GstTensorsInfo * info)
   unsigned int limit = info->num_tensors;
   GstTensorInfo *_info;
 
-  g_string_append_printf (gstr, "Num_Tensors = %u, Tensors = [",
-      info->num_tensors);
-  if (limit > NNS_TENSOR_SIZE_LIMIT) {
-    limit = NNS_TENSOR_SIZE_LIMIT;
-    g_string_append_printf (gstr,
-        "(Num_Tensors out of bound. Showing %d only)", limit);
+  g_string_append_printf (gstr, "Format = %s",
+      gst_tensor_get_format_string (info->format));
+  g_string_append_printf (gstr, ", Num_Tensors = %u", info->num_tensors);
+
+  if (info->format == _NNS_TENSOR_FORMAT_STATIC) {
+    g_string_append_printf (gstr, ", Tensors = [");
+    if (limit > NNS_TENSOR_SIZE_LIMIT) {
+      limit = NNS_TENSOR_SIZE_LIMIT;
+      g_string_append_printf (gstr,
+          "(Num_Tensors out of bound. Showing %d only)", limit);
+    }
+
+    for (i = 0; i < limit; i++) {
+      const gchar *name;
+      const gchar *type;
+      gchar *dim;
+
+      _info = gst_tensors_info_get_nth_info ((GstTensorsInfo *) info, i);
+      name = _info->name;
+      type = gst_tensor_get_type_string (_info->type);
+      dim = gst_tensor_get_dimension_string (_info->dimension);
+
+      g_string_append_printf (gstr, "{\"%s\", %s, %s}%s",
+          name ? name : "", type, dim,
+          (i == info->num_tensors - 1) ? "" : ", ");
+
+      g_free (dim);
+    }
+
+    g_string_append_printf (gstr, "]");
   }
-
-  for (i = 0; i < limit; i++) {
-    const gchar *name;
-    const gchar *type;
-    gchar *dim;
-
-    _info = gst_tensors_info_get_nth_info ((GstTensorsInfo *) info, i);
-    name = _info->name;
-    type = gst_tensor_get_type_string (_info->type);
-    dim = gst_tensor_get_dimension_string (_info->dimension);
-
-    g_string_append_printf (gstr, "{\"%s\", %s, %s}%s",
-        name ? name : "", type, dim, (i == info->num_tensors - 1) ? "" : ", ");
-
-    g_free (dim);
-  }
-
-  g_string_append_printf (gstr, "]");
 
   return g_string_free (gstr, FALSE);
 }


### PR DESCRIPTION
- Let the util function properly set format information.
- Skip copying n-th info if the format is not static.
- Add missing header `nnstreamer_log.h` in llama2 source.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
