### PR TITLE
bugfix : Memory management issue in XNNPACK delegate (issue #4755)

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -369,7 +369,14 @@ TFLiteInterpreter::invoke (const GstTensorMemory *input, GstTensorMemory *output
   if (is_xnnpack_delegated) {
     for (unsigned int i = 0; i < inputTensorMeta.num_tensors; ++i) {
       tensor_ptr = inputTensorPtr[i];
-      g_assert (tensor_ptr->bytes == input[i].size);
+
+      /* Replace g_assert with explicit error check for release builds */
+      if (tensor_ptr->bytes != input[i].size) {
+        ml_loge ("Tensor size mismatch for input tensor %u: expected %zu, got %zu",
+            i, tensor_ptr->bytes, input[i].size);
+        return -EINVAL;
+      }
+
       memcpy (tensor_ptr->data.raw, input[i].data, input[i].size);
     }
   } else {
@@ -398,7 +405,14 @@ TFLiteInterpreter::invoke (const GstTensorMemory *input, GstTensorMemory *output
   if (is_xnnpack_delegated || !is_cached_after_first_invoke) {
     for (unsigned int i = 0; i < outputTensorMeta.num_tensors; ++i) {
       tensor_ptr = outputTensorPtr[i];
-      g_assert (tensor_ptr->bytes == output[i].size);
+
+      /* Replace g_assert with explicit error check for release builds */
+      if (tensor_ptr->bytes != output[i].size) {
+        ml_loge ("Tensor size mismatch for output tensor %u: expected %zu, got %zu",
+            i, tensor_ptr->bytes, output[i].size);
+        return -EINVAL;
+      }
+
       memcpy (output[i].data, tensor_ptr->data.raw, output[i].size);
     }
   }


### PR DESCRIPTION
g_assert is completely removed in release mode.
The assertion tensor_ptr->bytes == input[i].size (comparing tensor sizes) is not a developer logic bug, but rather a data inconsistency that can occur at runtime. This is an error that should be handled with an if statement, not g_assert.

Bug 4: Memory Management Issue in XNNPACK Delegate

Location: Lines 380-400 in TFLiteInterpreter::invoke()
Issue: When XNNPACK delegate is used, memory is copied but if memcpy() fails or tensor sizes are mismatched, no cleanup is performed for partially processed tensors
Risk: Memory corruption or inconsistent state
Fix: Add proper validation before memcpy operations