### PR TITLE
Document code consistency

### DIFF
--- a/Documentation/component-description.md
+++ b/Documentation/component-description.md
@@ -55,7 +55,6 @@ In this page, we focus on the status of each elements. For requirements and desi
   - Caffe2 (stable)
   - PyTorch (stable)
   - TVM (stable)
-  - NNTrainer (stable. **maintained by its own community**)
   - TRIx NPU/Samsung (stable. **maintained by the manufacturer**)
   - Movidius-X NCS2/Intel (stable)
   - NNFW-Runtime/nnfw (stable)
@@ -97,6 +96,8 @@ In this page, we focus on the status of each elements. For requirements and desi
     - Protobuf (stable)
     - binary/octet-stream (stable)
   - Users can add plugins in run-time.
+- [tensor\_trainer](https://github.com/nnstreamer/nnstreamer/tree/main/gst/nnstreamer/elements/gsttensor_trainer.c) (stable)
+  - Trains models from tensor streams using a trainer subplugin selected by the ```framework``` property.
 - [tensor\_sink](https://github.com/nnstreamer/nnstreamer/tree/main/gst/nnstreamer/elements/gsttensor_sink.md) (stable)
   - ```appsink```-like element, which is specialized for ```other/tensors```. You may use appsink with capsfilter instead.
 - [tensor\_merge](https://github.com/nnstreamer/nnstreamer/tree/main/gst/nnstreamer/elements/gsttensor_merge.c) (stable)
@@ -106,7 +107,7 @@ In this page, we focus on the status of each elements. For requirements and desi
 - [tensor\_split](https://github.com/nnstreamer/nnstreamer/tree/main/gst/nnstreamer/elements/gsttensor_split.c) (stable)
   - This is the opposite of ```tensor_merge```. This splits a single-tensored (```other/tensors,num_tensors=1```) stream into multiple single-tensored streams. For example, a stream of ```dimensions=1920:1080``` may split into ```dimensions=1080:1080``` and ```dimensions=840:1080```.
   - Users can adjust how dimensions are split
-- [tensor\_mux](https://github.com/nnstreamer/nnstreamer/tree/main/gst/nnstreamer/tensor_mux) (stable)
+- [tensor\_mux](https://github.com/nnstreamer/nnstreamer/tree/main/gst/nnstreamer/elements/gsttensor_mux.c) (stable)
   - This combines multiple ```other/tensor(s)``` streams into a single ```other/tensors``` stream while keeping the input stream dimensions. Thus, the number of tensors (```num_tensors```) increase accordingly without changing dimensions of incoming tensors. For example, merging the two tensor streams, ```num_tensors=1,dimensions=3:2``` and ```num_tensors=1,dimensions=4:4:4``` becomes ```num_tensors=2,dimensions=3:2,4:4:4```, combining frames from the two streams, enforcing synchronization.
   - Both merge and mux combine multiple streams into a stream; however, merge combines multiple tensors into a tensor, updating the dimensions while mux keep the tensors and combine them into a single container.
   - Users can adjust sync-mode and sync-option to change its behaviors of when to create output tensors and how to choose input tensors..

--- a/Documentation/component-description.md
+++ b/Documentation/component-description.md
@@ -55,6 +55,7 @@ In this page, we focus on the status of each elements. For requirements and desi
   - Caffe2 (stable)
   - PyTorch (stable)
   - TVM (stable)
+  - NNTrainer (stable. **maintained by its own community**)
   - TRIx NPU/Samsung (stable. **maintained by the manufacturer**)
   - Movidius-X NCS2/Intel (stable)
   - NNFW-Runtime/nnfw (stable)

--- a/Documentation/getting-started-meson-build.md
+++ b/Documentation/getting-started-meson-build.md
@@ -17,10 +17,10 @@ This document assumes that you are using Ubuntu.
 
 ### Prerequisites
 The following dependencies are needed to compile/build/run.
-* gcc/g++ (C++14 if you want C++-class as filters)
+* gcc/g++ (C++17 for C++-class filters)
 * gstreamer 1.0 and its relatives
 * glib 2.0
-* meson >= 0.50
+* meson >= 0.62.0
 * ninja-build
 * Neural network frameworks or libraries for plugins (e.g., tensorflow) you want to use, including their pkgconfig files or mechanisms to allow meson to discover its headers and libraries. If you use development packages packaged by us for tensorflow/pytorch/openvino/..., you do not need to worry.
     * Possible frameworks for "extra" plugins: tensorflow, tensorflow-lite, pytorch, protobuf, flatbuf, openvino, ncsdk2, Verisilicon-Vivante, SNPE, TensorRT, mqtt, ...
@@ -119,7 +119,7 @@ $ DESTDIR=/home/me/somewhereelse/ ninja -C build install
 Then, it will install:
 - nnstreamer plugins to ```{libdir}/gstreamer-1.0/```
 - libraries to ```{libdir}/```
-- subplugins to ```{prefix}/lib/nnstreamer/PLUGIN-TYPE/```
+- subplugins to ```{libdir}/nnstreamer/PLUGIN-TYPE/``` (or ```{subplugindir}/PLUGIN-TYPE/``` when ```-Dsubplugindir``` is set)
 - common header files to ```{includedir}/```
 
 

--- a/Documentation/how-to-run-examples.md
+++ b/Documentation/how-to-run-examples.md
@@ -43,8 +43,8 @@ As of 2018/10/13, we support 16.04 and 18.04
 * [getting-started](getting-started.md)
 
 - Install related packages before building nnstreamer and examples.
-1. ninja-build, meson (>=0.50)
-2. liborc (>=0.4.25, optional)
+1. ninja-build, meson (>=0.62.0)
+2. liborc (>=0.4.17, optional)
 3. tensorflow, protobuf (>=3.6.1)
 4. tensorflow-lite
 

--- a/Documentation/how-to-run-examples.md
+++ b/Documentation/how-to-run-examples.md
@@ -7,7 +7,7 @@ title: How to run examples
 # Table of Contents
 * [Preparing nnstreamer for execution](#preparing-nnstreamer-for-execution)
   * [Use PPA](#use-ppa)
-  * [Build examples (Ubuntu 16.04)](#build-examples-ubuntu-1604-and-1804)
+  * [Build examples (Ubuntu)](#build-examples-ubuntu)
 * [Usage Examples](#usage-examples)
   * [Example : camera live-view image classification. w/ gst-launch, decoded by tensor_decoder](#example-camera-liveview-image-classification-w-gstlaunch-decoded-by-tensor_decoder)
   * [Example : camera live-view image classification, decoded by user application](#example-camera-liveview-image-classification-decoded-by-user-application)
@@ -37,9 +37,9 @@ $ sudo apt-get install nnstreamer-example
 $ cd /usr/lib/nnstreamer/bin
 ```
 
-As of 2018/10/13, we support 16.04 and 18.04
+Ubuntu 22.04 (LTS) is currently supported.
 
-## Build examples (Ubuntu 16.04 and 18.04)
+## Build examples (Ubuntu)
 * [getting-started](getting-started.md)
 
 - Install related packages before building nnstreamer and examples.


### PR DESCRIPTION
---
# PR Description

Update documentation to resolve inconsistencies with codebase.

This PR addresses several inconsistencies identified between the project's documentation and its current codebase. The changes ensure that build requirements, installation paths, example dependencies, and component descriptions are accurate and up-to-date, improving clarity and maintainability for users and developers.

**Changes proposed in this PR:**
- Updated Meson and C++ compiler version requirements in `getting-started-meson-build.md` to reflect current build settings.
- Corrected the subplugin installation path description in `getting-started-meson-build.md` to match the actual build output.
- Synchronized Meson and ORC minimum version requirements in `how-to-run-examples.md` with the project's dependencies.
- Added the `tensor_trainer` component description to `component-description.md` and removed an outdated NNTrainer entry.
- Corrected the file path link for `tensor_mux` in `component-description.md` to point to its actual source file.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
1. Review the updated sections in `Documentation/getting-started-meson-build.md` to verify Meson/C++ requirements and subplugin paths.
2. Check `Documentation/how-to-run-examples.md` for the corrected Meson/ORC versions.
3. Examine `Documentation/component-description.md` to confirm the addition of `tensor_trainer`, removal of the NNTrainer entry, and the corrected `tensor_mux` link.
4. Verify that the documentation accurately reflects the current state of the codebase and build system.

---
<a href="https://cursor.com/background-agent?bcId=bc-51e7bc88-3007-4bb4-b126-c8fe4bc554c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51e7bc88-3007-4bb4-b126-c8fe4bc554c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

