### PR TITLE
[Action] Get git diff size by cli tool

### DIFF
--- a/.github/actions/gitpush/action.yml
+++ b/.github/actions/gitpush/action.yml
@@ -25,9 +25,7 @@ runs:
         pushd nnstreamer.github.io
         mkdir -p ${{ inputs.dest }}
         cp -r ${{ inputs.source }} ${{ inputs.dest }}
-        git diff > git_diff.txt
-        DIFF_SIZE=$(stat -c%s git_diff.txt)
-        if [[ $DIFF_SIZE -ne 0 ]]; then
+        if git diff --shortstat | grep -q changed; then
           git config user.email "nnsuite@samsung.com"
           git config user.name "nnsuite"
           git add *


### PR DESCRIPTION
Get git diff size by cli tool.

*Fix daily build failure to publish docs to github.io

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

