### PR TITLE
[Filter] Add suspend mode for tensor_filter

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -135,6 +135,8 @@ typedef struct _GstTensorFilterProperties
   int latency; /**< The average latency over the recent 10 inferences in microseconds */
   int throughput; /**< The average throughput in the number of outputs per second */
   int invoke_dynamic; /**< True for supporting invoke with flexible output. */
+
+  uint32_t suspend; /**< Timeout (ms) for suspend. (Unload the framework) */
 } GstTensorFilterProperties;
 
 /**

--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -44,7 +44,8 @@ nnstreamer_single_sources = [
   'nnstreamer_conf.c',
   'nnstreamer_log.c',
   'nnstreamer_subplugin.c',
-  'nnstreamer_plugin_api_util_impl.c'
+  'nnstreamer_plugin_api_util_impl.c',
+  'nnstreamer_watchdog.c'
 ]
 
 if ml_agent_support_is_available

--- a/gst/nnstreamer/nnstreamer_watchdog.c
+++ b/gst/nnstreamer/nnstreamer_watchdog.c
@@ -1,0 +1,192 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * NNStreamer watchdog
+ * Copyright (C) 2024 Gichan Jang <gichan2.jang@samsung.com>
+ */
+/**
+ * @file	nnstreamer_watchdog.c
+ * @date	30 Oct 2024
+ * @brief	NNStreamer watchdog to manage the schedule in the element.
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Gichan Jang <gichan2.jang@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#include <nnstreamer_log.h>
+#include "nnstreamer_watchdog.h"
+
+/**
+ * @brief Structure for NNStreamer watchdog.
+ */
+typedef struct _NnstWatchdog
+{
+  GMainContext *context;
+  GMainLoop *loop;
+  GThread *thread;
+  GSource *source;
+  GMutex lock;
+  GCond cond;
+} NnstWatchdog;
+
+/**
+ * @brief Called when loop is running
+ */
+static gboolean
+_loop_running_cb (NnstWatchdog * watchdog)
+{
+  g_mutex_lock (&watchdog->lock);
+  g_cond_signal (&watchdog->cond);
+  g_mutex_unlock (&watchdog->lock);
+
+  return G_SOURCE_REMOVE;
+}
+
+/**
+ * @brief Watchdog thread.
+ */
+static gpointer
+_nnstreamer_watchdog_thread (gpointer ptr)
+{
+  NnstWatchdog *watchdog = (NnstWatchdog *) ptr;
+  GSource *idle_source;
+
+  g_main_context_push_thread_default (watchdog->context);
+
+  idle_source = g_idle_source_new ();
+  g_source_set_callback (idle_source,
+      (GSourceFunc) _loop_running_cb, watchdog, NULL);
+  g_source_attach (idle_source, watchdog->context);
+  g_source_unref (idle_source);
+
+  g_main_loop_run (watchdog->loop);
+
+  g_main_context_pop_thread_default (watchdog->context);
+
+  return NULL;
+}
+
+/**
+ * @brief Create nnstreamer watchdog. Recommended using watchdog handle with proper lock (e.g., GST_OBJECT_LOCK())
+ */
+gboolean
+nnstreamer_watchdog_create (nns_watchdog_h * watchdog_h)
+{
+  gint64 end_time;
+  gboolean ret = TRUE;
+  GError *error = NULL;
+  NnstWatchdog *watchdog;
+
+  if (!watchdog_h) {
+    ml_loge ("Invalid parameter: watchdog handle is NULL.");
+    return FALSE;
+  }
+
+  watchdog = g_try_new0 (NnstWatchdog, 1);
+  if (!watchdog) {
+    ml_loge ("Failed to allocate memory for watchdog.");
+    return FALSE;
+  }
+
+  watchdog->context = g_main_context_new ();
+  watchdog->loop = g_main_loop_new (watchdog->context, FALSE);
+
+  g_mutex_init (&watchdog->lock);
+  g_cond_init (&watchdog->cond);
+  g_mutex_lock (&watchdog->lock);
+  watchdog->thread =
+      g_thread_try_new ("suspend_watchdog", _nnstreamer_watchdog_thread,
+      watchdog, &error);
+
+  if (!watchdog->thread) {
+    ml_loge ("Failed to create watchdog thread: %s", error->message);
+    g_clear_error (&error);
+    ret = FALSE;
+    goto done;
+  }
+
+  end_time = g_get_monotonic_time () + 5 * G_TIME_SPAN_SECOND;
+  while (!g_main_loop_is_running (watchdog->loop)) {
+    if (!g_cond_wait_until (&watchdog->cond, &watchdog->lock, end_time)) {
+      ml_loge ("Failed to wait main loop running.");
+      ret = FALSE;
+      goto done;
+    }
+  }
+
+done:
+  g_mutex_unlock (&watchdog->lock);
+  g_mutex_clear (&watchdog->lock);
+  g_cond_clear (&watchdog->cond);
+  if (!ret) {
+    nnstreamer_watchdog_destroy (watchdog);
+    watchdog = NULL;
+  }
+  *watchdog_h = watchdog;
+
+  return ret;
+}
+
+/**
+ * @brief Destroy watchdog source. Recommended using watchdog handle with proper lock (e.g., GST_OBJECT_LOCK())
+ */
+void
+nnstreamer_watchdog_destroy (nns_watchdog_h watchdog_h)
+{
+  NnstWatchdog *watchdog = (NnstWatchdog *) watchdog_h;
+  nnstreamer_watchdog_release (watchdog);
+
+  if (watchdog && watchdog->context) {
+    g_main_loop_quit (watchdog->loop);
+    g_thread_join (watchdog->thread);
+    watchdog->thread = NULL;
+
+    g_main_loop_unref (watchdog->loop);
+    watchdog->loop = NULL;
+
+    g_main_context_unref (watchdog->context);
+    watchdog->context = NULL;
+
+    g_free (watchdog_h);
+  }
+}
+
+/**
+ * @brief Release watchdog source. Recommended using watchdog handle with proper lock (e.g., GST_OBJECT_LOCK())
+ */
+void
+nnstreamer_watchdog_release (nns_watchdog_h watchdog_h)
+{
+  NnstWatchdog *watchdog = (NnstWatchdog *) watchdog_h;
+  if (watchdog && watchdog->source) {
+    g_source_destroy (watchdog->source);
+    g_source_unref (watchdog->source);
+    watchdog->source = NULL;
+  }
+}
+
+/**
+ * @brief Set watchdog timeout. Recommended using watchdog handle with proper lock (e.g., GST_OBJECT_LOCK())
+ */
+gboolean
+nnstreamer_watchdog_feed (nns_watchdog_h watchdog_h, GSourceFunc func,
+    guint interval, void *user_data)
+{
+  NnstWatchdog *watchdog = (NnstWatchdog *) watchdog_h;
+
+  if (!watchdog || !func) {
+    ml_loge ("Invalid parameter: watchdog handle or func is NULL.");
+    return FALSE;
+  }
+
+  if (watchdog->context) {
+    watchdog->source = g_timeout_source_new (interval);
+    g_source_set_callback (watchdog->source, func, user_data, NULL);
+    g_source_attach (watchdog->source, watchdog->context);
+  } else {
+    ml_loge
+        ("Failed to feed to watchdog. Watchdog is not created or context is invalid.");
+    return FALSE;
+  }
+
+  return TRUE;
+}

