### PR TITLE
bugfix: Potential memory leak in model loading (issue #4755)

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -643,6 +643,7 @@ TFLiteInterpreter::loadModel (int num_threads, tflite_delegate_e delegate_e)
   if (delegate != nullptr) {
     if (interpreter->ModifyGraphWithDelegate (delegate) != kTfLiteOk) {
       ml_loge ("Failed to apply delegate\n");
+      setDelegate (nullptr, [] (TfLiteDelegate *) {});
       return -2;
     }
   }


### PR DESCRIPTION
After creating a delegate, if ModifyGraphWithDelegate fails, the delegate memory is not released.

Bug 5: Potential Memory Leak in Model Loading

Location: Lines 540-580 in TFLiteInterpreter::loadModel()
Issue: If delegate creation succeeds but interpreter->ModifyGraphWithDelegate() fails, the delegate memory is not properly freed
Risk: Memory leak of delegate resources
Fix: Use RAII or ensure cleanup in error paths