### PR TITLE
[Element/MQTT] missing header in util

### DIFF
--- a/gst/mqtt/ntputil.c
+++ b/gst/mqtt/ntputil.c
@@ -13,6 +13,7 @@
  */
 
 #include <errno.h>
+#include <arpa/inet.h>
 #include <netdb.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
Fix build error on android, add missing header for socket.
