### PR TITLE
[Build] Fix build for clang compielr on armv7l

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -811,8 +811,13 @@ if get_option('enable-float16')
   if arch == 'aarch64'
     message ('Float16 for aarch64 enabled. Modern gcc-aarch64 generally supports float16 with __fp16. It uses IEEE 754-2008 format.')
   elif arch == 'arm'
-    add_project_arguments('-mfp16-format=ieee', language: ['c', 'cpp'])
-    message ('Float16 for arm (32b) enabled. Modern gcc-arm generally supports float16 with __fp16 by -mfp16-format=ieee for IEEE 754-2008 format.')
+    if cc.get_id() != 'clang'
+      add_project_arguments('-mfp16-format=ieee', language: ['c', 'cpp'])
+      message ('Float16 for arm (32b) enabled. Modern gcc-arm generally supports float16 with __fp16 by -mfp16-format=ieee for IEEE 754-2008 format.')
+    else
+      add_project_link_arguments('-rtlib=compiler-rt', '-unwindlib=libgcc', language: ['c', 'cpp'])
+      message ('Float16 for arm (32b) enabled(Clang default to enabled).')
+    endif
   elif arch == 'x86_64' or arch == 'x86'
     # GCC 12+ has fp16 avx512 support.
     has_avx512fp16 = cc.has_argument('-mavx512fp16')

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -225,6 +225,12 @@ BuildRequires:	gst-plugins-bad-devel
 BuildRequires:	glib2-devel
 BuildRequires:	meson >= 0.62.0
 
+%{?_toolchain:
+%if %{toolchain_is clang}
+BuildRequires:	compiler-rt
+%endif
+}
+
 # To run test cases, we need gst plugins
 BuildRequires:	gst-plugins-good
 %if 0%{tizen_version_major} >= 5


### PR DESCRIPTION
This patch fixs the build break issue when using clang compielr on armv7l.

Resolves: #4822 

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


