### PR TITLE
[tensor_filter] Implement asynchronous callback for handling multiple…

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -1015,9 +1015,11 @@ _gst_tensor_filter_transform_update_outbuf (GstBaseTransform * trans,
     }
   }
 
-  for (i = 0; i < in_trans_data->num_tensors; i++) {
-    if (in_trans_data->mem[i]) {
-      gst_memory_unref (in_trans_data->mem[i]);
+  if (in_trans_data) {
+    for (i = 0; i < in_trans_data->num_tensors; i++) {
+      if (in_trans_data->mem[i]) {
+        gst_memory_unref (in_trans_data->mem[i]);
+      }
     }
   }
 
@@ -1810,6 +1812,9 @@ gst_tensor_filter_start (GstBaseTransform * trans)
     GST_OBJECT_UNLOCK (self);
   }
 
+  /* Property conditions are required for setting */
+  gst_tensor_filter_set_async_output_callback_notify_util (priv, self, nnstreamer_filter_async_output_callback);
+
   return priv->prop.fw_opened;
 }
 
@@ -1835,4 +1840,60 @@ gst_tensor_filter_stop (GstBaseTransform * trans)
   gst_tensor_filter_common_close_fw (priv);
 
   return TRUE;
+}
+
+/**
+ * @brief Callback function for handling asynchronous outputs from sub-plugins.
+ * @details
+ * This callback function is invoked by a sub-plugin when it generates one or more outputs
+ * asynchronously. It allows sub-plugins to send tensor data back to the main pipeline.
+ * This should be called whenever a sub-plugin has processed its input
+ * data and has generated output tensor(s).
+ * This function processes the given tensor memory (`output`), generates a GstBuffer from it,
+ * and pushes the GStreamer buffer to the next element in the pipeline for further processing.
+ *
+ * @param[in] cb_data  Data to be passed to the callback.
+ * @param[in] output A GstTensorMemory structure that contains the generated
+ *                   tensor(s) as output.
+ */
+void
+nnstreamer_filter_async_output_callback (void *cb_data, GstTensorMemory *output)
+{
+  guint i;
+  GstTensorFilter *self;
+  GstBaseTransform *trans;
+  GstTensorFilterPrivate *priv;
+  FilterTransformData *out_trans_data = NULL;
+  GstTensorFilterProperties *prop;
+  GstBuffer *outbuf;
+
+  g_return_if_fail (output != NULL || cb_data != NULL);
+
+  outbuf = gst_buffer_new ();
+  if (!outbuf) {
+    ml_loge ("Failed to allocate GstBuffer.");
+    return;
+  }
+
+  self = GST_TENSOR_FILTER_CAST (cb_data);
+  trans = GST_BASE_TRANSFORM_CAST (self);
+  priv = &self->priv;
+  prop = &priv->prop;
+
+  out_trans_data = _gst_tensor_filter_transform_get_output_data (trans);
+
+  for (i = 0; i < prop->output_meta.num_tensors; i++) {
+    if (!output[i].data) {
+      ml_loge ("Invalid tensor memory at index %d", i);
+      return;
+    }
+    out_trans_data->tensors[i].data = output[i].data;
+    out_trans_data->tensors[i].size = output[i].size;
+  }
+
+  _gst_tensor_filter_transform_update_outbuf (trans, NULL, out_trans_data, outbuf);
+  g_free (out_trans_data);
+  out_trans_data = NULL;
+
+  gst_pad_push (trans->srcpad, outbuf);
 }

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -3083,3 +3083,32 @@ nnstreamer_filter_shared_model_replace (void *instance, const char *key,
 done:
   G_UNLOCK (shared_model_table);
 }
+
+/**
+ * @brief Sets a callback function to handle asynchronous output.
+ *
+ * This utility function registers a callback that will be invoked by the
+ * sub-plugin (framework) whenever it produces asynchronous output.
+ * The callback function is used to process or handle the generated `GstTensorMemory`
+ * output.
+ *
+ * @param priv      Pointer to the GstTensorFilterPrivate structure.
+ * @param cb_data   Data to be passed to the callback.
+ *                  function as its first parameter. This can be used to provide context
+ *                  or additional arguments required by the callback.
+ * @param callback  Callback function that will be invoked whenever the framework emits
+ *                  an asynchronous output.
+ */
+void
+gst_tensor_filter_set_async_output_callback_notify_util (GstTensorFilterPrivate * priv, void *cb_data, void (*callback)(void *, GstTensorMemory *))
+{
+  GstTensorFilterFrameworkEventData event_data;
+
+  if (GST_TF_FW_V1 (priv->fw) && callback!= NULL && priv->fw->eventHandler!= NULL) {
+    event_data.async_output_callback = callback;
+    event_data.cb_data = cb_data;
+    if (priv->fw->eventHandler (priv->fw, &priv->prop, priv->privateData, SET_ASYNC_OUTPUT_CALLBACK, &event_data) != -ENOENT)
+      return;
+  }
+  ml_loge ("Failed to set async output callback");
+}

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -293,5 +293,11 @@ gst_tensor_filter_check_hw_availability (const gchar * name, const accl_hw hw, c
 extern void
 gst_tensor_filter_destroy_notify_util (GstTensorFilterPrivate *priv, void *data);
 
+/**
+ * @brief set async output callback util
+ */
+extern void
+gst_tensor_filter_set_async_output_callback_notify_util (GstTensorFilterPrivate *priv, void *cb_data, void (*callback)(void *, GstTensorMemory *));
+
 G_END_DECLS
 #endif /* __G_TENSOR_FILTER_COMMON_H__ */


### PR DESCRIPTION
[tensor_filter] Implement asynchronous callback for handling multiple output from sub-plugins

This commit introduces a callback mechanism inside the tensor_filter component to address scenarios where a sub-plugin produces multiple outputs.  When tensor_filter receives an input, it passes it to the specified sub-plugin.  The callback function previously defined by tensor_filter is triggered for each output produced by the sub-plugin.

ToDo: make property for async output callback
