### PR TITLE
[spec] Disable trix-engine build

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -35,7 +35,7 @@
 %define		lua_support 1
 %define		tvm_support 1
 %define		snpe_support 1
-%define		trix_engine_support 1
+%define		trix_engine_support 0
 %define		onnxruntime_support 1
 # Enable executorch_support when executorch package is ready.
 %define		executorch_support 0


### PR DESCRIPTION
This patch disables the trix-engine build since it is not used in public repository.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped



