### PR TITLE
[Action] action/upload-artifact version update

### DIFF
--- a/.github/workflows/ubuntu_clean_llvm_build.yml
+++ b/.github/workflows/ubuntu_clean_llvm_build.yml
@@ -41,7 +41,7 @@ jobs:
       if: env.rebuild == '1'
     - run: meson test -C build/ -v
       if: env.rebuild == '1'
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: Meson_LLVM_Testlog

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -47,7 +47,7 @@ jobs:
       env:
         CC: gcc
     - name: Upload core if something went wrong
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
         name: cores
@@ -61,7 +61,7 @@ jobs:
           gdb ${ERROREXEC} -c coredump -batch -ex bt
           echo "::endgroup::"
         fi
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: Meson_Testlog


### PR DESCRIPTION
GitHub Action \<Minimal meson build in Ubuntu with LLVM/clang> and \<Minimal meson build in Ubuntu with Valgrind> were failed with the following message.

```
Current runner version: '2.322.0'
Operating System
Runner Image
Runner Image Provisioner
GITHUB_TOKEN Permissions
Secret source: None
Prepare workflow directory
Prepare all required actions
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. 

```

The reason for this is that `action/upload-artifact@v3` is no longer available, since January 30th, 2025.
(https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

So, update version of action/upload-artifact to v4.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

