### PR TITLE
[Wait #4729][llamacpp] Implement a function that passes the output to tensor_filter by calling the callback

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -3083,3 +3083,32 @@ nnstreamer_filter_shared_model_replace (void *instance, const char *key,
 done:
   G_UNLOCK (shared_model_table);
 }
+
+/**
+ * @brief Sets a callback function to handle asynchronous output.
+ *
+ * This utility function registers a callback that will be invoked by the
+ * sub-plugin (framework) whenever it produces asynchronous output.
+ * The callback function is used to process or handle the generated `GstTensorMemory`
+ * output.
+ *
+ * @param priv      Pointer to the GstTensorFilterPrivate structure.
+ * @param cb_data   Data to be passed to the callback.
+ *                  function as its first parameter. This can be used to provide context
+ *                  or additional arguments required by the callback.
+ * @param callback  Callback function that will be invoked whenever the framework emits
+ *                  an asynchronous output.
+ */
+void
+gst_tensor_filter_set_async_output_callback_notify_util (GstTensorFilterPrivate * priv, void *cb_data, void (*callback)(void *, GstTensorMemory *))
+{
+  GstTensorFilterFrameworkEventData event_data;
+
+  if (GST_TF_FW_V1 (priv->fw) && callback!= NULL && priv->fw->eventHandler!= NULL) {
+    event_data.async_output_callback = callback;
+    event_data.cb_data = cb_data;
+    if (priv->fw->eventHandler (priv->fw, &priv->prop, priv->privateData, SET_ASYNC_OUTPUT_CALLBACK, &event_data) != -ENOENT)
+      return;
+  }
+  ml_loge ("Failed to set async output callback");
+}

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -293,5 +293,11 @@ gst_tensor_filter_check_hw_availability (const gchar * name, const accl_hw hw, c
 extern void
 gst_tensor_filter_destroy_notify_util (GstTensorFilterPrivate *priv, void *data);
 
+/**
+ * @brief set async output callback util
+ */
+extern void
+gst_tensor_filter_set_async_output_callback_notify_util (GstTensorFilterPrivate *priv, void *cb_data, void (*callback)(void *, GstTensorMemory *));
+
 G_END_DECLS
 #endif /* __G_TENSOR_FILTER_COMMON_H__ */


### PR DESCRIPTION
[llamacpp] Implement a function that passes the output to tensor_filter by calling the callback
    
llamacpp sub-plugin takes a callback from eventHandler and passes each generated token to tensor_filter by calling that callback.

### How to use
```sh
echo "Hello my name is" > input.txt && \
gst-launch-1.0 filesrc location=input.txt ! application/octet-stream ! \
tensor_converter ! other/tensors,format=flexible ! \
tensor_filter framework=llamacpp model=llama-2-7b-chat.Q2_K.gguf invoke-dynamic=TRUE ! \
other/tensors,format=flexible ! tensor_decoder mode=octet_stream ! \
application/octet-stream ! filesink location=output.txt && \
cat output.txt
```
Result
```
<s> Hello my name is Jake and I am a 23 year old male from the United States. Unterscheidung between the two is important because they have different meanings and connot
```