### PR TITLE
[llamacpp] Use custom props in llamacpp subplugin

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_llamacpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_llamacpp.cc
@@ -175,7 +175,7 @@ TensorFilterLlamaCpp::invoke_dynamic (GstTensorFilterProperties *prop,
     const GstTensorMemory *input, GstTensorMemory *output)
 {
   /** @todo: Get n_predict value from prop */
-  int n_prompt, n_pos, n_predict = 32, n_decode = 0;
+  int n_prompt, n_pos, n_predict = 32;
   llama_token new_token_id;
   llama_batch batch;
   std::string prompt, result = "";
@@ -243,8 +243,6 @@ TensorFilterLlamaCpp::invoke_dynamic (GstTensorFilterProperties *prop,
 
       /** prepare the next batch with the sampled token */
       batch = llama_batch_get_one (&new_token_id, 1);
-
-      n_decode += 1;
     }
   }
 


### PR DESCRIPTION
This PR removes unused variables and enables llamacpp sublugin to use custom props.
The length of output could be controlled by num_predict.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped