### PR TITLE
Cursor Testing. Never Mind. Review main branch for bugs

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -65,6 +65,7 @@ if gtest_dep.found()
   nnstreamer_unittest_deps = [
     unittest_util_dep,
     glib_dep,
+    gmodule_dep,
     gst_dep,
     gst_app_dep,
     gst_check_dep,

--- a/tests/nnstreamer_edge/nnstreamer-edge-custom-test-api.h
+++ b/tests/nnstreamer_edge/nnstreamer-edge-custom-test-api.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * @file   nnstreamer-edge-custom-test-api.h
+ * @brief  Shared definitions for the nnstreamer-edge custom test plugin.
+ */
+#ifndef __NNSTREAMER_EDGE_CUSTOM_TEST_API_H__
+#define __NNSTREAMER_EDGE_CUSTOM_TEST_API_H__
+
+/**
+ * @brief Payload generation modes for the custom edge test backend.
+ */
+typedef enum
+{
+  EDGE_CUSTOM_PAYLOAD_MODE_DEFAULT = 0,
+  EDGE_CUSTOM_PAYLOAD_MODE_STATIC = 1,
+} edge_custom_payload_mode_e;
+
+#define EDGE_CUSTOM_TEST_STATIC_PAYLOAD_SIZE 64U
+
+#define EDGE_CUSTOM_TEST_LIB "libnnstreamer-edge-custom-test.so"
+
+#endif /* __NNSTREAMER_EDGE_CUSTOM_TEST_API_H__ */


### PR DESCRIPTION
---
# PR Description

Fix edge src/sink resource leaks, error propagation, and data copy

This PR addresses several logical and performance bugs in the NNStreamer-edge
GStreamer elements. It ensures proper resource cleanup on start failures,
correctly propagates data transmission errors upstream, and optimizes
data handling in the source element to avoid unnecessary memory copies.

**Changes proposed in this PR:**
-   **Fix `gst_edgesrc_start()`/`gst_edgesink_start()` handle leaks:**
    Ensured `nns_edge_stop()` and `nns_edge_release_handle()` are called
    on start/connect failures to prevent resource leaks (FDs, threads).
    This allows for clean retries and avoids resource exhaustion.
-   **Improve `gst_edgesink_render()` error propagation:**
    Modified `gst_edgesink_render()` to return `GST_FLOW_ERROR` when
    `nns_edge_send()` fails. This enables upstream elements to react
    immediately to transmission failures, improving QoS and error handling.
-   **Implement zero-copy payload for `gst_edgesrc_create()`:**
    Introduced `EdgeSrcDataHolder` to wrap `nns_edge_data_h` and use
    `gst_memory_new_wrapped` with reference counting. This eliminates
    redundant memory copying for incoming tensor data, reducing CPU load
    and latency, especially for high-bandwidth scenarios.
-   **Add dedicated unit tests for bug verification:**
    Created a custom edge test API and three new GTest cases to verify
    the fixes: `srcStartFailureReleasesHandle`, `sinkPropagatesSendError`,
    and `srcZeroCopyPayload`. These tests simulate failure conditions
    and payload modes to ensure correct behavior.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
1.  Build the project: `ninja -C build`
2.  Run the new unit tests: `meson test -C build unittest_edge`
    (Note: Ensure `nnstreamer-edge-support` is enabled in Meson configuration for these tests to be generated and run.)

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>

---
<a href="https://cursor.com/background-agent?bcId=bc-4f8f1b92-3be6-4d95-9b03-dce6953b8176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f8f1b92-3be6-4d95-9b03-dce6953b8176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

