### PR TITLE
Fix: prevent leaks and exception escapes in tensor_filter_subplugin C wrappers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 2.6.0 -> 2.7.0
 	- 2.7.0 is a devel version for 2.8.0 release. Experimental features may be added to 2.7.x.
 
+	- C++ subplugin API (tensor_filter_subplugin) behavior change
+		- The framework now deletes the object returned by getEmptyInstance() when configure_instance() throws, instead of leaking it. The object must be heap-allocated and singly owned by the framework, and the derived destructor must be safe on a partially-configured instance.
+		- All in-tree subplugins conform. An out-of-tree subplugin whose getEmptyInstance() returns a static, pooled, or shared instance must be fixed to return a newly allocated object; see Documentation/writing-subplugin-tensor-filter.md.
+
 2.4.4 -> 2.6.0
         - llama.cpp upgrades
                 - Added context save/restore, KV-cache trimming, LoRA adapters, token-by-token samplers, and safer teardown paths so on-device LLMs support long chats and tuning.

--- a/Documentation/writing-subplugin-tensor-filter.md
+++ b/Documentation/writing-subplugin-tensor-filter.md
@@ -35,6 +35,15 @@ As in C subplugin, the derived (concrete) class should be registered at init and
 Subplugin writers are supposed to use the static methods of the base class, ```register_subplugin()``` and ```unregister_subplugin()```; refer to the function ```init_filter_snap()``` and ```fini_filter_snap()``` in the reference example.
 
 
+### Object ownership and exception rules
+
+```getEmptyInstance()``` must return a heap-allocated object that is singly owned by the framework: the framework deletes it (through the virtual destructor) when the filter is closed, or immediately if ```configure_instance()``` throws.
+Do not return a reference to a static, pooled, or otherwise shared instance, and do not retain a reference to the returned object inside the subplugin.
+
+If ```configure_instance()``` throws, clean up any external references to the object (e.g., entries in a global registry) before throwing, because the framework deletes the object right away.
+Consequently, the destructor of the derived class must be safe to run on a partially-configured (or never-configured) instance; the recommended pattern is an idempotent cleanup method that releases only what has been acquired and is null-safe for the rest.
+
+
 
 Note that C++ subplugin is simpler and easy-to-maintain compared to C subplugin. Unless you really need to write your subplugin in C, we recommend to use the ```nnstreamer::tensor_filter_subplugin``` base class.
 

--- a/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
+++ b/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
@@ -164,11 +164,25 @@ class tensor_filter_subplugin
     */
 
   virtual tensor_filter_subplugin &getEmptyInstance () = 0;
-  /**< Return a newly created "empty" object of the derived class. */
+  /**< Return a newly created "empty" object of the derived class.
+
+       The returned object MUST be heap-allocated and singly owned by
+       the framework: the framework deletes it (via the virtual
+       destructor) when the filter is closed, or immediately if
+       configure_instance() throws. Do not return a reference to a
+       static, pooled, or otherwise shared instance, and do not retain
+       a reference to the returned object inside the subplugin.
+   */
 
   virtual void configure_instance (const GstTensorFilterProperties *prop) = 0;
   /**< Configure a non-functional "empty" object as a
        functional "filled" object ready to be invoked.
+
+       If this method throws, the framework immediately deletes the
+       object. Thus, before throwing, it must clean up any external
+       references to "this" (e.g., entries in a global registry), and
+       the destructor of the derived class must be safe to run on a
+       partially-configured (or never-configured) instance.
 
        Possible exceptions: ... @todo describe them!
    */

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
@@ -88,24 +88,21 @@ tensor_filter_subplugin::cpp_open (const GstTensorFilterProperties *prop, void *
   tensor_filter_subplugin &obj = sp->getEmptyInstance ();
   /**
    * NOTE:
-   * getEmptyInstance() is expected to return a heap-allocated object.
-   * If configure_instance() throws, cpp_open() must delete the object to avoid leaks
-   * when open() is repeatedly attempted with invalid properties.
+   * getEmptyInstance() must return a heap-allocated, singly-owned object.
+   * If configure_instance() throws, obj_ptr deletes the object to avoid
+   * leaks when open() is repeatedly attempted with invalid properties.
+   * On success, ownership is transferred to *private_data via release().
    */
-  tensor_filter_subplugin *obj_ptr = std::addressof (obj);
+  std::unique_ptr<tensor_filter_subplugin> obj_ptr (std::addressof (obj));
   try {
     obj.configure_instance (prop);
   } catch (const std::invalid_argument &e) {
-    delete obj_ptr;
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
   } catch (const std::system_error &e) {
-    delete obj_ptr;
     _RETURN_ERR_WITH_MSG (e.code ().value () * -1, e.what ());
   } catch (const std::runtime_error &e) {
-    delete obj_ptr;
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
   } catch (const std::exception &e) {
-    delete obj_ptr;
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
   }
 
@@ -113,12 +110,8 @@ tensor_filter_subplugin::cpp_open (const GstTensorFilterProperties *prop, void *
    * nnstreamer_filter_find) empty object */
   obj.fwdesc.v1.subplugin_data = nullptr;
 
-/* 4. Save the object as *private_data */
-#if __GNUC__ < 5 || __cplusplus < 201103L
-  *private_data = obj_ptr;
-#else /* It is safer w/ addressof, but old gcc doesn't appear to support it */
-  *private_data = obj_ptr;
-#endif
+  /* 4. Save the object as *private_data */
+  *private_data = obj_ptr.release ();
 
   return 0;
 }

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
@@ -85,8 +85,16 @@ tensor_filter_subplugin::cpp_open (const GstTensorFilterProperties *prop, void *
   assert (sp->sanity == _SANITY_CHECK); /** tfsp is using me! */
 
   /* 2. Spawn another empty object and configure it; obj_ptr deletes it if configure_instance() throws */
-  tensor_filter_subplugin &obj = sp->getEmptyInstance ();
-  std::unique_ptr<tensor_filter_subplugin> obj_ptr (std::addressof (obj));
+  tensor_filter_subplugin *obj_raw;
+  try {
+    obj_raw = std::addressof (sp->getEmptyInstance ());
+  } catch (const std::exception &e) {
+    _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
+  } catch (...) {
+    _RETURN_ERR_WITH_MSG (-EINVAL, "Unknown exception from getEmptyInstance()");
+  }
+  std::unique_ptr<tensor_filter_subplugin> obj_ptr (obj_raw);
+  tensor_filter_subplugin &obj = *obj_ptr;
   try {
     obj.configure_instance (prop);
   } catch (const std::invalid_argument &e) {

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
@@ -233,13 +233,16 @@ tensor_filter_subplugin::cpp_getModelInfo (const GstTensorFilterFramework *tf,
   UNUSED (tf);
   UNUSED (prop);
 
+  int ret;
   try {
-    return obj->getModelInfo (ops, *in_info, *out_info);
+    ret = obj->getModelInfo (ops, *in_info, *out_info);
   } catch (const std::exception &e) {
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
   } catch (...) {
     _RETURN_ERR_WITH_MSG (-EINVAL, "Unknown exception from getModelInfo()");
   }
+
+  return ret;
 }
 
 /**
@@ -256,13 +259,16 @@ tensor_filter_subplugin::cpp_eventHandler (const GstTensorFilterFramework *tf,
   UNUSED (tf);
   UNUSED (prop);
 
+  int ret;
   try {
-    return obj->eventHandler (ops, *data);
+    ret = obj->eventHandler (ops, *data);
   } catch (const std::exception &e) {
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
   } catch (...) {
     _RETURN_ERR_WITH_MSG (-EINVAL, "Unknown exception from eventHandler()");
   }
+
+  return ret;
 }
 
 /**

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
@@ -88,6 +88,8 @@ tensor_filter_subplugin::cpp_open (const GstTensorFilterProperties *prop, void *
   tensor_filter_subplugin *obj_raw;
   try {
     obj_raw = std::addressof (sp->getEmptyInstance ());
+  } catch (const std::bad_alloc &e) {
+    _RETURN_ERR_WITH_MSG (-ENOMEM, e.what ());
   } catch (const std::exception &e) {
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
   } catch (...) {
@@ -97,6 +99,8 @@ tensor_filter_subplugin::cpp_open (const GstTensorFilterProperties *prop, void *
   tensor_filter_subplugin &obj = *obj_ptr;
   try {
     obj.configure_instance (prop);
+  } catch (const std::bad_alloc &e) {
+    _RETURN_ERR_WITH_MSG (-ENOMEM, e.what ());
   } catch (const std::invalid_argument &e) {
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
   } catch (const std::system_error &e) {

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
@@ -62,7 +62,7 @@ namespace nnstreamer
   do {                                                                  \
     try {                                                               \
       obj = get_tfsp_with_checks (private_data);                        \
-    } catch (const std::exception &e) {                                 \
+    } catch (...) {                                                     \
       /** @todo Write exception handlers. */                            \
       return -EINVAL;                                                   \
       /** @todo return different error codes according to exceptions */ \
@@ -84,9 +84,7 @@ tensor_filter_subplugin::cpp_open (const GstTensorFilterProperties *prop, void *
   tensor_filter_subplugin *sp = (tensor_filter_subplugin *) tfsp->v1.subplugin_data;
   assert (sp->sanity == _SANITY_CHECK); /** tfsp is using me! */
 
-  /* 2. Spawn another empty object and configure the empty object.
-   * If configure_instance() throws, obj_ptr deletes the object; see the
-   * ownership contract of getEmptyInstance() in nnstreamer_cppplugin_api_filter.hh */
+  /* 2. Spawn another empty object and configure it; obj_ptr deletes it if configure_instance() throws */
   tensor_filter_subplugin &obj = sp->getEmptyInstance ();
   std::unique_ptr<tensor_filter_subplugin> obj_ptr (std::addressof (obj));
   try {
@@ -178,6 +176,8 @@ tensor_filter_subplugin::cpp_invoke (const GstTensorFilterFramework *tf,
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
   } catch (const std::exception &e) {
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
+  } catch (...) {
+    _RETURN_ERR_WITH_MSG (-EINVAL, "Unknown exception from invoke()");
   }
 
   return 0;
@@ -213,6 +213,8 @@ tensor_filter_subplugin::cpp_getFrameworkInfo (const GstTensorFilterFramework *t
   } catch (const std::exception &e) {
     /** @todo Write exception handlers. */
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
+  } catch (...) {
+    _RETURN_ERR_WITH_MSG (-EINVAL, "Unknown exception from getFrameworkInfo()");
   }
   return 0;
 }
@@ -231,7 +233,13 @@ tensor_filter_subplugin::cpp_getModelInfo (const GstTensorFilterFramework *tf,
   UNUSED (tf);
   UNUSED (prop);
 
-  return obj->getModelInfo (ops, *in_info, *out_info);
+  try {
+    return obj->getModelInfo (ops, *in_info, *out_info);
+  } catch (const std::exception &e) {
+    _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
+  } catch (...) {
+    _RETURN_ERR_WITH_MSG (-EINVAL, "Unknown exception from getModelInfo()");
+  }
 }
 
 /**
@@ -248,7 +256,13 @@ tensor_filter_subplugin::cpp_eventHandler (const GstTensorFilterFramework *tf,
   UNUSED (tf);
   UNUSED (prop);
 
-  return obj->eventHandler (ops, *data);
+  try {
+    return obj->eventHandler (ops, *data);
+  } catch (const std::exception &e) {
+    _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
+  } catch (...) {
+    _RETURN_ERR_WITH_MSG (-EINVAL, "Unknown exception from eventHandler()");
+  }
 }
 
 /**

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
@@ -84,15 +84,10 @@ tensor_filter_subplugin::cpp_open (const GstTensorFilterProperties *prop, void *
   tensor_filter_subplugin *sp = (tensor_filter_subplugin *) tfsp->v1.subplugin_data;
   assert (sp->sanity == _SANITY_CHECK); /** tfsp is using me! */
 
-  /* 2. Spawn another empty object and configure the empty object */
+  /* 2. Spawn another empty object and configure the empty object.
+   * If configure_instance() throws, obj_ptr deletes the object; see the
+   * ownership contract of getEmptyInstance() in nnstreamer_cppplugin_api_filter.hh */
   tensor_filter_subplugin &obj = sp->getEmptyInstance ();
-  /**
-   * NOTE:
-   * getEmptyInstance() must return a heap-allocated, singly-owned object.
-   * If configure_instance() throws, obj_ptr deletes the object to avoid
-   * leaks when open() is repeatedly attempted with invalid properties.
-   * On success, ownership is transferred to *private_data via release().
-   */
   std::unique_ptr<tensor_filter_subplugin> obj_ptr (std::addressof (obj));
   try {
     obj.configure_instance (prop);
@@ -104,6 +99,8 @@ tensor_filter_subplugin::cpp_open (const GstTensorFilterProperties *prop, void *
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
   } catch (const std::exception &e) {
     _RETURN_ERR_WITH_MSG (-EINVAL, e.what ());
+  } catch (...) {
+    _RETURN_ERR_WITH_MSG (-EINVAL, "Unknown exception from configure_instance()");
   }
 
   /** 3. Mark that this is not a representative (found by

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -5937,17 +5937,20 @@ class cpp_mock_subplugin : public nnstreamer::tensor_filter_subplugin
   static const char *mock_name;
   static cpp_mock_subplugin *registered;
   static guint instances_alive;
+  static guint resources_alive;
   static bool throw_on_configure;
 
-  /** @brief Count a live instance */
+  /** @brief constructor */
   cpp_mock_subplugin ()
   {
     instances_alive++;
   }
 
-  /** @brief Discount a live instance */
+  /** @brief destructor */
   ~cpp_mock_subplugin ()
   {
+    if (resource_held)
+      resources_alive--;
     instances_alive--;
   }
 
@@ -5957,10 +5960,12 @@ class cpp_mock_subplugin : public nnstreamer::tensor_filter_subplugin
     return *(new cpp_mock_subplugin ());
   }
 
-  /** @brief mandatory method. throws if throw_on_configure is set */
+  /** @brief mandatory method; acquires a resource, then throws if throw_on_configure */
   void configure_instance (const GstTensorFilterProperties *prop) override
   {
     UNUSED (prop);
+    resources_alive++;
+    resource_held = true;
     if (throw_on_configure)
       throw std::invalid_argument ("Configuration failure for testing");
   }
@@ -6005,26 +6010,51 @@ class cpp_mock_subplugin : public nnstreamer::tensor_filter_subplugin
     unregister_subplugin<cpp_mock_subplugin> (registered);
     registered = nullptr;
   }
+
+  private:
+  bool resource_held = false;
 };
 
 const char *cpp_mock_subplugin::mock_name = "cpp_mock_subplugin";
 cpp_mock_subplugin *cpp_mock_subplugin::registered = nullptr;
 guint cpp_mock_subplugin::instances_alive = 0;
+guint cpp_mock_subplugin::resources_alive = 0;
 bool cpp_mock_subplugin::throw_on_configure = false;
 
 /**
- * @brief Test C++ subplugin open: when configure_instance() throws, repeated
- *        open attempts must neither crash nor leak the instance spawned by
- *        getEmptyInstance().
+ * @brief Test fixture registering/unregistering the mock C++ subplugin.
  */
-TEST (testTensorFilterCppSubplugin, openFailNoLeak)
+class testTensorFilterCppSubplugin : public ::testing::Test
+{
+  protected:
+  /** @brief register the mock subplugin */
+  void SetUp () override
+  {
+    cpp_mock_subplugin::init ();
+  }
+
+  /** @brief unregister the mock subplugin and verify no instance leaks */
+  void TearDown () override
+  {
+    cpp_mock_subplugin::throw_on_configure = false;
+    cpp_mock_subplugin::fini ();
+    EXPECT_EQ (cpp_mock_subplugin::instances_alive, 0U);
+    EXPECT_EQ (cpp_mock_subplugin::resources_alive, 0U);
+  }
+};
+
+/**
+ * @brief Test C++ subplugin open: when configure_instance() throws, repeated
+ *        open attempts must neither crash nor leak the spawned instance and
+ *        the resources it acquired before throwing.
+ */
+TEST_F (testTensorFilterCppSubplugin, openFailNoLeak)
 {
   const GstTensorFilterFramework *fw;
   GstTensorFilterProperties prop;
   gpointer private_data;
   guint i;
 
-  cpp_mock_subplugin::init ();
   cpp_mock_subplugin::throw_on_configure = true;
 
   fw = nnstreamer_filter_find (cpp_mock_subplugin::mock_name);
@@ -6033,19 +6063,15 @@ TEST (testTensorFilterCppSubplugin, openFailNoLeak)
   memset (&prop, 0, sizeof (prop));
   prop.fwname = cpp_mock_subplugin::mock_name;
 
-  /* Only the representative instance from register_subplugin() is alive. */
   EXPECT_EQ (cpp_mock_subplugin::instances_alive, 1U);
 
   for (i = 0; i < 100U; i++) {
     private_data = nullptr;
     EXPECT_EQ (fw->open (&prop, &private_data), -EINVAL);
     EXPECT_TRUE (private_data == nullptr);
-    /* The instance spawned for this failed attempt must have been deleted. */
-    EXPECT_EQ (cpp_mock_subplugin::instances_alive, 1U);
+    ASSERT_EQ (cpp_mock_subplugin::instances_alive, 1U);
+    ASSERT_EQ (cpp_mock_subplugin::resources_alive, 0U);
   }
-
-  cpp_mock_subplugin::fini ();
-  EXPECT_EQ (cpp_mock_subplugin::instances_alive, 0U);
 }
 
 /**
@@ -6053,14 +6079,11 @@ TEST (testTensorFilterCppSubplugin, openFailNoLeak)
  *        configured instance is transferred to *private_data and the
  *        instance is deleted by close.
  */
-TEST (testTensorFilterCppSubplugin, openCloseOwnership)
+TEST_F (testTensorFilterCppSubplugin, openCloseOwnership)
 {
   const GstTensorFilterFramework *fw;
   GstTensorFilterProperties prop;
   gpointer private_data = nullptr;
-
-  cpp_mock_subplugin::init ();
-  cpp_mock_subplugin::throw_on_configure = false;
 
   fw = nnstreamer_filter_find (cpp_mock_subplugin::mock_name);
   ASSERT_TRUE (fw && fw->open && fw->close);
@@ -6072,14 +6095,12 @@ TEST (testTensorFilterCppSubplugin, openCloseOwnership)
 
   EXPECT_EQ (fw->open (&prop, &private_data), 0);
   EXPECT_TRUE (private_data != nullptr);
-  /* The configured instance is alive, owned via *private_data. */
   EXPECT_EQ (cpp_mock_subplugin::instances_alive, 2U);
+  EXPECT_EQ (cpp_mock_subplugin::resources_alive, 1U);
 
   fw->close (&prop, &private_data);
   EXPECT_EQ (cpp_mock_subplugin::instances_alive, 1U);
-
-  cpp_mock_subplugin::fini ();
-  EXPECT_EQ (cpp_mock_subplugin::instances_alive, 0U);
+  EXPECT_EQ (cpp_mock_subplugin::resources_alive, 0U);
 }
 
 /**

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -6033,7 +6033,8 @@ const char *cpp_mock_subplugin::mock_name = "cpp_mock_subplugin";
 cpp_mock_subplugin *cpp_mock_subplugin::registered = nullptr;
 guint cpp_mock_subplugin::instances_alive = 0;
 guint cpp_mock_subplugin::resources_alive = 0;
-cpp_mock_subplugin::throw_point_t cpp_mock_subplugin::throw_point = cpp_mock_subplugin::THROW_NONE;
+cpp_mock_subplugin::throw_point_t cpp_mock_subplugin::throw_point
+    = cpp_mock_subplugin::THROW_NONE;
 
 /**
  * @brief Test fixture registering/unregistering the mock C++ subplugin.
@@ -6071,9 +6072,8 @@ TEST_F (testTensorFilterCppSubplugin, openFailNoLeak_n)
   GstTensorFilterProperties prop;
   gpointer private_data;
   guint i;
-  const cpp_mock_subplugin::throw_point_t points[]
-      = { cpp_mock_subplugin::THROW_BEFORE_ACQUIRE,
-          cpp_mock_subplugin::THROW_AFTER_ACQUIRE, cpp_mock_subplugin::THROW_AFTER_RELEASE };
+  const cpp_mock_subplugin::throw_point_t points[] = { cpp_mock_subplugin::THROW_BEFORE_ACQUIRE,
+    cpp_mock_subplugin::THROW_AFTER_ACQUIRE, cpp_mock_subplugin::THROW_AFTER_RELEASE };
 
   fw = nnstreamer_filter_find (cpp_mock_subplugin::mock_name);
   ASSERT_TRUE (fw && fw->open && fw->close);

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -5934,11 +5934,18 @@ TEST_REQUIRE_TFLITE (testTensorFilter, reopenTFlite02)
 class cpp_mock_subplugin : public nnstreamer::tensor_filter_subplugin
 {
   public:
+  enum throw_point_t {
+    THROW_NONE = 0,
+    THROW_BEFORE_ACQUIRE,
+    THROW_AFTER_ACQUIRE,
+    THROW_AFTER_RELEASE,
+  };
+
   static const char *mock_name;
   static cpp_mock_subplugin *registered;
   static guint instances_alive;
   static guint resources_alive;
-  static bool throw_on_configure;
+  static throw_point_t throw_point;
 
   /** @brief constructor */
   cpp_mock_subplugin ()
@@ -5960,14 +5967,21 @@ class cpp_mock_subplugin : public nnstreamer::tensor_filter_subplugin
     return *(new cpp_mock_subplugin ());
   }
 
