### PR TITLE
[Tizen HAL] Add tizen hal filters for snpe / vivante

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -571,7 +571,7 @@ if get_option('enable-openvino')
   )
 endif
 
-if get_option('enable-vivante')
+if get_option('enable-vivante') and not tizen_hal_support_is_available
   subdir('vivante')
 endif
 
@@ -642,7 +642,7 @@ if get_option('enable-mediapipe')
   )
 endif
 
-if snpe_support_is_available
+if snpe_support_is_available and not tizen_hal_support_is_available
   # Decide source code file wrt snpe api version.
   if snpe_api_version == 2
     filter_sub_snpe_sources = ['tensor_filter_snpe.cc']
@@ -968,6 +968,44 @@ if llama2c_support_is_available
   static_library('nnstreamer_filter_llama2c',
     filter_sub_llama2c_sources,
     dependencies: nnstreamer_filter_llama2c_deps,
+    install: true,
+    install_dir: nnstreamer_libdir
+  )
+endif
+
+if tizen_hal_support_is_available
+  # build snpe tizen hal filter
+  filter_sub_tizen_hal_snpe_srcs = ['tensor_filter_tizen_hal_snpe.cc']
+  nnstreamer_filter_tizen_hal_pass_deps = [glib_dep, nnstreamer_single_dep, tizen_hal_support_deps]
+
+  shared_library('nnstreamer_filter_snpe',
+    filter_sub_tizen_hal_snpe_srcs,
+    dependencies: nnstreamer_filter_tizen_hal_pass_deps,
+    install: true,
+    install_dir: filter_subplugin_install_dir
+  )
+
+  static_library('nnstreamer_filter_snpe',
+    filter_sub_tizen_hal_snpe_srcs,
+    dependencies: nnstreamer_filter_tizen_hal_pass_deps,
+    install: true,
+    install_dir: nnstreamer_libdir
+  )
+
+  # build vivante tizen hal filter
+  filter_sub_tizen_hal_vivante_srcs = ['tensor_filter_tizen_hal_vivante.cc']
+  nnstreamer_filter_tizen_hal_pass_deps = [glib_dep, nnstreamer_single_dep, tizen_hal_support_deps]
+
+  shared_library('nnstreamer_filter_vivante',
+    filter_sub_tizen_hal_vivante_srcs,
+    dependencies: nnstreamer_filter_tizen_hal_pass_deps,
+    install: true,
+    install_dir: filter_subplugin_install_dir
+  )
+
+  static_library('nnstreamer_filter_vivante',
+    filter_sub_tizen_hal_vivante_srcs,
+    dependencies: nnstreamer_filter_tizen_hal_pass_deps,
     install: true,
     install_dir: nnstreamer_libdir
   )

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tizen_hal_snpe.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tizen_hal_snpe.cc
@@ -1,0 +1,267 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * NNStreamer tensor_filter, sub-plugin for SNPE
+ * Copyright (C) 2025 Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ */
+/**
+ * @file      tensor_filter_tizen_hal_snpe.cc
+ * @date      15 Jan 2025
+ * @brief     NNStreamer tensor-filter sub-plugin for Tizen HAL SNPE (Qualcomm Neural Processing SDK)
+ * @see       http://github.com/nnstreamer/nnstreamer
+              https://developer.qualcomm.com/software/qualcomm-neural-processing-sdk
+ * @author    Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ * @bug       No known bugs except for NYI items
+ *
+ * This is the per-NN-framework plugin (Tizen HAL SNPE) for tensor_filter.
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <glib.h>
+#include <nnstreamer_cppplugin_api_filter.hh>
+#include <nnstreamer_log.h>
+#include <nnstreamer_plugin_api_util.h>
+#include <nnstreamer_util.h>
+
+#include <hal-ml.h>
+
+#define SNPE_FRAMEWORK_NAME "snpe"
+
+namespace nnstreamer
+{
+namespace tensor_filter_snpe_tizen_hal
+{
+extern "C" {
+void init_filter_snpe_tizen_hal (void) __attribute__ ((constructor));
+void fini_filter_snpe_tizen_hal (void) __attribute__ ((destructor));
+}
+
+/** @brief tensor-filter-subplugin concrete class for SNPE */
+class snpe_tizen_hal_subplugin final : public tensor_filter_subplugin
+{
+  private:
+  static const char *fw_name;
+  static snpe_tizen_hal_subplugin *registeredRepresentation;
+  static const GstTensorFilterFrameworkInfo framework_info;
+
+  hal_ml_h hal_handle;
+
+  public:
+  static void init_filter_snpe_tizen_hal ();
+  static void fini_filter_snpe_tizen_hal ();
+
+  snpe_tizen_hal_subplugin ();
+  ~snpe_tizen_hal_subplugin ();
+
+  tensor_filter_subplugin &getEmptyInstance ();
+  void configure_instance (const GstTensorFilterProperties *prop);
+  void invoke (const GstTensorMemory *input, GstTensorMemory *output);
+  void getFrameworkInfo (GstTensorFilterFrameworkInfo &info);
+  int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info);
+  int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data);
+};
+
+const char *snpe_tizen_hal_subplugin::fw_name = "snpe";
+
+/**
+ * @brief Constructor for snpe_tizen_hal_subplugin.
+ */
+snpe_tizen_hal_subplugin::snpe_tizen_hal_subplugin ()
+    : tensor_filter_subplugin (), hal_handle (nullptr)
+{
+  int ret = hal_ml_create ("snpe", &hal_handle);
+  if (ret == HAL_ML_ERROR_INVALID_PARAMETER) {
+    throw std::invalid_argument ("SNPE HAL is not supported");
+  }
+
+  if (ret != HAL_ML_ERROR_NONE) {
+    throw std::runtime_error ("Failed to initialize SNPE HAL ML");
+  }
+}
+
+/**
+ * @brief Destructor for snpe subplugin.
+ */
+snpe_tizen_hal_subplugin::~snpe_tizen_hal_subplugin ()
+{
+  if (hal_handle)
+    hal_ml_destroy (hal_handle);
+}
+
+/**
+ * @brief Method to get empty object.
+ */
+tensor_filter_subplugin &
+snpe_tizen_hal_subplugin::getEmptyInstance ()
+{
+  return *(new snpe_tizen_hal_subplugin ());
+}
+
+/**
+ * @brief Method to prepare/configure SNPE instance.
+ */
+void
+snpe_tizen_hal_subplugin::configure_instance (const GstTensorFilterProperties *prop)
+{
+  hal_ml_param_h param = nullptr;
+
+  int ret = hal_ml_param_create (&param);
+  if (ret != HAL_ML_ERROR_NONE) {
+    throw std::runtime_error ("Failed to create hal_ml_param for configuring instance");
+  }
+
+  ret = hal_ml_param_set (param, "properties", (void *) prop);
+  if (ret != HAL_ML_ERROR_NONE) {
+    hal_ml_param_destroy (param);
+    throw std::runtime_error ("Failed to set 'properties' parameter for SNPE configuration");
+  }
+
+  ret = hal_ml_request (hal_handle, "configure_instance", param);
+  if (ret != HAL_ML_ERROR_NONE) {
+    hal_ml_param_destroy (param);
+    throw std::runtime_error ("Failed to configure SNPE instance");
+  }
+
+  hal_ml_param_destroy (param);
+}
+
+/**
+ * @brief Method to execute the model.
+ */
+void
+snpe_tizen_hal_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
+{
+  if (!input) {
+    throw std::runtime_error ("Invalid input buffer, it is NULL.");
+  }
+  if (!output) {
+    throw std::runtime_error ("Invalid output buffer, it is NULL.");
+  }
+
+  int ret = hal_ml_request_invoke (hal_handle, input, output);
+  if (ret != HAL_ML_ERROR_NONE) {
+    throw std::runtime_error ("Failed to invoke SNPE model execution");
+  }
+}
+
+/**
+ * @brief Method to get the information of SNPE subplugin.
+ */
+void
+snpe_tizen_hal_subplugin::getFrameworkInfo (GstTensorFilterFrameworkInfo &info)
+{
+  hal_ml_param_h param = nullptr;
+  int ret = hal_ml_param_create (&param);
+  if (ret != HAL_ML_ERROR_NONE) {
+    throw std::runtime_error ("Failed to create hal_ml_param for getting framework info");
+  }
+
+  ret = hal_ml_param_set (param, "framework_info", (void *) std::addressof (info));
+  if (ret != HAL_ML_ERROR_NONE) {
+    hal_ml_param_destroy (param);
+    throw std::runtime_error ("Failed to set 'framework_info' parameter");
+  }
+
+  ret = hal_ml_request (hal_handle, "get_framework_info", param);
+  if (ret != HAL_ML_ERROR_NONE) {
+    hal_ml_param_destroy (param);
+    throw std::runtime_error ("Failed to get framework info");
+  }
+
+  hal_ml_param_destroy (param);
+  info.name = fw_name;
+}
+
+/**
+ * @brief Method to get the model information.
+ */
+int
+snpe_tizen_hal_subplugin::getModelInfo (
+    model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info)
+{
+  hal_ml_param_h param = nullptr;
+  int ret = hal_ml_param_create (&param);
+  if (ret != HAL_ML_ERROR_NONE) {
+    nns_loge ("Failed to create hal_ml_param");
+  }
+
+  if (hal_ml_param_set (param, "ops", (void *) &ops) != HAL_ML_ERROR_NONE
+      || hal_ml_param_set (param, "in_info", (void *) std::addressof (in_info)) != HAL_ML_ERROR_NONE
+      || hal_ml_param_set (param, "out_info", (void *) std::addressof (out_info))
+             != HAL_ML_ERROR_NONE) {
+    hal_ml_param_destroy (param);
+    nns_loge ("Failed to set parameters for getModelInfo");
+    return HAL_ML_ERROR_RUNTIME_ERROR;
+  }
+
+  ret = hal_ml_request (hal_handle, "get_model_info", param);
+  hal_ml_param_destroy (param);
+
+  return ret;
+}
+
+/**
+ * @brief Method to handle events.
+ */
+int
+snpe_tizen_hal_subplugin::eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data)
+{
+  hal_ml_param_h param = nullptr;
+  int ret = hal_ml_param_create (&param);
+  if (ret != HAL_ML_ERROR_NONE) {
+    nns_loge ("Failed to create hal_ml_param");
+  }
+
+  if (hal_ml_param_set (param, "ops", (void *) &ops) != HAL_ML_ERROR_NONE
+      || hal_ml_param_set (param, "data", (void *) std::addressof (data)) != HAL_ML_ERROR_NONE) {
+    hal_ml_param_destroy (param);
+    nns_loge ("Failed to set parameters for event handler");
+    return HAL_ML_ERROR_RUNTIME_ERROR;
+  }
+
+  ret = hal_ml_request (hal_handle, "event_handler", param);
+  hal_ml_param_destroy (param);
+
+  return ret;
+}
+
+snpe_tizen_hal_subplugin *snpe_tizen_hal_subplugin::registeredRepresentation = nullptr;
+
+/** @brief Initialize this object for tensor_filter subplugin runtime register */
+void
+snpe_tizen_hal_subplugin::init_filter_snpe_tizen_hal (void)
+{
+  registeredRepresentation
+      = tensor_filter_subplugin::register_subplugin<snpe_tizen_hal_subplugin> ();
+}
+
+/** @brief Destruct the subplugin */
+void
+snpe_tizen_hal_subplugin::fini_filter_snpe_tizen_hal (void)
+{
+  assert (registeredRepresentation != nullptr);
+  tensor_filter_subplugin::unregister_subplugin (registeredRepresentation);
+}
+
+/**
+ * @brief Register the sub-plugin for SNPE.
+ */
+void
+init_filter_snpe_tizen_hal ()
+{
+  snpe_tizen_hal_subplugin::init_filter_snpe_tizen_hal ();
+}
+
+/**
+ * @brief Destruct the sub-plugin for SNPE.
+ */
+void
+fini_filter_snpe_tizen_hal ()
+{
+  snpe_tizen_hal_subplugin::fini_filter_snpe_tizen_hal ();
+}
+
+} /* namespace tensor_filter_snpe_tizen_hal */
+} /* namespace nnstreamer */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tizen_hal_vivante.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tizen_hal_vivante.cc
@@ -1,0 +1,264 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * NNStreamer tensor_filter, sub-plugin for Vivante
+ * Copyright (C) 2025 Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ */
+/**
+ * @file      tensor_filter_tizen_hal_vivante.cc
+ * @date      15 Jan 2025
+ * @brief     NNStreamer tensor-filter sub-plugin for Tizen HAL Vivante
+ * @see       http://github.com/nnstreamer/nnstreamer
+ * @author    Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ * @bug       No known bugs except for NYI items
+ *
+ * This is the per-NN-framework plugin (Tizen HAL Vivante) for tensor_filter.
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <glib.h>
+#include <nnstreamer_cppplugin_api_filter.hh>
+#include <nnstreamer_log.h>
+#include <nnstreamer_plugin_api_util.h>
+#include <nnstreamer_util.h>
+
+#include <hal-ml.h>
+
+
+namespace nnstreamer
+{
+namespace tensor_filter_vivante_tizen_hal
+{
+extern "C" {
+void init_filter_vivante_tizen_hal (void) __attribute__ ((constructor));
+void fini_filter_vivante_tizen_hal (void) __attribute__ ((destructor));
+}
+
+/** @brief tensor-filter-subplugin concrete class for Vivante */
+class vivante_tizen_hal_subplugin final : public tensor_filter_subplugin
+{
+  private:
+  static const char *fw_name;
+  static vivante_tizen_hal_subplugin *registeredRepresentation;
+  static const GstTensorFilterFrameworkInfo framework_info;
+
+  hal_ml_h hal_handle;
+
+  public:
+  static void init_filter_vivante_tizen_hal ();
+  static void fini_filter_vivante_tizen_hal ();
+
+  vivante_tizen_hal_subplugin ();
+  ~vivante_tizen_hal_subplugin ();
+
+  tensor_filter_subplugin &getEmptyInstance ();
+  void configure_instance (const GstTensorFilterProperties *prop);
+  void invoke (const GstTensorMemory *input, GstTensorMemory *output);
+  void getFrameworkInfo (GstTensorFilterFrameworkInfo &info);
+  int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info);
+  int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data);
+};
+
+const char *vivante_tizen_hal_subplugin::fw_name = "vivante";
+
+/**
+ * @brief Constructor for vivante_tizen_hal_subplugin.
+ */
+vivante_tizen_hal_subplugin::vivante_tizen_hal_subplugin ()
+    : tensor_filter_subplugin (), hal_handle (nullptr)
+{
+  int ret = hal_ml_create ("vivante", &hal_handle);
+  if (ret == HAL_ML_ERROR_INVALID_PARAMETER) {
+    throw std::invalid_argument ("Vivante is not supported");
+  }
+  if (ret != HAL_ML_ERROR_NONE) {
+    throw std::runtime_error ("Failed to initialize Vivante HAL ML");
+  }
+}
+
+/**
+ * @brief Destructor for vivante subplugin.
+ */
+vivante_tizen_hal_subplugin::~vivante_tizen_hal_subplugin ()
+{
+  if (hal_handle)
+    hal_ml_destroy (hal_handle);
+}
+
+/**
+ * @brief Method to get empty object.
+ */
+tensor_filter_subplugin &
+vivante_tizen_hal_subplugin::getEmptyInstance ()
+{
+  return *(new vivante_tizen_hal_subplugin ());
+}
+
+
+/**
+ * @brief Method to prepare/configure Vivante instance.
+ */
+void
+vivante_tizen_hal_subplugin::configure_instance (const GstTensorFilterProperties *prop)
+{
+  hal_ml_param_h param = nullptr;
+
+  int ret = hal_ml_param_create (&param);
+  if (ret != HAL_ML_ERROR_NONE) {
+    throw std::runtime_error ("Failed to create hal_ml_param for configuring instance");
+  }
+
+  ret = hal_ml_param_set (param, "properties", (void *) prop);
+  if (ret != HAL_ML_ERROR_NONE) {
+    hal_ml_param_destroy (param);
+    throw std::runtime_error ("Failed to set 'properties' parameter for SNPE configuration");
+  }
+
+  ret = hal_ml_request (hal_handle, "configure_instance", param);
+  if (ret != HAL_ML_ERROR_NONE) {
+    hal_ml_param_destroy (param);
+    throw std::runtime_error ("Failed to configure SNPE instance");
+  }
+
+  hal_ml_param_destroy (param);
+}
+
+/**
+ * @brief Method to execute the model.
+ */
+void
+vivante_tizen_hal_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
+{
+  if (!input)
+    throw std::runtime_error ("Invalid input buffer, it is NULL.");
+  if (!output)
+    throw std::runtime_error ("Invalid output buffer, it is NULL.");
+
+  int ret = hal_ml_request_invoke (hal_handle, input, output);
+  if (ret != HAL_ML_ERROR_NONE) {
+    throw std::runtime_error ("Failed to invoke Vivante model");
+  }
+}
+
+/**
+ * @brief Method to get the information of Vivante subplugin.
+ */
+void
+vivante_tizen_hal_subplugin::getFrameworkInfo (GstTensorFilterFrameworkInfo &info)
+{
+  hal_ml_param_h param = nullptr;
+  int ret = hal_ml_param_create (&param);
+  if (ret != HAL_ML_ERROR_NONE) {
+    throw std::runtime_error ("Failed to create hal_ml_param for getting framework info");
+  }
+
+  ret = hal_ml_param_set (param, "framework_info", (void *) std::addressof (info));
+  if (ret != HAL_ML_ERROR_NONE) {
+    hal_ml_param_destroy (param);
+    throw std::runtime_error ("Failed to set 'framework_info' parameter");
+  }
+
+  ret = hal_ml_request (hal_handle, "get_framework_info", param);
+  if (ret != HAL_ML_ERROR_NONE) {
+    hal_ml_param_destroy (param);
+    throw std::runtime_error ("Failed to get framework info");
+  }
+
+  hal_ml_param_destroy (param);
+  info.name = fw_name;
+}
+
+/**
+ * @brief Method to get the model information.
+ */
+int
+vivante_tizen_hal_subplugin::getModelInfo (
+    model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info)
+{
+  hal_ml_param_h param = nullptr;
+  int ret = hal_ml_param_create (&param);
+  if (ret != HAL_ML_ERROR_NONE) {
+    nns_loge ("Failed to create hal_ml_param");
+  }
+
+  if (hal_ml_param_set (param, "ops", (void *) &ops) != HAL_ML_ERROR_NONE
+      || hal_ml_param_set (param, "in_info", (void *) std::addressof (in_info)) != HAL_ML_ERROR_NONE
+      || hal_ml_param_set (param, "out_info", (void *) std::addressof (out_info))
+             != HAL_ML_ERROR_NONE) {
+    hal_ml_param_destroy (param);
+    nns_loge ("Failed to set parameters for getModelInfo");
+    return HAL_ML_ERROR_RUNTIME_ERROR;
+  }
+
+  ret = hal_ml_request (hal_handle, "get_model_info", param);
+  hal_ml_param_destroy (param);
+
+  return ret;
+}
+
+/**
+ * @brief Method to handle events.
+ */
+int
+vivante_tizen_hal_subplugin::eventHandler (
+    event_ops ops, GstTensorFilterFrameworkEventData &data)
+{
+  hal_ml_param_h param = nullptr;
+  int ret = hal_ml_param_create (&param);
+  if (ret != HAL_ML_ERROR_NONE) {
+    nns_loge ("Failed to create hal_ml_param");
+  }
+
+  if (hal_ml_param_set (param, "ops", (void *) &ops) != HAL_ML_ERROR_NONE
+      || hal_ml_param_set (param, "data", (void *) std::addressof (data)) != HAL_ML_ERROR_NONE) {
+    hal_ml_param_destroy (param);
+    nns_loge ("Failed to set parameters for event handler");
+    return HAL_ML_ERROR_RUNTIME_ERROR;
+  }
+
+  ret = hal_ml_request (hal_handle, "event_handler", param);
+  hal_ml_param_destroy (param);
+
+  return ret;
+}
+
+vivante_tizen_hal_subplugin *vivante_tizen_hal_subplugin::registeredRepresentation = nullptr;
+
+/** @brief Initialize this object for tensor_filter subplugin runtime register */
+void
+vivante_tizen_hal_subplugin::init_filter_vivante_tizen_hal (void)
+{
+  registeredRepresentation
+      = tensor_filter_subplugin::register_subplugin<vivante_tizen_hal_subplugin> ();
+}
+
+/** @brief Destruct the subplugin */
+void
+vivante_tizen_hal_subplugin::fini_filter_vivante_tizen_hal (void)
+{
+  assert (registeredRepresentation != nullptr);
+  tensor_filter_subplugin::unregister_subplugin (registeredRepresentation);
+}
+
+/**
+ * @brief Register the sub-plugin for Vivante.
+ */
+void
+init_filter_vivante_tizen_hal ()
+{
+  vivante_tizen_hal_subplugin::init_filter_vivante_tizen_hal ();
+}
+
+/**
+ * @brief Destruct the sub-plugin for Vivante.
+ */
+void
+fini_filter_vivante_tizen_hal ()
+{
+  vivante_tizen_hal_subplugin::fini_filter_vivante_tizen_hal ();
+}
+
+} /* namespace tensor_filter_vivante_tizen_hal */
+} /* namespace nnstreamer */

