### PR TITLE
[Action] Generate test coverage from github action 

### DIFF
--- a/.github/workflows/gen_coverage_badge.py
+++ b/.github/workflows/gen_coverage_badge.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+##
+# Copyright (C) 2024 Samsung Electronics
+# License: Apache-2.0
+#
+# @file gen_github_badge_svg.py
+# @brief A tool for generating a github badge image in svg format
+# @author Wook Song <wook16.song@samsung.com>
+# @author Gichan Jang <gichan2.jang@samsung.com>
+# @note
+# usage :  python gen_badge.py {gcov-index-file} {output.svg}
+#
+import sys
+import os
+from bs4 import BeautifulSoup
+from pybadges import badge
+
+##
+# @brief Get a gradient colorcode from green to red of given value (scaled)
+# @param[in] val A value to be conveted to a gradient colorcode (i.e., #FFFFFF)
+# @param[in] scale A limit for the val, 0 <= val <= scale
+def get_code_g_y_r(val, scale):
+    """get_code_g_y_r(val, scale) -> str"""
+    if val <= 50:
+        red = 255
+        green = val * (255 / (float(scale) / 2))
+    else:
+        green = 255 * val / scale
+        red = 255 - (val - 50) * (255 / (float(scale) / 2))
+
+    rgb = (int(red), int(green), int(0))
+
+    return '#%02x%02x%02x' % rgb
+
+##
+# @brief Generate a github badge svg file representing code coverage
+# @param[in] html A concatenated string of the whole contents in index.html that is the result of LCOV
+# @param[in] path A file path to save the svg file
+def gen_coverage_badge(html, path):
+    #parse LCOV html
+    soup = BeautifulSoup(html, 'html.parser')
+    lines, line_hits, funcs, func_hits = \
+        soup.find('table').find_all('td', {'class': 'headerCovTableEntry'})
+    line_hits = float(line_hits.text)
+    lines = float(lines.text)
+    line_coverage = line_hits / lines
+    rgb_code = get_code_g_y_r(line_coverage * 100, 100)
+    coverage_str = str(format(line_coverage * 100, '.2f')) + '%'
+    s = badge(left_text='coverage', right_text=coverage_str, right_color=rgb_code)
+
+    file = open(path, "w")
+    file.write(s)
+    file.close()
+
+
+if __name__ == '__main__':
+    # argv[1]: [url/file] a path or url of LCOV html to get information for badge generation
+    # argv[2]: [file] a file path to save the generated svg file
+    if len(sys.argv) < 3:
+        exit(1)
+
+    str_html = ''
+    if os.path.isfile(sys.argv[1]):
+        with open(sys.argv[1], 'r') as f:
+            str_html = f.read()
+            if not BeautifulSoup(str_html, "html.parser").find():
+                exit(1)
+    else:
+        exit(1)
+
+    path_out_svg=''
+    if not os.access(os.path.dirname(sys.argv[2]) or os.getcwd(), os.W_OK):
+        exit(1)
+    else:
+        path_out_svg = os.path.abspath(sys.argv[2])
+        if os.path.isdir(path_out_svg) or os.path.islink(path_out_svg):
+          exit(1)
+
+    gen_coverage_badge(str_html, path_out_svg)

--- a/.github/workflows/gen_coverage_badge.py
+++ b/.github/workflows/gen_coverage_badge.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
 # Copyright (C) 2024 Samsung Electronics
-# License: Apache-2.0
 #
 # @file gen_github_badge_svg.py
 # @brief A tool for generating a github badge image in svg format

--- a/.github/workflows/update_gbs_cache.yml
+++ b/.github/workflows/update_gbs_cache.yml
@@ -14,13 +14,13 @@ jobs:
       matrix:
         include:
           - gbs_build_arch: "x86_64"
-            gbs_build_option: "--define \"unit_test 1\""
+            gbs_build_option: "--define \"unit_test 1\" --define \"testcoverage 1\""
           - gbs_build_arch: "i586"
             gbs_build_option: "--define \"unit_test 1\""
           - gbs_build_arch: "armv7l"
-            gbs_build_option: "--define \"unit_test 0\""
+            gbs_build_option: "--define \"unit_test 1\""
           - gbs_build_arch: "aarch64"
-            gbs_build_option: "--define \"unit_test 0\""
+            gbs_build_option: "--define \"unit_test 1\""
 
     runs-on: ubuntu-22.04
 
@@ -43,7 +43,7 @@ jobs:
         echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     - name: build and tests on GBS
-      run: gbs build --define "unit_test 1" --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }}
+      run: gbs build ${{ matrix.gbs_build_option }} --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }}
 
     - name: save gbs cache
       uses: actions/cache/save@v4
@@ -52,14 +52,30 @@ jobs:
         path: ~/GBS-ROOT/local/cache
         key: gbs-cache-${{ matrix.gbs_build_arch }}-${{ steps.get-date.outputs.date }}
 
-    - name: Release daily build result
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
-        AWS_EC2_METADATA_DISABLED: true
+    - if: matrix.gbs_build_arch == 'x86_64'
+      name: extract test coverage result
       run: |
