### PR TITLE
bugfix: Map Iterator Invalidation (issue #4755)

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_python3.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python3.cc
@@ -521,7 +521,7 @@ PYCore::freeOutputTensors (void *data)
   it = outputArrayMap.find (data);
   if (it != outputArrayMap.end ()) {
     Py_SAFEDECREF (it->second);
-    outputArrayMap.erase (it);
+    outputArrayMap.erase (it++);
   } else {
     ml_loge ("Cannot find output data: 0x%lx", (unsigned long) data);
   }


### PR DESCRIPTION
In the current code, it is a 'false positive' because it is no longer used after the call to outputArrayMap.erase(it) However, if additional code uses it, it is recommended to change it to a valid pointer.