--- a/gst/nnstreamer/nnstreamer_watchdog.h
+++ b/gst/nnstreamer/nnstreamer_watchdog.h
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * NNStreamer watchdog header
+ * Copyright (C) 2024 Gichan Jang <gichan2.jang@samsung.com>
+ */
+/**
+ * @file	nnstreamer_watchdog.h
+ * @date	30 Oct 2024
+ * @brief	NNStreamer watchdog header to manage the schedule in the element.
+ * @see		https://github.com/nnstreamer/nnstreamer
+ * @author	Gichan Jang <gichan2.jang@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+
+#ifndef __NNSTREAMER_WATCHDOG_H__
+#define __NNSTREAMER_WATCHDOG_H__
+
+#include <glib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void *nns_watchdog_h;
+
+/**
+ * @brief Create nnstreamer watchdog. Recommended using watchdog handle with proper lock (e.g., GST_OBJECT_LOCK())
+ */
+gboolean nnstreamer_watchdog_create (nns_watchdog_h *watchdog_h);
+
+/**
+ * @brief Destroy nnstreamer watchdog. Recommended using watchdog handle with proper lock (e.g., GST_OBJECT_LOCK())
+ */
+void nnstreamer_watchdog_destroy (nns_watchdog_h watchdog_h);
+
+/**
+ * @brief Release watchdog source. Recommended using watchdog handle with proper lock (e.g., GST_OBJECT_LOCK())
+ */
+void nnstreamer_watchdog_release (nns_watchdog_h watchdog_h);
+
+/**
+ * @brief Set watchdog timeout. Recommended using watchdog handle with proper lock (e.g., GST_OBJECT_LOCK())
+ */
+gboolean nnstreamer_watchdog_feed (nns_watchdog_h watchdog_h, GSourceFunc func, guint interval, void *user_data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __NNSTREAMER_WATCHDOG_H__ */

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -30,6 +30,7 @@
 #include <nnstreamer_subplugin.h>
 #include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_plugin_api_filter.h>
+#include "nnstreamer_watchdog.h"
 
 G_BEGIN_DECLS
 
@@ -170,10 +171,7 @@ typedef struct _GstTensorFilterPrivate
   gint64 latency_reported; /**< latency value reported (ns) in last LATENCY query */
 
   GstTensorFilterCombination combi;
-  GMainContext *main_context;
-  GMainLoop *main_loop;
-  GThread *thread;
-  GSource *source;
+  nns_watchdog_h watchdog_h; /**< Watchdog to monitor occasional inputs */;
 } GstTensorFilterPrivate;
 
 /**

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -106,7 +106,8 @@ enum
   PROP_SHARED_TENSOR_FILTER_KEY,
   PROP_LATENCY_REPORT,
   PROP_INVOKE_DYNAMIC,
-  PROP_CONFIG
+  PROP_CONFIG,
+  PROP_SUSPEND
 };
 
 /**
@@ -169,6 +170,10 @@ typedef struct _GstTensorFilterPrivate
   gint64 latency_reported; /**< latency value reported (ns) in last LATENCY query */
 
   GstTensorFilterCombination combi;
