### PR TITLE
[Test/Edge] verify edge handle release on state change

### DIFF
--- a/tests/nnstreamer_edge/edge/unittest_edge.cc
+++ b/tests/nnstreamer_edge/edge/unittest_edge.cc
@@ -386,7 +386,7 @@ TEST (edgeCustom, sinkInvalidProp2_n)
   EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (1000000);
 
-  /* Handle creation precedes the libINVALID.so load failure; start() must clear the stale handle. */
+  /* On load failure the library frees the handle without clearing the out-param; start() must NULL it. */
   edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sinkx");
   ASSERT_NE (edge_handle, nullptr);
   EXPECT_EQ (GST_EDGESINK_CAST (edge_handle)->edge_h, (nns_edge_h) NULL);
@@ -507,7 +507,7 @@ TEST (edgeCustom, srcInvalidProp2_n)
   EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (1000000);
 
-  /* Handle creation precedes the libINVALID.so load failure; start() must clear the stale handle. */
+  /* On load failure the library frees the handle without clearing the out-param; start() must NULL it. */
   edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "srcx");
   ASSERT_NE (edge_handle, nullptr);
   EXPECT_EQ (GST_EDGESRC_CAST (edge_handle)->edge_h, (nns_edge_h) NULL);

--- a/tests/nnstreamer_edge/edge/unittest_edge.cc
+++ b/tests/nnstreamer_edge/edge/unittest_edge.cc
@@ -318,8 +318,9 @@ TEST (edgeCustom, sinkReleasesHandle)
 
   edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sinkx");
   ASSERT_NE (edge_handle, nullptr);
-  sink = GST_EDGESINK (edge_handle);
+  sink = GST_EDGESINK_CAST (edge_handle);
 
+  /* setPipelineStateSync () returning makes the lock-free edge_h reads safe (happens-before). */
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_NE (sink->edge_h, (nns_edge_h) NULL);
 
@@ -355,9 +356,10 @@ TEST (edgeCustom, sinkInvalidProp_n)
   EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (1000000);
 
+  /* Without custom-lib, start() bails out early; assert the handle was never created. */
   edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sinkx");
   ASSERT_NE (edge_handle, nullptr);
-  EXPECT_EQ (GST_EDGESINK (edge_handle)->edge_h, (nns_edge_h) NULL);
+  EXPECT_EQ (GST_EDGESINK_CAST (edge_handle)->edge_h, (nns_edge_h) NULL);
   gst_object_unref (edge_handle);
 
   gst_object_unref (gstpipe);
@@ -384,9 +386,10 @@ TEST (edgeCustom, sinkInvalidProp2_n)
   EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (1000000);
 
+  /* Handle creation precedes the libINVALID.so load failure; start() must clear the stale handle. */
   edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sinkx");
   ASSERT_NE (edge_handle, nullptr);
-  EXPECT_EQ (GST_EDGESINK (edge_handle)->edge_h, (nns_edge_h) NULL);
+  EXPECT_EQ (GST_EDGESINK_CAST (edge_handle)->edge_h, (nns_edge_h) NULL);
   gst_object_unref (edge_handle);
 
   gst_object_unref (gstpipe);
@@ -438,7 +441,7 @@ TEST (edgeCustom, srcReleasesHandle)
 
   edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "srcx");
   ASSERT_NE (edge_handle, nullptr);
-  src = GST_EDGESRC (edge_handle);
+  src = GST_EDGESRC_CAST (edge_handle);
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_NE (src->edge_h, (nns_edge_h) NULL);
@@ -474,9 +477,10 @@ TEST (edgeCustom, srcInvalidProp_n)
   EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (1000000);
 
+  /* Without custom-lib, start() bails out early; assert the handle was never created. */
   edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "srcx");
   ASSERT_NE (edge_handle, nullptr);
-  EXPECT_EQ (GST_EDGESRC (edge_handle)->edge_h, (nns_edge_h) NULL);
+  EXPECT_EQ (GST_EDGESRC_CAST (edge_handle)->edge_h, (nns_edge_h) NULL);
   gst_object_unref (edge_handle);
 
   gst_object_unref (gstpipe);
@@ -503,9 +507,10 @@ TEST (edgeCustom, srcInvalidProp2_n)
   EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (1000000);
 
+  /* Handle creation precedes the libINVALID.so load failure; start() must clear the stale handle. */
   edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "srcx");
   ASSERT_NE (edge_handle, nullptr);
-  EXPECT_EQ (GST_EDGESRC (edge_handle)->edge_h, (nns_edge_h) NULL);
+  EXPECT_EQ (GST_EDGESRC_CAST (edge_handle)->edge_h, (nns_edge_h) NULL);
   gst_object_unref (edge_handle);
 
   gst_object_unref (gstpipe);

--- a/tests/nnstreamer_edge/edge/unittest_edge.cc
+++ b/tests/nnstreamer_edge/edge/unittest_edge.cc
@@ -12,8 +12,8 @@
 #include <glib.h>
 #include <gst/app/gstappsrc.h>
 #include <gst/gst.h>
