### PR TITLE
[decoder] Do not clear properties_table in BoundingBox destructor

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
@@ -543,11 +543,6 @@ BoundingBox::~BoundingBox ()
 
   g_array_free (centroids, TRUE);
   g_array_free (distanceArray, TRUE);
-
-  G_LOCK (box_properties_table);
-  g_hash_table_destroy (properties_table);
-  properties_table = nullptr;
-  G_UNLOCK (box_properties_table);
 }
 
 /**


### PR DESCRIPTION
The properties_table contains the list of properties for loaded sub-modules. The properties are only added on initial module load which happens once, this is why the table is a static singleton not tied to the lifecycle of any one BoundingBox instance.

The issue is this table is cleared in the BoundingBox destructor, which means after any BoundingBox instance is removed, no new instances will be able to find any sub-module properties.

Fix this by not clearing the properties_table in the destructor.
