### PR TITLE
[Action] Fix `NNStreamer + NNTrainer gbs build daily test`

### DIFF
--- a/.github/workflows/update_gbs_cache.yml
+++ b/.github/workflows/update_gbs_cache.yml
@@ -81,7 +81,7 @@ jobs:
     - if: matrix.gbs_build_arch == 'x86_64' && steps.gbs-build.outcome == 'success'
       name: extract test coverage result
       run: |
-        pip install pybadges beautifulsoup4 setuptools
+        pip install pybadges beautifulsoup4 setuptools standard-imghdr
         mkdir -p ~/testresult/
         pushd ~/testresult/
         cp ~/GBS-ROOT/local/repos/tizen/x86_64/RPMS/*-coverage*.rpm .


### PR DESCRIPTION
# Description

GitHub Action <NNStreamer + NNTrainer gbs build daily test> was failed with the following message.

```
Traceback (most recent call last):
  File "/home/runner/work/***/***/.github/workflows/gen_coverage_badge.py", line 16, in <module>
    from pybadges import badge
  File "/opt/hostedtoolcache/Python/3.13.1/x64/lib/python3.13/site-packages/pybadges/__init__.py", line 33, in <module>
    import imghdr
ModuleNotFoundError: No module named 'imghdr'
```

https://github.com/nnstreamer/nnstreamer/blob/268d09a28e350b5a443fff3a1479ed931a755f2c/.github/workflows/update_gbs_cache.yml#L81-L90

The reason for this is that the module `imghdr` is no longer part of the Python standard library. It was removed in Python 3.13.
(https://docs.python.org/ko/3/library/imghdr.html)

So, install the module `imghdr` with pip, before this step.

# Further Work

1. Fix error in step \<Run nntrainer GBS build>.

```
Run pushd nntrainer
~/work/***/***/nntrainer ~/work/***/***
info: generate repositories ...
warning: No local package repository for arch armv7l
info: build conf has been downloaded at:
      /var/tmp/runner-gbs/tizen.conf
info: start building packages from: /home/runner/work/***/***/nntrainer (git)
2025-02-06 20:46 +0000
gbs 2.0.[1](https://github.com/nnstreamer/nnstreamer/actions/runs/13187162277/job/36811917404#step:16:1)

...

warning: build failed, Leaving the logs in /home/runner/GBS-ROOT/local/repos/tizen/armv7l/logs/fail/nntrainer-0.6.0-0/log.txt
info: *** Build Status Summary ***
=== the following packages failed to build due to rpmbuild issue (1) ===
nntrainer: /home/runner/GBS-ROOT/local/repos/tizen/armv7l/logs/fail/nntrainer-0.6.0-0/log.txt
=== Total succeeded built packages: (0) ===
info: generated html format report:
     /home/runner/GBS-ROOT/local/repos/tizen/armv7l/index.html
info: generated RPM packages can be found from local repo:
     /home/runner/GBS-ROOT/local/repos/tizen/armv7l/RPMS
info: build logs can be found in:
     /home/runner/GBS-ROOT/local/repos/tizen/armv7l/logs
info: build roots located in:
     /home/runner/GBS-ROOT/local/BUILD-ROOTS/scratch.armv7l.*
error: <gbs>some packages failed to be built
Error: Process completed with exit code 1.
```

2. Fix error in step \<build and tests on GBS>.

```
Run gbs build --define "unit_test 1" --define "_skip_debug_rpm 1" -A aarch64
info: generate repositories ...
warning: No local package repository for arch aarch[6](https://github.com/nnstreamer/nnstreamer/actions/runs/13187162277/job/36811917794#step:8:7)4
info: build conf has been downloaded at:
      /var/tmp/runner-gbs/tizen.conf
info: start building packages from: /home/runner/work/***/*** (git)
2025-02-06 20:1[8](https://github.com/nnstreamer/nnstreamer/actions/runs/13187162277/job/36811917794#step:8:9) +0000
gbs 2.0.1

...

warning: build failed, Leaving the logs in /home/runner/GBS-ROOT/local/repos/tizen/aarch64/logs/fail/***-2.4.2-0/log.txt
info: *** Build Status Summary ***
=== the following packages failed to build due to rpmbuild issue (1) ===
***: /home/runner/GBS-ROOT/local/repos/tizen/aarch64/logs/fail/***-2.4.2-0/log.txt
=== Total succeeded built packages: (0) ===
info: generated html format report:
     /home/runner/GBS-ROOT/local/repos/tizen/aarch64/index.html
info: generated RPM packages can be found from local repo:
     /home/runner/GBS-ROOT/local/repos/tizen/aarch64/RPMS
info: generated source RPM packages can be found from local repo:
     /home/runner/GBS-ROOT/local/repos/tizen/aarch64/SRPMS
info: build logs can be found in:
     /home/runner/GBS-ROOT/local/repos/tizen/aarch64/logs
info: build roots located in:
     /home/runner/GBS-ROOT/local/BUILD-ROOTS/scratch.aarch64.*
error: <gbs>some packages failed to be built
Error: Process completed with exit code 1.
```

# Self Evaluation

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
4. Run test: [ ]Passed [ ]Failed [*]Skipped
