### PR TITLE
[gcov] Fix test coverage generation failure

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -932,8 +932,10 @@ CXXFLAGS=`echo $CXXFLAGS | sed -e "s|-std=gnu++11||"`
 # To test coverage, disable optimizations (and should unset _FORTIFY_SOURCE to use -O0)
 CFLAGS=`echo $CFLAGS | sed -e "s|-O[1-9]|-O0|g"`
 CFLAGS=`echo $CFLAGS | sed -e "s|-Wp,-D_FORTIFY_SOURCE=[1-9]||g"`
+export CFLAGS+=" -fprofile-update=atomic"
 CXXFLAGS=`echo $CXXFLAGS | sed -e "s|-O[1-9]|-O0|g"`
 CXXFLAGS=`echo $CXXFLAGS | sed -e "s|-Wp,-D_FORTIFY_SOURCE=[1-9]||g"`
+export CXXFLAGS+=" -fprofile-update=atomic"
 # also, use the meson's base option, -Db_coverage, instead of --coverage/-fprofile-arcs and -ftest-coverage
 %define enable_test_coverage -Db_coverage=true
 %else


### PR DESCRIPTION
Test coverage generation has been failed due to gcc bug. Add comile option to fix it.

Refer: https://manpages.debian.org/unstable/lcov/geninfo.1.en.html#negative:


**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
