### PR TITLE
[Spec] Skip test in case that ASAN is enabled

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -971,8 +971,8 @@ export ORC_DEBUG=2
 
 %define test_script $(pwd)/packaging/run_unittests_binaries.sh
 
-# if it's tizen && non-TV, run unittest even if "unit_test"==0 for build-time sanity checks.
-%if ( %{with tizen} && "%{?profile}" != "tv" )
+# if it's tizen && non-TV && ASAN is enabled, run unittest even if "unit_test"==0 for build-time sanity checks.
+%if ( %{with tizen} && "%{?profile}" != "tv"  && "%{asan}" != "1")
 %if 0%{nnfw_support}
     bash %{test_script} ./tests/tizen_nnfw_runtime/unittest_nnfw_runtime_raw
 %endif


### PR DESCRIPTION
In case of GCC v14, the build process is stopped when ASAN option is enabled. Build engineer suggested to skip the test in such case to avoid the build failure.


**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