-#include "../../../gst/edge/edge_sink.h"
-#include "../../../gst/edge/edge_src.h"
+#include "edge_sink.h"
+#include "edge_src.h"
 #include "nnstreamer_log.h"
 #include "unittest_util.h"
 
@@ -342,6 +342,7 @@ TEST (edgeCustom, sinkInvalidProp_n)
 {
   gchar *pipeline = nullptr;
   GstElement *gstpipe = nullptr;
+  GstElement *edge_handle = nullptr;
 
   /* Create a nnstreamer pipeline */
   pipeline = g_strdup_printf (
@@ -354,6 +355,11 @@ TEST (edgeCustom, sinkInvalidProp_n)
   EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (1000000);
 
+  edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sinkx");
+  ASSERT_NE (edge_handle, nullptr);
+  EXPECT_EQ (GST_EDGESINK (edge_handle)->edge_h, (nns_edge_h) NULL);
+  gst_object_unref (edge_handle);
+
   gst_object_unref (gstpipe);
   g_free (pipeline);
 }
@@ -365,6 +371,7 @@ TEST (edgeCustom, sinkInvalidProp2_n)
 {
   gchar *pipeline = nullptr;
   GstElement *gstpipe = nullptr;
+  GstElement *edge_handle = nullptr;
 
   /* Create a nnstreamer pipeline */
   pipeline = g_strdup_printf (
@@ -376,6 +383,11 @@ TEST (edgeCustom, sinkInvalidProp2_n)
 
   EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (1000000);
+
+  edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sinkx");
+  ASSERT_NE (edge_handle, nullptr);
+  EXPECT_EQ (GST_EDGESINK (edge_handle)->edge_h, (nns_edge_h) NULL);
+  gst_object_unref (edge_handle);
 
   gst_object_unref (gstpipe);
   g_free (pipeline);
@@ -450,6 +462,7 @@ TEST (edgeCustom, srcInvalidProp_n)
 {
   gchar *pipeline = nullptr;
   GstElement *gstpipe = nullptr;
+  GstElement *edge_handle = nullptr;
 
   /* Create a nnstreamer pipeline */
   pipeline = g_strdup_printf ("edgesrc connect-type=CUSTOM name=srcx ! "
@@ -460,6 +473,11 @@ TEST (edgeCustom, srcInvalidProp_n)
 
   EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (1000000);
+
+  edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "srcx");
+  ASSERT_NE (edge_handle, nullptr);
+  EXPECT_EQ (GST_EDGESRC (edge_handle)->edge_h, (nns_edge_h) NULL);
+  gst_object_unref (edge_handle);
 
   gst_object_unref (gstpipe);
   g_free (pipeline);
@@ -472,6 +490,7 @@ TEST (edgeCustom, srcInvalidProp2_n)
 {
   gchar *pipeline = nullptr;
   GstElement *gstpipe = nullptr;
+  GstElement *edge_handle = nullptr;
 
   /* Create a nnstreamer pipeline */
   pipeline = g_strdup_printf (
@@ -483,6 +502,11 @@ TEST (edgeCustom, srcInvalidProp2_n)
 
   EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (1000000);
+
+  edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "srcx");
+  ASSERT_NE (edge_handle, nullptr);
+  EXPECT_EQ (GST_EDGESRC (edge_handle)->edge_h, (nns_edge_h) NULL);
+  gst_object_unref (edge_handle);
 
   gst_object_unref (gstpipe);
   g_free (pipeline);

--- a/tests/nnstreamer_edge/edge/unittest_edge.cc
+++ b/tests/nnstreamer_edge/edge/unittest_edge.cc
@@ -12,6 +12,8 @@
 #include <glib.h>
 #include <gst/app/gstappsrc.h>
 #include <gst/gst.h>
+#include "../../../gst/edge/edge_sink.h"
+#include "../../../gst/edge/edge_src.h"
 #include "nnstreamer_log.h"
 #include "unittest_util.h"
 
@@ -297,6 +299,43 @@ TEST (edgeCustom, sinkNormal)
 }
 
 /**
+ * @brief Ensure edgesink releases its handle when the pipeline goes to NULL state.
+ */
+TEST (edgeCustom, sinkReleasesHandle)
+{
+  gchar *pipeline = nullptr;
+  GstElement *gstpipe = nullptr;
+  GstElement *edge_handle = nullptr;
+  GstEdgeSink *sink = nullptr;
+
+  pipeline = g_strdup_printf (
+      "videotestsrc ! videoconvert ! videoscale ! "
+      "video/x-raw,width=320,height=240,format=RGB,framerate=10/1 ! "
+      "tensor_converter ! edgesink connect-type=CUSTOM custom-lib=%s name=sinkx port=0",
+      CUSTOM_LIB_PATH);
+  gstpipe = gst_parse_launch (pipeline, nullptr);
+  ASSERT_NE (gstpipe, nullptr);
+
+  edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sinkx");
+  ASSERT_NE (edge_handle, nullptr);
+  sink = GST_EDGESINK (edge_handle);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_NE (sink->edge_h, (nns_edge_h) NULL);
+
+  /* GstBaseSink calls stop() on READY to NULL, the handle should survive READY. */
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_READY, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_NE (sink->edge_h, (nns_edge_h) NULL);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (sink->edge_h, (nns_edge_h) NULL);
+
+  gst_object_unref (edge_handle);
+  gst_object_unref (gstpipe);
+  g_free (pipeline);
+}
+
+/**
  * @brief Test for edgesink custom connection with invalid property.
  */
 TEST (edgeCustom, sinkInvalidProp_n)
@@ -364,6 +403,42 @@ TEST (edgeCustom, srcNormal)
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (100000);
 
+  gst_object_unref (gstpipe);
+  g_free (pipeline);
+}
+
+/**
+ * @brief Ensure edgesrc releases its handle when stopping (PAUSED to READY).
+ */
+TEST (edgeCustom, srcReleasesHandle)
+{
+  gchar *pipeline = nullptr;
+  GstElement *gstpipe = nullptr;
+  GstElement *edge_handle = nullptr;
+  GstEdgeSrc *src = nullptr;
+
+  pipeline = g_strdup_printf ("edgesrc connect-type=CUSTOM custom-lib=%s name=srcx ! "
+                              "other/tensors,num_tensors=1,dimensions=3:320:240:1,types=uint8,format=static,framerate=30/1 ! "
+                              "tensor_sink",
+      CUSTOM_LIB_PATH);
+  gstpipe = gst_parse_launch (pipeline, nullptr);
+  ASSERT_NE (gstpipe, nullptr);
+
+  edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "srcx");
+  ASSERT_NE (edge_handle, nullptr);
+  src = GST_EDGESRC (edge_handle);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_NE (src->edge_h, (nns_edge_h) NULL);
+
+  /* GstBaseSrc calls stop() on PAUSED to READY, the handle should be released in READY. */
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_READY, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (src->edge_h, (nns_edge_h) NULL);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (src->edge_h, (nns_edge_h) NULL);
+
+  gst_object_unref (edge_handle);
   gst_object_unref (gstpipe);
   g_free (pipeline);
 }

--- a/tests/nnstreamer_edge/meson.build
+++ b/tests/nnstreamer_edge/meson.build
@@ -8,7 +8,7 @@ library('nnstreamer-edge-custom-test',
 
 unittest_edge = executable('unittest_edge',
   join_paths('edge', 'unittest_edge.cc'),
-  dependencies: [nnstreamer_unittest_deps],
+  dependencies: [nnstreamer_unittest_deps, gstedge_dep],
   install: get_option('install-test'),
   install_dir: unittest_install_dir
 )

--- a/tests/nnstreamer_edge/meson.build
+++ b/tests/nnstreamer_edge/meson.build
@@ -6,9 +6,12 @@ library('nnstreamer-edge-custom-test',
   install_dir: unittest_install_dir
 )
 
+# Headers only: linking the gstedge plugin module would leave the installed
+# test binary unable to resolve libgstedge.so (plugin dir is not in the loader path).
 unittest_edge = executable('unittest_edge',
   join_paths('edge', 'unittest_edge.cc'),
-  dependencies: [nnstreamer_unittest_deps, gstedge_dep],
+  dependencies: [nnstreamer_unittest_deps,
+    gstedge_dep.partial_dependency(includes: true, compile_args: true)],
   install: get_option('install-test'),
   install_dir: unittest_install_dir
 )


### PR DESCRIPTION
Add regression tests verifying that `edgesink` and `edgesrc` release their `nns_edge_h` handles at the proper state transitions.

**Note: the original plugin-side fix has been dropped from this PR.**
This PR originally also modified `gst/edge/edge_sink.c` and `gst/edge/edge_src.c` to release `nns_edge_h` on all failure/stop paths. An equivalent fix was independently merged into main via 14f7cca7 ("[Edge] function to release edge handle"), so after rebasing onto main only the tests remain here.

**Changes proposed in this PR:**
- Added `sinkReleasesHandle` and `srcReleasesHandle` GTest cases to `unittest_edge.cc`:
  - `edgesink` (GstBaseSink): `stop()` is invoked on READY→NULL, so the handle must survive READY and be released after NULL.
  - `edgesrc` (GstBaseSrc): `stop()` is invoked on PAUSED→READY, so the handle must be released in READY.
- Linked `unittest_edge` with `gstedge_dep` to inspect the element state.

The earlier revision of these tests asserted that the sink handle is released after READY, which is incorrect for a GstBaseSink and caused deterministic failures in the GBS (x86_64, unit_test 1) and pdebuild CI jobs. The assertions now follow the actual base-class lifecycle, and the polling helper (unnecessary since state changes are synchronous) has been removed.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Verified on Ubuntu 22.04 (meson `-Denable-test=true -Dwerror=true`): `unittest_edge` passes 13/13 both via `meson test` and when executed directly from the build tree as the GBS/pdebuild jobs do.

**How to evaluate:**
1. Ensure the `nnstreamer-edge` development package is installed.
2. `meson setup build -Denable-test=true && ninja -C build`
3. `meson test -C build unittest_edge -v`

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>