### PR TITLE
bugfix: Incomplete Error Handling in Run Method (issue #4755)

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_python3.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python3.cc
@@ -50,6 +50,7 @@
 #include <nnstreamer_cppplugin_api_filter.hh>
 #include <nnstreamer_log.h>
 #include <nnstreamer_util.h>
+#include <vector>
 #include "nnstreamer_python3_helper.h"
 
 /**
@@ -541,6 +542,7 @@ PYCore::run (const GstTensorMemory *input, GstTensorMemory *output)
   GstTensorInfo *_info;
   int res = 0;
   PyObject *result;
+  std::vector<void *> newlyAddedItems;
 
 #if (DBG)
   gint64 start_time = g_get_real_time ();
@@ -587,13 +589,19 @@ PYCore::run (const GstTensorMemory *input, GstTensorMemory *output)
         output[i].data = PyArray_DATA (output_array);
         Py_XINCREF (output_array);
         outputArrayMap.insert (std::make_pair (output[i].data, output_array));
+        newlyAddedItems.push_back (output[i].data);
       } else {
         ml_loge ("Output tensor type/size is not matched\n");
         res = -2;
         break;
       }
     }
-
+    if (res != 0) {
+      /* Clean up only items added in this function call */
+      for (void *data : newlyAddedItems) {
+        freeOutputTensors (data);
+      }
+    }
     Py_SAFEDECREF (result);
   } else {
     Py_ERRMSG ("Fail to call 'invoke'");


### PR DESCRIPTION
If, for some reason, a Python array object is not properly created in the middle of a loop, or if type/size checks fail (e.g., line 591), an error will occur and the loop will abort.
Therefore, as pointed out in the bug report, if an error occurs within the PYCore::run() function, previously created arrays must be cleaned up.

Bug 10: Incomplete Error Handling in Run Method

Location: Lines 570-620 in PYCore::run()
Issue: If output array creation fails midway through the loop, previous arrays in the map are not cleaned up properly, leading to reference leaks
Risk: Python object reference leaks
Fix: Clean up partial results on failure
