### PR TITLE
[build] Fix install dir of executorch filter

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -863,7 +863,7 @@ if executorch_support_is_available
     filter_sub_executorch_sources,
     dependencies: nnstreamer_filter_executorch_deps,
     install: true,
-    install_dir: filter_subplugin_install_dir
+    install_dir: nnstreamer_libdir
   )
 endif
 
@@ -889,7 +889,7 @@ if executorch_llama_support_is_available
     filter_sub_executorch_sources,
     dependencies: nnstreamer_filter_executorch_llama_deps,
     install: true,
-    install_dir: filter_subplugin_install_dir
+    install_dir: nnstreamer_libdir
   )
 endif
 


### PR DESCRIPTION
Let executorch filter static lib be installed in nnstreamer_libdir.


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped
