### PR TITLE
[Filter/litert] Add LiteRT 2.x (CompiledModel API) subplugin

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -32,18 +32,29 @@ jobs:
     - name: install LiteRT SDK
       if: env.rebuild == '1'
       run: |
+        # When bumping LITERT_VER, refresh the pinned hashes below:
+        # the zip hash from the release asset, the wheel hashes from
+        # https://pypi.org/pypi/ai-edge-litert/<ver>/json (digests.sha256).
+        # The wheel hash is per python tag: this job pins python 3.11 above,
+        # so the cp311 macosx_12_0_arm64 wheel is the one downloaded.
         LITERT_VER=2.2.0
+        LITERT_SDK_ZIP_SHA256=0aa619d80aef27303ad9c6e3759a20110f77e7b11ade9b68061b8c6e5904b0c6
+        LITERT_WHEEL_SHA256=60831e57ce2887db83783bcff2cd5e33b24e3b37b23ff29d7b68c511e20f6a5b
         LITERT_ROOT=$HOME/litert-sdk
         mkdir -p $LITERT_ROOT/lib $LITERT_ROOT/include/litert/build_common
         curl -sL -o litert_cc_sdk.zip https://github.com/google-ai-edge/LiteRT/releases/download/v${LITERT_VER}/litert_cc_sdk.zip
+        echo "${LITERT_SDK_ZIP_SHA256}  litert_cc_sdk.zip" | shasum -a 256 -c -
         unzip -q litert_cc_sdk.zip -d /tmp/litert-cc-sdk
         cp -r /tmp/litert-cc-sdk/litert_cc_sdk/litert/c $LITERT_ROOT/include/litert/
         # generate build_config.h (all optional features on; runtime dylib decides)
         sed -e 's/#cmakedefine01 \(.*\)/#define \1 0/' \
           /tmp/litert-cc-sdk/litert_cc_sdk/litert/build_common/build_config.h.in \
           > $LITERT_ROOT/include/litert/build_common/build_config.h
-        # take the prebuilt runtime library from the official pip wheel (macosx arm64)
-        pip download ai-edge-litert==${LITERT_VER} --no-deps -q -d /tmp/litert-wheel
+        # take the prebuilt runtime library from the official pip wheel
+        # (macosx arm64), with the expected wheel content pinned by hash
+        printf 'ai-edge-litert==%s --hash=sha256:%s\n' \
+          "$LITERT_VER" "$LITERT_WHEEL_SHA256" > /tmp/litert-req.txt
+        pip download --require-hashes --no-deps -q -r /tmp/litert-req.txt -d /tmp/litert-wheel
         unzip -q -o /tmp/litert-wheel/*.whl 'ai_edge_litert/*.dylib' -d /tmp/litert-wheel/x
         cp /tmp/litert-wheel/x/ai_edge_litert/libLiteRt.dylib $LITERT_ROOT/lib/
         cp /tmp/litert-wheel/x/ai_edge_litert/libLiteRtMetalAccelerator.dylib $LITERT_ROOT/lib/ || true
@@ -51,6 +62,8 @@ jobs:
         # not depend on DYLD_LIBRARY_PATH (which macOS SIP strips from the
         # environment of protected processes such as the CI step shell)
         install_name_tool -id $LITERT_ROOT/lib/libLiteRt.dylib $LITERT_ROOT/lib/libLiteRt.dylib
+        # modifying the install name invalidates the existing code signature;
+        # re-sign ad-hoc so the (hash-verified, see above) dylib stays loadable
         codesign -f -s - $LITERT_ROOT/lib/libLiteRt.dylib
         echo "LITERT_ROOT=$LITERT_ROOT" >> $GITHUB_ENV
     - name: meson build

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -46,7 +46,8 @@ jobs:
         echo "${LITERT_SDK_ZIP_SHA256}  litert_cc_sdk.zip" | shasum -a 256 -c -
         unzip -q litert_cc_sdk.zip -d /tmp/litert-cc-sdk
         cp -r /tmp/litert-cc-sdk/litert_cc_sdk/litert/c $LITERT_ROOT/include/litert/
-        # generate build_config.h (all optional features on; runtime dylib decides)
+        # generate build_config.h (all optional features off at compile time;
+        # the prebuilt runtime dylib ships its own feature set)
         sed -e 's/#cmakedefine01 \(.*\)/#define \1 0/' \
           /tmp/litert-cc-sdk/litert_cc_sdk/litert/build_common/build_config.h.in \
           > $LITERT_ROOT/include/litert/build_common/build_config.h

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -28,12 +28,64 @@ jobs:
           brew install cask
     - name: install minimal requirements
       if: env.rebuild == '1'
-      run: brew install meson ninja pkg-config cmake libffi glib gstreamer numpy json-glib
-    - uses: BSFishy/meson-build@v1.0.3
+      run: brew install meson ninja pkg-config cmake libffi glib gstreamer numpy json-glib googletest
+    - name: install LiteRT SDK
       if: env.rebuild == '1'
-      with:
-        action: build
+      run: |
+        LITERT_VER=2.2.0
+        LITERT_ROOT=$HOME/litert-sdk
+        mkdir -p $LITERT_ROOT/lib $LITERT_ROOT/include/litert/build_common
+        curl -sL -o litert_cc_sdk.zip https://github.com/google-ai-edge/LiteRT/releases/download/v${LITERT_VER}/litert_cc_sdk.zip
+        unzip -q litert_cc_sdk.zip -d /tmp/litert-cc-sdk
+        cp -r /tmp/litert-cc-sdk/litert_cc_sdk/litert/c $LITERT_ROOT/include/litert/
+        # generate build_config.h (all optional features on; runtime dylib decides)
+        sed -e 's/#cmakedefine01 \(.*\)/#define \1 0/' \
+          /tmp/litert-cc-sdk/litert_cc_sdk/litert/build_common/build_config.h.in \
+          > $LITERT_ROOT/include/litert/build_common/build_config.h
+        # take the prebuilt runtime library from the official pip wheel (macosx arm64)
+        pip download ai-edge-litert==${LITERT_VER} --no-deps -q -d /tmp/litert-wheel
+        unzip -q -o /tmp/litert-wheel/*.whl 'ai_edge_litert/*.dylib' -d /tmp/litert-wheel/x
+        cp /tmp/litert-wheel/x/ai_edge_litert/libLiteRt.dylib $LITERT_ROOT/lib/
+        cp /tmp/litert-wheel/x/ai_edge_litert/libLiteRtMetalAccelerator.dylib $LITERT_ROOT/lib/ || true
+        # pin the install name to an absolute path so that linked binaries do
+        # not depend on DYLD_LIBRARY_PATH (which macOS SIP strips from the
+        # environment of protected processes such as the CI step shell)
+        install_name_tool -id $LITERT_ROOT/lib/libLiteRt.dylib $LITERT_ROOT/lib/libLiteRt.dylib
+        codesign -f -s - $LITERT_ROOT/lib/libLiteRt.dylib
+        echo "LITERT_ROOT=$LITERT_ROOT" >> $GITHUB_ENV
+    - name: meson build
+      if: env.rebuild == '1'
+      # orcc-support is disabled: the orc test code in unittest_plugins.cc
+      # does not compile on macOS (orc_int64 is long while int64_t is
+      # long long); it never has, hidden until now by the check-rebuild bug
+      # that skipped every step of this job.
+      run: |
+        meson setup build -Dorcc-support=disabled
+        meson compile -C build
+    - name: check litert subplugin built
+      if: env.rebuild == '1'
+      run: |
+        ls build/ext/nnstreamer/tensor_filter/ | grep litert
+        test -f build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_litert.dylib || test -f build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_litert.so
+    - name: run litert unit tests
+      if: env.rebuild == '1'
+      run: |
+        export DYLD_LIBRARY_PATH=$LITERT_ROOT/lib
+        meson test -C build unittest_filter_litert -v
+    - name: SSAT run on filter-litert
+      if: env.rebuild == '1'
+      run: |
+        git clone --depth 1 https://github.com/myungjoo/SSAT.git $HOME/ssat
+        export PATH=$PATH:$HOME/ssat
+        export DYLD_LIBRARY_PATH=$LITERT_ROOT/lib
+        export NNSTREAMER_BUILD_ROOT_PATH=`pwd`/build
+        export NNSTREAMER_FILTERS=`pwd`/build/ext/nnstreamer/tensor_filter
+        export NNSTREAMER_DECODERS=`pwd`/build/ext/nnstreamer/tensor_decoder
+        export NNSTREAMER_CONVERTERS=`pwd`/build/ext/nnstreamer/tensor_converter
+        export GST_PLUGIN_PATH=`pwd`/build/gst
+        export NNSTREAMER_CONF=`pwd`/build/nnstreamer-test.ini
+        cd tests/nnstreamer_filter_litert
+        bash runTest.sh
 
 # TODO: add more subplugins to be built
-# TODO: add unit testing
 # TODO: add valgrind testing

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -87,18 +87,29 @@ jobs:
     - name: install LiteRT SDK (x86_64 only)
       if: env.rebuild == '1' && matrix.os == 'ubuntu-22.04'
       run: |
+        # When bumping LITERT_VER, refresh the pinned hashes below:
+        # the zip hash from the release asset, the wheel hashes from
+        # https://pypi.org/pypi/ai-edge-litert/<ver>/json (digests.sha256).
+        # The wheel hash is per python tag: this job pins python 3.11 above,
+        # so the cp311 manylinux_2_27_x86_64 wheel is the one downloaded.
         LITERT_VER=2.2.0
+        LITERT_SDK_ZIP_SHA256=0aa619d80aef27303ad9c6e3759a20110f77e7b11ade9b68061b8c6e5904b0c6
+        LITERT_WHEEL_SHA256=0171f556fffa335281acd7d468de999fd4de32f6bf1a5f14e680676591cef764
         LITERT_ROOT=$HOME/litert-sdk
         mkdir -p $LITERT_ROOT/lib $LITERT_ROOT/include/litert/build_common
         wget -q https://github.com/google-ai-edge/LiteRT/releases/download/v${LITERT_VER}/litert_cc_sdk.zip
+        echo "${LITERT_SDK_ZIP_SHA256}  litert_cc_sdk.zip" | sha256sum -c -
         unzip -q litert_cc_sdk.zip -d /tmp/litert-cc-sdk
         cp -r /tmp/litert-cc-sdk/litert_cc_sdk/litert/c $LITERT_ROOT/include/litert/
         # generate build_config.h (all optional features on; runtime .so decides)
         sed -e 's/#cmakedefine01 \(.*\)/#define \1 0/' \
           /tmp/litert-cc-sdk/litert_cc_sdk/litert/build_common/build_config.h.in \
           > $LITERT_ROOT/include/litert/build_common/build_config.h
-        # take the prebuilt runtime library from the official pip wheel
-        pip download ai-edge-litert==${LITERT_VER} --no-deps -q -d /tmp/litert-wheel
+        # take the prebuilt runtime library from the official pip wheel,
+        # with the expected wheel content pinned by hash
+        printf 'ai-edge-litert==%s --hash=sha256:%s\n' \
+          "$LITERT_VER" "$LITERT_WHEEL_SHA256" > /tmp/litert-req.txt
+        pip download --require-hashes --no-deps -q -r /tmp/litert-req.txt -d /tmp/litert-wheel
         unzip -q -o /tmp/litert-wheel/*.whl 'ai_edge_litert/libLiteRt.so' -d /tmp/litert-wheel/x
         cp /tmp/litert-wheel/x/ai_edge_litert/libLiteRt.so $LITERT_ROOT/lib/
         echo "LITERT_ROOT=$LITERT_ROOT" >> $GITHUB_ENV

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -84,6 +84,25 @@ jobs:
         curl -fsSL -o tests/test_models/models/TinyStories-656K-Q2_K.gguf \
           "https://huggingface.co/tensorblock/TinyStories-656K-GGUF/resolve/main/TinyStories-656K-Q2_K.gguf"
         echo "5a798ebc1cad921e0ce639b2f10c4bcce492654a79d4b4ca52bd0268416f6b87  tests/test_models/models/TinyStories-656K-Q2_K.gguf" | sha256sum -c
+    - name: install LiteRT SDK (x86_64 only)
+      if: env.rebuild == '1' && matrix.os == 'ubuntu-22.04'
+      run: |
+        LITERT_VER=2.2.0
+        LITERT_ROOT=$HOME/litert-sdk
+        mkdir -p $LITERT_ROOT/lib $LITERT_ROOT/include/litert/build_common
+        wget -q https://github.com/google-ai-edge/LiteRT/releases/download/v${LITERT_VER}/litert_cc_sdk.zip
+        unzip -q litert_cc_sdk.zip -d /tmp/litert-cc-sdk
+        cp -r /tmp/litert-cc-sdk/litert_cc_sdk/litert/c $LITERT_ROOT/include/litert/
+        # generate build_config.h (all optional features on; runtime .so decides)
+        sed -e 's/#cmakedefine01 \(.*\)/#define \1 0/' \
+          /tmp/litert-cc-sdk/litert_cc_sdk/litert/build_common/build_config.h.in \
+          > $LITERT_ROOT/include/litert/build_common/build_config.h
+        # take the prebuilt runtime library from the official pip wheel
+        pip download ai-edge-litert==${LITERT_VER} --no-deps -q -d /tmp/litert-wheel
+        unzip -q -o /tmp/litert-wheel/*.whl 'ai_edge_litert/libLiteRt.so' -d /tmp/litert-wheel/x
+        cp /tmp/litert-wheel/x/ai_edge_litert/libLiteRt.so $LITERT_ROOT/lib/
+        echo "LITERT_ROOT=$LITERT_ROOT" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=$LITERT_ROOT/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
     - name: build and unit test
       if: env.rebuild == '1'
       run: |
@@ -128,6 +147,9 @@ jobs:
     - name: SSAT run with Valgrind on decoder-bounding-box
       if: env.rebuild == '1'
       run: if [ '${{ matrix.os }}' == 'ubuntu-22.04' ]; then export NNSTREAMER_BUILD_ROOT_PATH=`pwd`/build && export NNSTREAMER_FILTERS=`pwd`/build/ext/nnstreamer/tensor_filter && export NNSTREAMER_DECODERS=`pwd`/build/ext/nnstreamer/tensor_decoder && export NNSTREAMER_CONVERTERS=`pwd`/build/ext/nnstreamer/tensor_converter && export GST_PLUGIN_PATH=`pwd`/build/gst && export NNSTREAMER_CONF=`pwd`/build/nnstreamer-test.ini && pushd tests/nnstreamer_decoder_boundingbox && G_SLICE=always-malloc G_DEBUG=gc-friendly ssat -n -p=1 --enable-valgrind --valgrind-suppression ../../tools/debugging/valgrind_suppression --summary summary.txt -cn _n && popd; fi
+    - name: SSAT run on filter-litert
+      if: env.rebuild == '1'
+      run: if [ '${{ matrix.os }}' == 'ubuntu-22.04' ] && [ -n "$LITERT_ROOT" ]; then export NNSTREAMER_BUILD_ROOT_PATH=`pwd`/build && export NNSTREAMER_FILTERS=`pwd`/build/ext/nnstreamer/tensor_filter && export NNSTREAMER_DECODERS=`pwd`/build/ext/nnstreamer/tensor_decoder && export NNSTREAMER_CONVERTERS=`pwd`/build/ext/nnstreamer/tensor_converter && export GST_PLUGIN_PATH=`pwd`/build/gst && export NNSTREAMER_CONF=`pwd`/build/nnstreamer-test.ini && pushd tests/nnstreamer_filter_litert && ssat -n -p=1 --summary summary.txt && popd; fi
     - name: GTEST run with Valgrind on a case
       if: env.rebuild == '1'
       run: if [ '${{ matrix.os }}' == 'ubuntu-22.04' ]; then export NNSTREAMER_BUILD_ROOT_PATH=`pwd`/build && export NNSTREAMER_FILTERS=`pwd`/build/ext/nnstreamer/tensor_filter && export NNSTREAMER_DECODERS=`pwd`/build/ext/nnstreamer/tensor_decoder && export NNSTREAMER_CONVERTERS=`pwd`/build/ext/nnstreamer/tensor_converter && export GST_PLUGIN_PATH=`pwd`/build/gst && export NNSTREAMER_CONF=`pwd`/build/nnstreamer-test.ini && G_SLICE=always-malloc G_DEBUG=gc-friendly ./packaging/run_unittests_binaries.sh --valgrind ./tests/ || echo "There are Valgrind errors. Please fix it. As we have a lot of Valgrind errors from different libraries and possible from nnstreamer itself, we are not halting the build with Valgrind errors until we get them all."; fi

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -101,7 +101,8 @@ jobs:
         echo "${LITERT_SDK_ZIP_SHA256}  litert_cc_sdk.zip" | sha256sum -c -
         unzip -q litert_cc_sdk.zip -d /tmp/litert-cc-sdk
         cp -r /tmp/litert-cc-sdk/litert_cc_sdk/litert/c $LITERT_ROOT/include/litert/
-        # generate build_config.h (all optional features on; runtime .so decides)
+        # generate build_config.h (all optional features off at compile time;
+        # the prebuilt runtime .so ships its own feature set)
         sed -e 's/#cmakedefine01 \(.*\)/#define \1 0/' \
           /tmp/litert-cc-sdk/litert_cc_sdk/litert/build_common/build_config.h.in \
           > $LITERT_ROOT/include/litert/build_common/build_config.h
@@ -125,6 +126,10 @@ jobs:
           # llamacpp tests would silently vanish from this job.
           test -f build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_llamacpp.so
           cp ~/llama-backends/libggml-*.so build/tests/
+          # Same for litert: the feature degrades to "off" silently under auto
+          # detection and its SSAT script reports success with zero cases when
+          # the .so is absent; assert so a detection regression cannot go green.
+          test -f build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_litert.so
         fi
 
         sudo mkdir -m 777 /cores

--- a/Documentation/component-description.md
+++ b/Documentation/component-description.md
@@ -52,6 +52,8 @@ In this page, we focus on the status of each elements. For requirements and desi
   - Tensorflow (stable) (1.09, 1.13, 2.3, 2.7, 2.8 tested)
   - Tensorflow-lite (stable) (1.09, 1.13, 2.3, 2.7, 2.8 tested)
       - For tensorflow-lite version 2.x, use ```tensorflow2-lite``` as the subplugin name, which allows to use both tensorflow-lite 1.x and 2.x simultaneously in a pipeline.
+  - LiteRT (new) (2.2.0 tested)
+      - Targets the LiteRT 2.x CompiledModel API (the successor of tensorflow-lite); use ```litert``` as the subplugin name. It may coexist with ```tensorflow2-lite``` (classic Interpreter API) in a pipeline.
   - Caffe2 (stable)
   - PyTorch (stable)
   - TVM (stable)

--- a/ext/nnstreamer/tensor_filter/README.md
+++ b/ext/nnstreamer/tensor_filter/README.md
@@ -33,6 +33,17 @@ If you want to use tensorflow-lite custom operators with your own tensorflow-lit
 
 By default, this subplugin loads ```./libtensorflow2-lite-custom.so```, which is the user's custom tensorflow-lite binary.
 
+### LiteRT
+- subplugin name: 'litert'
+
+This subplugin targets the LiteRT 2.x "CompiledModel" C API, the successor line of TensorFlow-Lite. It consumes the standard ```.tflite``` flatbuffer model and may coexist with the classic-Interpreter-API ```tensorflow2-lite``` subplugin, so the two runtimes can be compared on the same model in one pipeline.
+
+Custom properties (```custom=Key1:Value1,Key2:Value2```):
+- ```Accelerators```: hardware accelerators to enable: cpu, gpu, npu; combinable with '+' (e.g., ```Accelerators:npu+cpu```). Default: cpu. The standard ```accelerator``` property is also honored.
+- ```Signature```: the key of the model signature to run. Default: the first signature.
+
+To build, provide the LiteRT SDK via pkg-config (```litert.pc```) or the ```LITERT_ROOT``` environment variable (expecting ```$LITERT_ROOT/lib/libLiteRt.so``` and ```$LITERT_ROOT/include/litert/c/*.h```), and use the ```litert-support``` meson option. The "install LiteRT SDK" steps in ```.github/workflows/ubuntu_clean_meson_build.yml``` and ```.github/workflows/macos.yaml``` are working examples that assemble the SDK from the official LiteRT releases (headers from ```litert_cc_sdk.zip```, the runtime library from the ```ai-edge-litert``` wheel).
+
 ### SNAP
 ### NCNN
 - subplugin name: 'ncnn'

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -725,6 +725,32 @@ if tensorrt10_support_is_available
   )
 endif
 
+if litert_support_is_available
+  filter_sub_litert_sources = ['tensor_filter_litert.cc']
+
+  nnstreamer_filter_litert_deps = [glib_dep, nnstreamer_single_dep, litert_support_deps]
+
+  # The upstream LiteRT C headers carry redundant redeclarations; do not let
+  # them break -Werror builds regardless of how the SDK include path is given.
+  litert_extra_args = cxx.get_supported_arguments(['-Wno-redundant-decls'])
+
+  shared_library('nnstreamer_filter_litert',
+    filter_sub_litert_sources,
+    cpp_args: litert_extra_args,
+    dependencies: nnstreamer_filter_litert_deps,
+    install: true,
+    install_dir: filter_subplugin_install_dir
+  )
+
+  static_library('nnstreamer_filter_litert',
+    filter_sub_litert_sources,
+    cpp_args: litert_extra_args,
+    dependencies: nnstreamer_filter_litert_deps,
+    install: true,
+    install_dir: nnstreamer_libdir
+  )
+endif
+
 if lua_support_is_available
   if lua_support_deps[0].version().version_compare('>=5.3')
     message ('tensor-filter::lua does not support Lua >= 5.3, yet. Fix #3531 first.')

--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -1,0 +1,711 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * GStreamer Tensor_Filter, LiteRT Module
+ * Copyright (C) 2026 MyungJoo Ham <myungjoo.ham@samsung.com>
+ */
+/**
+ * @file   tensor_filter_litert.cc
+ * @date   20 Aug 2026
+ * @brief  LiteRT 2.x (CompiledModel API) module for tensor_filter gstreamer plugin
+ * @see    http://github.com/nnstreamer/nnstreamer
+ * @see    https://github.com/google-ai-edge/LiteRT
+ * @author MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * This is the per-NN-framework plugin (LiteRT) for tensor_filter.
+ * This subplugin targets the LiteRT 2.x "CompiledModel" C API
+ * (litert::Environment / Model / CompiledModel / TensorBuffer), which is
+ * a different API from the classic TensorFlow-Lite Interpreter API used
+ * by the tensorflow2-lite subplugin. Both subplugins may coexist; use
+ * framework=litert for this one.
+ *
+ * The model file consumed is the standard .tflite flatbuffer.
+ *
+ * Custom properties (tensor_filter custom=...):
+ *  - Accelerators:cpu|gpu|npu
+ *      Hardware accelerators to enable, combinable with '+'
+ *      (e.g., "Accelerators:npu+cpu"). Default: cpu.
+ *      The standard "accelerator" property (e.g., accelerator=true:gpu)
+ *      is also honored when this custom property is not given.
+ *  - Signature:<key>
+ *      Select the model signature to run by its key string.
+ *      Default: the first signature (index 0).
+ *
+ * @todo Zero-copy invoke by wrapping GstTensorMemory with
+ *       LiteRtCreateTensorBufferFromHostMemory when alignment permits.
+ * @todo Support dynamic input dimensions (invoke_dynamic).
+ * @todo Expose accelerator-specific opaque options (GPU precision, NPU
+ *       compiler plugin paths, etc.).
+ */
+
+#include <cerrno>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <glib.h>
+
+#include <nnstreamer_cppplugin_api_filter.hh>
+#include <nnstreamer_log.h>
+#include <nnstreamer_plugin_api_util.h>
+#include <nnstreamer_util.h>
+
+#include <litert/c/litert_common.h>
+#include <litert/c/litert_compiled_model.h>
+#include <litert/c/litert_environment.h>
+#include <litert/c/litert_layout.h>
+#include <litert/c/litert_model.h>
+#include <litert/c/litert_model_types.h>
+#include <litert/c/litert_options.h>
+#include <litert/c/litert_tensor_buffer.h>
+#include <litert/c/litert_tensor_buffer_requirements.h>
+#include <litert/c/litert_tensor_buffer_types.h>
+
+namespace nnstreamer
+{
+namespace tensorfilter_litert
+{
+extern "C" {
+void _init_filter_litert (void) __attribute__ ((constructor));
+void _fini_filter_litert (void) __attribute__ ((destructor));
+}
+
+/**
+ * @brief Throw std::runtime_error if a LiteRT C API call fails.
+ */
+#define LITERT_CHECK(expr)                                                         \
+  do {                                                                             \
+    LiteRtStatus _status = (expr);                                                 \
+    if (_status != kLiteRtStatusOk) {                                              \
+      ml_loge ("LiteRT error %d at %s", (int) _status, #expr);                     \
+      throw std::runtime_error (std::string ("LiteRT call failed (status ")        \
+                                + std::to_string ((int) _status) + "): " + #expr); \
+    }                                                                              \
+  } while (0)
+
+/** @brief litert subplugin class */
+class litert_subplugin final : public tensor_filter_subplugin
+{
+  public:
+  static void init_filter_litert ();
+  static void fini_filter_litert ();
+
+  litert_subplugin ();
+  ~litert_subplugin ();
+
+  tensor_filter_subplugin &getEmptyInstance ();
+  void configure_instance (const GstTensorFilterProperties *prop);
+  void invoke (const GstTensorMemory *input, GstTensorMemory *output);
+  void getFrameworkInfo (GstTensorFilterFrameworkInfo &info);
+  int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info);
+  int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data);
+
+  private:
+  static const char *name;
+  static const accl_hw hw_list[];
+  static const int num_hw = 3;
+  static litert_subplugin *registeredRepresentation;
+
+  bool configured{}; /**< Whether this instance has a compiled model. */
+  gchar *model_path{}; /**< .tflite model file path */
+  LiteRtHwAcceleratorSet accel_set{ kLiteRtHwAcceleratorCpu }; /**< accelerators to request */
+  std::string signature_key{}; /**< requested signature key; empty = default */
+  LiteRtParamIndex signature_index{}; /**< resolved signature index */
+
+  LiteRtEnvironment env{};
+  LiteRtModel model{};
+  LiteRtCompiledModel compiled_model{};
+
+  GstTensorsInfo inputTensorMeta;
+  GstTensorsInfo outputTensorMeta;
+
+  std::vector<LiteRtTensorBuffer> input_buffers{}; /**< managed, reused per invoke */
+  std::vector<LiteRtTensorBuffer> output_buffers{}; /**< managed, reused per invoke */
+
+  void cleanup ();
+  void parseCustomProperties (const GstTensorFilterProperties *prop);
+  void applyHwList (const GstTensorFilterProperties *prop);
+  LiteRtParamIndex resolveSignature () const;
+  void setTensorMeta (LiteRtSignature sig, bool is_input, GstTensorsInfo *meta);
+  void createTensorBuffers ();
+
+  static tensor_type convertElementType (LiteRtElementType type);
+  static void convertLayout (const LiteRtLayout &layout, tensor_dim dim);
+  static LiteRtHwAcceleratorSet parseAcceleratorValue (const gchar *value);
+};
+
+const char *litert_subplugin::name = "litert";
+const accl_hw litert_subplugin::hw_list[] = { ACCL_CPU, ACCL_GPU, ACCL_NPU };
+litert_subplugin *litert_subplugin::registeredRepresentation = nullptr;
+
+/**
+ * @brief constructor of litert_subplugin
+ */
+litert_subplugin::litert_subplugin () : tensor_filter_subplugin ()
+{
+  gst_tensors_info_init (std::addressof (inputTensorMeta));
+  gst_tensors_info_init (std::addressof (outputTensorMeta));
+}
+
+/**
+ * @brief destructor of litert_subplugin
+ */
+litert_subplugin::~litert_subplugin ()
+{
+  cleanup ();
+}
+
+/**
+ * @brief Release all LiteRT objects owned by this instance.
+ */
+void
+litert_subplugin::cleanup ()
+{
+  for (auto &buf : input_buffers)
+    LiteRtDestroyTensorBuffer (buf);
+  input_buffers.clear ();
+  for (auto &buf : output_buffers)
+    LiteRtDestroyTensorBuffer (buf);
+  output_buffers.clear ();
+
+  if (compiled_model != nullptr) {
+    LiteRtDestroyCompiledModel (compiled_model);
+    compiled_model = nullptr;
+  }
+  if (model != nullptr) {
+    LiteRtDestroyModel (model);
+    model = nullptr;
+  }
+  if (env != nullptr) {
+    LiteRtDestroyEnvironment (env);
+    env = nullptr;
+  }
+
+  gst_tensors_info_free (std::addressof (inputTensorMeta));
+  gst_tensors_info_free (std::addressof (outputTensorMeta));
+
+  g_free (model_path);
+  model_path = nullptr;
+
+  configured = false;
+}
+
+/**
+ * @brief Method to get an empty object
+ */
+tensor_filter_subplugin &
+litert_subplugin::getEmptyInstance ()
+{
+  return *(new litert_subplugin ());
+}
+
+/**
+ * @brief Parse a custom property "Accelerators" value such as "npu+cpu".
+ * @return the corresponding LiteRT accelerator bit set
+ */
+LiteRtHwAcceleratorSet
+litert_subplugin::parseAcceleratorValue (const gchar *value)
+{
+  LiteRtHwAcceleratorSet set = kLiteRtHwAcceleratorNone;
+  gchar **entries = g_strsplit_set (value, "+|", -1);
+
+  for (guint i = 0; entries[i] != nullptr; ++i) {
+    const gchar *entry = entries[i];
+
+    if (g_ascii_strcasecmp (entry, "cpu") == 0) {
+      set |= kLiteRtHwAcceleratorCpu;
+    } else if (g_ascii_strcasecmp (entry, "gpu") == 0) {
+      set |= kLiteRtHwAcceleratorGpu;
+    } else if (g_ascii_strcasecmp (entry, "npu") == 0) {
+      set |= kLiteRtHwAcceleratorNpu;
+    } else if (g_ascii_strcasecmp (entry, "none") == 0) {
+      /* no-op; explicit "let LiteRT decide" */
+    } else {
+      std::string bad_entry (entry);
+      g_strfreev (entries);
+      throw std::invalid_argument ("Unknown accelerator \"" + bad_entry
+                                   + "\". Supported: cpu, gpu, npu (combinable with '+').");
+    }
+  }
+  g_strfreev (entries);
+
+  return set;
+}
+
+/**
+ * @brief Map the standard "accelerator" property (prop->hw_list) to LiteRT accelerators.
+ */
+void
+litert_subplugin::applyHwList (const GstTensorFilterProperties *prop)
+{
+  LiteRtHwAcceleratorSet set = kLiteRtHwAcceleratorNone;
+
+  for (gint i = 0; i < prop->num_hw; ++i) {
+    if (prop->hw_list[i] & ACCL_NPU)
+      set |= kLiteRtHwAcceleratorNpu;
+    else if (prop->hw_list[i] & ACCL_GPU)
+      set |= kLiteRtHwAcceleratorGpu;
+    else if (prop->hw_list[i] & ACCL_CPU)
+      set |= kLiteRtHwAcceleratorCpu;
+    else if (prop->hw_list[i] == ACCL_AUTO || prop->hw_list[i] == ACCL_DEFAULT)
+      set |= kLiteRtHwAcceleratorCpu;
+  }
+
+  if (set != kLiteRtHwAcceleratorNone)
+    accel_set = set;
+}
+
+/**
+ * @brief Parse the custom properties string (e.g., "Accelerators:gpu,Signature:serving_default").
+ */
+void
+litert_subplugin::parseCustomProperties (const GstTensorFilterProperties *prop)
+{
+  if (!prop->custom_properties)
+    return;
+
+  gchar **options = g_strsplit (prop->custom_properties, ",", -1);
+
+  try {
+    for (guint i = 0; i < g_strv_length (options); ++i) {
+      gchar **option = g_strsplit (options[i], ":", 2);
+
+      if (g_strv_length (option) == 2) {
+        g_strstrip (option[0]);
+        g_strstrip (option[1]);
+
+        if (g_ascii_strcasecmp (option[0], "Accelerators") == 0) {
+          accel_set = parseAcceleratorValue (option[1]);
+        } else if (g_ascii_strcasecmp (option[0], "Signature") == 0) {
+          signature_key = option[1];
+        } else {
+          ml_logw ("Unknown custom property [%s]. This is ignored.", option[0]);
+        }
+      } else if (option[0] != nullptr && option[0][0] != '\0') {
+        g_strfreev (option);
+        throw std::invalid_argument (
+            std::string ("Malformed custom property \"") + options[i]
+            + "\". Expected Key:Value pairs separated by ','.");
+      }
+      g_strfreev (option);
+    }
+  } catch (...) {
+    g_strfreev (options);
+    throw;
+  }
+  g_strfreev (options);
+}
+
+/**
+ * @brief Convert a LiteRT element type to nnstreamer tensor_type.
+ */
+tensor_type
+litert_subplugin::convertElementType (LiteRtElementType type)
+{
+  switch (type) {
+    case kLiteRtElementTypeFloat32:
+      return _NNS_FLOAT32;
+    case kLiteRtElementTypeFloat64:
+      return _NNS_FLOAT64;
+    case kLiteRtElementTypeFloat16:
+      return _NNS_FLOAT16;
+    case kLiteRtElementTypeInt8:
+      return _NNS_INT8;
+    case kLiteRtElementTypeInt16:
+      return _NNS_INT16;
+    case kLiteRtElementTypeInt32:
+      return _NNS_INT32;
+    case kLiteRtElementTypeInt64:
+      return _NNS_INT64;
+    case kLiteRtElementTypeUInt8:
+    case kLiteRtElementTypeBool:
+      return _NNS_UINT8;
+    case kLiteRtElementTypeUInt16:
+      return _NNS_UINT16;
+    case kLiteRtElementTypeUInt32:
+      return _NNS_UINT32;
+    case kLiteRtElementTypeUInt64:
+      return _NNS_UINT64;
+    default:
+      throw std::invalid_argument (std::string ("Unsupported LiteRT element type: ")
+                                   + std::to_string ((int) type));
+  }
+}
+
+/**
+ * @brief Convert a LiteRT layout to nnstreamer tensor_dim (reversed order).
+ */
+void
+litert_subplugin::convertLayout (const LiteRtLayout &layout, tensor_dim dim)
+{
+  guint rank = layout.rank;
+
+  for (guint i = 0; i < NNS_TENSOR_RANK_LIMIT; ++i)
+    dim[i] = 0;
+
+  if (rank > NNS_TENSOR_RANK_LIMIT)
+    throw std::invalid_argument (std::string ("Tensor rank ") + std::to_string (rank) + " exceeds the limit ("
+                                 + std::to_string (NNS_TENSOR_RANK_LIMIT) + ").");
+
+  if (rank == 0) {
+    /* scalar; represent as a single-element tensor */
+    dim[0] = 1;
+    return;
+  }
+
+  /* the order of dimension is reversed at CAPS negotiation */
+  for (guint i = 0; i < rank; ++i) {
+    int32_t d = layout.dimensions[rank - 1 - i];
+
+    if (d < 0)
+      throw std::invalid_argument (
+          "Dynamic dimensions are not supported yet by the litert subplugin.");
+    dim[i] = (uint32_t) d;
+  }
+}
+
+/**
+ * @brief Resolve the signature to run; by key if given, otherwise index 0.
+ */
+LiteRtParamIndex
+litert_subplugin::resolveSignature () const
+{
+  LiteRtParamIndex num_signatures = 0;
+
+  LITERT_CHECK (LiteRtGetNumModelSignatures (model, &num_signatures));
+  if (num_signatures == 0)
+    throw std::runtime_error ("The model does not have any signature to run.");
+
+  if (signature_key.empty ())
+    return 0;
+
+  for (LiteRtParamIndex i = 0; i < num_signatures; ++i) {
+    LiteRtSignature sig = nullptr;
+    const char *key = nullptr;
+
+    LITERT_CHECK (LiteRtGetModelSignature (model, i, &sig));
+    LITERT_CHECK (LiteRtGetSignatureKey (sig, &key));
+    if (key != nullptr && signature_key == key)
+      return i;
+  }
+
+  throw std::invalid_argument (std::string ("Signature \"") + signature_key
+                               + "\" is not found in the model.");
+}
+
+/**
+ * @brief Fill a GstTensorsInfo from the signature's input or output tensors.
+ *
+ * The element type and name come from the model signature; the dimensions
+ * come from the compiled model's resolved layouts so that dynamic dimensions
+ * declared in the model (e.g., batch = -1) are resolved to the concrete
+ * shapes allocated by the runtime, matching the classic Interpreter API
+ * behavior after AllocateTensors().
+ */
+void
+litert_subplugin::setTensorMeta (LiteRtSignature sig, bool is_input, GstTensorsInfo *meta)
+{
+  size_t num_tensors = 0;
+  std::vector<LiteRtLayout> out_layouts;
+
+  if (is_input) {
+    LITERT_CHECK (LiteRtGetNumSignatureInputs (sig, &num_tensors));
+  } else {
+    LITERT_CHECK (LiteRtGetNumSignatureOutputs (sig, &num_tensors));
+    out_layouts.resize (num_tensors);
+    LITERT_CHECK (LiteRtGetCompiledModelOutputTensorLayouts (compiled_model,
+        signature_index, num_tensors, out_layouts.data (), false));
+  }
+
+  if (num_tensors > NNS_TENSOR_SIZE_LIMIT)
+    throw std::invalid_argument (
+        std::string ("The number of ") + (is_input ? "input" : "output")
+        + " tensors (" + std::to_string (num_tensors) + ") exceeds the limit ("
+        + std::to_string (NNS_TENSOR_SIZE_LIMIT) + ").");
+
+  meta->num_tensors = (unsigned int) num_tensors;
+
+  for (size_t i = 0; i < num_tensors; ++i) {
+    LiteRtTensor tensor = nullptr;
+    const char *tensor_name = nullptr;
+    LiteRtTensorTypeId type_id;
+    LiteRtRankedTensorType ranked_type;
+    LiteRtLayout layout;
+    GstTensorInfo *info = gst_tensors_info_get_nth_info (meta, (guint) i);
+
+    if (is_input) {
+      LITERT_CHECK (LiteRtGetSignatureInputName (sig, i, &tensor_name));
+      LITERT_CHECK (LiteRtGetSignatureInputTensorByIndex (sig, i, &tensor));
+      LITERT_CHECK (LiteRtGetCompiledModelInputTensorLayout (
+          compiled_model, signature_index, i, &layout));
+    } else {
+      LITERT_CHECK (LiteRtGetSignatureOutputName (sig, i, &tensor_name));
+      LITERT_CHECK (LiteRtGetSignatureOutputTensorByIndex (sig, i, &tensor));
+      layout = out_layouts[i];
+    }
+
+    LITERT_CHECK (LiteRtGetTensorTypeId (tensor, &type_id));
+    if (type_id != kLiteRtRankedTensorType)
+      throw std::invalid_argument ("Tensors with dynamic (unranked) types are not supported.");
+
+    LITERT_CHECK (LiteRtGetRankedTensorType (tensor, &ranked_type));
+
+    info->type = convertElementType (ranked_type.element_type);
+    convertLayout (layout, info->dimension);
+    info->name = g_strdup (tensor_name);
+
+    ml_logd ("litert %s tensorMeta[%zu] >> name[%s], type[%d]",
+        is_input ? "input" : "output", i, info->name ? info->name : "(null)", info->type);
+  }
+}
+
+/**
+ * @brief Create managed tensor buffers for all inputs/outputs, reused across invokes.
+ */
+void
+litert_subplugin::createTensorBuffers ()
+{
+  LiteRtSignature sig = nullptr;
+  std::vector<LiteRtLayout> out_layouts (outputTensorMeta.num_tensors);
+  guint i;
+
+  LITERT_CHECK (LiteRtGetModelSignature (model, signature_index, &sig));
+  LITERT_CHECK (LiteRtGetCompiledModelOutputTensorLayouts (compiled_model,
+      signature_index, out_layouts.size (), out_layouts.data (), false));
+
+  for (i = 0; i < inputTensorMeta.num_tensors; ++i) {
+    LiteRtTensorBufferRequirements reqs = nullptr;
+    LiteRtRankedTensorType ranked_type;
+    LiteRtTensor tensor = nullptr;
+    LiteRtTensorBuffer buf = nullptr;
+
+    LITERT_CHECK (LiteRtGetSignatureInputTensorByIndex (sig, i, &tensor));
+    LITERT_CHECK (LiteRtGetRankedTensorType (tensor, &ranked_type));
+    /* use the runtime-resolved layout; the model may declare dynamic dims */
+    LITERT_CHECK (LiteRtGetCompiledModelInputTensorLayout (
+        compiled_model, signature_index, i, &ranked_type.layout));
+    LITERT_CHECK (LiteRtGetCompiledModelInputBufferRequirements (
+        compiled_model, signature_index, i, &reqs));
+    LITERT_CHECK (LiteRtCreateManagedTensorBufferFromRequirements (
+        env, &ranked_type, reqs, &buf));
+    input_buffers.push_back (buf);
+  }
+
+  for (i = 0; i < outputTensorMeta.num_tensors; ++i) {
+    LiteRtTensorBufferRequirements reqs = nullptr;
+    LiteRtRankedTensorType ranked_type;
+    LiteRtTensor tensor = nullptr;
+    LiteRtTensorBuffer buf = nullptr;
+
+    LITERT_CHECK (LiteRtGetSignatureOutputTensorByIndex (sig, i, &tensor));
+    LITERT_CHECK (LiteRtGetRankedTensorType (tensor, &ranked_type));
+    ranked_type.layout = out_layouts[i];
+    LITERT_CHECK (LiteRtGetCompiledModelOutputBufferRequirements (
+        compiled_model, signature_index, i, &reqs));
+    LITERT_CHECK (LiteRtCreateManagedTensorBufferFromRequirements (
+        env, &ranked_type, reqs, &buf));
+    output_buffers.push_back (buf);
+  }
+}
+
+/**
+ * @brief Configure the instance: load and compile the model, gather tensor info.
+ */
+void
+litert_subplugin::configure_instance (const GstTensorFilterProperties *prop)
+{
+  LiteRtOptions options = nullptr;
+  LiteRtSignature sig = nullptr;
+
+  if (prop->num_models != 1 || !prop->model_files[0] || prop->model_files[0][0] == '\0') {
+    ml_loge ("LiteRT filter requires one .tflite model file.");
+    throw std::invalid_argument ("The .tflite model file is not given.");
+  }
+
+  if (configured)
+    cleanup ();
+
+  gst_tensors_info_init (std::addressof (inputTensorMeta));
+  gst_tensors_info_init (std::addressof (outputTensorMeta));
+
+  model_path = g_strdup (prop->model_files[0]);
+
+  applyHwList (prop);
+  try {
+    parseCustomProperties (prop);
+  } catch (const std::invalid_argument &e) {
+    cleanup ();
+    ml_loge ("Failed to parse custom property: %s", e.what ());
+    throw std::invalid_argument (
+        "Failed to parse custom property: " + std::string (e.what ()));
+  }
+
+  try {
+    LITERT_CHECK (LiteRtCreateEnvironment (0, nullptr, &env));
+    LITERT_CHECK (LiteRtCreateModelFromFile (env, model_path, &model));
+
+    signature_index = resolveSignature ();
+    LITERT_CHECK (LiteRtGetModelSignature (model, signature_index, &sig));
+
+    LITERT_CHECK (LiteRtCreateOptions (&options));
+    LITERT_CHECK (LiteRtSetOptionsHardwareAccelerators (options, accel_set));
+    {
+      LiteRtStatus status = LiteRtCreateCompiledModel (env, model, options, &compiled_model);
+      LiteRtDestroyOptions (options);
+      options = nullptr;
+      if (status != kLiteRtStatusOk) {
+        ml_loge ("Failed to compile the LiteRT model %s (status %d). "
+                 "Check whether the requested accelerator is available.",
+            model_path, (int) status);
+        throw std::runtime_error ("LiteRtCreateCompiledModel failed.");
+      }
+    }
+
+    /* tensor meta needs the compiled model for runtime-resolved layouts */
+    setTensorMeta (sig, true, std::addressof (inputTensorMeta));
+    setTensorMeta (sig, false, std::addressof (outputTensorMeta));
+
+    createTensorBuffers ();
+  } catch (...) {
+    if (options != nullptr)
+      LiteRtDestroyOptions (options);
+    cleanup ();
+    throw;
+  }
+
+  configured = true;
+}
+
+/**
+ * @brief Invoke the model with the given input and output tensors.
+ */
+void
+litert_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
+{
+  guint i;
+
+  if (!configured)
+    throw std::runtime_error ("Invoke called before a model is configured.");
+
+  if (input == nullptr || output == nullptr)
+    throw std::invalid_argument ("Invoke called with a null tensor memory.");
+
+  /* Fill input buffers */
+  for (i = 0; i < inputTensorMeta.num_tensors; ++i) {
+    void *host_mem = nullptr;
+
+    if (input[i].data == nullptr)
+      throw std::invalid_argument ("Input tensor memory is null.");
+
+    LITERT_CHECK (LiteRtLockTensorBuffer (
+        input_buffers[i], &host_mem, kLiteRtTensorBufferLockModeWrite));
+    std::memcpy (host_mem, input[i].data, input[i].size);
+    LITERT_CHECK (LiteRtUnlockTensorBuffer (input_buffers[i]));
+  }
+
+  LITERT_CHECK (LiteRtRunCompiledModel (compiled_model, signature_index,
+      input_buffers.size (), input_buffers.data (), output_buffers.size (),
+      output_buffers.data ()));
+
+  /* Read back output buffers */
+  for (i = 0; i < outputTensorMeta.num_tensors; ++i) {
+    void *host_mem = nullptr;
+
+    if (output[i].data == nullptr)
+      throw std::invalid_argument ("Output tensor memory is null.");
+
+    LITERT_CHECK (LiteRtLockTensorBuffer (
+        output_buffers[i], &host_mem, kLiteRtTensorBufferLockModeRead));
+    std::memcpy (output[i].data, host_mem, output[i].size);
+    LITERT_CHECK (LiteRtUnlockTensorBuffer (output_buffers[i]));
+  }
+}
+
+/**
+ * @brief Describe the framework to the tensor_filter infrastructure.
+ */
+void
+litert_subplugin::getFrameworkInfo (GstTensorFilterFrameworkInfo &info)
+{
+  info.name = name;
+  info.allow_in_place = FALSE;
+  info.allocate_in_invoke = FALSE;
+  info.run_without_model = FALSE;
+  info.verify_model_path = TRUE;
+  info.hw_list = hw_list;
+  info.num_hw = num_hw;
+}
+
+/**
+ * @brief Get the in/out tensors info of the configured model.
+ */
+int
+litert_subplugin::getModelInfo (
+    model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info)
+{
+  if (ops != GET_IN_OUT_INFO)
+    return -ENOENT;
+
+  if (!configured)
+    return -EINVAL;
+
+  gst_tensors_info_copy (std::addressof (in_info), std::addressof (inputTensorMeta));
+  gst_tensors_info_copy (std::addressof (out_info), std::addressof (outputTensorMeta));
+
+  return 0;
+}
+
+/**
+ * @brief Handle tensor_filter framework events.
+ */
+int
+litert_subplugin::eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data)
+{
+  UNUSED (ops);
+  UNUSED (data);
+  return -ENOENT;
+}
+
+/**
+ * @brief Register the litert_subplugin object.
+ */
+void
+litert_subplugin::init_filter_litert (void)
+{
+  registeredRepresentation
+      = tensor_filter_subplugin::register_subplugin<litert_subplugin> ();
+  nnstreamer_filter_set_custom_property_desc (name, "Accelerators",
+      "Hardware accelerators to enable: cpu, gpu, npu; combinable with '+' "
+      "(e.g., \"npu+cpu\"). Default: cpu",
+      "Signature",
+      "Key of the model signature to run (default: the first signature)", NULL);
+}
+
+/**
+ * @brief Unregister the litert_subplugin object.
+ */
+void
+litert_subplugin::fini_filter_litert (void)
+{
+  g_assert (registeredRepresentation != nullptr);
+  tensor_filter_subplugin::unregister_subplugin (registeredRepresentation);
+}
+
+/** @brief Initialize this object for tensor_filter subplugin runtime register */
+void
+_init_filter_litert (void)
+{
+  litert_subplugin::init_filter_litert ();
+}
+
+/** @brief Destruct the subplugin */
+void
+_fini_filter_litert (void)
+{
+  litert_subplugin::fini_filter_litert ();
+}
+
+} /* namespace tensorfilter_litert */
+} /* namespace nnstreamer */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -33,6 +33,9 @@
  *
  * @todo Zero-copy invoke by wrapping GstTensorMemory with
  *       LiteRtCreateTensorBufferFromHostMemory when alignment permits.
