### PR TITLE
[CodeClean] Fix coverity issues

### DIFF
--- a/ext/nnstreamer/tensor_decoder/box_properties/yolo.cc
+++ b/ext/nnstreamer/tensor_decoder/box_properties/yolo.cc
@@ -544,6 +544,7 @@ YoloV10::decode (const GstTensorsConfig *config, const GstTensorMemory *input)
 /** @brief Constructor of YoloV8-OBB */
 YoloV8_OBB::YoloV8_OBB ()
 {
+  scaled_output = 0;
   conf_threshold = YOLO_DETECTION_CONF_THRESHOLD;
   iou_threshold = YOLO_DETECTION_IOU_THRESHOLD;
   name = g_strdup_printf ("yolov8-obb");

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
@@ -105,10 +105,10 @@ static int
 bb_init (void **pdata)
 {
   /** @todo check if we need to ensure plugin_data is not yet allocated */
-  BoundingBox *bdata = new BoundingBox ();
-  *pdata = bdata;
-
-  if (bdata == NULL) {
+  try {
+    BoundingBox *bdata = new BoundingBox ();
+    *pdata = bdata;
+  } catch (...) {
     GST_ERROR ("Failed to allocate memory for decoder subplugin.");
     return FALSE;
   }
@@ -353,8 +353,8 @@ get_rotated_rect_corners (detectedObject *obj, Point corners[4])
   float cos_a = cos (angle);
   float sin_a = sin (angle);
 
-  float half_w = obj->width / 2;
-  float half_h = obj->height / 2;
+  float half_w = static_cast<float> (obj->width) / 2;
+  float half_h = static_cast<float> (obj->height) / 2;
 
   float dx[4] = { -half_w, half_w, half_w, -half_w };
   float dy[4] = { -half_h, -half_h, half_h, half_h };


### PR DESCRIPTION
This patch fixes `NO_CAST.INTEGER_DIVISON`, `COMPARE_RESULT_OF_NEW`, `UNINIT.CTOR`.
WGID 113301~113303

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped