### PR TITLE
meson.build: Support NumPy >= 2.2 header path changes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -455,10 +455,10 @@ if not get_option('python3-support').disabled()
 
     python3_inc_args = []
     python3_inc_args += run_command(pg_pkgconfig, ['python3', '--cflags'], check : true).stdout().strip().split()
-    python3_inc_args += run_command('python3', ['-c', 'import site\nfor i in site.getsitepackages(): print("-I" + i + "/numpy/core/include")'], check : true).stdout().strip().split()
+    python3_inc_args += run_command('python3', ['-c', 'import site\nfor i in site.getsitepackages(): print("-I" + i + "/numpy/_core/include")'], check : true).stdout().strip().split()
     r = run_command('python3', ['-m', 'site', '--user-site'], check : false)
     if r.returncode() == 0
-      python3_inc_args += '-I' + r.stdout().strip() + '/numpy/core/include'
+      python3_inc_args += '-I' + r.stdout().strip() + '/numpy/_core/include'
     endif
     python3_inc_valid_args = []
 


### PR DESCRIPTION
Since NumPy 2.2.0, header files have moved from `numpy/core/include` to `numpy/_core/include` due to the transition to the Meson build system. This patch updates `meson.build` to reflect the new path, ensuring successful builds with newer NumPy versions.

Note: This update does not maintain compatibility with older NumPy (< 2.2.0).


---
# [Template] fix new NumPy versions(>=2.2.0) headers include path

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
1. build with yocto walnascar(5.2)