### PR TITLE
[filter][tizen-hal] Remove confusing warning log

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tizen_hal.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tizen_hal.cc
@@ -116,8 +116,6 @@ tizen_hal_subplugin::configure_instance (const GstTensorFilterProperties *prop)
 
       if (g_ascii_strcasecmp (option[0], "backend") == 0) {
         backend_name = g_strdup (option[1]);
-      } else {
-        nns_logw ("Unknown option '%s' in custom properties.", options[op]);
       }
     }
 


### PR DESCRIPTION
- custom prop other than "backend" could be used in the hal backend.
- Remove the confusing log.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped