### PR TITLE
[docs] fix tensor_transform example and gst-debugger url

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_transform.md
+++ b/gst/nnstreamer/elements/gsttensor_transform.md
@@ -9,7 +9,7 @@ title: tensor_transform
 - Transformation the shape, data values (arithmetics or normalization), or data type of ```other/tensor``` stream.
 - If possible, the tensor_transform element exploits [ORC: Optimized inner Loop Runtime Compiler](https://gitlab.freedesktop.org/gstreamer/orc) to accelerate the supported operations.
 - Aggregate multiple operators into a single transform instance for performance optimization.
-  - E.g., ```tensor_transform mode=typecast option=uint8 ! tensor_transform mode=arithmetic option=mul:4 ! tensor_transform mode=arithmetic option=add:25 can be optimized by tensor_transform mode=arithmetic option=typecast:uint8,mul:8,add:25```
+  - E.g., ```tensor_transform mode=typecast option=uint8 ! tensor_transform mode=arithmetic option=mul:4 ! tensor_transform mode=arithmetic option=add:25 can be optimized by tensor_transform mode=arithmetic option=typecast:uint8,mul:4,add:25```
 
 ## Planned Features
 

--- a/tools/debugging/README.md
+++ b/tools/debugging/README.md
@@ -168,7 +168,7 @@ This guide is written on Ubuntu 16.04 X86_64 distribution.
 
 #### Build the source code
 ```bash
-$ git clone https://github.com/GNOME/gst-debugger.git
+$ git clone https://gitlab.gnome.org/Archive/gst-debugger.git
 $ cd gst-debugger
 $ git checkout 0.90.0
 $ ./autogen.sh


### PR DESCRIPTION
- Fixed a typo in the `tensor_transform` example usage.
- Updated the `gst-debugger` url: the [GitHub repo](https://github.com/GNOME/gst-debugger.git) is no longer accessible and has been archived on [GitLab](https://gitlab.gnome.org/Archive/gst-debugger.git).