### PR TITLE
[Filter/tensorrt10] Fix segfault: do not pass CUDA managed memory downstream

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
@@ -313,10 +313,9 @@ tensorrt10_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *out
     throw std::runtime_error ("Invalid output buffer, it is NULL.");
 
   cudaError_t status;
-  std::size_t i;
 
   /* Copy input data to Cuda memory space */
-  for (i = 0; i < _tensorrt10_input_tensor_infos.size (); ++i) {
+  for (std::size_t i = 0; i < _tensorrt10_input_tensor_infos.size (); ++i) {
     const auto &tensorrt10_tensor_info = _tensorrt10_input_tensor_infos[i];
     g_assert (tensorrt10_tensor_info.buffer_size == input[i].size);
 
@@ -339,7 +338,7 @@ tensorrt10_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *out
    * at all. The core releases these buffers with g_free() since the
    * eventHandler does not handle DESTROY_NOTIFY.
    */
-  for (i = 0; i < _tensorrt10_output_tensor_infos.size (); ++i) {
+  for (std::size_t i = 0; i < _tensorrt10_output_tensor_infos.size (); ++i) {
     const auto &tensorrt10_tensor_info = _tensorrt10_output_tensor_infos[i];
     g_assert (tensorrt10_tensor_info.buffer_size == output[i].size);
     output[i].data = g_malloc (output[i].size);
@@ -354,7 +353,7 @@ tensorrt10_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *out
 
     /* Copy the results from the persistent device buffers to host memory */
     /** @todo pageable dst makes this copy synchronous; pin it if it matters */
-    for (i = 0; i < _tensorrt10_output_tensor_infos.size (); ++i) {
+    for (std::size_t i = 0; i < _tensorrt10_output_tensor_infos.size (); ++i) {
       const auto &tensorrt10_tensor_info = _tensorrt10_output_tensor_infos[i];
       status = cudaMemcpyAsync (output[i].data, tensorrt10_tensor_info.buffer,
           output[i].size, cudaMemcpyDeviceToHost, _stream);
@@ -373,7 +372,9 @@ tensorrt10_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *out
       throw std::runtime_error ("Failed to synchronize the cuda stream");
     }
   } catch (...) {
-    for (i = 0; i < _tensorrt10_output_tensor_infos.size (); ++i) {
+    /* Drain pending D2H copies targeting output[] before freeing it */
+    cudaStreamSynchronize (_stream);
+    for (std::size_t i = 0; i < _tensorrt10_output_tensor_infos.size (); ++i) {
       g_free (output[i].data);
       output[i].data = nullptr;
     }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
@@ -329,7 +329,7 @@ tensorrt10_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *out
     }
   }
 
-  /* Allocate plain host memory for the output tensors.
+  /** Allocate plain host memory for the output tensors.
    * The buffers handed over to the pipeline MUST be ordinary host memory:
    * downstream elements may read them from another thread (e.g., after a
    * queue) while this filter is already running the next inference. CPU
@@ -636,7 +636,7 @@ tensorrt10_subplugin::loadModel (const GstTensorFilterProperties *prop)
 
     } else if (tensorrt10_tensor_info.mode == nvinfer1::TensorIOMode::kOUTPUT) {
 
-      /* Persistent device buffer for the output; invoke() copies the result
+      /** Persistent device buffer for the output; invoke() copies the result
        * into per-frame host memory before handing it to the pipeline. */
       allocBuffer (&tensorrt10_tensor_info.buffer, tensorrt10_tensor_info.buffer_size);
       if (!_Context->setOutputTensorAddress (

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
@@ -314,20 +314,6 @@ tensorrt10_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *out
 
   cudaError_t status;
 
-  /* Copy input data to Cuda memory space */
-  for (std::size_t i = 0; i < _tensorrt10_input_tensor_infos.size (); ++i) {
-    const auto &tensorrt10_tensor_info = _tensorrt10_input_tensor_infos[i];
-    g_assert (tensorrt10_tensor_info.buffer_size == input[i].size);
-
-    status = cudaMemcpyAsync (tensorrt10_tensor_info.buffer, input[i].data,
-        input[i].size, cudaMemcpyHostToDevice, _stream);
-
-    if (status != cudaSuccess) {
-      ml_loge ("Failed to copy to cuda input buffer");
-      throw std::runtime_error ("Failed to copy to cuda input buffer");
-    }
-  }
-
   /** Allocate plain host memory for the output tensors.
    * The buffers handed over to the pipeline MUST be ordinary host memory:
    * downstream elements may read them from another thread (e.g., after a
@@ -345,6 +331,20 @@ tensorrt10_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *out
   }
 
   try {
+    /* Copy input data to Cuda memory space */
+    for (std::size_t i = 0; i < _tensorrt10_input_tensor_infos.size (); ++i) {
+      const auto &tensorrt10_tensor_info = _tensorrt10_input_tensor_infos[i];
+      g_assert (tensorrt10_tensor_info.buffer_size == input[i].size);
+
+      status = cudaMemcpyAsync (tensorrt10_tensor_info.buffer, input[i].data,
+          input[i].size, cudaMemcpyHostToDevice, _stream);
+
+      if (status != cudaSuccess) {
+        ml_loge ("Failed to copy to cuda input buffer");
+        throw std::runtime_error ("Failed to copy to cuda input buffer");
+      }
+    }
+
     /* Execute the network */
     if (!_Context->enqueueV3 (_stream)) {
       ml_loge ("Failed to execute the network");
@@ -372,7 +372,7 @@ tensorrt10_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *out
       throw std::runtime_error ("Failed to synchronize the cuda stream");
     }
   } catch (...) {
-    /* Drain pending D2H copies targeting output[] before freeing it */
+    /* Drain pending copies (H2D reads input[], D2H writes output[]) first */
     cudaStreamSynchronize (_stream);
     for (std::size_t i = 0; i < _tensorrt10_output_tensor_infos.size (); ++i) {
       g_free (output[i].data);

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
@@ -353,6 +353,7 @@ tensorrt10_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *out
     }
 
     /* Copy the results from the persistent device buffers to host memory */
+    /** @todo pageable dst makes this copy synchronous; pin it if it matters */
     for (i = 0; i < _tensorrt10_output_tensor_infos.size (); ++i) {
       const auto &tensorrt10_tensor_info = _tensorrt10_output_tensor_infos[i];
       status = cudaMemcpyAsync (output[i].data, tensorrt10_tensor_info.buffer,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
@@ -641,13 +641,14 @@ tensorrt10_subplugin::loadModel (const GstTensorFilterProperties *prop)
       /** Persistent device buffer for the output; invoke() copies the result
        * into per-frame host memory before handing it to the pipeline. */
       allocBuffer (&tensorrt10_tensor_info.buffer, tensorrt10_tensor_info.buffer_size);
+      /* Register the buffer first so cleanup() can free it on failure */
+      _tensorrt10_output_tensor_infos.push_back (tensorrt10_tensor_info);
+
       if (!_Context->setOutputTensorAddress (
               tensorrt10_tensor_info.name, tensorrt10_tensor_info.buffer)) {
         ml_loge ("Unable to set output tensor address");
         throw std::runtime_error ("Unable to set output tensor address");
       }
-
-      _tensorrt10_output_tensor_infos.push_back (tensorrt10_tensor_info);
 
     } else {
       ml_loge ("TensorIOMode not supported");

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
@@ -158,7 +158,6 @@ class tensorrt10_subplugin final : public tensor_filter_subplugin
   void cleanup ();
   void allocBuffer (void **buffer, gsize size);
   void loadModel (const GstTensorFilterProperties *prop);
-  void checkUnifiedMemory () const;
   void convertTensorsInfo (const std::vector<NvInferTensorInfo> &tensorrt10_tensor_infos,
       GstTensorsInfo &info) const;
   std::size_t getVolume (const nvinfer1::Dims &shape) const;
@@ -207,6 +206,11 @@ tensorrt10_subplugin::cleanup ()
     tensorrt10_tensor_info.buffer = nullptr;
   }
   _tensorrt10_input_tensor_infos.clear ();
+
+  for (auto &tensorrt10_tensor_info : _tensorrt10_output_tensor_infos) {
+    cudaFree (tensorrt10_tensor_info.buffer);
+    tensorrt10_tensor_info.buffer = nullptr;
+  }
 
   if (_model_path != nullptr) {
     g_free (_model_path);
@@ -300,7 +304,7 @@ tensorrt10_subplugin::configure_instance (const GstTensorFilterProperties *prop)
 void
 tensorrt10_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
 {
-  ml_logi ("tensorrt10_subplugin::invoke");
+  ml_logd ("tensorrt10_subplugin::invoke");
   g_assert (_configured);
 
   if (!input)
@@ -309,9 +313,10 @@ tensorrt10_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *out
     throw std::runtime_error ("Invalid output buffer, it is NULL.");
 
   cudaError_t status;
+  std::size_t i;
 
   /* Copy input data to Cuda memory space */
-  for (std::size_t i = 0; i < _tensorrt10_input_tensor_infos.size (); ++i) {
+  for (i = 0; i < _tensorrt10_input_tensor_infos.size (); ++i) {
     const auto &tensorrt10_tensor_info = _tensorrt10_input_tensor_infos[i];
     g_assert (tensorrt10_tensor_info.buffer_size == input[i].size);
 
@@ -324,29 +329,54 @@ tensorrt10_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *out
     }
   }
 
-  for (std::size_t i = 0; i < _tensorrt10_output_tensor_infos.size (); ++i) {
+  /* Allocate plain host memory for the output tensors.
+   * The buffers handed over to the pipeline MUST be ordinary host memory:
+   * downstream elements may read them from another thread (e.g., after a
+   * queue) while this filter is already running the next inference. CPU
+   * access to CUDA managed memory while the GPU is active is invalid on
+   * systems without concurrentManagedAccess (e.g., Windows/WSL2 and
+   * pre-Pascal GPUs) and causes SIGSEGV; device memory is not CPU-visible
+   * at all. The core releases these buffers with g_free() since the
+   * eventHandler does not handle DESTROY_NOTIFY.
+   */
+  for (i = 0; i < _tensorrt10_output_tensor_infos.size (); ++i) {
     const auto &tensorrt10_tensor_info = _tensorrt10_output_tensor_infos[i];
     g_assert (tensorrt10_tensor_info.buffer_size == output[i].size);
-    allocBuffer (&output[i].data, output[i].size);
-    if (!_Context->setOutputTensorAddress (
-            tensorrt10_tensor_info.name, output[i].data)) {
-      ml_loge ("Unable to set output tensor address");
-      throw std::runtime_error ("Unable to set output tensor address");
+    output[i].data = g_malloc (output[i].size);
+  }
+
+  try {
+    /* Execute the network */
+    if (!_Context->enqueueV3 (_stream)) {
+      ml_loge ("Failed to execute the network");
+      throw std::runtime_error ("Failed to execute the network");
     }
-  }
 
-  /* Execute the network */
-  if (!_Context->enqueueV3 (_stream)) {
-    ml_loge ("Failed to execute the network");
-    throw std::runtime_error ("Failed to execute the network");
-  }
+    /* Copy the results from the persistent device buffers to host memory */
+    for (i = 0; i < _tensorrt10_output_tensor_infos.size (); ++i) {
+      const auto &tensorrt10_tensor_info = _tensorrt10_output_tensor_infos[i];
+      status = cudaMemcpyAsync (output[i].data, tensorrt10_tensor_info.buffer,
+          output[i].size, cudaMemcpyDeviceToHost, _stream);
 
-  /* Wait for GPU to finish the inference */
-  status = cudaStreamSynchronize (_stream);
+      if (status != cudaSuccess) {
+        ml_loge ("Failed to copy from cuda output buffer");
+        throw std::runtime_error ("Failed to copy from cuda output buffer");
+      }
+    }
 
-  if (status != cudaSuccess) {
-    ml_loge ("Failed to synchronize the cuda stream");
-    throw std::runtime_error ("Failed to synchronize the cuda stream");
+    /* Wait for GPU to finish the inference and the output copies */
+    status = cudaStreamSynchronize (_stream);
+
+    if (status != cudaSuccess) {
+      ml_loge ("Failed to synchronize the cuda stream");
+      throw std::runtime_error ("Failed to synchronize the cuda stream");
+    }
+  } catch (...) {
+    for (i = 0; i < _tensorrt10_output_tensor_infos.size (); ++i) {
+      g_free (output[i].data);
+      output[i].data = nullptr;
+    }
+    throw;
   }
 }
 
@@ -383,19 +413,15 @@ tensorrt10_subplugin::getModelInfo (
 }
 
 /**
- * @brief Override eventHandler to free Cuda data buffer.
+ * @brief Event handler. Output buffers are plain host memory allocated with
+ * g_malloc() in invoke(); returning -ENOENT for DESTROY_NOTIFY lets the
+ * core release them with g_free().
  */
 int
 tensorrt10_subplugin::eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data)
 {
-  if (ops == DESTROY_NOTIFY) {
-    if (data.data != nullptr) {
-      cudaFree (data.data);
-    }
-
-    return 0;
-  }
-
+  UNUSED (ops);
+  UNUSED (data);
   return -ENOENT;
 }
 
@@ -515,8 +541,6 @@ tensorrt10_subplugin::loadModel (const GstTensorFilterProperties *prop)
     throw std::runtime_error ("Unable to set GPU device index");
   }
 
-  checkUnifiedMemory ();
-
   // Parse model from .onnx and create .engine if necessary
   std::filesystem::path model_fs_path (_model_path);
   if (".onnx" == model_fs_path.extension ()) {
@@ -598,7 +622,6 @@ tensorrt10_subplugin::loadModel (const GstTensorFilterProperties *prop)
         throw std::runtime_error ("Unable to set input shape");
       }
 
-      // Allocate only for input, memory for output is allocated in the invoke method.
       allocBuffer (&tensorrt10_tensor_info.buffer, tensorrt10_tensor_info.buffer_size);
 
       // Register the buffer before any call that may throw so that
@@ -612,6 +635,15 @@ tensorrt10_subplugin::loadModel (const GstTensorFilterProperties *prop)
       }
 
     } else if (tensorrt10_tensor_info.mode == nvinfer1::TensorIOMode::kOUTPUT) {
+
+      /* Persistent device buffer for the output; invoke() copies the result
+       * into per-frame host memory before handing it to the pipeline. */
+      allocBuffer (&tensorrt10_tensor_info.buffer, tensorrt10_tensor_info.buffer_size);
+      if (!_Context->setOutputTensorAddress (
+              tensorrt10_tensor_info.name, tensorrt10_tensor_info.buffer)) {
+        ml_loge ("Unable to set output tensor address");
+        throw std::runtime_error ("Unable to set output tensor address");
+      }
 
       _tensorrt10_output_tensor_infos.push_back (tensorrt10_tensor_info);
 
@@ -658,53 +690,17 @@ tensorrt10_subplugin::convertTensorsInfo (
 }
 
 /**
- * @brief Return whether Unified Memory is supported or not.
- * @note After Cuda version 6, logical Unified Memory is supported in
- * programming language level. However, if the target device is not supported,
- * then cudaMemcpy() internally occurs and it makes performance degradation.
- */
-void
-tensorrt10_subplugin::checkUnifiedMemory () const
-{
-  int version;
-
-  if (cudaRuntimeGetVersion (&version) != cudaSuccess) {
-    ml_loge ("Unable to get cuda runtime version");
-    throw std::runtime_error ("Unable to get cuda runtime version");
-  }
-
-  /* Unified memory requires at least CUDA-6 */
-  if (version < 6000) {
-    ml_loge ("Unified memory requires at least CUDA-6");
-    throw std::runtime_error ("Unified memory requires at least CUDA-6");
-  }
-
-  // Get device properties
-  cudaDeviceProp prop;
-  cudaGetDeviceProperties (&prop, _device_id);
-  if (prop.managedMemory == 0) {
-    ml_loge ("The current device does not support managedmemory");
-    throw std::runtime_error ("The current device does not support managedmemory");
-  }
-
-  // The cuda programming guide specifies at least compute capability version 5
-  //  https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#unified-memory-programming
-  if (prop.major < 5) {
-    ml_loge ("The minimum required compute capability for unified memory is version 5");
-    throw std::runtime_error (
-        "The minimum required compute capability for unified memory is version 5");
-  }
-}
-
-/**
- * @brief Allocates a GPU buffer memory
+ * @brief Allocates a GPU device buffer memory
  * @param[out] buffer : pointer to allocated memory
  * @param[in] size : allocation size in bytes
+ * @note Plain device memory is used instead of managed (unified) memory:
+ * these buffers are only accessed by the GPU and via cudaMemcpyAsync(),
+ * and managed memory must never leak into the pipeline (see invoke()).
  */
 void
 tensorrt10_subplugin::allocBuffer (void **buffer, gsize size)
 {
-  cudaError_t status = cudaMallocManaged (buffer, size);
+  cudaError_t status = cudaMalloc (buffer, size);
 
   if (status != cudaSuccess) {
     ml_loge ("Failed to allocate Cuda memory");

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
@@ -211,6 +211,7 @@ tensorrt10_subplugin::cleanup ()
     cudaFree (tensorrt10_tensor_info.buffer);
     tensorrt10_tensor_info.buffer = nullptr;
   }
+  _tensorrt10_output_tensor_infos.clear ();
 
   if (_model_path != nullptr) {
     g_free (_model_path);


### PR DESCRIPTION
### Problem

Reported in #4850: `tensor_filter framework=tensorrt10` segfaults when its output is consumed via a `queue`, but only when the buffer content is actually read (`fakesink dump=true`).

### Root cause

The subplugin allocates its output tensors with `cudaMallocManaged()` on every `invoke()` and hands the **CUDA managed pointers** directly to the pipeline (`allocate_in_invoke`). With a `queue`, downstream runs in a separate thread and reads the buffer of frame N while the filter thread is already executing frame N+1's inference (`enqueueV3`). On systems without `concurrentManagedAccess` (Windows, **WSL2**, pre-Pascal GPUs), CPU access to managed memory while the GPU is active is invalid and raises SIGSEGV. Without the queue the read happens synchronously while the GPU is idle, and with `dump=false` nothing touches the memory — which is exactly the reported symptom matrix.

### Fix

- Allocate a persistent **device** buffer for each output at load time and set the output tensor addresses once, symmetric with the inputs.
- In `invoke()`, copy the results into plain host memory (`g_malloc`) and hand only host memory to the pipeline. `eventHandler` no longer consumes `DESTROY_NOTIFY`, so the core releases the buffers with `g_free()`.
- Use `cudaMalloc` instead of `cudaMallocManaged` (the buffers are GPU-only now) and drop the unified-memory capability check, which would needlessly reject devices.
- Free the output buffers when `invoke()` fails mid-way; demote the per-invoke info log to debug.

This also removes a per-frame `cudaMallocManaged`/`cudaFree` pair; the added D2H copy is work the managed path did implicitly via page migration anyway.

### Verification (RTX 4070, WSL2 Ubuntu 22.04, CUDA 13.1, TensorRT 10.15.1, GStreamer 1.20.3)

`cudaGetDeviceProperties`: `managedMemory=1, concurrentManagedAccess=0` on this setup.

1. A standalone CUDA program mimicking both memory patterns (per-invoke managed output handed to a consumer thread vs. persistent device buffer + D2H copy into `malloc`ed host memory): the managed pattern **segfaults**, the host-copy pattern runs clean.
2. The reported pipeline itself, with a tiny ONNX classifier (input `[1,3,224,224]`, output `[1,1000]`, built to `.engine` by this subplugin):
   ```
   videotestsrc num-buffers=200 ! video/x-raw,width=224,height=224,format=RGB \
     ! tensor_converter ! tensor_transform mode=transpose option=1:2:0:3 \
     ! tensor_transform mode=arithmetic option=typecast:float32,div:255 \
     ! tensor_filter framework=tensorrt10 model=tiny_cls.onnx ! queue ! fakesink dump=true
   ```
   - **Before** this patch: `Segmentation fault` (exit 139), crashing mid-hexdump exactly like the report.
   - **After** this patch: exit 0, all 200 frames consumed, clean EOS.

Fixes #4850

Related:
- #4861 adds the SSAT regression case for #4850 (and fixes the library-name gate in runTest.sh)
- #4860 fixes resource leaks when configuration fails midway; rebases over this PR
- Suggested merge order: this PR -> #4860 -> #4861

🤖 Generated with [Claude Code](https://claude.com/claude-code)

