### PR TITLE
bugfix: Resourc Cleanup Race (issue #4753)

### DIFF
--- a/gst/mqtt/mqttsrc.h
+++ b/gst/mqtt/mqttsrc.h
@@ -65,6 +65,7 @@ struct _GstMqttSrc {
   GCond mqtt_src_gcond;
   gboolean is_connected;
   gboolean is_subscribed;
+  gboolean is_disconnect_finished;
 
   MQTTAsync mqtt_client_handle;
   MQTTAsync_connectOptions mqtt_conn_opts;


### PR DESCRIPTION
Issue: MQTT client handle destruction may race with callback execution

This fix ensures the stop function waits for MQTTAsync_disconnect to complete. This prevents use-after-free bugs where Paho threads access destroyed mutexes/ memory during finalize.

