### PR TITLE
[Tests] Fix invalid ini path

### DIFF
--- a/tests/nnstreamer_grpc/runTest.sh
+++ b/tests/nnstreamer_grpc/runTest.sh
@@ -32,7 +32,7 @@ if [[ -z $PATH_TO_PLUGIN ]]; then
 fi
 
 if [[ -d $PATH_TO_PLUGIN ]]; then
-    ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer"
+    ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/registerer"
     if [[ -d ${ini_path} ]]; then
         check=$(ls ${ini_path} | grep nnstreamer-grpc.${SO_EXT})
         if [[ ! $check ]]; then


### PR DESCRIPTION
Fix invalid ini path.
This patch increases test coverage from 78.5% to 81.3%.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

