### PR TITLE
dist: disable tflite2-custom

### DIFF
--- a/debian/nnstreamer-tensorflow2-lite.install
+++ b/debian/nnstreamer-tensorflow2-lite.install
@@ -1,2 +1,1 @@
 /usr/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow2-lite.so
-/usr/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow2-lite-custom.so

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,7 +4,7 @@ option('audio-support', type: 'feature', value: 'enabled')
 option('tf-support', type: 'feature', value: 'auto')
 option('tflite-support', type: 'feature', value: 'auto')
 option('tflite2-support', type: 'feature', value: 'auto')
-option('tflite2-custom-support', type: 'feature', value: 'auto') # requires tflite2-support!
+option('tflite2-custom-support', type: 'feature', value: 'disabled') # requires tflite2-support. disabled due to incompleteness.
 option('pytorch-support', type: 'feature', value: 'auto')
 option('caffe2-support', type: 'feature', value: 'auto')
 option('deepview-rt-support', type: 'feature', value: 'auto')

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -796,7 +796,7 @@ NNStreamer's datareposrc/sink plugins for reading and writing files in MLOps Dat
 
 # Support tensorflow2-lite
 %if 0%{?tensorflow2_lite_support}
-%define enable_tf2_lite -Dtflite2-support=enabled -Dtflite2-custom-support=enabled
+%define enable_tf2_lite -Dtflite2-support=enabled -Dtflite2-custom-support=disabled
 %else
 %define enable_tf2_lite -Dtflite2-support=disabled -Dtflite2-custom-support=disabled
 %endif
@@ -1148,7 +1148,6 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow2-lite.so
-%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow2-lite-custom.so
 %endif
 
 %if 0%{?python3_support}


### PR DESCRIPTION
tflite2-custom (using custom tflite2 binary per pipeline) is not stable and not maintained.

Disable it from the default builds until it gets stable.
