### PR TITLE
Update deprecated url

### DIFF
--- a/.github/workflows/_typos.toml
+++ b/.github/workflows/_typos.toml
@@ -1,5 +1,5 @@
 [files]
-extend-exclude = ["tests/test_models/models/*", "tests/test_models/labels/*", "tests/test_models/data/*"]
+extend-exclude = ["tests/test_models/models/*", "tests/test_models/labels/*", "tests/test_models/data/*", "tests/nnstreamer_decoder_boundingbox/*"]
 
 [default.extend-words]
 mosquitto = "mosquitto"

--- a/Documentation/component-description.md
+++ b/Documentation/component-description.md
@@ -100,7 +100,7 @@ In this page, we focus on the status of each elements. For requirements and desi
 - [tensor\_sink](https://github.com/nnstreamer/nnstreamer/tree/main/gst/nnstreamer/elements/gsttensor_sink.md) (stable)
   - ```appsink```-like element, which is specialized for ```other/tensors```. You may use appsink with capsfilter instead.
 - [tensor\_merge](https://github.com/nnstreamer/nnstreamer/tree/main/gst/nnstreamer/elements/gsttensor_merge.c) (stable)
-  - This combines multiple single-tensored (```other/tensors,num_tensors=1```) streams into a single-tensored stream by merging dimensions of incoming tensor streams. For example, it may merge two ```dimensions=640:480``` streams into ```dimensons=1280:480```, ```dimensions=640:960```, or ```dimensions=640:480:2```, according to a given configuration.
+  - This combines multiple single-tensored (```other/tensors,num_tensors=1```) streams into a single-tensored stream by merging dimensions of incoming tensor streams. For example, it may merge two ```dimensions=640:480``` streams into ```dimensions=1280:480```, ```dimensions=640:960```, or ```dimensions=640:480:2```, according to a given configuration.
   - Users can adjust sync-mode and sync-option to change its behaviors of when to create output tensors and how to choose input tensors.
   - Users can adjust how dimensions are merged (the rank merged, the order of merged streams).
 - [tensor\_split](https://github.com/nnstreamer/nnstreamer/tree/main/gst/nnstreamer/elements/gsttensor_split.c) (stable)

--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ For more details, please access the following manuals.
   <img src="Documentation/media/PrintNanny.webp" height=180>
 </a>
 <a href="https://github.com/NXPmicro/nxp-nnstreamer-examples">
-  <img src="https://github.com/NXPmicro/nxp-nnstreamer-examples/raw/main/segmentation/segmentation_demo.webp" height=180>
+  <img src="https://github.com/NXPmicro/nxp-nnstreamer-examples/raw/main/tasks/semantic-segmentation/segmentation_demo.webp" height=180>
 </a>
 <a href="https://github.com/NXPmicro/nxp-nnstreamer-examples">
-  <img src="https://github.com/NXPmicro/nxp-nnstreamer-examples/raw/main/pose/pose_demo.webp" height=180>
+  <img src="https://github.com/NXPmicro/nxp-nnstreamer-examples/raw/main/tasks/pose-estimation/pose_demo.webp" height=180>
 </a>
 
 


### PR DESCRIPTION
This patch updates deprecated nxp examples webp url.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
