### PR TITLE
bugfix: Threading issue with Python GIL (issue #4755)

### DIFF
--- a/ext/nnstreamer/extra/nnstreamer_python3_helper.h
+++ b/ext/nnstreamer/extra/nnstreamer_python3_helper.h
@@ -87,5 +87,27 @@ extern int nnstreamer_python_status_check ();
 
 #ifdef __cplusplus
 } /* extern "C" */
+
+/**
+ * @brief RAII wrapper for managing Python GIL.
+ */
+class PyGILGuard
+{
+  public:
+  PyGILState_STATE gstate;
+
+  PyGILGuard () : gstate (PyGILState_Ensure ())
+  {
+  }
+  ~PyGILGuard ()
+  {
+    PyGILState_Release (gstate);
+  }
+
+  // Prevent copying to ensure single ownership
+  PyGILGuard (const PyGILGuard &) = delete;
+  PyGILGuard &operator= (const PyGILGuard &) = delete;
+};
+
 #endif
 #endif /* __NNS_PYTHON_HELPER_H__ */

--- a/ext/nnstreamer/tensor_converter/tensor_converter_python3.cc
+++ b/ext/nnstreamer/tensor_converter/tensor_converter_python3.cc
@@ -252,9 +252,8 @@ py_close (void **private_data)
 
   g_return_if_fail (core != NULL);
 
-  PyGILState_STATE gstate = PyGILState_Ensure ();
+  PyGILGuard gil_guard;
   delete core;
-  PyGILState_Release (gstate);
 
   *private_data = NULL;
 }
@@ -269,7 +268,6 @@ py_open (const gchar *path, void **priv_data)
 {
   int ret = 0;
   PYConverterCore *core;
-  PyGILState_STATE gstate;
 
   if (!Py_IsInitialized ())
     throw std::runtime_error ("Python is not initialize.");
@@ -286,8 +284,7 @@ py_open (const gchar *path, void **priv_data)
 
   /* init null */
   *priv_data = NULL;
-
-  gstate = PyGILState_Ensure ();
+  PyGILGuard gil_guard;
   core = new PYConverterCore (path);
   if (core == NULL) {
     Py_ERRMSG ("Failed to allocate memory for converter subplugin or path invalid: Python\n");
@@ -304,7 +301,6 @@ py_open (const gchar *path, void **priv_data)
 
   *priv_data = core;
 done:
-  PyGILState_Release (gstate);
   return ret;
 }
 
@@ -356,13 +352,11 @@ python_convert (GstBuffer *in_buf, GstTensorsConfig *config, void *priv_data)
 {
   GstBuffer *ret;
   PYConverterCore *core = static_cast<PYConverterCore *> (priv_data);
-  PyGILState_STATE gstate;
   g_return_val_if_fail (in_buf, NULL);
   g_return_val_if_fail (config, NULL);
 
-  gstate = PyGILState_Ensure ();
+  PyGILGuard gil_guard;
   ret = core->convert (in_buf, config);
-  PyGILState_Release (gstate);
   return ret;
 }
 

--- a/ext/nnstreamer/tensor_decoder/tensordec-python3.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-python3.cc
@@ -278,9 +278,8 @@ decoder_py_exit (void **pdata)
   PYDecoderCore *core = static_cast<PYDecoderCore *> (*pdata);
 
   g_return_if_fail (core != NULL);
-  PyGILState_STATE gstate = PyGILState_Ensure ();
+  PyGILGuard gil_guard;
   delete core;
-  PyGILState_Release (gstate);
 
   *pdata = NULL;
 }
@@ -312,7 +311,7 @@ decoder_py_setOption (void **pdata, int opNum, const char *param)
     /* init null */
     *pdata = NULL;
 
-    PyGILState_STATE gstate = PyGILState_Ensure ();
+    PyGILGuard gil_guard;
 
     try {
       core = new PYDecoderCore (path);
@@ -332,7 +331,6 @@ decoder_py_setOption (void **pdata, int opNum, const char *param)
     ret = TRUE;
 
   done:
-    PyGILState_Release (gstate);
     return ret;
   }
 
@@ -347,9 +345,8 @@ decoder_py_getOutCaps (void **pdata, const GstTensorsConfig *config)
   GstCaps *caps;
   PYDecoderCore *core = static_cast<PYDecoderCore *> (*pdata);
 
-  PyGILState_STATE gstate = PyGILState_Ensure ();
+  PyGILGuard gil_guard;
   caps = core->getOutCaps (config);
-  PyGILState_Release (gstate);
   setFramerateFromConfig (caps, config);
   return caps;
 }
@@ -365,9 +362,8 @@ decoder_py_decode (void **pdata, const GstTensorsConfig *config,
   g_return_val_if_fail (input, GST_FLOW_ERROR);
   g_return_val_if_fail (outbuf, GST_FLOW_ERROR);
 
-  PyGILState_STATE gstate = PyGILState_Ensure ();
+  PyGILGuard gil_guard;
   ret = core->decode (config, input, outbuf);
-  PyGILState_Release (gstate);
   return ret;
 }
 


### PR DESCRIPTION
- Multiple functions acquire/release GIL but if an exception occurs between lock/unlock, GIL state becomes inconsistent.
- Solved using RAII pattern

Bug 11: Threading Issue with Python GIL

Location: Throughout the Python filter
Issue: Multiple functions acquire/release GIL but if an exception occurs between lock/unlock, GIL state becomes inconsistent
Risk: Deadlock or Python interpreter corruption
Fix: Use RAII pattern for GIL management