### PR TITLE
[Build] bump meson version to 0.62.0 and fix deprecations

### DIFF
--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -65,7 +65,7 @@ jobs:
         sudo apt-get update && sudo apt-get install -y pbuilder debootstrap curl ubuntu-dev-tools qemu-user-static debian-archive-keyring ubuntu-keyring debhelper
         echo "::endgroup::"
         echo "DISTRIBUTION=${{ matrix.distroname }}" > ~/.pbuilderrc
-        echo "OTHERMIRROR=\"deb [trusted=yes] http://archive.ubuntu.com/ubuntu ${{ matrix.distroname }}-backports universe |deb [trusted=yes] http://ppa.launchpad.net/nnstreamer/ppa/ubuntu ${{ matrix.distroname }} main\"" >> ~/.pbuilderrc
+        echo "OTHERMIRROR=\"deb [trusted=yes] http://archive.ubuntu.com/ubuntu ${{ matrix.distroname }}-backports universe |deb [trusted=yes] http://ppa.launchpad.net/nnstreamer/ppa/ubuntu ${{ matrix.distroname }} main |deb [trusted=yes] http://ppa.launchpad.net/kubuntu-ppa/backports-extra/ubuntu ${{ matrix.distroname }} main\"" >> ~/.pbuilderrc
         cat ~/.pbuilderrc
         sudo mkdir -p /root/
         sudo ln -s ~/.pbuilderrc /root/

--- a/.github/workflows/risc-v.yml
+++ b/.github/workflows/risc-v.yml
@@ -26,7 +26,8 @@ jobs:
           githubToken: ${{ github.token }}
           run: |
             apt-get -qy update
-            apt-get -qy install meson ninja-build libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libglib2.0-dev libjson-glib-dev gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good libgtest-dev libpng-dev libopencv-dev python3 python3-dev python3-numpy pkg-config gcc g++ liblua5.1-dev bash wget libpng-dev
+            apt-get -qy install ninja-build libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libglib2.0-dev libjson-glib-dev gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good libgtest-dev libpng-dev libopencv-dev python3 python3-dev python3-numpy python3-pip pkg-config gcc g++ liblua5.1-dev bash wget libpng-dev
+            pip3 install meson
             bash .github/workflows/get_ssat.sh
             meson build -Denable-tizen=false -Denable-test=true
             ninja -C build

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
 Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
- ninja-build, meson (>=0.49), debhelper (>=9), nnstreamer-edge-dev,
+ ninja-build, meson (>=0.62.0), debhelper (>=9), nnstreamer-edge-dev,
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev, libjson-glib-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev, flex, bison,

--- a/ext/nnstreamer/meson.build
+++ b/ext/nnstreamer/meson.build
@@ -25,9 +25,7 @@ if grpc_support_is_available
         output: ['@BASENAME@.grpc.pb.h', '@BASENAME@.grpc.pb.cc'],
         arguments : [
           '--proto_path=@CURRENT_SOURCE_DIR@/include',
-          #FIXME: external_program.path() will be deprecated in 0.55.0
-          #      use external_program.full_path() instead.
-          '--plugin=protoc-gen-grpc=' + prog_grpc_cpp_plugin.path(),
+          '--plugin=protoc-gen-grpc=' + prog_grpc_cpp_plugin.full_path(),
           '--grpc_out=@BUILD_DIR@',
           '@INPUT@'
         ]

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -271,7 +271,6 @@ if tflite2_support_is_available
     ##       If the user has downloaded libtensorflow-lite manually, it may incur inconsistency.
     ## @todo This does not use pkgconfig or find_library/meson-dep info
     ##       because it does not allow querying libpath and static/shared of a dependency object.
-    ## @todo If we are allowed to use meson > 0.53, use "FS" module!
 
     filepaths = [
         join_paths(meson.current_source_dir(), 'libtensorflow2-lite.so'),
@@ -283,7 +282,7 @@ if tflite2_support_is_available
     ]
     filepath = ''
     foreach file : filepaths
-      if run_command('bash', '-c', '[ -f "' + file + '" ]', check : false).returncode() == 0
+      if fs.is_file(file)
         message('Found: ' + file)
         filepath = file
         configure_file (
@@ -308,7 +307,7 @@ if tflite2_support_is_available
       ]
 
       foreach file : filepaths
-        if run_command('bash', '-c', '[ -f "'+ file + '" ]', check : false).returncode() == 0
+        if fs.is_file(file)
           somake = run_command('gcc', '-shared', '-o', custom_tflite_lib, '-Wl,--whole-archive', file, '-Wl,--no-whole-archive', check : false)
           if somake.returncode() == 0
             message('Successfully created libtensorflow2-lite-custom.so from archive: ' + file)
