### PR TITLE
dist:ubuntu 24.04 ppa support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,12 +12,15 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  protobuf-compiler (>=3.12), libprotobuf-dev [amd64 arm64 armhf],
  libpaho-mqtt-dev,
  tensorflow2-lite-dev,
- pytorch | libtorch-dev, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
+ pytorch | libtorch-dev | gcc,
+ libedgetpu1-std (>=12), libedgetpu-dev (>=12),
  openvino-dev, openvino-cpu-mkldnn [amd64],
  nnfw-dev [amd64] | gcc,
  tvm-runtime-dev, onnxruntime-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer
+
+## @todo pytorch ppa build fails in Ubuntu 24.04. revive it when pytorch gets proper ppa support.
 
 Package: nnstreamer
 Architecture: any

--- a/debian/control.ubuntu.ppa
+++ b/debian/control.ubuntu.ppa
@@ -12,12 +12,15 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  protobuf-compiler (>=3.12), libprotobuf-dev [amd64 arm64 armhf],
  libpaho-mqtt-dev,
  tensorflow2-lite-dev,
- pytorch | libtorch-dev, libedgetpu1-std (>=12), libedgetpu-dev (>=12),
+ pytorch | libtorch-dev | gcc,
+ libedgetpu1-std (>=12), libedgetpu-dev (>=12),
  openvino-dev, openvino-cpu-mkldnn [amd64],
  nnfw-dev [amd64] | gcc,
  tvm-runtime-dev, onnxruntime-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer
+
+## @todo pytorch ppa build fails in Ubuntu 24.04. revive it when pytorch gets proper ppa support.
 
 Package: nnstreamer
 Architecture: any


### PR DESCRIPTION
Pytorch is still not supported with Ubuntu 24.04 PPA. Allow to build deb packages without pytorch.

