### PR TITLE
bugfix: Python object reference leack (issue #4755)

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_python3.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python3.cc
@@ -481,6 +481,7 @@ PYCore::setInputTensorDim (const GstTensorsInfo *in_info, GstTensorsInfo *out_in
     _info = gst_tensors_info_get_nth_info ((GstTensorsInfo *) in_info, i);
     shape = PyTensorShape_New (shape_cls, _info);
     if (nullptr == shape) {
+      Py_SAFEDECREF (param);
       Py_UNLOCK ();
       throw std::runtime_error ("PyTensorShape_New(); has failed.");
     }


### PR DESCRIPTION
If PyTensorShape_New() fails after some shapes are created, previously created Python objects are not decremented.

Bug 8: Python Object Reference Leak

Location: Lines 500-520 in PYCore::setInputTensorDim()
Issue: If PyTensorShape_New() fails after some shapes are created, previously created Python objects are not decremented
Risk: Python object memory leak
Fix: Use cleanup loop for partial allocations