### PR TITLE
[Action] Disable making large image

### DIFF
--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -48,7 +48,7 @@ jobs:
         key: yocto-cache-yocto-5.0.3
 
     - name: acquire some disk space
-      if: steps.rebuild.outputs.rebuild == '1'
+      if: false # Enable this step when you need to make new cache.
       run: |
           df -h
           sudo apt-get update --fix-missing \


### PR DESCRIPTION
When there is no Yocto cache, unnecessary packages should be removed due to lack of space in the runner.
We don't need this option when we have the cache.
Activate again if there is no cache.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


