### PR TITLE
[workflow] Remove deprecated ubuntu-20.04 workflows

### DIFF
--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -15,30 +15,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        #os: [ ubuntu-20.04, ubuntu-22.04 ]
-        ## ppa/nnstreamer's ubuntu 20.04 has gpgv error:
-        # E: Release signed by unknown key (key id CADA0F77901522B3)
-        #    The specified keyring /usr/share/keyrings/ubuntu-archive-keyring.gpg may be incorrect or out of date.
-        #    You can find the latest Debian release key at https://ftp-master.debian.org/keys.html
-        # E: debootstrap failed
-        # E: Tail of debootstrap.log:
-        # amd64: ok
-        # 2024-01-24 15:01:58 URL:http://ppa.launchpad.net/nnstreamer/ppa/ubuntu/dists/focal/InRelease [18035/18035] -> "/var/cache/pbuilder/build/10399/var/lib/apt/lists/partial/ppa.launchpad.net_nnstreamer_ppa_ubuntu_dists_focal_InRelease" [1]
-        # gpgv: Signature made Wed Jan 24 09:12:55 2024 UTC
-        # gpgv:                using RSA key 373A37D40E480F96524A4027CADA0F77901522B3
-        # gpgv: Can't check signature: No public key
-        # E: End of debootstrap.log
-        # W: Aborting with an error
         os: [ ubuntu-22.04 ]
-        #arch: [ amd64, arm64 ]
-        ## pdebuild with `--architecture arm64` is meaningless
-        ## pbuilder create --architecture arm64 currently fails
         arch: [ amd64 ]
         include:
           - distroname: jammy
             os: ubuntu-22.04
-        #  - distroname: focal
-        #    os: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/risc-v.yml
+++ b/.github/workflows/risc-v.yml
@@ -1,4 +1,4 @@
-name: Test on RISCV64 Ubuntu 20.04
+name: Test on RISCV64 Ubuntu 22.04
 
 on:
   pull_request:
@@ -6,8 +6,8 @@ on:
 
 jobs:
   build_job:
-    runs-on: ubuntu-20.04
-    name: Build on Ubuntu 20.04 RISC-V 64
+    runs-on: ubuntu-22.04
+    name: Build on Ubuntu 22.04 RISC-V 64
     steps:
       - uses: actions/checkout@v4
         with:
@@ -22,7 +22,7 @@ jobs:
         id: Build
         with:
           arch: riscv64
-          distro: ubuntu20.04
+          distro: ubuntu22.04
           githubToken: ${{ github.token }}
           run: |
             apt-get -qy update

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-22.04-arm ]
+        os: [ ubuntu-22.04, ubuntu-22.04-arm ]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
ubuntu-20.04 is deprecated in github actions.

- Remove 20.04 option in pdebuild.yml
- Change 20.04 -> 22.04 for the riscv64-ubuntu workflow.


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