+ * @todo Share one LiteRtEnvironment across instances. Each filter instance
+ *       currently creates its own environment; with GPU/NPU accelerators
+ *       that may mean one device context per instance.
  * @todo Support dynamic input dimensions (invoke_dynamic).
  * @todo Expose accelerator-specific opaque options (GPU precision, NPU
  *       compiler plugin paths, etc.).
@@ -123,6 +126,8 @@ class litert_subplugin final : public tensor_filter_subplugin
 
   std::vector<LiteRtTensorBuffer> input_buffers{}; /**< managed, reused per invoke */
   std::vector<LiteRtTensorBuffer> output_buffers{}; /**< managed, reused per invoke */
+  std::vector<size_t> input_buffer_sizes{}; /**< actual LiteRT buffer sizes */
+  std::vector<size_t> output_buffer_sizes{}; /**< actual LiteRT buffer sizes */
 
   void cleanup ();
   void parseCustomProperties (const GstTensorFilterProperties *prop);
@@ -166,9 +171,11 @@ litert_subplugin::cleanup ()
   for (auto &buf : input_buffers)
     LiteRtDestroyTensorBuffer (buf);
   input_buffers.clear ();
+  input_buffer_sizes.clear ();
   for (auto &buf : output_buffers)
     LiteRtDestroyTensorBuffer (buf);
   output_buffers.clear ();
