### PR TITLE
[RepoSrc] mem in out buffer

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_reposrc.c
+++ b/gst/nnstreamer/elements/gsttensor_reposrc.c
@@ -303,9 +303,9 @@ gst_tensor_reposrc_gen_dummy_buffer (GstTensorRepoSrc * self)
     _info = gst_tensors_info_get_nth_info (&self->config.info, i);
     size = gst_tensor_info_get_size (_info);
     mem = gst_allocator_alloc (NULL, size, NULL);
-    gst_tensor_buffer_append_memory (buf, mem, _info);
 
     if (!gst_memory_map (mem, &map, GST_MAP_WRITE)) {
+      gst_memory_unref (mem);
       gst_buffer_unref (buf);
       ml_logf ("Cannot map gst memory (tensor-repo-src).");
       return NULL;
@@ -313,6 +313,8 @@ gst_tensor_reposrc_gen_dummy_buffer (GstTensorRepoSrc * self)
 
     memset (map.data, 0, map.size);
     gst_memory_unmap (mem, &map);
+
+    gst_tensor_buffer_append_memory (buf, mem, _info);
   }
 
   return buf;


### PR DESCRIPTION
When creating buffer, appending tensor may allocate new memory.
Append memory after updating its contents.
