### PR TITLE
Fix workflows for daily github action

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: "3.10"
     - name: Install packages for hotdoc
       run: |
-        sudo apt-get install python3-dev libxml2-dev libxslt1-dev cmake libyaml-dev libclang-dev llvm-dev libglib2.0-dev libjson-glib-dev flex
+        sudo apt-get update && sudo apt-get install -y python3-dev libxml2-dev libxslt1-dev cmake libyaml-dev libclang-dev llvm-dev libglib2.0-dev libjson-glib-dev flex
         python -m pip install --upgrade pip
         pip install hotdoc
 
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install packages for doxygen
-      run: sudo apt-get install doxygen graphviz texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
+      run: sudo apt-get update && sudo apt-get install -y doxygen graphviz texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
     - name: Generate doxygen
       run: |
         doxygen .github/workflows/static.check.scripts/Doxyfile.prj

--- a/.github/workflows/update_gbs_cache.yml
+++ b/.github/workflows/update_gbs_cache.yml
@@ -108,7 +108,7 @@ jobs:
     - name: Run nntrainer GBS build
       run: |
         pushd nntrainer
-        gbs build --skip-srcrpm -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_option }} --define "_skip_debug_rpm 1"
+        gbs build --skip-srcrpm -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_arch == 'x86_64' && '--define "unit_test 1"' || '' }}
         popd
 
   print_result:

--- a/.github/workflows/update_pbuilder_cache.yml
+++ b/.github/workflows/update_pbuilder_cache.yml
@@ -21,7 +21,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: make cache dir for pbuilder
         ## prevent permission error
         run: sudo mkdir --mode a=rwx --parents /var/cache/pbuilder


### PR DESCRIPTION
Fix publishing docs 
- Add apt-get update command to prevent possible fetch error.

Fix pubuilder_cache workflow
- Fix python version to 3.11. Recent Python have dropped some packages.

Fix daily gbs cache workflow
- Check nntrainer with `--define 'unit_test 1'` for x86_64 only.
- Do not run testcoverage for nntrainer.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

