### PR TITLE
[build] Fix GBS build error with clang

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_executorch_llama.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_executorch_llama.cc
@@ -64,14 +64,15 @@ class executorch_llama_subplugin final : public tensor_filter_subplugin
   executorch_llama_subplugin (){};
   ~executorch_llama_subplugin (){};
 
-  tensor_filter_subplugin &getEmptyInstance ();
-  void configure_instance (const GstTensorFilterProperties *prop);
-  void invoke (const GstTensorMemory *input, GstTensorMemory *output);
+  tensor_filter_subplugin &getEmptyInstance () override;
+  void configure_instance (const GstTensorFilterProperties *prop) override;
+  void invoke (const GstTensorMemory *input, GstTensorMemory *output) override;
   void invoke_dynamic (GstTensorFilterProperties *prop,
       const GstTensorMemory *input, GstTensorMemory *output) override;
-  void getFrameworkInfo (GstTensorFilterFrameworkInfo &info);
-  int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info);
-  int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data);
+  void getFrameworkInfo (GstTensorFilterFrameworkInfo &info) override;
+  int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info,
+      GstTensorsInfo &out_info) override;
+  int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data) override;
 };
 
 const char *executorch_llama_subplugin::fw_name = "executorch-llama";

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
@@ -204,7 +204,6 @@ TensorFilterOpenvino::loadModel (accl_hw hw)
 {
   std::string targetDevice;
   std::vector<std::string> strVector;
-  std::vector<std::string>::iterator strVectorIter;
 
   if (this->_isLoaded) {
     /** @todo Can OpenVino support to replace the loaded model with a new one? */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_trix_engine.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_trix_engine.cc
@@ -34,6 +34,7 @@ TensorFilterTRIxEngine::TensorFilterTRIxEngine ()
     : dev_type_ (NPUCOND_CONN_UNKNOWN), dev_ (nullptr), model_path_ (nullptr),
       model_meta_ (nullptr), model_id_ (0), trix_in_info_ (), trix_out_info_ ()
 {
+  UNUSED (dev_type_);
   gst_tensors_info_init (addressof (nns_in_info_));
   gst_tensors_info_init (addressof (nns_out_info_));
 }

--- a/tests/gstreamer_mqtt/unittest_ntp_util_mock.cc
+++ b/tests/gstreamer_mqtt/unittest_ntp_util_mock.cc
@@ -131,7 +131,7 @@ class ntpUtilMockTest : public ::testing::Test
   /**
    * @brief tear down the base fixture
    */
-  void TearDown ()
+  void TearDown () override
   {
     g_free (host.h_name);
     g_free (host.h_aliases[0]);

--- a/tests/nnstreamer_example/meson.build
+++ b/tests/nnstreamer_example/meson.build
@@ -44,10 +44,15 @@ library('nnstreamer_customfilter_scaler_allocator',
 # custom_example_opencv
 opencv_dep = dependency('opencv', required: false)
 if opencv_dep.found()
+  extra_compile_arg = cxx.get_supported_arguments([
+    '-Wno-format-nonliteral'
+  ])
+  extra_dep = declare_dependency(compile_args: extra_compile_arg)
+
   library('nnstreamer_customfilter_opencv_scaler',
     join_paths('custom_example_opencv',
         'nnstreamer_customfilter_opencv_scaler.cc'),
-    dependencies: [glib_dep, gst_dep, nnstreamer_dep, opencv_dep],
+    dependencies: [glib_dep, gst_dep, nnstreamer_dep, opencv_dep, extra_dep],
     install: get_option('install-test'),
     install_dir: customfilter_install_dir
   )
@@ -55,7 +60,7 @@ if opencv_dep.found()
   library('nnstreamer_customfilter_opencv_average',
     join_paths('custom_example_opencv',
         'nnstreamer_customfilter_opencv_average.cc'),
-    dependencies: [glib_dep, gst_dep, nnstreamer_dep, opencv_dep],
+    dependencies: [glib_dep, gst_dep, nnstreamer_dep, opencv_dep, extra_dep],
     install: get_option('install-test'),
     install_dir: customfilter_install_dir
   )


### PR DESCRIPTION
Recently Tizen upgrade its toolchains (gcc 14.1.0 / clang 18.1.6).
This fix complaints from the clang build.

- Remove an unused variable in openvino.cc
- Use `UNUSED` macro for an unused variable in trix_engine.cc
- Add override keyword for some overridden methods.
- Add proper Wno flag to fix compile opencv related sources.



**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped
