### PR TITLE
[Common] caps for compatibility

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_crop.c
+++ b/gst/nnstreamer/elements/gsttensor_crop.c
@@ -402,7 +402,7 @@ gst_tensor_crop_sink_event (GstCollectPads * pads, GstCollectData * data,
       gboolean ret;
       gst_event_parse_caps (event, &caps);
 
-      ret = gst_tensors_config_from_cap (&cpad->config, caps);
+      ret = gst_tensors_config_from_caps (&cpad->config, caps);
       gst_event_unref (event);
 
       return ret;

--- a/gst/nnstreamer/elements/gsttensor_demux.c
+++ b/gst/nnstreamer/elements/gsttensor_demux.c
@@ -239,7 +239,7 @@ gst_tensor_demux_event (GstPad * pad, GstObject * parent, GstEvent * event)
     {
       GstCaps *caps;
       gst_event_parse_caps (event, &caps);
-      gst_tensors_config_from_cap (&tensor_demux->tensors_config, caps);
+      gst_tensors_config_from_caps (&tensor_demux->tensors_config, caps);
       break;
     }
     case GST_EVENT_EOS:

--- a/gst/nnstreamer/elements/gsttensor_if.c
+++ b/gst/nnstreamer/elements/gsttensor_if.c
@@ -683,7 +683,7 @@ gst_tensor_if_event (GstPad * pad, GstObject * parent, GstEvent * event)
     {
       GstCaps *caps;
       gst_event_parse_caps (event, &caps);
-      if (!gst_tensors_config_from_cap (&tensor_if->in_config, caps)) {
+      if (!gst_tensors_config_from_caps (&tensor_if->in_config, caps)) {
         GST_ERROR_OBJECT (tensor_if, "Failed to parse caps.\n");
         gst_event_unref (event);
         return FALSE;

--- a/gst/nnstreamer/elements/gsttensor_sparseenc.c
+++ b/gst/nnstreamer/elements/gsttensor_sparseenc.c
@@ -242,7 +242,7 @@ gst_tensor_sparse_enc_sink_event (GstPad * pad, GstObject * parent,
       gst_event_parse_caps (event, &caps);
       silent_debug_caps (self, caps, "caps");
 
-      ret = gst_tensors_config_from_cap (&self->in_config, caps);
+      ret = gst_tensors_config_from_caps (&self->in_config, caps);
       gst_event_unref (event);
       return ret;
     }

--- a/gst/nnstreamer/elements/gsttensor_split.c
+++ b/gst/nnstreamer/elements/gsttensor_split.c
@@ -224,8 +224,9 @@ gst_tensor_split_event (GstPad * pad, GstObject * parent, GstEvent * event)
     case GST_EVENT_CAPS:
     {
       GstCaps *caps;
+
       gst_event_parse_caps (event, &caps);
-      if (!gst_tensors_config_from_cap (&split->sink_tensor_conf, caps)) {
+      if (!gst_tensors_config_from_caps (&split->sink_tensor_conf, caps)) {
         GST_ELEMENT_ERROR (split, STREAM, WRONG_TYPE,
             ("This stream contains no valid type."), NULL);
       }

--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -56,7 +56,7 @@ gst_tensors_config_from_structure (GstTensorsConfig *config,
  * @return TRUE/FALSE (if successfully configured, return TRUE)
  */
 extern gboolean
-gst_tensors_config_from_cap (GstTensorsConfig *config, const GstCaps * caps);
+gst_tensors_config_from_caps (GstTensorsConfig *config, const GstCaps *caps);
 
 /**
  * @brief Parse caps from peer pad and set tensors config.

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
@@ -169,12 +169,14 @@ gst_tensors_info_get_dimensions_string (const GstTensorsInfo * info);
  * @brief Get the string of dimensions in tensors info and rank count
  * @param info tensors info structure
  * @param rank rank count of given tensor dimension
+ * @param padding fill 1 if actual rank is smaller than rank
  * @return Formatted string of given dimension
  * @note If rank count is 3, then returned string is 'd1:d2:d3`.
  * The returned value should be freed with g_free()
  */
 extern gchar *
-gst_tensors_info_get_rank_dimensions_string (const GstTensorsInfo * info, const unsigned int rank);
+gst_tensors_info_get_rank_dimensions_string (const GstTensorsInfo * info,
+    const unsigned int rank, const gboolean padding);
 
 /**
  * @brief Get the string of types in tensors info
@@ -337,12 +339,14 @@ gst_tensor_get_dimension_string (const tensor_dim dim);
  * @brief Get dimension string from given tensor dimension and rank count.
  * @param dim tensor dimension
  * @param rank rank count of given tensor dimension
+ * @param padding fill 1 if actual rank is smaller than rank
  * @return Formatted string of given dimension
  * @note If rank count is 3, then returned string is 'd1:d2:d3`.
  * The returned value should be freed with g_free().
  */
 extern gchar *
-gst_tensor_get_rank_dimension_string (const tensor_dim dim, const unsigned int rank);
+gst_tensor_get_rank_dimension_string (const tensor_dim dim,
+    const unsigned int rank, const gboolean padding);
 
 /**
  * @brief Compare dimension strings

--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -1503,7 +1503,7 @@ gst_tensors_config_from_structure (GstTensorsConfig * config,
  * @return TRUE/FALSE (if successfully configured, return TRUE)
  */
 gboolean
-gst_tensors_config_from_cap (GstTensorsConfig * config, const GstCaps * caps)
+gst_tensors_config_from_caps (GstTensorsConfig * config, const GstCaps * caps)
 {
   GstStructure *structure;
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -273,12 +273,13 @@ gst_tensor_filter_get_dimension_string (const GstTensorFilterProperties * prop,
 
   if (tinfo->num_tensors > 0) {
     guint i;
+    GstTensorInfo *_info;
     GString *dimensions = g_string_new (NULL);
 
     for (i = 0; i < tinfo->num_tensors; ++i) {
-      dim_str =
-          gst_tensor_get_rank_dimension_string (gst_tensors_info_get_nth_info (
-              (GstTensorsInfo *) tinfo, i)->dimension, *(_rank + i));
+      _info = gst_tensors_info_get_nth_info ((GstTensorsInfo *) tinfo, i);
+      dim_str = gst_tensor_get_rank_dimension_string (_info->dimension,
+          *(_rank + i), FALSE);
       g_string_append (dimensions, dim_str);
 
       if (i < tinfo->num_tensors - 1) {

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -1086,7 +1086,7 @@ TEST (commonTensorConfig, parseCapInvalidParam_p)
   GstCaps *caps = gst_caps_new_simple ("other/tensors", "format", G_TYPE_STRING,
       "flexible", "framerate", GST_TYPE_FRACTION, 30, 1, NULL);
   gst_tensors_config_init (&config);
-  EXPECT_TRUE (gst_tensors_config_from_cap (&config, caps));
+  EXPECT_TRUE (gst_tensors_config_from_caps (&config, caps));
 }
 
 /**
@@ -1096,7 +1096,7 @@ TEST (commonTensorConfig, parseCapInvalidParam0_n)
 {
   GstCaps *caps = gst_caps_new_simple ("other/tensor", "format", G_TYPE_STRING,
       "flexible", "framerate", GST_TYPE_FRACTION, 30, 1, NULL);
-  EXPECT_FALSE (gst_tensors_config_from_cap (NULL, caps));
+  EXPECT_FALSE (gst_tensors_config_from_caps (NULL, caps));
 }
 
 /**
@@ -1106,7 +1106,7 @@ TEST (commonTensorConfig, parseCapInvalidParam1_n)
 {
   GstTensorsConfig config;
   gst_tensors_config_init (&config);
-  EXPECT_FALSE (gst_tensors_config_from_cap (&config, NULL));
+  EXPECT_FALSE (gst_tensors_config_from_caps (&config, NULL));
 }
 
 /**
@@ -1118,7 +1118,7 @@ TEST (commonTensorConfig, parseUnfixedCaps_n)
   GstCaps *caps = gst_caps_new_simple ("other/tensor", "format", G_TYPE_STRING,
       "static", "framerate", GST_TYPE_FRACTION_RANGE, 0, 1, G_MAXINT, 1, NULL);
   gst_tensors_config_init (&config);
-  EXPECT_FALSE (gst_tensors_config_from_cap (&config, caps));
+  EXPECT_FALSE (gst_tensors_config_from_caps (&config, caps));
 }
 
 /**


### PR DESCRIPTION
Update util functions to support old dimension format (padding with 1).

For example, if model has one tensor with shape '1', possible caps includes dimension '1' and '1:1:1:1'.
This PR fixes negotiation failure case using caps-filter.