-        aws s3 cp --recursive --region ap-northeast-2 ~/GBS-ROOT/local/repos/tizen/${{ matrix.gbs_build_arch }}/RPMS/ s3://nnstreamer-release/nnstreamer/${{ steps.get-date.outputs.date }}/RPMS/
-        aws s3 cp --recursive --region ap-northeast-2 ~/GBS-ROOT/local/repos/tizen/${{ matrix.gbs_build_arch }}/RPMS/ s3://nnstreamer-release/nnstreamer/latest/RPMS/
+        pip install pybadges beautifulsoup4 setuptools
+        mkdir -p ~/testresult/
+        pushd ~/testresult/
+        cp ~/GBS-ROOT/local/repos/tizen/x86_64/RPMS/*-coverage*.rpm .
+        rpm2cpio *-coverage*.rpm | cpio -idv
+        popd
+        python3 .github/workflows/gen_coverage_badge.py ~/testresult/usr/share/nnstreamer/unittest/result/index.html ~/testresult/usr/share/nnstreamer/unittest/result/coverage_badge.svg
+
+    - if: matrix.gbs_build_arch == 'x86_64'
+      name: Update github.io
+      run: |
+        git clone https://${{ secrets.TAOS_ACCOUNT }}:${{ secrets.TAOS_ACCOUNT_TOKEN }}@github.com/nnstreamer/nnstreamer.github.io.git
+        pushd nnstreamer.github.io
+        mkdir -p testresult
+        cp -r ~/testresult/usr/share/nnstreamer/unittest/result/* testresult
+        git config user.email "nnsuite@samsung.com"
+        git config user.name "nnsuite"
+        git add *
+        git commit -s -m "${{ steps.get-date.outputs.date }} : Update unit test result."
+        git push origin main -f
+        popd
 
     - name: Get nntrainer
       uses: actions/checkout@v4

--- a/.github/workflows/update_gbs_cache.yml
+++ b/.github/workflows/update_gbs_cache.yml
@@ -1,4 +1,4 @@
-name: Update GBS cache once a day + nntrainer gbs build test
+name: NNStreamer + NNTrainer gbs build daily test.
 
 on:
   schedule:
@@ -11,6 +11,7 @@ on:
 jobs:
   cache_gbs_build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - gbs_build_arch: "x86_64"
@@ -51,6 +52,15 @@ jobs:
       with:
         path: ~/GBS-ROOT/local/cache
         key: gbs-cache-${{ matrix.gbs_build_arch }}-${{ steps.get-date.outputs.date }}
+
+    - name: Release daily build result
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
+        AWS_EC2_METADATA_DISABLED: true
+      run: |
+        aws s3 cp --recursive --region ap-northeast-2 ~/GBS-ROOT/local/repos/tizen/${{ matrix.gbs_build_arch }}/RPMS/ s3://nnstreamer-release/nnstreamer/${{ steps.get-date.outputs.date }}/RPMS/
+        aws s3 cp --recursive --region ap-northeast-2 ~/GBS-ROOT/local/repos/tizen/${{ matrix.gbs_build_arch }}/RPMS/ s3://nnstreamer-release/nnstreamer/latest/RPMS/
 
     - if: matrix.gbs_build_arch == 'x86_64'
       name: extract test coverage result

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # NNStreamer <img align="right" src="Documentation/media/lfaidata-project-badge-incubation-black.svg" width="150"/>
 
 [![Gitter][gitter-image]][gitter-url]
-[![DailyBuild](http://ci.nnstreamer.ai/nnstreamer/ci/daily-build/badge/daily_build_badge.svg)](http://ci.nnstreamer.ai/nnstreamer/ci/daily-build/build_result/)
+[![DailyBuild](http://ci.nnstreamer.ai/nnstreamer/ci/daily-build/badge/daily_build_badge.svg)](https://release.nnstreamer.com/#nnstreamer/latest/)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4401/badge)](https://bestpractices.coreinfrastructure.org/projects/4401)
-[![Code Coverage](http://ci.nnstreamer.ai/nnstreamer/ci/badge/codecoverage.svg)](http://ci.nnstreamer.ai/nnstreamer/ci/gcov_html/index.html)
+[![Code Coverage](https://nnstreamer.github.io/testresult/coverage_badge.svg)](https://nnstreamer.github.io/testresult/)
 <a href="https://scan.coverity.com/projects/nnstreamer-nnstreamer">
 <img alt="Coverity Scan Defect Status" src="https://scan.coverity.com/projects/22501/badge.svg"/>
 </a>
@@ -40,7 +40,7 @@ neural network developers to manage neural network pipelines and their filters e
 
 - Ready: CI system ensures build-ability and unit-testing. Users may easily build and execute. However, we do not have automated release & deployment system for this instance.
 - Available: binary packages are released and deployed automatically and periodically along with CI tests.
-- [Daily Release](http://ci.nnstreamer.ai/nnstreamer/ci/daily-build/build_result/latest/)
+- [Daily Release](https://release.nnstreamer.com/#nnstreamer/latest/)
 - SDK Support: Tizen Studio (5.5 M2+) / Android Studio (JCenter, "nnstreamer")
 - [Enabled features of official releases](Documentation/features-per-distro.md)
 


### PR DESCRIPTION
 - Generate test coverage result and upload the result to github.io
 - Generate coverage badge
 - Use badge created by Github Action and change the action name for redability.
 - Use S3  instead of EC2 for daily release.
 
test coverage result: https://nnstreamer.github.io/testresult/
test coverage badge: https://nnstreamer.github.io/testresult/coverage_badge.svg
daily release: https://release.nnstreamer.com/#nnstreamer/latest/


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

