### PR TITLE
[test] Set `LD_LIBRARY_PATH` for unittest_edge

### DIFF
--- a/tests/nnstreamer_edge/meson.build
+++ b/tests/nnstreamer_edge/meson.build
@@ -13,6 +13,9 @@ unittest_edge = executable('unittest_edge',
   install_dir: unittest_install_dir
 )
 
+# Let the test lib for custom connection be loaded runtime.
+testenv.append('LD_LIBRARY_PATH', meson.current_build_dir())
+
 test('unittest_edge', unittest_edge, env: testenv)
 
 # Run unittest_query


### PR DESCRIPTION
- Let the nnsedge custom lib be loaded during unittest_edge runtime.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

