### PR TITLE
action: run ubuntu arm build/test in arm machines

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-22.04-arm ]
 
     steps:
     - uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
       with:
         mode: rebuild
     - if: env.rebuild == '1'
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: install requirements


### PR DESCRIPTION
Building and running at aarch64 machines
is much faster than at x64 machines.

Note: actions/setup-python@v1 is not compatible with arm machines. Update it to the latest.