+  output_buffer_sizes.clear ();
 
   if (compiled_model != nullptr) {
     LiteRtDestroyCompiledModel (compiled_model);
@@ -213,6 +220,11 @@ litert_subplugin::parseAcceleratorValue (const gchar *value)
 
   for (guint i = 0; entries[i] != nullptr; ++i) {
     const gchar *entry = entries[i];
+
+    if (entry[0] == '\0') {
+      /* tolerate empty entries from consecutive/trailing delimiters ("cpu++gpu") */
+      continue;
+    }
 
     if (g_ascii_strcasecmp (entry, "cpu") == 0) {
       set |= kLiteRtHwAcceleratorCpu;
@@ -320,7 +332,7 @@ litert_subplugin::convertElementType (LiteRtElementType type)
     case kLiteRtElementTypeInt64:
       return _NNS_INT64;
     case kLiteRtElementTypeUInt8:
-    case kLiteRtElementTypeBool:
+    case kLiteRtElementTypeBool: /* nnstreamer has no bool; both are 1-byte */
       return _NNS_UINT8;
     case kLiteRtElementTypeUInt16:
       return _NNS_UINT16;
@@ -348,6 +360,10 @@ litert_subplugin::convertLayout (const LiteRtLayout &layout, tensor_dim dim)
   if (rank > NNS_TENSOR_RANK_LIMIT)
     throw std::invalid_argument (std::string ("Tensor rank ") + std::to_string (rank) + " exceeds the limit ("
                                  + std::to_string (NNS_TENSOR_RANK_LIMIT) + ").");
+
+  if (layout.has_strides)
+    throw std::invalid_argument (
+        "Strided (non-contiguous) tensor layouts are not supported yet by the litert subplugin.");
 
   if (rank == 0) {
     /* scalar; represent as a single-element tensor */
@@ -414,16 +430,23 @@ litert_subplugin::setTensorMeta (LiteRtSignature sig, bool is_input, GstTensorsI
     LITERT_CHECK (LiteRtGetNumSignatureInputs (sig, &num_tensors));
   } else {
     LITERT_CHECK (LiteRtGetNumSignatureOutputs (sig, &num_tensors));
-    out_layouts.resize (num_tensors);
-    LITERT_CHECK (LiteRtGetCompiledModelOutputTensorLayouts (compiled_model,
-        signature_index, num_tensors, out_layouts.data (), false));
   }
+
+  if (num_tensors == 0)
+    throw std::invalid_argument (std::string ("The model signature has no ")
+                                 + (is_input ? "input" : "output") + " tensor.");
 
   if (num_tensors > NNS_TENSOR_SIZE_LIMIT)
     throw std::invalid_argument (
         std::string ("The number of ") + (is_input ? "input" : "output")
         + " tensors (" + std::to_string (num_tensors) + ") exceeds the limit ("
         + std::to_string (NNS_TENSOR_SIZE_LIMIT) + ").");
+
+  if (!is_input) {
+    out_layouts.resize (num_tensors);
+    LITERT_CHECK (LiteRtGetCompiledModelOutputTensorLayouts (compiled_model,
+        signature_index, num_tensors, out_layouts.data (), false));
+  }
 
   meta->num_tensors = (unsigned int) num_tensors;
 
@@ -491,6 +514,17 @@ litert_subplugin::createTensorBuffers ()
     LITERT_CHECK (LiteRtCreateManagedTensorBufferFromRequirements (
         env, &ranked_type, reqs, &buf));
     input_buffers.push_back (buf);
+
+    /* the buffer LiteRT allocated must be able to hold the whole tensor */
+    size_t buf_size = 0;
+    LITERT_CHECK (LiteRtGetTensorBufferSize (buf, &buf_size));
+    gsize nns_size
+        = gst_tensors_info_get_size (std::addressof (inputTensorMeta), (gint) i);
+    if (buf_size < (size_t) nns_size)
+      throw std::runtime_error ("LiteRT input buffer " + std::to_string (i) + " is smaller ("
+                                + std::to_string (buf_size) + " B) than the tensor ("
+                                + std::to_string (nns_size) + " B).");
+    input_buffer_sizes.push_back (buf_size);
   }
 
   for (i = 0; i < outputTensorMeta.num_tensors; ++i) {
@@ -507,6 +541,16 @@ litert_subplugin::createTensorBuffers ()
     LITERT_CHECK (LiteRtCreateManagedTensorBufferFromRequirements (
         env, &ranked_type, reqs, &buf));
     output_buffers.push_back (buf);
+
+    size_t buf_size = 0;
+    LITERT_CHECK (LiteRtGetTensorBufferSize (buf, &buf_size));
+    gsize nns_size
+        = gst_tensors_info_get_size (std::addressof (outputTensorMeta), (gint) i);
+    if (buf_size < (size_t) nns_size)
+      throw std::runtime_error ("LiteRT output buffer " + std::to_string (i) + " is smaller ("
+                                + std::to_string (buf_size) + " B) than the tensor ("
+                                + std::to_string (nns_size) + " B).");
+    output_buffer_sizes.push_back (buf_size);
   }
 }
 
@@ -599,6 +643,12 @@ litert_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
     if (input[i].data == nullptr)
       throw std::invalid_argument ("Input tensor memory is null.");
 
+    /* never write past the buffer LiteRT actually allocated */
+    if (input[i].size > input_buffer_sizes[i])
+      throw std::invalid_argument ("Input tensor " + std::to_string (i) + " ("
+                                   + std::to_string (input[i].size) + " B) exceeds the LiteRT buffer ("
+                                   + std::to_string (input_buffer_sizes[i]) + " B).");
+
     LITERT_CHECK (LiteRtLockTensorBuffer (
         input_buffers[i], &host_mem, kLiteRtTensorBufferLockModeWrite));
     std::memcpy (host_mem, input[i].data, input[i].size);
@@ -615,6 +665,12 @@ litert_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
 
     if (output[i].data == nullptr)
       throw std::invalid_argument ("Output tensor memory is null.");
+
+    /* never read past the buffer LiteRT actually allocated */
+    if (output[i].size > output_buffer_sizes[i])
+      throw std::invalid_argument ("Output tensor " + std::to_string (i) + " ("
+                                   + std::to_string (output[i].size) + " B) exceeds the LiteRT buffer ("
+                                   + std::to_string (output_buffer_sizes[i]) + " B).");
 
     LITERT_CHECK (LiteRtLockTensorBuffer (
         output_buffers[i], &host_mem, kLiteRtTensorBufferLockModeRead));

--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -126,8 +126,8 @@ class litert_subplugin final : public tensor_filter_subplugin
 
   std::vector<LiteRtTensorBuffer> input_buffers{}; /**< managed, reused per invoke */
   std::vector<LiteRtTensorBuffer> output_buffers{}; /**< managed, reused per invoke */
-  std::vector<size_t> input_buffer_sizes{}; /**< actual LiteRT buffer sizes */
-  std::vector<size_t> output_buffer_sizes{}; /**< actual LiteRT buffer sizes */
+  std::vector<size_t> input_tensor_sizes{}; /**< nnstreamer tensor sizes; each is <= its LiteRT buffer */
+  std::vector<size_t> output_tensor_sizes{}; /**< nnstreamer tensor sizes; each is <= its LiteRT buffer */
 
   void cleanup ();
   void parseCustomProperties (const GstTensorFilterProperties *prop);
@@ -171,11 +171,11 @@ litert_subplugin::cleanup ()
   for (auto &buf : input_buffers)
     LiteRtDestroyTensorBuffer (buf);
   input_buffers.clear ();
-  input_buffer_sizes.clear ();
+  input_tensor_sizes.clear ();
   for (auto &buf : output_buffers)
     LiteRtDestroyTensorBuffer (buf);
   output_buffers.clear ();
-  output_buffer_sizes.clear ();
+  output_tensor_sizes.clear ();
 
   if (compiled_model != nullptr) {
     LiteRtDestroyCompiledModel (compiled_model);
@@ -195,6 +195,12 @@ litert_subplugin::cleanup ()
 
   g_free (model_path);
   model_path = nullptr;
+
+  /** restore the property defaults so a re-configured instance does not
+   *  inherit the previous model's accelerator or signature selection */
+  accel_set = kLiteRtHwAcceleratorCpu;
+  signature_key.clear ();
+  signature_index = 0;
 
   configured = false;
 }
@@ -524,7 +530,7 @@ litert_subplugin::createTensorBuffers ()
       throw std::runtime_error ("LiteRT input buffer " + std::to_string (i) + " is smaller ("
                                 + std::to_string (buf_size) + " B) than the tensor ("
                                 + std::to_string (nns_size) + " B).");
-    input_buffer_sizes.push_back (buf_size);
+    input_tensor_sizes.push_back ((size_t) nns_size);
   }
 
   for (i = 0; i < outputTensorMeta.num_tensors; ++i) {
@@ -550,7 +556,7 @@ litert_subplugin::createTensorBuffers ()
       throw std::runtime_error ("LiteRT output buffer " + std::to_string (i) + " is smaller ("
                                 + std::to_string (buf_size) + " B) than the tensor ("
                                 + std::to_string (nns_size) + " B).");
-    output_buffer_sizes.push_back (buf_size);
+    output_tensor_sizes.push_back ((size_t) nns_size);
   }
 }
 