--- a/meson.build
+++ b/meson.build
@@ -668,7 +668,11 @@ features = {
   'llamacpp-support' : {
     'target': 'llama',
     'project_args': { 'ENABLE_LLAMACPP' : 1 }
-  }
+  },
+  'tizen-hal-support': {
+    'target': 'hal-api-ml',
+    'project_args': { 'ENABLE_TIZEN_HAL' : 1 }
+  },
 }
 
 project_args = {}

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,7 @@
 # features
 option('video-support', type: 'feature', value: 'enabled')
 option('audio-support', type: 'feature', value: 'enabled')
+option('tizen-hal-support', type: 'feature', value: 'auto')
 option('tf-support', type: 'feature', value: 'auto')
 option('tflite-support', type: 'feature', value: 'auto')
 option('tflite2-support', type: 'feature', value: 'auto')

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -45,6 +45,9 @@
 %define		datarepo_support 1
 %define		ml_agent_support 1
 
+# Support Tizen HAL ML for Tizen 10.0+
+%define		tizen_hal_support 1
+
 %define		check_test 1
 %define		release_test 1
 
@@ -374,6 +377,11 @@ BuildRequires: pkgconfig(json-glib-1.0)
 BuildRequires: pkgconfig(mlops-agent)
 %endif
 
+# For tizen-hal
+%if 0%{?tizen_hal_support}
+BuildRequires: pkgconfig(hal-api-ml)
+%endif
+
 # Note that debug packages generate an additional build and storage cost.
 # If you do not need debug packages, run '$ gbs -c .TAOS-CI/.gbs.conf build ... --define "_skip_debug_rpm 1"'.
 
