### PR TITLE
bugfix: Move static buffer flag to instance level in mqttsink (issue #4753)

### DIFF
--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -87,6 +87,7 @@ struct _GstMqttSink {
   GstMQTTMessageHdr mqtt_msg_hdr;
   gpointer mqtt_msg_buf;
   gsize mqtt_msg_buf_size;
+  gboolean is_static_sized_buf;
 
   MQTTAsync mqtt_client_handle;
   MQTTAsync_connectOptions mqtt_conn_opts;


### PR DESCRIPTION
Issue: The static buffer flag is_static_sized_buf is declared static but used across multiple instances, causing potential conflicts

**Bug https://github.com/nnstreamer/nnstreamer/issues/3: Static Buffer Size Issue**

Location: Lines 800-850 in gst_mqtt_sink_render()
Issue: The static buffer flag is_static_sized_buf is declared static but used across multiple instances, causing potential conflicts
Risk: Buffer management issues between multiple sinks
Fix: Move static variable to instance-level