@@ -643,11 +649,13 @@ litert_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
     if (input[i].data == nullptr)
       throw std::invalid_argument ("Input tensor memory is null.");
 
-    /* never write past the buffer LiteRT actually allocated */
-    if (input[i].size > input_buffer_sizes[i])
+    /** Reject any size mismatch: a larger input would overflow the LiteRT
+     *  buffer, and a smaller one would leave the tail of the reused buffer
+     *  holding the previous invoke's data (silently wrong inference). */
+    if (input[i].size != input_tensor_sizes[i])
       throw std::invalid_argument ("Input tensor " + std::to_string (i) + " ("
-                                   + std::to_string (input[i].size) + " B) exceeds the LiteRT buffer ("
-                                   + std::to_string (input_buffer_sizes[i]) + " B).");
+                                   + std::to_string (input[i].size) + " B) does not match the model tensor ("
+                                   + std::to_string (input_tensor_sizes[i]) + " B).");
 
     LITERT_CHECK (LiteRtLockTensorBuffer (
         input_buffers[i], &host_mem, kLiteRtTensorBufferLockModeWrite));
@@ -666,11 +674,12 @@ litert_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
     if (output[i].data == nullptr)
       throw std::invalid_argument ("Output tensor memory is null.");
 
-    /* never read past the buffer LiteRT actually allocated */
-    if (output[i].size > output_buffer_sizes[i])
+    /** Reject any size mismatch: a larger output would read past the LiteRT
+     *  buffer, and a smaller one would silently truncate the result. */
+    if (output[i].size != output_tensor_sizes[i])
       throw std::invalid_argument ("Output tensor " + std::to_string (i) + " ("
-                                   + std::to_string (output[i].size) + " B) exceeds the LiteRT buffer ("
-                                   + std::to_string (output_buffer_sizes[i]) + " B).");
+                                   + std::to_string (output[i].size) + " B) does not match the model tensor ("
+                                   + std::to_string (output_tensor_sizes[i]) + " B).");
 
     LITERT_CHECK (LiteRtLockTensorBuffer (
         output_buffers[i], &host_mem, kLiteRtTensorBufferLockModeRead));

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -129,6 +129,10 @@ endif
 NNSTREAMER_FILTER_QNN_SRCS := \
     $(NNSTREAMER_EXT_HOME)/tensor_filter/tensor_filter_qnn.cc
 
+# filter litert (LiteRT 2.x CompiledModel API; requires libLiteRt.so and LiteRT C headers)
+NNSTREAMER_FILTER_LITERT_SRCS := \
+    $(NNSTREAMER_EXT_HOME)/tensor_filter/tensor_filter_litert.cc
+
 # filter snap
 NNSTREAMER_FILTER_SNAP_SRCS := \
     $(NNSTREAMER_EXT_HOME)/tensor_filter/tensor_filter_snap.cc

--- a/meson.build
+++ b/meson.build
@@ -282,28 +282,47 @@ if not get_option('litert-support').disabled()
     # Check whether LITERT_ROOT (where the LiteRT SDK is located) is set.
     # Expected layout: $LITERT_ROOT/lib/libLiteRt.so and
     #                  $LITERT_ROOT/include/litert/c/litert_common.h