@@ -569,6 +577,16 @@ Requires:	nnstreamer-single = %{version}-%{release}
 Requires:	executorch
 %description executorch
 NNStreamer's tensor_filter subplugin of executorch
+%endif
+
+# for tizen-hal
+%if 0%{?tizen_hal_support}
+%package tizen-hal
+Summary:	NNStreamer tizen-hal Support
+Requires:	nnstreamer-single = %{version}-%{release}
+Requires:	hal-api-ml
+%description tizen-hal
+NNStreamer's tensor_filter subplugin of tizen-hal
 %endif
 
 %package devel
@@ -798,6 +816,13 @@ NNStreamer's datareposrc/sink plugins for reading and writing files in MLOps Dat
 %define element_restriction -Denable-element-restriction=true -Dallowed-elements=%{allowed_element}
 %endif #if tizen
 
+# Support tizen-hal
+%if 0%{?tizen_hal_support}
+%define enable_tizen_hal -Dtizen-hal-support=enabled
+%else
+%define enable_tizen_hal -Dtizen-hal-support=disabled
+%endif
+
 # Support tensorflow
 %if 0%{?tensorflow_support}
 %define enable_tf -Dtf-support=enabled
@@ -977,7 +1002,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir
 	%{enable_flatbuf} %{enable_trix_engine} %{enable_datarepo} \
 	%{enable_tizen_sensor} %{enable_mqtt} %{enable_lua} %{enable_tvm} %{enable_onnxruntime} %{enable_executorch} \
         %{enable_test} %{enable_test_coverage} %{install_test} \