-  /** @brief mandatory method; acquires a resource, then throws if throw_on_configure */
+  /** @brief mandatory method; acquires a resource and throws at the point set by throw_point */
   void configure_instance (const GstTensorFilterProperties *prop) override
   {
     UNUSED (prop);
+    if (throw_point == THROW_BEFORE_ACQUIRE)
+      throw std::invalid_argument ("Configuration failure for testing");
     resources_alive++;
     resource_held = true;
-    if (throw_on_configure)
+    if (throw_point == THROW_AFTER_ACQUIRE)
       throw std::invalid_argument ("Configuration failure for testing");
+    if (throw_point == THROW_AFTER_RELEASE) {
+      resources_alive--;
+      resource_held = false;
+      throw std::invalid_argument ("Configuration failure for testing");
+    }
   }
 
   /** @brief mandatory method */
@@ -6019,7 +6033,7 @@ const char *cpp_mock_subplugin::mock_name = "cpp_mock_subplugin";
 cpp_mock_subplugin *cpp_mock_subplugin::registered = nullptr;
 guint cpp_mock_subplugin::instances_alive = 0;
 guint cpp_mock_subplugin::resources_alive = 0;
-bool cpp_mock_subplugin::throw_on_configure = false;
+cpp_mock_subplugin::throw_point_t cpp_mock_subplugin::throw_point = cpp_mock_subplugin::THROW_NONE;
 
 /**
  * @brief Test fixture registering/unregistering the mock C++ subplugin.
@@ -6027,16 +6041,19 @@ bool cpp_mock_subplugin::throw_on_configure = false;
 class testTensorFilterCppSubplugin : public ::testing::Test
 {
   protected:
-  /** @brief register the mock subplugin */
+  /** @brief reset counters and register the mock subplugin */
   void SetUp () override
   {
+    cpp_mock_subplugin::instances_alive = 0;
+    cpp_mock_subplugin::resources_alive = 0;
+    cpp_mock_subplugin::throw_point = cpp_mock_subplugin::THROW_NONE;
     cpp_mock_subplugin::init ();
   }
 
   /** @brief unregister the mock subplugin and verify no instance leaks */
   void TearDown () override
   {
-    cpp_mock_subplugin::throw_on_configure = false;
+    cpp_mock_subplugin::throw_point = cpp_mock_subplugin::THROW_NONE;
     cpp_mock_subplugin::fini ();
     EXPECT_EQ (cpp_mock_subplugin::instances_alive, 0U);
     EXPECT_EQ (cpp_mock_subplugin::resources_alive, 0U);
@@ -6044,18 +6061,19 @@ class testTensorFilterCppSubplugin : public ::testing::Test
 };
 
 /**
- * @brief Test C++ subplugin open: when configure_instance() throws, repeated
- *        open attempts must neither crash nor leak the spawned instance and
- *        the resources it acquired before throwing.
+ * @brief Test C++ subplugin open: when configure_instance() throws at any
+ *        point, repeated open attempts must neither crash nor leak the
+ *        spawned instance and the resources it acquired before throwing.
  */
-TEST_F (testTensorFilterCppSubplugin, openFailNoLeak)
+TEST_F (testTensorFilterCppSubplugin, openFailNoLeak_n)
 {
   const GstTensorFilterFramework *fw;
   GstTensorFilterProperties prop;
   gpointer private_data;
   guint i;
-
-  cpp_mock_subplugin::throw_on_configure = true;
+  const cpp_mock_subplugin::throw_point_t points[]
+      = { cpp_mock_subplugin::THROW_BEFORE_ACQUIRE,
+          cpp_mock_subplugin::THROW_AFTER_ACQUIRE, cpp_mock_subplugin::THROW_AFTER_RELEASE };
 
   fw = nnstreamer_filter_find (cpp_mock_subplugin::mock_name);
   ASSERT_TRUE (fw && fw->open && fw->close);
@@ -6065,12 +6083,15 @@ TEST_F (testTensorFilterCppSubplugin, openFailNoLeak)
 
   EXPECT_EQ (cpp_mock_subplugin::instances_alive, 1U);
 
-  for (i = 0; i < 100U; i++) {
-    private_data = nullptr;
-    EXPECT_EQ (fw->open (&prop, &private_data), -EINVAL);
-    EXPECT_TRUE (private_data == nullptr);
-    ASSERT_EQ (cpp_mock_subplugin::instances_alive, 1U);
-    ASSERT_EQ (cpp_mock_subplugin::resources_alive, 0U);
+  for (cpp_mock_subplugin::throw_point_t point : points) {
+    cpp_mock_subplugin::throw_point = point;
+    for (i = 0; i < 100U; i++) {
+      private_data = nullptr;
+      EXPECT_EQ (fw->open (&prop, &private_data), -EINVAL);
+      EXPECT_TRUE (private_data == nullptr);
+      ASSERT_EQ (cpp_mock_subplugin::instances_alive, 1U);
+      ASSERT_EQ (cpp_mock_subplugin::resources_alive, 0U);
+    }
   }
 }
 
@@ -6079,7 +6100,7 @@ TEST_F (testTensorFilterCppSubplugin, openFailNoLeak)
  *        configured instance is transferred to *private_data and the
  *        instance is deleted by close.
  */
-TEST_F (testTensorFilterCppSubplugin, openCloseOwnership)
+TEST_F (testTensorFilterCppSubplugin, openCloseOwnership_p)
 {
   const GstTensorFilterFramework *fw;
   GstTensorFilterProperties prop;

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -13,10 +13,12 @@
 #include <gst/check/gstharness.h>
 #include <gst/check/gsttestclock.h>
 #include <gst/gst.h>
+#include <nnstreamer_cppplugin_api_filter.hh>
 #include <nnstreamer_plugin_api_converter.h>
 #include <nnstreamer_plugin_api_decoder.h>
 #include <nnstreamer_plugin_api_filter.h>
 #include <nnstreamer_subplugin.h>
+#include <nnstreamer_util.h>
 #include <string.h>
 #include <tensor_common.h>
 #include <tensor_meta.h>
@@ -5923,6 +5925,161 @@ TEST_REQUIRE_TFLITE (testTensorFilter, reopenTFlite02)
 
   g_free (prop);
   g_free (test_model);
+}
+
+/**
+ * @brief Mock C++ subplugin (tensor_filter_subplugin) to test open/close paths
+ *        of the C++ subplugin API wrapper (tensor_filter_support_cc.cc).
+ */
+class cpp_mock_subplugin : public nnstreamer::tensor_filter_subplugin
+{
+  public:
+  static const char *mock_name;
+  static cpp_mock_subplugin *registered;
+  static guint instances_alive;
+  static bool throw_on_configure;
+
+  /** @brief Count a live instance */
+  cpp_mock_subplugin ()
+  {
+    instances_alive++;
+  }
+
+  /** @brief Discount a live instance */
+  ~cpp_mock_subplugin ()
+  {
+    instances_alive--;
+  }
+
+  /** @brief mandatory method */
+  tensor_filter_subplugin &getEmptyInstance () override
+  {
+    return *(new cpp_mock_subplugin ());
+  }
+
+  /** @brief mandatory method. throws if throw_on_configure is set */
+  void configure_instance (const GstTensorFilterProperties *prop) override
+  {
+    UNUSED (prop);
+    if (throw_on_configure)
+      throw std::invalid_argument ("Configuration failure for testing");
+  }
+
+  /** @brief mandatory method */
+  void invoke (const GstTensorMemory *input, GstTensorMemory *output) override
+  {
+    UNUSED (input);
+    UNUSED (output);
+  }
+
+  /** @brief mandatory method */
+  void getFrameworkInfo (GstTensorFilterFrameworkInfo &info) override
+  {
+    info.name = mock_name;
+    info.allow_in_place = FALSE;
+    info.allocate_in_invoke = FALSE;
+    info.run_without_model = TRUE;
+    info.verify_model_path = FALSE;
+    info.hw_list = nullptr;
+    info.num_hw = 0;
+  }
+
+  /** @brief mandatory method */
+  int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info) override
+  {
+    UNUSED (ops);
+    UNUSED (in_info);
+    UNUSED (out_info);
+    return -ENOENT;
+  }
+
+  /** @brief register this mock subplugin */
+  static void init ()
+  {
+    registered = register_subplugin<cpp_mock_subplugin> ();
+  }
+
+  /** @brief unregister this mock subplugin */
+  static void fini ()
+  {
+    unregister_subplugin<cpp_mock_subplugin> (registered);
+    registered = nullptr;
+  }
+};
+
+const char *cpp_mock_subplugin::mock_name = "cpp_mock_subplugin";
+cpp_mock_subplugin *cpp_mock_subplugin::registered = nullptr;
+guint cpp_mock_subplugin::instances_alive = 0;
+bool cpp_mock_subplugin::throw_on_configure = false;
+
+/**
+ * @brief Test C++ subplugin open: when configure_instance() throws, repeated
+ *        open attempts must neither crash nor leak the instance spawned by
+ *        getEmptyInstance().
+ */
+TEST (testTensorFilterCppSubplugin, openFailNoLeak)
+{
+  const GstTensorFilterFramework *fw;
+  GstTensorFilterProperties prop;
+  gpointer private_data;
+  guint i;
+
+  cpp_mock_subplugin::init ();
+  cpp_mock_subplugin::throw_on_configure = true;
+
+  fw = nnstreamer_filter_find (cpp_mock_subplugin::mock_name);
+  ASSERT_TRUE (fw && fw->open && fw->close);
+
+  memset (&prop, 0, sizeof (prop));
+  prop.fwname = cpp_mock_subplugin::mock_name;
+
+  /* Only the representative instance from register_subplugin() is alive. */
+  EXPECT_EQ (cpp_mock_subplugin::instances_alive, 1U);
+
+  for (i = 0; i < 100U; i++) {
+    private_data = nullptr;
+    EXPECT_EQ (fw->open (&prop, &private_data), -EINVAL);
+    EXPECT_TRUE (private_data == nullptr);
+    /* The instance spawned for this failed attempt must have been deleted. */
+    EXPECT_EQ (cpp_mock_subplugin::instances_alive, 1U);
+  }
+
+  cpp_mock_subplugin::fini ();
+  EXPECT_EQ (cpp_mock_subplugin::instances_alive, 0U);
+}
+
+/**
+ * @brief Test C++ subplugin open/close: on success, the ownership of the
+ *        configured instance is transferred to *private_data and the
+ *        instance is deleted by close.
+ */
+TEST (testTensorFilterCppSubplugin, openCloseOwnership)
+{
+  const GstTensorFilterFramework *fw;
+  GstTensorFilterProperties prop;
+  gpointer private_data = nullptr;
+
+  cpp_mock_subplugin::init ();
+  cpp_mock_subplugin::throw_on_configure = false;
+
+  fw = nnstreamer_filter_find (cpp_mock_subplugin::mock_name);
+  ASSERT_TRUE (fw && fw->open && fw->close);
+
+  memset (&prop, 0, sizeof (prop));
+  prop.fwname = cpp_mock_subplugin::mock_name;
+
+  EXPECT_EQ (cpp_mock_subplugin::instances_alive, 1U);
+
+  EXPECT_EQ (fw->open (&prop, &private_data), 0);
+  EXPECT_TRUE (private_data != nullptr);
+  /* The configured instance is alive, owned via *private_data. */
+  EXPECT_EQ (cpp_mock_subplugin::instances_alive, 2U);
+
+  fw->close (&prop, &private_data);
+  EXPECT_EQ (cpp_mock_subplugin::instances_alive, 1U);
+
+  cpp_mock_subplugin::fini ();
+  EXPECT_EQ (cpp_mock_subplugin::instances_alive, 0U);
 }
 
 /**


### PR DESCRIPTION
## What

Originally: `cpp_open()` leaked the object returned by `getEmptyInstance()` whenever `configure_instance()` threw (identified by cursor). The scope grew through review rounds into making the C++ subplugin C-ABI wrappers exception-safe as a whole:

- `cpp_open()`: the spawned instance is owned by a `std::unique_ptr` and `release()`d into `*private_data` only on success; both `getEmptyInstance()` and `configure_instance()` are guarded, including `catch (...)`.
- `cpp_invoke()`, `cpp_getFrameworkInfo()`, `cpp_getModelInfo()`, `cpp_eventHandler()`, and `GET_TFSP_WITH_CHECKS`: `catch (...)` coverage so no exception can propagate into the C caller (undefined behavior / `std::terminate`).

## API contract (affects out-of-tree subplugin authors)

The object returned by `getEmptyInstance()` must be heap-allocated and singly owned by the framework: it is deleted on close, or immediately when `configure_instance()` throws. Previously a failed configure leaked the object and never ran its destructor; now the destructor always runs, so it must be safe on a partially-configured instance. The rule is documented in `nnstreamer_cppplugin_api_filter.hh` and `Documentation/writing-subplugin-tensor-filter.md`. All 24 in-tree subplugins conform (`return *(new X ());`).

Related: dali cleanup fix #4859; tensorrt10 cleanup rework #4860 (its `cleanup()` must stay idempotent since the framework now also destroys the instance on a failed configure).

## Tests

`testTensorFilterCppSubplugin` (gtest fixture, runs in the gating meson/Valgrind and Tizen GBS unit-test jobs):
- `openFailNoLeak_n`: repeated failing opens with `configure_instance()` throwing at three distinct points (before/after acquiring a resource, after acquire-and-release); asserts, via instance and resource counters, that neither the instance nor its resources leak.
- `openCloseOwnership_p`: successful open transfers ownership to `*private_data`; close destroys the instance and releases its resources.