+    # A stale or partial LITERT_ROOT must not break unrelated builds:
+    # unless litert-support is explicitly enabled, every failure below
+    # degrades to "feature off" instead of aborting.
+    litert_enabled = get_option('litert-support').enabled()
     cmd = run_command('sh', '-c', 'echo $LITERT_ROOT', check : false)
     LITERT_ROOT = cmd.returncode() == 0 ? cmd.stdout().strip() : ''
     if LITERT_ROOT != ''
       message('Got LITERT_ROOT: @0@'.format(LITERT_ROOT))
-      if not fs.is_dir(LITERT_ROOT)
-        error('@0@ does not exist'.format(LITERT_ROOT))
-      endif
+      litert_root_ok = true
 
-      litert_lib = cxx.find_library('LiteRt',
-        dirs: join_paths(LITERT_ROOT, 'lib'),
-        required: true
-      )
+      if not fs.is_dir(LITERT_ROOT)
+        if litert_enabled
+          error('LITERT_ROOT (@0@) does not exist.'.format(LITERT_ROOT))
+        endif
+        message('LITERT_ROOT (@0@) does not exist; ignoring it.'.format(LITERT_ROOT))
+        litert_root_ok = false
+      endif
 
       litert_include_path = join_paths(LITERT_ROOT, 'include')
-      if not fs.is_file(join_paths(litert_include_path, 'litert', 'c', 'litert_common.h'))
-        error('LiteRT header files are not found in your LITERT_ROOT path.')
+      if litert_root_ok and not fs.is_file(join_paths(litert_include_path, 'litert', 'c', 'litert_common.h'))
+        if litert_enabled
+          error('LiteRT header files are not found in your LITERT_ROOT path.')
+        endif
+        message('LiteRT header files are not found in LITERT_ROOT; ignoring it.')
+        litert_root_ok = false
       endif
 
-      litert_dep = declare_dependency(
-        dependencies: litert_lib,
-        include_directories: include_directories(litert_include_path, is_system: true)
-      )
+      if litert_root_ok
+        litert_lib = cxx.find_library('LiteRt',
+          dirs: join_paths(LITERT_ROOT, 'lib'),
+          required: litert_enabled
+        )
+        if litert_lib.found()
+          litert_dep = declare_dependency(
+            dependencies: litert_lib,
+            include_directories: include_directories(litert_include_path, is_system: true)
+          )
+        else
+          message('libLiteRt is not found in LITERT_ROOT; ignoring it.')
+        endif
+      endif
     else
       message('If you want to build the LiteRT sub-plugin, provide litert.pc or LITERT_ROOT as the path of the LiteRT SDK.')
     endif

--- a/meson.build
+++ b/meson.build
@@ -273,6 +273,61 @@ if not get_option('snpe-support').disabled()
   endif
 endif
 
+# litert (LiteRT 2.x CompiledModel C API)
+litert_dep = dependency('', required: false)
+if not get_option('litert-support').disabled()
+  # Check pkg-config (litert.pc) first.
+  litert_dep = dependency('litert', required: false)
+  if not litert_dep.found()
+    # Check whether LITERT_ROOT (where the LiteRT SDK is located) is set.
+    # Expected layout: $LITERT_ROOT/lib/libLiteRt.so and
+    #                  $LITERT_ROOT/include/litert/c/litert_common.h
+    cmd = run_command('sh', '-c', 'echo $LITERT_ROOT', check : false)
+    LITERT_ROOT = cmd.returncode() == 0 ? cmd.stdout().strip() : ''
+    if LITERT_ROOT != ''
+      message('Got LITERT_ROOT: @0@'.format(LITERT_ROOT))
+      if not fs.is_dir(LITERT_ROOT)
+        error('@0@ does not exist'.format(LITERT_ROOT))
+      endif
+
+      litert_lib = cxx.find_library('LiteRt',
+        dirs: join_paths(LITERT_ROOT, 'lib'),
+        required: true
+      )
+
+      litert_include_path = join_paths(LITERT_ROOT, 'include')
+      if not fs.is_file(join_paths(litert_include_path, 'litert', 'c', 'litert_common.h'))
+        error('LiteRT header files are not found in your LITERT_ROOT path.')
+      endif
+
+      litert_dep = declare_dependency(
+        dependencies: litert_lib,
+        include_directories: include_directories(litert_include_path, is_system: true)
+      )
+    else
+      message('If you want to build the LiteRT sub-plugin, provide litert.pc or LITERT_ROOT as the path of the LiteRT SDK.')
+    endif
+  endif
+
+  if litert_dep.found()
+    litert_check_code = '''
+    #include <litert/c/litert_environment.h>
+    int main() {
+      LiteRtEnvironment env = 0;
+      LiteRtCreateEnvironment(0, 0, &env);
+      LiteRtDestroyEnvironment(env);
+      return 0;
+    }
+    '''
+    if not cxx.links(litert_check_code, dependencies: litert_dep, name: 'litert sanity')
+      if get_option('litert-support').enabled()
+        error('Cannot compile/link against the detected LiteRT SDK.')
+      endif
+      litert_dep = dependency('', required: false)
+    endif
+  endif
+endif
+
 # cuda
 cuda_version_str = ''
 cuda_major = 0
