### PR TITLE
[Action] Fix for failure case

### DIFF
--- a/.github/workflows/update_gbs_cache.yml
+++ b/.github/workflows/update_gbs_cache.yml
@@ -50,12 +50,7 @@ jobs:
 
     - name: build and tests on GBS
       id: gbs-build
-      continue-on-error: true
       run: gbs build ${{ matrix.gbs_build_option }} --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }}
-
-    - name: report GBS build and test result
-      id: gbs-result
-      run: echo "${{ matrix.gbs_build_arch }}=${{ steps.gbs-build.outcome }}" >> $GITHUB_OUTPUT
 
     - name: save gbs cache
       uses: actions/cache/save@v4
@@ -63,6 +58,10 @@ jobs:
       with:
         path: ~/GBS-ROOT/local/cache
         key: gbs-cache-${{ matrix.gbs_build_arch }}-${{ steps.get-date.outputs.date }}
+
+    - name: report GBS build and test result
+      id: gbs-result
+      run: echo "${{ matrix.gbs_build_arch }}=${{ steps.gbs-build.outcome }}" >> $GITHUB_OUTPUT
 
     - name: Release daily build result to release.nnstreamer.com
       if: steps.gbs-build.outcome == 'success'
@@ -78,7 +77,7 @@ jobs:
       uses: ./.github/actions/s3_upload
       with:
         source: ~/GBS-ROOT/local/repos/tizen/${{ matrix.gbs_build_arch }}/logs/*/*/log.txt
-        dest: logs/tizen_gbs_${{ matrix.gbs_build_arch }}_log.txt
+        dest: logs/nnstreamer_tizen_gbs_${{ matrix.gbs_build_arch }}_log.txt
         s3_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
         s3_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
 

--- a/.github/workflows/update_pbuilder_cache.yml
+++ b/.github/workflows/update_pbuilder_cache.yml
@@ -60,19 +60,9 @@ jobs:
 
       - name: run pdebuild
         id: pdebuild
-        continue-on-error: true
         run: |
           mkdir -p ~/daily_build/ubuntu
           pdebuild --logfile ~/daily_build/pdebuild_log.txt --buildresult ~/daily_build/ubuntu --architecture ${{ matrix.arch }} -- --distribution ${{ matrix.distroname }}
-
-      - name: generate badge
-        run: |
-          pip install pybadges setuptools
-          if [ '${{ steps.pdebuild.outcome }}' == 'success' ]; then
-            python3 -m pybadges --left-text=test --right-text=success --right-color=green > ~/daily_build/pdebuild_result.svg
-          else
-            python3 -m pybadges --left-text=test --right-text=failure --right-color=red > ~/daily_build/pdebuild_result.svg
-          fi
 
       - name: save pbuilder cache
         uses: actions/cache/save@v4
@@ -82,6 +72,15 @@ jobs:
             /var/cache/pbuilder/aptcache
             /var/cache/pbuilder/base.tgz
           key: pbuilder-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('**/debian/control') }}-${{ steps.get-date.outputs.date }}
+
+      - name: generate badge
+        run: |
+          pip install pybadges setuptools
+          if [ '${{ steps.pdebuild.outcome }}' == 'success' ]; then
+            python3 -m pybadges --left-text=test --right-text=success --right-color=green > ~/daily_build/pdebuild_result.svg
+          else
+            python3 -m pybadges --left-text=test --right-text=failure --right-color=red > ~/daily_build/pdebuild_result.svg
+          fi
 
       - name: Release daily build result to release.nnstreamer.com
         if: steps.pdebuild.outcome == 'success'

--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -17,8 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: -${{ github.event.pull_request.commits }}
+        fetch-depth: ${{ github.event.pull_request.commits }}
     - name: Check if rebuild required
       uses: ./.github/actions/check-rebuild
       with:
@@ -64,7 +63,6 @@ jobs:
     - name: build
       if: steps.rebuild.outputs.rebuild == '1'
       id: yocto-build
-      continue-on-error: true
       run: |
         echo "::group::apt-get install"
         sudo apt-get update


### PR DESCRIPTION
Even if the step failed, the `continue-on-error` was used to continue the next step. 
But `continue-on-error` marks success even if the step fails. 
So, let's use `always()` for subsequent steps.


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

