### PR TITLE
bugfix : Memory Leak in Custom Option Parsing(issue #4755)

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -161,6 +161,12 @@ nnfw_parse_custom_option (const GstTensorFilterProperties * prop,
          * Update description in init_filter_nnfw() when adding new custom option for nnfw.
          */
         if (g_ascii_strcasecmp (option[0], "Runtime") == 0) {
+          if (pdata->accelerator != NULL) {
+            nns_logw
+                ("Trying to set new runtime '%s', previous runtime '%s' is ignored.",
+                option[1], pdata->accelerator);
+            g_free (pdata->accelerator);
+          }
           pdata->accelerator = g_strdup (option[1]);
         } else {
           nns_logw ("Unknown option (%s).", options[i]);


### PR DESCRIPTION
In theory, this is a memory leak, but in practice, this scenario does not occur: nnfw_parse_custom_option() is only called from nnfw_open() nnfw_open() always allocates a new pdata, so pdata->accelerator always starts with NULL There are no repeated calls to the same pdata instance But. If we can support "Runtime:accel_A, Runtime:accel_B", code is memory leak

Bug 1: Memory Leak in Custom Option Parsing
Location: Lines 153-175 in nnfw_parse_custom_option()
Issue: When parsing custom options, the allocated option array from g_strsplit() is freed, but if the accelerator is set multiple times in options, previous pdata->accelerator values leak
Risk: Memory leak on repeated property setting
Fix: Free existing pdata->accelerator before reassigning