-	%{fp16_support} %{nnsedge} %{enable_ml_agent} \
+	%{fp16_support} %{nnsedge} %{enable_ml_agent} %{enable_tizen_hal} \
 	%{builddir}
 
 ninja -C %{builddir} %{?_smp_mflags}
@@ -1241,6 +1266,14 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_tvm.so
+%endif
+
+%if 0%{?tizen_hal_support}
+%files tizen-hal
+%manifest nnstreamer.manifest
+%defattr(-,root,root,-)
+%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_snpe.so
+%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_vivante.so
 %endif
 
 # for snpe


### PR DESCRIPTION
- Add snpe and vivante tensor_filter for Tizen HAL.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

See also
https://github.com/nnstreamer/hal-api-ml
https://github.com/nnstreamer/hal-backend-ml-accelerator

Diagram
```mermaid
---
title: Tizen ML HAL Architecture
config:
  class:
    hideEmptyMembersBox: true
---
classDiagram
  class hal-backend-ml.git {
    hal-backend-ml-snpe
    hal-backend-ml-vivante
    ..
    tensor_typedef.h
    nnstreamer_plugin_api_filter.h
  }
  hal-backend-ml.git -- libhal-backend-ml-snpe.so
  snpe <|.. hal-backend-ml.git : BuildRequires/Requires
  class snpe {
    snpe
  }
  hal-backend-ml.git -- libhal-backend-ml-vivante.so
  vivante <|.. hal-backend-ml.git : BuildRequires/Requires
  class vivante {
    ovxlib
    amlogic-vsi-npu-sdk
  }
  libhal-backend-ml-snpe.so .. libhal-backend-ml-vivante.so

  note for hal-backend-ml.git "
  tensor_typedef.h and nnstreamer_plugin_api_filter.h
  are copy-and-pasted from nnstreamer.git
  "
  class hal-api-ml.git {
    typedef void *hal_ml_h
    typedef void *hal_ml_param_h
    int hal_ml_init(char *backend_name, hal_ml_h *handle)
    int hal_ml_deinit(hal_ml_h handle)
    int hal_ml_request(hal_ml_h handle, char *request_name, hal_ml_param_h param)
    int hal_ml_request_invoke(hal_ml_h handle, const void *input, void *output)
    hal_ml_request_invoke_dynamic(hal_ml_h handle, void *prop, const void *input, void *output)
    int hal_ml_param_create(hal_ml_param_h *param)
    int hal_ml_param_destroy(hal_ml_param_h param)
    int hal_ml_param_set(hal_ml_param_h param, const char *key, const void *value)
  }
  hal-api-ml.git -- libhal-api-ml.so
  libhal-api-ml.so <-- libnnstreamer_filter_snpe.so
  libhal-api-ml.so <-- libnnstreamer_filter_vivante.so
  libhal-api-ml.so --> libhal-backend-ml-snpe.so : hal-common-api(dlopen)
  libhal-api-ml.so --> libhal-backend-ml-vivante.so : hal-common-api(dlopen)
  libnnstreamer_filter_snpe.so .. libnnstreamer_filter_vivante.so
  nns_defs <|.. libnnstreamer_filter_snpe.so : include
  class nns_defs {
    tensor_typedef.h
    nnstreamer_plugin_api_filter.h
  }
  nnstreamer .. libnnstreamer_filter_snpe.so
  nnstreamer .. libnnstreamer_filter_vivante.so
  Tizen-ML-API .. nnstreamer
  Tizen-ML-Apps .. Tizen-ML-API
```

## How To Build and Test

1. gbs build common-hal-api
  https://review.tizen.org/gerrit/c/platform/hal/api/common/+/318242 (apply this commit)
  https://github.sec.samsung.net/Tizen/common-hal-api

2. gbs build hal-api-ml
  https://github.com/nnstreamer/hal-api-ml

3. gbs build rootstrap-data-common
  https://review.tizen.org/gerrit/c/platform/hal/backend/rootstrap-data-common/+/318391 (apply this commit)
  https://github.sec.samsung.net/Tizen/rootstrap-data-common/

4. gbs build rootstrap
  https://github.sec.samsung.net/Tizen/rootstrap

5. gbs build hal-backend-ml
  https://github.com/nnstreamer/hal-backend-ml-accelerator

6. gbs build nnstreamer
  https://github.com/nnstreamer/nnstreamer/pull/4679 (apply this commit)

7. test Tizen ML apps (It should work with no change)
