### PR TITLE
[build] Fix nnfw build failure issue

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  pytorch | libtorch-dev | gcc,
  libedgetpu1-std (>=12), libedgetpu-dev (>=12),
  openvino-dev, openvino-cpu-mkldnn [amd64],
- nnfw-dev [amd64] | gcc,
+ onert-dev [amd64],
  tvm-runtime-dev, onnxruntime-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer
@@ -98,7 +98,7 @@ Description: NNStreamer OpenVino support
 Package: nnstreamer-nnfw
 Architecture: amd64
 Multi-Arch: same
-Depends: nnstreamer-single, nnfw, ${shlibs:Depends}, ${misc:Depends}
+Depends: nnstreamer-single, onert, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer NNFW (ONE) support
  This package allows nnstreamer to support NNFW (ONE, On-Device Neural Engine).
 

--- a/debian/control.ubuntu.ppa
+++ b/debian/control.ubuntu.ppa
@@ -15,7 +15,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  pytorch | libtorch-dev | gcc,
  libedgetpu1-std (>=12), libedgetpu-dev (>=12),
  openvino-dev, openvino-cpu-mkldnn [amd64],
- nnfw-dev [amd64] | gcc,
+ onert-dev [amd64],
  tvm-runtime-dev, onnxruntime-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer
@@ -98,7 +98,7 @@ Description: NNStreamer OpenVino support
 Package: nnstreamer-nnfw
 Architecture: amd64
 Multi-Arch: same
-Depends: nnstreamer-single, nnfw, ${shlibs:Depends}, ${misc:Depends}
+Depends: nnstreamer-single, onert, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer NNFW (ONE) support
  This package allows nnstreamer to support NNFW (ONE, On-Device Neural Engine).
 

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -3,11 +3,6 @@ if nnfw_runtime_support_is_available
 
   nnstreamer_filter_nnfw_deps = [nnfw_runtime_support_deps, nnstreamer_single_dep]
 
-  # Check old function (@todo remove this definition later, nnfw ver >= 1.6.0)
-  if not cc.has_header_symbol('nnfw/nnfw.h', 'nnfw_set_input_tensorinfo', dependencies: nnfw_dep)
-    nnstreamer_filter_nnfw_deps += declare_dependency(compile_args: ['-DNNFW_USE_OLD_API=1'])
-  endif
-
   nnfw_plugin_lib = shared_library('nnstreamer_filter_nnfw',
     filter_sub_nnfw_sources,
     dependencies: nnstreamer_filter_nnfw_deps,

--- a/meson.build
+++ b/meson.build
@@ -196,15 +196,6 @@ if (pg_orcc.found())
 endif
 orc_dep = dependency('orc-0.4', version: '>= 0.4.17', required: get_option('orcc-support'))
 
-# nnfw
-nnfw_dep = dependency('', required: false)
-if not get_option('nnfw-runtime-support').disabled()
-  nnfw_dep = dependency('nnfw', required: false)
-  if not nnfw_dep.found()
-    nnfw_dep = cc.find_library('nnfw-dev', required: get_option('nnfw-runtime-support'))
-  endif
-endif
-
 # snpe
 snpe_dep = dependency('', required: false)
 snpe_api_version = 0 # Check whether the snpe api version is 1 or 2
@@ -566,7 +557,8 @@ features = {
     'project_args': { 'ENABLE_MOVIDIUS_NCSDK2' : 1}
   },
   'nnfw-runtime-support': {
-    'extra_deps': [ nnfw_dep ],
+    'target': 'onert',
+    'target_alt': 'nnfw',
     'project_args': { 'ENABLE_NNFW_RUNTIME': 1 }
   },
   'armnn-support': {

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -24,7 +24,6 @@ RUN set -x && \
     apt-get update && \
     apt-get install software-properties-common gpg-agent && \
     add-apt-repository ppa:nnstreamer/ppa -u && \
-    add-apt-repository ppa:one-runtime/ppa -u && \
     apt-get install \
         git \
         build-essential \
@@ -83,7 +82,6 @@ RUN set -x && \
     apt-get update && \
     apt-get install software-properties-common gpg-agent && \
     add-apt-repository ppa:nnstreamer/ppa -u && \
-    add-apt-repository ppa:one-runtime/ppa -u && \
     apt-get install \
             gstreamer1.0-plugins-base \
             gstreamer1.0-tools && \


### PR DESCRIPTION
Update nnfw dep resolving in meson
- Use dep from `target: onert` and `target_alt: nnfw`
- Remove checking old symbol.

Fix dependency nnfw -> onert
- nnfw is deprecated package. Use onert.

Fix docker file to resolve ppa issue
- one-runtime/ppa do not have proper package, remove it.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped