### PR TITLE
[filter][vivante] Support model-json based initialization

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -1215,6 +1215,8 @@ gst_tensor_filter_detect_framework (const gchar * const *model_files,
       detected_fw = g_strdup ("openvino");
     else if (g_str_equal (ext[0], ".tvn"))
       detected_fw = g_strdup ("trix-engine");
+    else if (g_str_equal (ext[0], ".nb"))
+      detected_fw = g_strdup ("vivante");
   } else if (num_models == 2) {
     if (g_str_equal (ext[0], ".pb") && g_str_equal (ext[1], ".pb") &&
         !g_str_equal (model_files[0], model_files[1]))


### PR DESCRIPTION
- Let `gst_tensor_filter_detect_framework` allows vivante to take 1 value for model_files

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