@@ -586,6 +641,10 @@ features = {
     # Assume that qnn.pc file is given.
     'target': 'qnn',
     'project_args': { 'ENABLE_QNN' : 1 },
+  },
+  'litert-support': {
+    'extra_deps': [ litert_dep ],
+    'project_args': { 'ENABLE_LITERT' : 1 },
   },
   'flatbuf-support': {
     'extra_deps': [ flatc_dep, flatbuf_dep, flatbuf_version_check_dep ],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,7 @@ option('tf-support', type: 'feature', value: 'auto')
 option('tflite-support', type: 'feature', value: 'auto')
 option('tflite2-support', type: 'feature', value: 'auto')
 option('tflite2-custom-support', type: 'feature', value: 'disabled') # requires tflite2-support. disabled due to incompleteness.
+option('litert-support', type: 'feature', value: 'auto') # LiteRT 2.x CompiledModel API. Provide litert.pc or LITERT_ROOT.
 option('pytorch-support', type: 'feature', value: 'auto')
 option('caffe2-support', type: 'feature', value: 'auto')
 option('deepview-rt-support', type: 'feature', value: 'auto')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -409,6 +409,18 @@ if gtest_dep.found()
     test('unittest_filter_onnxruntime', unittest_filter_onnxruntime, env: testenv)
   endif
 
+  # LiteRT unittest
+  if litert_support_is_available
+    unittest_filter_litert = executable('unittest_filter_litert',
+      join_paths('nnstreamer_filter_litert', 'unittest_filter_litert.cc'),
+      dependencies: [nnstreamer_unittest_deps],
+      install: get_option('install-test'),
+      install_dir: unittest_install_dir
+    )
+
+    test('unittest_filter_litert', unittest_filter_litert, env: testenv)
+  endif
+
   # LLAMACPP unittest
   if llamacpp_support_is_available
     unittest_filter_llamacpp = executable('unittest_filter_llamacpp',

--- a/tests/nnstreamer_filter_litert/runTest.sh
+++ b/tests/nnstreamer_filter_litert/runTest.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
+## @file runTest.sh
+## @author MyungJoo Ham <myungjoo.ham@samsung.com>
+## @date Aug 20 2026
+## @brief SSAT Test Cases for the LiteRT (CompiledModel API) tensor filter sub-plugin
+##
+
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}"
+fi
+
+# This is compatible with SSAT (https://github.com/myungjoo/SSAT)
+testInit $1
+
+# NNStreamer and plugins path for test
+PATH_TO_PLUGIN="../../build"
+
+if [[ -d $PATH_TO_PLUGIN ]]; then
+    ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
+    if [[ -d ${ini_path} ]]; then
+        check=$(ls ${ini_path} | grep litert.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find litert shared lib"
+            report
+            exit
+        fi
+    else
+        echo "Cannot find ${ini_path}"
+    fi
+else
+    ini_file="/etc/nnstreamer.ini"
+    if [[ -f ${ini_file} ]]; then
+        path=$(grep "^filters" ${ini_file})
+        key=${path%=*}
+        value=${path##*=}
+
+        if [[ $key != "filters" ]]; then
+            echo "String Error"
+            report
+            exit
+        fi
+
+        if [[ -d ${value} ]]; then
+            check=$(ls ${value} | grep litert.so)
+            if [[ ! $check ]]; then
+                echo "Cannot find litert lib"
+                report
+                exit
+            fi
+        else
+            echo "Cannot find ${value}"
+            report
+            exit
+        fi
+    else
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
+    fi
+fi
+
+PATH_TO_MODEL="../test_models/models/mobilenet_v1_1.0_224_quant.tflite"
+PATH_TO_LABEL="../test_models/labels/labels.txt"
+PATH_TO_IMAGE="../test_models/data/orange.png"
+PATH_TO_CLASS="class.out.log"
+
+# Test 1: Positive. Golden classification result, same model and golden label
+# as the tensorflow2-lite SSAT tests; cross-runtime divergence fails here.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! tensor_converter ! tensor_filter framework=litert model=${PATH_TO_MODEL} ! tensor_decoder mode=image_labeling option1=${PATH_TO_LABEL} ! filesink location=${PATH_TO_CLASS}" 1 0 0 $PERFORMANCE
+class=$(cat ${PATH_TO_CLASS})
+[ "$class" = "orange" ]
+testResult $? 1 "Golden test comparison" 0 1
+
+# Test 2: Positive. Explicit cpu accelerator custom property.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! tensor_converter ! tensor_filter framework=litert model=${PATH_TO_MODEL} custom=Accelerators:cpu ! tensor_decoder mode=image_labeling option1=${PATH_TO_LABEL} ! filesink location=${PATH_TO_CLASS}" 2 0 0 $PERFORMANCE
+class=$(cat ${PATH_TO_CLASS})
+[ "$class" = "orange" ]
+testResult $? 2 "Golden test comparison with Accelerators:cpu" 0 1
+
+# Test 3: Negative. Mismatched input dimensions must fail.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=42,height=42,framerate=0/1 ! tensor_converter ! tensor_filter framework=litert model=${PATH_TO_MODEL} ! fakesink" 3_n 0 1 $PERFORMANCE
+
+# Test 4: Negative. Invalid model path must fail.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=224,height=224 ! tensor_converter ! tensor_filter framework=litert model=invalid_model_path.tflite ! fakesink" 4_n 0 1 $PERFORMANCE
+
+# Test 5: Negative. Unknown accelerator custom property must fail.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! tensor_converter ! tensor_filter framework=litert model=${PATH_TO_MODEL} custom=Accelerators:tpu ! fakesink" 5_n 0 1 $PERFORMANCE
+
+report

--- a/tests/nnstreamer_filter_litert/runTest.sh
+++ b/tests/nnstreamer_filter_litert/runTest.sh
@@ -25,7 +25,7 @@ PATH_TO_PLUGIN="../../build"
 if [[ -d $PATH_TO_PLUGIN ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
     if [[ -d ${ini_path} ]]; then
-        check=$(ls ${ini_path} | grep litert.so)
+        check=$(ls ${ini_path} | grep -E 'litert\.(so|dylib)')
         if [[ ! $check ]]; then
             echo "Cannot find litert shared lib"
             report
@@ -48,7 +48,7 @@ else
         fi
 
         if [[ -d ${value} ]]; then
-            check=$(ls ${value} | grep litert.so)
+            check=$(ls ${value} | grep -E 'litert\.(so|dylib)')
             if [[ ! $check ]]; then
                 echo "Cannot find litert lib"
                 report

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -1,0 +1,816 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * @file    unittest_filter_litert.cc
+ * @date    20 Aug 2026
+ * @brief   Unit test for the LiteRT (CompiledModel API) tensor filter sub-plugin
+ * @author  MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @see     http://github.com/nnstreamer/nnstreamer
+ * @bug     No known bugs
+ *
+ * The golden results (e.g., argmax 951 for orange.png) are shared with the
+ * tensorflow2-lite subplugin unit tests, which run the very same .tflite
+ * model files with the classic Interpreter API. Any divergence between the
+ * two subplugins on the same model is therefore caught at unit test level.
+ */
+
+#include <gtest/gtest.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gst/gst.h>
+
+#include <nnstreamer_plugin_api_filter.h>
+#include <nnstreamer_util.h>
+#include <tensor_common.h>
+#include <unittest_util.h>
+#include "nnstreamer_plugin_api.h"
+#include "nnstreamer_plugin_api_util.h"
+
+/**
+ * @brief internal function to get model file path
+ */
+static gboolean
+_GetModelFilePath (gchar **model_file, int option)
+{
+  const gchar *src_root = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  g_autofree gchar *root_path = src_root ? g_strdup (src_root) : g_get_current_dir ();
+  std::string model_name;
+
+  switch (option) {
+    case 0:
+      model_name = "mobilenet_v2_1.0_224_quant.tflite";
+      break;
+    case 1:
+      model_name = "mobilenet_v2_1.0_224.tflite";
+      break;
+    case 2:
+      model_name = "simple_32_in_32_out.tflite";
+      break;
+    default:
+      break;
+  }
+
+  *model_file = g_build_filename (
+      root_path, "tests", "test_models", "models", model_name.c_str (), NULL);
+
+  return g_file_test (*model_file, G_FILE_TEST_EXISTS);
+}
+
+/**
+ * @brief internal function to get the orange.png
+ */
+static gboolean
+_GetOrangePngFilePath (gchar **input_file)
+{
+  const gchar *src_root = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  g_autofree gchar *root_path = src_root ? g_strdup (src_root) : g_get_current_dir ();
+
+  *input_file = g_build_filename (
+      root_path, "tests", "test_models", "data", "orange.png", NULL);
+
+  return g_file_test (*input_file, G_FILE_TEST_EXISTS);
+}
+
+/**
+ * @brief Set tensor filter properties
+ */
+static void
+_SetFilterProp (GstTensorFilterProperties *prop, const gchar *name,
+    const gchar **models, const gchar *custom = NULL)
+{
+  memset (prop, 0, sizeof (GstTensorFilterProperties));
+  prop->fwname = name;
+  prop->fw_opened = 0;
+  prop->model_files = models;
+  prop->num_models = models ? g_strv_length ((gchar **) models) : 0;
+  prop->custom_properties = custom;
+}
+
+/**
+ * @brief Signal to validate the classification result in tensor_sink
+ */
+static void
+check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  GstMemory *mem_res;
+  GstMapInfo info_res;
+  gboolean mapped;
+  UNUSED (element);
+
+  mem_res = gst_buffer_get_memory (buffer, 0);
+  mapped = gst_memory_map (mem_res, &info_res, GST_MAP_READ);
+  ASSERT_TRUE (mapped);
+
+  gint is_float = (gint) * ((guint8 *) user_data);
+  guint idx, max_idx = 0U;
+
+  if (is_float == 0) {
+    guint8 *output = (guint8 *) info_res.data;
+    guint8 max_value = 0;
+
+    for (idx = 0; idx < info_res.size; ++idx) {
+      if (output[idx] > max_value) {
+        max_value = output[idx];
+        max_idx = idx;
+      }
+    }
+  } else {
+    gfloat *output = (gfloat *) info_res.data;
+    gfloat max_value = G_MINFLOAT;
+
+    for (idx = 0; idx < (info_res.size / sizeof (gfloat)); ++idx) {
+      if (output[idx] > max_value) {
+        max_value = output[idx];
+        max_idx = idx;
+      }
+    }
+  }
+
+  gst_memory_unmap (mem_res, &info_res);
+  gst_memory_unref (mem_res);
+
+  /** the same golden index as the tensorflow2-lite unit tests */
+  EXPECT_EQ (max_idx, 951U) << "The classification result differs from the "
+                               "tensorflow2-lite subplugin's golden result "
+                               "for the same model file.";
+}
+
+/**
+ * @brief Check the litert subplugin is registered.
+ */
+TEST (nnstreamerFilterLiteRT, checkExistence)
+{
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+}
+
+/**
+ * @brief Positive case with open/close.
+ */
+TEST (nnstreamerFilterLiteRT, openClose00)
+{
+  int ret;
+  void *data = NULL;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  ret = sp->open (&prop, &data);
+  EXPECT_EQ (ret, 0);
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Negative case with an invalid model file path.
+ */
+TEST (nnstreamerFilterLiteRT, openClose00_n)
+{
+  int ret;
+  void *data = NULL;
+
+  const gchar *model_files[] = { "some/invalid/model/path.tflite", NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  ret = sp->open (&prop, &data);
+  EXPECT_NE (ret, 0);
+}
+
+/**
+ * @brief Negative case with an existing file that is not a valid flatbuffer.
+ */
+TEST (nnstreamerFilterLiteRT, openClose01_n)
+{
+  int ret;
+  void *data = NULL;
+  g_autofree gchar *garbage_file = NULL;
+  gint fd;
+
+  fd = g_file_open_tmp ("litert_garbage_XXXXXX.tflite", &garbage_file, NULL);
+  ASSERT_GE (fd, 0);
+  ASSERT_TRUE (g_file_set_contents (
+      garbage_file, "This is not a tflite flatbuffer at all.", -1, NULL));
+  g_close (fd, NULL);
+
+  const gchar *model_files[] = { garbage_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  ret = sp->open (&prop, &data);
+  EXPECT_NE (ret, 0);
+
+  g_unlink (garbage_file);
+}
+
+/**
+ * @brief Negative case with no model file given.
+ */
+TEST (nnstreamerFilterLiteRT, openClose02_n)
+{
+  int ret;
+  void *data = NULL;
+
+  const gchar *model_files[] = { NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  ret = sp->open (&prop, &data);
+  EXPECT_NE (ret, 0);
+}
+
+/**
+ * @brief Positive case: getModelInfo of the float mobilenet model.
+ */
+TEST (nnstreamerFilterLiteRT, getModelInfo00)
+{
+  int ret;
+  void *data = NULL;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  GstTensorsInfo in_info, out_info;
+  ret = sp->getModelInfo (NULL, &prop, data, GET_IN_OUT_INFO, &in_info, &out_info);
+  EXPECT_EQ (ret, 0);
+
+  EXPECT_EQ (in_info.num_tensors, 1U);
+  EXPECT_EQ (in_info.info[0].dimension[0], 3U);
+  EXPECT_EQ (in_info.info[0].dimension[1], 224U);
+  EXPECT_EQ (in_info.info[0].dimension[2], 224U);
+  EXPECT_EQ (in_info.info[0].dimension[3], 1U);
+  EXPECT_EQ (in_info.info[0].type, _NNS_FLOAT32);
+
+  EXPECT_EQ (out_info.num_tensors, 1U);
+  EXPECT_EQ (out_info.info[0].dimension[0], 1001U);
+  EXPECT_EQ (out_info.info[0].dimension[1], 1U);
+  EXPECT_EQ (out_info.info[0].type, _NNS_FLOAT32);
+
+  sp->close (&prop, &data);
+
+  gst_tensors_info_free (&in_info);
+  gst_tensors_info_free (&out_info);
+}
+
+/**
+ * @brief Positive case: getModelInfo of the quantized mobilenet model.
+ */
+TEST (nnstreamerFilterLiteRT, getModelInfo01)
+{
+  int ret;
+  void *data = NULL;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 0));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  GstTensorsInfo in_info, out_info;
+  ret = sp->getModelInfo (NULL, &prop, data, GET_IN_OUT_INFO, &in_info, &out_info);
+  EXPECT_EQ (ret, 0);
+
+  EXPECT_EQ (in_info.num_tensors, 1U);
+  EXPECT_EQ (in_info.info[0].dimension[0], 3U);
+  EXPECT_EQ (in_info.info[0].dimension[1], 224U);
+  EXPECT_EQ (in_info.info[0].dimension[2], 224U);
+  EXPECT_EQ (in_info.info[0].type, _NNS_UINT8);
+
+  EXPECT_EQ (out_info.num_tensors, 1U);
+  EXPECT_EQ (out_info.info[0].dimension[0], 1001U);
+  EXPECT_EQ (out_info.info[0].type, _NNS_UINT8);
+
+  sp->close (&prop, &data);
+
+  gst_tensors_info_free (&in_info);
+  gst_tensors_info_free (&out_info);
+}
+
+/**
+ * @brief Negative case: getModelInfo with an unsupported ops.
+ */
+TEST (nnstreamerFilterLiteRT, getModelInfo02_n)
+{
+  int ret;
+  void *data = NULL;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  GstTensorsInfo in_info, out_info;
+  ret = sp->getModelInfo (NULL, &prop, data, SET_INPUT_INFO, &in_info, &out_info);
+  EXPECT_NE (ret, 0);
+
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Positive case: direct invoke; output canary must be overwritten.
+ */
+TEST (nnstreamerFilterLiteRT, invoke00)
+{
+  int ret;
+  void *data = NULL;
+  GstTensorMemory input, output;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  input.size = sizeof (float) * 224 * 224 * 3;
+  output.size = sizeof (float) * 1001;
+  input.data = g_malloc0 (input.size);
+  output.data = g_malloc (output.size);
+  memset (output.data, 0xAA, output.size); /* canary */
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  ret = sp->invoke (NULL, &prop, data, &input, &output);
+  EXPECT_EQ (ret, 0);
+
+  /* mobilenet output is a softmax; it cannot remain the 0xAA canary */
+  gboolean changed = FALSE;
+  for (gsize i = 0; i < output.size; ++i) {
+    if (((guint8 *) output.data)[i] != 0xAA) {
+      changed = TRUE;
+      break;
+    }
+  }
+  EXPECT_TRUE (changed) << "invoke() succeeded but did not write the output buffer.";
+
+  g_free (input.data);
+  g_free (output.data);
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Positive case: repeated invoke with the same input must be deterministic.
+ */
+TEST (nnstreamerFilterLiteRT, invokeConsistency)
+{
+  int ret;
+  void *data = NULL;
+  GstTensorMemory input, output1, output2;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  input.size = sizeof (float) * 224 * 224 * 3;
+  output1.size = output2.size = sizeof (float) * 1001;
+  input.data = g_malloc (input.size);
+  output1.data = g_malloc0 (output1.size);
+  output2.data = g_malloc0 (output2.size);
+
+  /* a deterministic non-trivial input pattern */
+  for (gsize i = 0; i < input.size / sizeof (float); ++i)
+    ((float *) input.data)[i] = (float) (i % 255) / 255.0f - 0.5f;
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  EXPECT_EQ (sp->invoke (NULL, &prop, data, &input, &output1), 0);
+  EXPECT_EQ (sp->invoke (NULL, &prop, data, &input, &output2), 0);
+  EXPECT_EQ (memcmp (output1.data, output2.data, output1.size), 0)
+      << "Two invocations with identical input produced different outputs.";
+
+  g_free (input.data);
+  g_free (output1.data);
+  g_free (output2.data);
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Negative case: invoke with null tensor memories.
+ */
+TEST (nnstreamerFilterLiteRT, invoke01_n)
+{
+  int ret;
+  void *data = NULL;
+  GstTensorMemory input, output;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  input.size = output.size = sizeof (float);
+  input.data = g_malloc0 (input.size);
+  output.data = g_malloc0 (output.size);
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  EXPECT_NE (sp->invoke (NULL, &prop, data, NULL, &output), 0);
+  EXPECT_NE (sp->invoke (NULL, &prop, data, &input, NULL), 0);
+
+  g_free (input.data);
+  g_free (output.data);
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Positive case: explicit cpu accelerator via custom property.
+ */
+TEST (nnstreamerFilterLiteRT, customPropAccelCpu)
+{
+  int ret;
+  void *data = NULL;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files, "Accelerators:cpu");
+
+  ret = sp->open (&prop, &data);
+  EXPECT_EQ (ret, 0);
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Negative case: unknown accelerator name must be rejected.
+ */
+TEST (nnstreamerFilterLiteRT, customProp00_n)
+{
+  int ret;
+  void *data = NULL;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files, "Accelerators:tpu");
+
+  ret = sp->open (&prop, &data);
+  EXPECT_NE (ret, 0);
+}
+
+/**
+ * @brief Negative case: malformed custom property string must be rejected.
+ */
+TEST (nnstreamerFilterLiteRT, customProp01_n)
+{
+  int ret;
+  void *data = NULL;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files, "JustAKeyWithoutValue");
+
+  ret = sp->open (&prop, &data);
+  EXPECT_NE (ret, 0);
+}
+
+/**
+ * @brief Negative case: nonexistent signature key must be rejected.
+ */
+TEST (nnstreamerFilterLiteRT, customProp02_n)
+{
+  int ret;
+  void *data = NULL;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files, "Signature:no_such_signature_key");
+
+  ret = sp->open (&prop, &data);
+  EXPECT_NE (ret, 0);
+}
+
+/**
+ * @brief Negative case to launch gst pipeline: wrong dimension.
+ */
+TEST (nnstreamerFilterLiteRT, launch00_n)
+{
+  GstElement *gstpipe;
+  GError *err = NULL;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  g_autofree gchar *pipeline = g_strdup_printf (
+      "videotestsrc num-buffers=10 ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=42,height=42,framerate=0/1 ! tensor_converter ! tensor_filter framework=litert model=\"%s\" ! tensor_sink",
+      model_file);
+
+  gstpipe = gst_parse_launch (pipeline, &err);
+  ASSERT_TRUE (gstpipe != nullptr);
+
+  EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (gstpipe);
+}
+
+/**
+ * @brief Negative case to launch gst pipeline: wrong data type.
+ */
+TEST (nnstreamerFilterLiteRT, launch01_n)
+{
+  GstElement *gstpipe;
+  GError *err = NULL;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  /* uint8 stream fed into the float32 model */
+  g_autofree gchar *pipeline = g_strdup_printf (
+      "videotestsrc num-buffers=10 ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! tensor_converter ! tensor_filter framework=litert model=\"%s\" ! tensor_sink",
+      model_file);
+
+  gstpipe = gst_parse_launch (pipeline, &err);
+  ASSERT_TRUE (gstpipe != nullptr);
+
+  EXPECT_NE (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (gstpipe);
+}
+
+/**
+ * @brief Positive case: classification result of the float model.
+ */
+TEST (nnstreamerFilterLiteRT, floatModelResult)
+{
+  GstElement *gstpipe;
+  GError *err = NULL;
+  g_autofree gchar *model_file = NULL;
+  g_autofree gchar *input_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+  ASSERT_TRUE (_GetOrangePngFilePath (&input_file));
+
+  g_autofree gchar *pipeline = g_strdup_printf (
+      "filesrc location=\"%s\" ! pngdec ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:-127.5,div:127.5 ! tensor_filter framework=litert model=\"%s\" ! tensor_sink name=sink",
+      input_file, model_file);
+
+  gstpipe = gst_parse_launch (pipeline, &err);
+  ASSERT_TRUE (gstpipe != nullptr);
+
+  GstElement *sink_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sink");
+  ASSERT_TRUE (sink_handle != nullptr);
+
+  guint8 is_float = 1;
+  g_signal_connect (sink_handle, "new-data", (GCallback) check_output, &is_float);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT * 10),
+      0);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (gstpipe);
+}
+
+/**
+ * @brief Positive case: classification result of the quantized model.
+ */
+TEST (nnstreamerFilterLiteRT, quantModelResult)
+{
+  GstElement *gstpipe;
+  GError *err = NULL;
+  g_autofree gchar *model_file = NULL;
+  g_autofree gchar *input_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 0));
+  ASSERT_TRUE (_GetOrangePngFilePath (&input_file));
+
+  g_autofree gchar *pipeline = g_strdup_printf (
+      "filesrc location=\"%s\" ! pngdec ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! tensor_converter ! tensor_filter framework=litert model=\"%s\" ! tensor_sink name=sink",
+      input_file, model_file);
+
+  gstpipe = gst_parse_launch (pipeline, &err);
+  ASSERT_TRUE (gstpipe != nullptr);
+
+  GstElement *sink_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sink");
+  ASSERT_TRUE (sink_handle != nullptr);
+
+  guint8 is_float = 0;
+  g_signal_connect (sink_handle, "new-data", (GCallback) check_output, &is_float);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT * 10),
+      0);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (gstpipe);
+}
+
+/**
+ * @brief Signal to validate the result in tensor_sink of 32 input/output model.
+ */
+static void
+check_output_many (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  GstMemory *mem_res;
+  GstMapInfo info_res;
+  gboolean mapped;
+  UNUSED (element);
+
+  guint *data_received = (guint *) user_data;
+  (*data_received)++;
+
+  for (guint i = 0; i < 32; i++) {
+    mem_res = gst_tensor_buffer_get_nth_memory (buffer, i);
+    mapped = gst_memory_map (mem_res, &info_res, GST_MAP_READ);
+    ASSERT_TRUE (mapped);
+    gfloat *output = (gfloat *) info_res.data;
+    EXPECT_EQ (17.f, *output);
+    gst_memory_unmap (mem_res, &info_res);
+    gst_memory_unref (mem_res);
+  }
+}
+
+/**
+ * @brief Positive case: model with 32 input/output tensors.
+ */
+TEST (nnstreamerFilterLiteRT, manyInOutModel)
+{
+  GstElement *gstpipe;
+  GError *err = NULL;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 2));
+
+  /* make 32 "t. ! queue ! mux.sink_## " */
+  gchar *tee_queue_mux = g_strdup ("");
+  for (int i = 0; i < 32; i++) {
+    gchar *aux = g_strdup (tee_queue_mux);
+    g_free (tee_queue_mux);
+    tee_queue_mux = g_strdup_printf ("%s t. ! queue ! mux.sink_%d ", aux, i);
+    g_free (aux);
+  }
+
+  g_autofree gchar *pipeline = g_strdup_printf (
+      "videotestsrc pattern=2 num-buffers=10 is-live=true ! "
+      "videoscale ! videoconvert ! video/x-raw,format=GRAY8,width=1,height=1,framerate=30/1 ! "
+      "tensor_converter ! tensor_transform mode=typecast option=float32 ! tee name=t "
+      "%s"
+      "tensor_mux name=mux ! other/tensors,format=static,num_tensors=32 ! "
+      "tensor_filter framework=litert model=\"%s\" ! tensor_sink name=sinkx",
+      tee_queue_mux, model_file);
+
+  g_free (tee_queue_mux);
+
+  gstpipe = gst_parse_launch (pipeline, &err);
+  ASSERT_TRUE (gstpipe != nullptr);
+
+  GstElement *sink_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sinkx");
+  ASSERT_TRUE (sink_handle != nullptr);
+
+  guint data_received = 0U;
+  g_signal_connect (sink_handle, "new-data", (GCallback) check_output_many, &data_received);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT * 10),
+      0);
+  g_usleep (1000 * 1000 * 5); /* wait for 5 seconds to check all output is valid */
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  EXPECT_EQ (10U, data_received);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (gstpipe);
+}
+
+/**
+ * @brief Positive case: reopen (RELOAD-like flow) with a different model.
+ */
+TEST (nnstreamerFilterLiteRT, reopenDifferentModel)
+{
+  int ret;
+  void *data = NULL;
+  g_autofree gchar *model_file_float = NULL;
+  g_autofree gchar *model_file_quant = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file_float, 1));
+  ASSERT_TRUE (_GetModelFilePath (&model_file_quant, 0));
+
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  const gchar *model_files_float[] = { model_file_float, NULL };
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files_float);
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+  sp->close (&prop, &data);
+
+  const gchar *model_files_quant[] = { model_file_quant, NULL };
+  _SetFilterProp (&prop, "litert", model_files_quant);
+  data = NULL;
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  GstTensorsInfo in_info, out_info;
+  ret = sp->getModelInfo (NULL, &prop, data, GET_IN_OUT_INFO, &in_info, &out_info);
+  EXPECT_EQ (ret, 0);
+  EXPECT_EQ (in_info.info[0].type, _NNS_UINT8);
+
+  sp->close (&prop, &data);
+  gst_tensors_info_free (&in_info);
+  gst_tensors_info_free (&out_info);
+}
+
+/**
+ * @brief Main gtest
+ */
+int
+main (int argc, char **argv)
+{
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
+
+  gst_init (&argc, &argv);
+
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+
+  return result;
+}

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -115,7 +115,9 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
     }
   } else {
     gfloat *output = (gfloat *) info_res.data;
-    gfloat max_value = G_MINFLOAT;
+    /** -G_MAXFLOAT: G_MINFLOAT is the smallest positive normalized value,
+     *  which would break the max search for all-negative outputs */
+    gfloat max_value = -G_MAXFLOAT;
 
     for (idx = 0; idx < (info_res.size / sizeof (gfloat)); ++idx) {
       if (output[idx] > max_value) {


### PR DESCRIPTION
This adds a new tensor_filter subplugin, `framework=litert`, targeting the LiteRT 2.x **CompiledModel C API** — the actively developed successor line of TensorFlow Lite (LiteRT Next, GA since early 2026). It is a separate subplugin from `tensorflow2-lite` (classic Interpreter API); both coexist so users can A/B the two runtimes on the same `.tflite` model, following the `tensorrt`/`tensorrt10` precedent.

Addresses the mid-term plan discussed in #4849. The Yocto CI fixes found while stabilizing this PR are split into #4857.

## Design
- **C API only** (`litert/c/*.h`): the sole runtime dependency is `libLiteRt.so` / `libLiteRt.dylib` (ABI-versioned, `VERS_1.0`). No absl/flatbuffers/cc-SDK build needed.
- **Detection**: pkg-config `litert.pc` first, then `LITERT_ROOT` env var fallback (same pattern as `snpe-support`), plus a compile/link sanity check. `-Dlitert-support=auto|enabled|disabled`. Both detection paths verified.
- **Tensor meta**: element type/name from the model signature; **dimensions from the compiled model's runtime-resolved layouts**, so models declaring dynamic batch (e.g., `[-1,1]`) resolve to concrete shapes — matching classic `AllocateTensors()` semantics.
- **Invoke**: managed tensor buffers created once from compiled-model buffer requirements, reused across invokes with lock/unlock + memcpy (accelerator-agnostic). Zero-copy host wrapping is a follow-up TODO.
- **Properties**: `custom=Accelerators:cpu|gpu|npu` (combinable with `+`), `custom=Signature:<key>`; the standard `accelerator=` property is honored too.

## Build script support
- Ubuntu/Tizen/Yocto: the meson option covers all three (auto-disables silently when the SDK is absent — no packaging changes required at this stage).
- macOS: same meson option; the subplugin builds as `.dylib` and the loader accepts it.
- Android: `NNSTREAMER_FILTER_LITERT_SRCS` added to `jni/nnstreamer.mk` for ndk-build consumers.

## Tests
**gtest** — `tests/nnstreamer_filter_litert/unittest_filter_litert.cc`, 21 cases (positive/negative), coverage exceeding the existing tflite2/onnxruntime suites:
- golden classification results (orange.png → argmax 951) **shared with the tensorflow2-lite unit tests on the same model files**, so any cross-runtime divergence fails at unit test level with a descriptive gtest message
- determinism check (two invokes, identical input → identical output), output-canary overwrite check
- 32-in/32-out model (dynamic batch resolution path), quant + float models, reopen with different model
- negatives: invalid path, garbage flatbuffer, no model, null tensor memories, unknown accelerator, malformed custom property, unknown signature key, wrong pipeline dims/type, unsupported getModelInfo ops

**SSAT** — `tests/nnstreamer_filter_litert/runTest.sh`, 6 cases: golden image-labeling (same model/golden label as the tensorflow2-lite SSAT tests), `Accelerators:cpu`, and negative cases (wrong dims, invalid model, unknown accelerator).

## CI coverage for litert (verified green)
- **Ubuntu x86_64 (meson job)**: installs the LiteRT SDK (headers from `litert_cc_sdk.zip` v2.2.0, `libLiteRt.so` from the official `ai-edge-litert` wheel), then runs the litert gtest suite via `meson test` (21/21 observed), the gtest suite again under Valgrind, and the litert SSAT suite.
- **macOS arm64 (macos job)**: installs the SDK likewise (`libLiteRt.dylib` + Metal GPU accelerator from the macOS wheel; install name pinned to an absolute path since SIP strips `DYLD_LIBRARY_PATH`), verifies the subplugin `.dylib` is built, and runs the litert gtest (21/21 observed) and SSAT suites — the first unit testing ever wired into the macOS job.
- Jobs without the SDK (arm meson, Tizen GBS, Android NDK, RISC-V, pdebuild, Yocto) verify the auto-disable path builds cleanly.

Two pre-existing issues found and fixed on the way, since the macOS enablement depends on them:
- `check-rebuild` computed the rebuild flag with `grep | wc -l`; BSD `wc` pads its output, so every step of the macOS job has been silently skipped (~15s fake-success) since the action was introduced.
- Building with `-Dorcc-support=disabled` (needed on macOS, where the orc test code never compiled) fails under default werror due to an unused parameter in `gsttensor_transform.c`.

Verified on Ubuntu 22.04 x86_64 (WSL2) against LiteRT v2.2.0: full build (werror), 21/21 gtest, 6/6 SSAT, `unittest_common`/`unittest_filter_single` regression check, config sanity with the SDK absent/disabled, and both detection paths (`litert.pc` and `LITERT_ROOT`).

## Follow-ups (out of scope here)
- Zero-copy invoke; `invoke_dynamic` for dynamic shapes
- Accelerator opaque options (GPU precision, NPU compiler/dispatch library paths)
- Android ndk-build module wiring + prepare_litert.sh (AAR extraction); Yocto litert recipe in meta-neural-network
- GPU/NPU accelerator runtime packaging guidance per OS (CI exercises the XNNPACK CPU path; macOS ships the Metal accelerator alongside)

🤖 Generated with [Claude Code](https://claude.com/claude-code)