@@ -515,7 +514,7 @@ if get_option('enable-edgetpu')
     This temporarily overrides the runtime dependency on edge tpu and
     it is removed after installation.
     '''
-    rpath_edgetpu_test_helper = join_paths(meson.build_root(), 'tests/nnstreamer_filter_edgetpu')
+    rpath_edgetpu_test_helper = join_paths(meson.project_build_root(), 'tests/nnstreamer_filter_edgetpu')
   endif
 
   shared_library('nnstreamer_filter_edgetpu',
@@ -583,10 +582,7 @@ if get_option('enable-mediapipe')
     error('MEDIAPIPE_HOME is not set')
   endif
   message('MEDIAPIPE_HOME: ' + MEDIAPIPE_HOME)
-  # TODO: This is not a portable way to check if a directory exists
-  # After bumping up to 0.53.0, the following line can be replaced with one that uses FS module
-  mediapipe_dir_exist = run_command('[', '-d', MEDIAPIPE_HOME, ']', check : false).returncode()
-  if mediapipe_dir_exist != 0
+  if not fs.is_dir(MEDIAPIPE_HOME)
     error('Cannot find MEDIAPIPE_HOME: ' + MEDIAPIPE_HOME)
   endif
 
@@ -597,7 +593,7 @@ if get_option('enable-mediapipe')
     join_paths(MEDIAPIPE_HOME, 'bazel-mediapipe/external/com_google_absl'),
   )
 
-  run_command('sh', '-c', meson.source_root() + '/tools/development/gen_mediapipe_libs.sh ' + nnstreamer_libdir, check : true)
+  run_command('sh', '-c', meson.project_source_root() + '/tools/development/gen_mediapipe_libs.sh ' + nnstreamer_libdir, check : true)
 
   mediapipe_internal_dep = cxx.find_library('mediapipe_internal', dirs: nnstreamer_libdir)
   mediapipe_external_dep = cxx.find_library('mediapipe_external', dirs: nnstreamer_libdir)

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 project('nnstreamer', 'c', 'cpp',
   version: '2.7.0',
   license: ['LGPL-2.1'],
-  meson_version: '>=0.50.0',
+  meson_version: '>=0.62.0',
   default_options: [
     'werror=true',
     'warning_level=2',
@@ -23,6 +23,7 @@ cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')
 build_platform = ''
 so_ext = 'so'
+fs = import('fs')
 
 if get_option('enable-tizen')
   # Pass __TIZEN__ to the compiler
@@ -169,9 +170,8 @@ flatbuf_dep = disabler()
 flatbuf_version_check_dep = disabler()
 flatc_dep = disabler()
 if flatc.found()
-  # TODO: After bumping up meson version to 0.62.0, we can use flatc.version()
   # Please refer https://mesonbuild.com/Reference-manual_returned_external_program.html#external_programversion
-  flatc_ver = run_command(flatc, '--version', check : true).stdout().split()[2]
+  flatc_ver = flatc.version()
   flatbuf_dep = dependency('flatbuffers', version: flatc_ver,
       required : get_option('flatbuf-support'),
       not_found_message : 'flatbuffers version '+flatc_ver+' is required because flatc (flatbuf-compiler) '+flatc_ver+' is installed'
@@ -212,10 +212,7 @@ if not get_option('snpe-support').disabled()
       SNPE_ROOT = cmd.stdout().strip()
       if SNPE_ROOT != ''
         message('Got SNPE_ROOT: @0@'.format(SNPE_ROOT))
-        # TODO: This is not a portable way to check if a directory exists
-        # After bumping up to 0.53.0, the following line can be replaced with one that uses FS module
-        snpe_dir_not_exist = run_command('[', '-d', SNPE_ROOT, ']', check : false).returncode()
-        if snpe_dir_not_exist != 0
+        if not fs.is_dir(SNPE_ROOT)
           error('@0@ does not exists'.format(SNPE_ROOT))
         endif
 
@@ -232,7 +229,7 @@ if not get_option('snpe-support').disabled()
         ]
 
         foreach snpe_include_dir : snpe_include_dirs
-          if run_command('[', '-d', snpe_include_dir, ']').returncode() == 0
+          if fs.is_dir(snpe_include_dir)
             snpe_include_path = snpe_include_dir
             break
           endif
@@ -880,10 +877,10 @@ if get_option('enable-test')
     configuration: nnstreamer_test_conf
   )
 
-  path_gst_plugin = join_paths(meson.build_root(), 'gst')
-  path_ext_plugin = join_paths(meson.build_root(), 'ext')
-
-  path_nns_conf = join_paths(meson.build_root(), 'nnstreamer-test.ini')
+  path_gst_plugin = join_paths(meson.project_build_root(), 'gst')
+  path_ext_plugin = join_paths(meson.project_build_root(), 'ext')
+  # path_nns_conf is used for unittests
+  path_nns_conf = join_paths(meson.project_build_root(), 'nnstreamer-test.ini')
   path_nns_plugin_prefix = join_paths(path_ext_plugin, 'nnstreamer')
   path_nns_plugin_filters = join_paths(path_nns_plugin_prefix, 'tensor_filter')
   path_nns_plugin_decoders = join_paths(path_nns_plugin_prefix, 'tensor_decoder')
@@ -897,8 +894,8 @@ if get_option('enable-test')
   testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
   testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
   testenv.set('NNSTREAMER_TRAINERS', path_nns_plugin_trainers)
-  testenv.set('NNSTREAMER_SOURCE_ROOT_PATH', meson.source_root())
-  testenv.set('NNSTREAMER_BUILD_ROOT_PATH', meson.build_root())
+  testenv.set('NNSTREAMER_SOURCE_ROOT_PATH', meson.project_source_root())
+  testenv.set('NNSTREAMER_BUILD_ROOT_PATH', meson.project_build_root())
   if have_python3
     py3_module_path = join_paths(meson.current_build_dir(), 'ext/nnstreamer/extra')
     run_command('ln', '-sf',

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -223,7 +223,7 @@ BuildRequires:	gstreamer-devel
 BuildRequires:	gst-plugins-base-devel
 BuildRequires:	gst-plugins-bad-devel
 BuildRequires:	glib2-devel
-BuildRequires:	meson >= 0.50.0
+BuildRequires:	meson >= 0.62.0
 
 # To run test cases, we need gst plugins
 BuildRequires:	gst-plugins-good

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -9,7 +9,7 @@ tizen_apptest_deps = [
 # Format for adding subplugin into extensions -
 # [name, extension abbreviation, dependencies, model file name/folder path/file path, test name]
 extensions = []
-custom_filter_path = join_paths(meson.build_root(), 'tests', 'nnstreamer_example',
+custom_filter_path = join_paths(meson.project_build_root(), 'tests', 'nnstreamer_example',
     'libnnstreamer_customfilter_passthrough.' + so_ext)
 extensions += [['custom', 'custom', nnstreamer_unittest_deps, custom_filter_path, 'custom']]
 extensions += [['custom', 'custom', nnstreamer_unittest_deps, custom_filter_path, 'custom-set']]

--- a/tests/nnstreamer_filter_mvncsdk2/meson.build
+++ b/tests/nnstreamer_filter_mvncsdk2/meson.build
@@ -28,7 +28,7 @@ filter_mvncsdk2_testenv.set('NNSTREAMER_CONF', path_nns_conf)
 filter_mvncsdk2_testenv.set('NNSTREAMER_FILTERS', path_nns_plugin_filters)
 filter_mvncsdk2_testenv.set('NNSTREAMER_DECODERS', path_nns_plugin_decoders)
 filter_mvncsdk2_testenv.set('NNSTREAMER_CONVERTERS', path_nns_plugin_converters)
-filter_mvncsdk2_testenv.set('NNSTREAMER_SOURCE_ROOT_PATH', meson.source_root())
+filter_mvncsdk2_testenv.set('NNSTREAMER_SOURCE_ROOT_PATH', meson.project_source_root())
 filter_mvncsdk2_testenv.set('LD_LIBRARY_PATH', meson.current_build_dir())
 
 test('unittest_filter_mvncsdk2', unittest_mvncsdk, env: filter_mvncsdk2_testenv)

--- a/tools/development/parser/meson.build
+++ b/tools/development/parser/meson.build
@@ -13,7 +13,7 @@ if not flex.found()
   subdir_done()
 endif
 flex_cdata = configuration_data()
-flex_cdata.set('FLEX', flex.path())
+flex_cdata.set('FLEX', flex.full_path())
 if cc.get_id() == 'msvc'
   flex_cdata.set('FLEX_ARGS', '--nounistd')
 else
@@ -39,7 +39,7 @@ if not bison.found()
   subdir_done()
 endif
 bison_cdata = configuration_data()
-bison_cdata.set('BISON', bison.path())
+bison_cdata.set('BISON', bison.full_path())
 bison_cdata.set('BISON_ARGS', '')
 
 gen_grammar = configure_file(input : 'gen_grammar.py.in',


### PR DESCRIPTION
This commit bumps the minimum required Meson version to 0.62.0 and modernizes the build scripts.

1. Use the 'fs' module for portable 'fs.is_dir()' and 'fs.is_file()' checks, replacing shell-based 'run_command'.
2. Fix deprecation warnings by replacing:
    - 'meson.source_root()' -> 'meson.project_source_root()'
    - 'meson.build_root()' -> 'meson.project_build_root()'
    - 'ExternalProgram.path()' -> 'ExternalProgram.full_path()'
3. Update packaging/nnstreamer.spec and debian/control
4. Use 'flatc.version()' instead of parsing 'run_command' output.
5. Fix CI workflows for Ubuntu 22.04 compatibility:
    - pdebuild.yml: Add 'ppa:kubuntu-ppa/backports-extra'
    - risc-v.yml: Use 'python3 -m pip install meson'

Issue; https://github.com/nnstreamer/nnstreamer/issues/4810