+  GMainContext *main_context;
+  GMainLoop *main_loop;
+  GThread *thread;
+  GSource *source;
 } GstTensorFilterPrivate;
 
 /**
@@ -272,6 +277,11 @@ gst_tensor_filter_load_tensor_info (GstTensorFilterPrivate * priv);
  * @brief Open NN framework.
  */
 extern void gst_tensor_filter_common_open_fw (GstTensorFilterPrivate * priv);
+
+/**
+ * @brief Unload NN framework.
+ */
+extern void gst_tensor_filter_common_unload_fw (GstTensorFilterPrivate * priv);
 
 /**
  * @brief Close NN framework.

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -36,6 +36,7 @@ NNSTREAMER_COMMON_SRCS := \
     $(NNSTREAMER_GST_HOME)/nnstreamer_log.c \
     $(NNSTREAMER_GST_HOME)/nnstreamer_subplugin.c \
     $(NNSTREAMER_GST_HOME)/nnstreamer_plugin_api_util_impl.c \
+    $(NNSTREAMER_GST_HOME)/nnstreamer_watchdog.c \
     $(NNSTREAMER_GST_HOME)/tensor_filter/tensor_filter_common.c \
     $(NNSTREAMER_GST_HOME)/tensor_filter/tensor_filter_custom.c \
     $(NNSTREAMER_GST_HOME)/tensor_filter/tensor_filter_custom_easy.c \

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -112,6 +112,16 @@ if gtest_dep.found()
 
     test('unittest_plugins', unittest_plugins, env: testenv)
 
+    # Run unittest_watchdog
+    unittest_watchdog = executable('unittest_watchdog',
+      join_paths('nnstreamer_watchdog', 'unittest_watchdog.cc'),
+      dependencies: [nnstreamer_unittest_deps],
+      install: get_option('install-test'),
+      install_dir: unittest_install_dir
+    )
+
+    test('unittest_watchdog', unittest_watchdog, env: testenv)
+
     # Run unittest_if
     unittest_if = executable('unittest_if',
       join_paths('nnstreamer_if', 'unittest_if.cc'),

--- a/tests/nnstreamer_watchdog/unittest_watchdog.cc
+++ b/tests/nnstreamer_watchdog/unittest_watchdog.cc
@@ -1,0 +1,137 @@
+/**
+ * @file        unittest_watchdog.cc
+ * @date        31 Oct 2024
+ * @brief       Unit test for watchdog commonm uitil.
+ * @see         https://github.com/nnstreamer/nnstreamer
+ * @author      Gichan Jang <gichan2.jang@samsung.com>
+ * @bug         No known bugs
+ */
+
+#include <gtest/gtest.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include "../gst/nnstreamer/nnstreamer_watchdog.h"
+
+/**
+ * @brief Test for watchdog creation.
+ */
+TEST (NnstWatchdog, create)
+{
+  nns_watchdog_h watchdog_h = NULL;
+  gboolean ret = FALSE;
+
+  ret = nnstreamer_watchdog_create (&watchdog_h);
+  EXPECT_EQ (TRUE, ret);
+
+  nnstreamer_watchdog_destroy (watchdog_h);
+}
+
+/**
+ * @brief Called when watchdog is triggered.
+ */
+static gboolean
+_watchdog_trigger (gpointer ptr)
+{
+  guint *received = (guint *) ptr;
+
+  if (received)
+    (*received)++;
+
+  /** Trigger 10 times */
+  return (*received) != 10;
+}
+
+/**
+ * @brief Test for feeding watchdog.
+ */
+TEST (NnstWatchdog, feed)
+{
+  nns_watchdog_h watchdog_h = nullptr;
+  gboolean ret = FALSE;
+  guint *received = (guint *) g_malloc0 (sizeof (guint));
+  const guint interval_ms = 50;
+
+  ASSERT_NE (nullptr, received);
+
+  ret = nnstreamer_watchdog_create (&watchdog_h);
+  EXPECT_EQ (TRUE, ret);
+
+  ret = nnstreamer_watchdog_feed (watchdog_h, _watchdog_trigger, interval_ms, received);
+  EXPECT_EQ (TRUE, ret);
+
+  g_usleep (1000000);
+  EXPECT_EQ (10U, *received);
+
+  nnstreamer_watchdog_destroy (watchdog_h);
+  g_free (received);
+}
+
+/**
+ * @brief Test for watchdog creation with invalid param.
+ */
+TEST (NnstWatchdog, create_n)
+{
+  gboolean ret = FALSE;
+
+  ret = nnstreamer_watchdog_create (NULL);
+  EXPECT_EQ (FALSE, ret);
+}
+
+/**
+ * @brief Test for deeding watchdog with invalid param.
+ */
+TEST (NnstWatchdog, feed_1_n)
+{
+  nns_watchdog_h watchdog_h = nullptr;
+  gboolean ret = FALSE;
+  const guint interval_ms = 50;
+
+  ret = nnstreamer_watchdog_create (&watchdog_h);
+  EXPECT_EQ (TRUE, ret);
+
+  ret = nnstreamer_watchdog_feed (NULL, _watchdog_trigger, interval_ms, NULL);
+  EXPECT_EQ (FALSE, ret);
+
+  nnstreamer_watchdog_destroy (watchdog_h);
+}
+
+/**
+ * @brief Test for feeding watchdog with invalid param.
+ */
+TEST (NnstWatchdog, feed_2_n)
+{
+  nns_watchdog_h watchdog_h = nullptr;
+  gboolean ret = FALSE;
+  const guint interval_ms = 50;
+
+  ret = nnstreamer_watchdog_create (&watchdog_h);
+  EXPECT_EQ (TRUE, ret);
+
+  ret = nnstreamer_watchdog_feed (watchdog_h, NULL, interval_ms, NULL);
+  EXPECT_EQ (FALSE, ret);
+
+  nnstreamer_watchdog_destroy (watchdog_h);
+}
+
+/**
+ * @brief Main GTest
+ */
+int
+main (int argc, char **argv)
+{
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
+
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+
+  return result;
+}


### PR DESCRIPTION
 - Add suspend mode for tensor_filter
   - When there is no input within suspend timeout, unload NN framework. Reload the framework when the input comes again.
 - Separate watchdog code
   - Separate the watchdog because it can be used in other elements to manage time window.

Related issue: https://github.com/nnstreamer/nnstreamer/issues/4424

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
