### PR TITLE
[build] Fix llamacpp deps in meson.build

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -935,8 +935,8 @@ endif
 
 if llamacpp_support_is_available
   filter_sub_llamacpp_sources = ['tensor_filter_llamacpp.cc']
-  libggml_dep = cc.find_library('ggml')
-  nnstreamer_filter_llamacpp_deps = [glib_dep, nnstreamer_single_dep, llamacpp_support_deps, libggml_dep]
+
+  nnstreamer_filter_llamacpp_deps = [glib_dep, nnstreamer_single_dep, llamacpp_support_deps]
 
   shared_library('nnstreamer_filter_llamacpp',
     filter_sub_llamacpp_sources,


### PR DESCRIPTION
- Remove explicit ggml dep, which is included in llamacpp_support_deps.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [ ]Skipped
