### PR TITLE
[CI/Yocto] Fix and harden the Yocto job

### DIFF
--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -1,4 +1,4 @@
-name: Build test / Yocto-5.0.3 (scarthgap-5.0.3)
+name: Build test / Yocto-5.0.19 (scarthgap-5.0.19)
 
 on:
   pull_request:
@@ -64,12 +64,20 @@ jobs:
           /var/cache/yocto/downloads
           /var/cache/yocto/sstate-cache
           /var/cache/yocto/persistent
-        key: yocto-cache-yocto-5.0.3
+        key: yocto-cache-yocto-5.0.19
 
     - name: acquire some disk space
-      if: inputs.acquire-space == 'enable'
+      # Also run on pull requests: when the sstate cache is cold (e.g., the
+      # nightly cache refresh failed), a from-scratch build exhausts the
+      # runner disk. The step exits early when there is already enough room.
+      if: inputs.acquire-space == 'enable' || github.event_name == 'pull_request'
       run: |
           df -h
+          avail_gb=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          if [ "${{ inputs.acquire-space }}" != "enable" ] && [ "$avail_gb" -gt 40 ]; then
+            echo "Enough free disk space (${avail_gb}G); skipping cleanup."
+            exit 0
+          fi
           sudo apt-get update --fix-missing \
             && sudo apt-get remove -y '^dotnet-.*' '^llvm-.*' '^mysql-server-core-.*' '^postgresql-.*' '^temurin-.*' \
             azure-cli google-chrome-stable google-cloud-cli firefox powershell microsoft-edge-stable mono-devel \
@@ -92,7 +100,12 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Prepare poky and meta-neural-network"
-        git clone git://git.yoctoproject.org/poky -b yocto-5.0.3 && cd poky
+        # Prefer the official repository; fall back to the GitHub mirror when
+        # git.yoctoproject.org is unreachable (it intermittently drops
+        # connections from GitHub-hosted runners).
+        git clone git://git.yoctoproject.org/poky -b yocto-5.0.19 \
+          || { rm -rf poky; git clone https://github.com/yoctoproject/poky -b yocto-5.0.19; }
+        cd poky
         git clone https://github.com/nnstreamer/meta-neural-network -b scarthgap
         echo 'SRC_URI = "git://${{ github.workspace }}/;protocol=file;usehead=1;nobranch=1"' >> meta-neural-network/recipes-nnstreamer/nnstreamer/nnstreamer_%.bbappend
         source oe-init-build-env
@@ -140,7 +153,7 @@ jobs:
           /var/cache/yocto/downloads
           /var/cache/yocto/sstate-cache
           /var/cache/yocto/persistent
-        key: yocto-cache-yocto-5.0.3
+        key: yocto-cache-yocto-5.0.19
 
     - name: generate badge
       if: contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) && steps.yocto-build.outcome != 'skipped'


### PR DESCRIPTION
The Yocto CI job has been failing for reasons unrelated to the code under test. Three fixes:

1. **Upgrade poky yocto-5.0.3 → yocto-5.0.19 (both scarthgap).** The GitHub runner image's `tar` recently gained a CVE fix that uses the `openat2` syscall, which the old pseudo does not intercept; `do_package` then dies with `tar: ... Cannot mkdir: Bad address` (observed at `linux-libc-headers` after ~1h of build). The pseudo fix is backported in scarthgap point releases — see the [Yocto 5.0.15 release notes](https://docs.yoctoproject.org/migration-guides/release-notes-5.0.15.html). Cache keys follow the new tag.

2. **Fall back to the GitHub poky mirror on clone failure.** `git.yoctoproject.org` intermittently refuses connections from GitHub-hosted runners, failing the job at the very first step. The official repository stays primary; the mirror is used only when the clone fails (verified working on a PR run during the current outage). A partially created directory from a mid-transfer failure is removed before retrying.

3. **Run the acquire-disk-space step on pull requests too**, exiting early when there is already enough free space (observed runners vary between ~20G and ~87G free). A cold sstate cache — e.g., when the nightly cache refresh itself failed on the outage above — makes PR runs build from scratch, so they need the same headroom the manual dispatch path already provides. The warm case only costs a `df` invocation.

These were found while stabilizing CI for #4855; split into an independent PR since they are unrelated to that feature.

Note: the first run of this PR builds from a cold cache (the old cache key no longer matches) and will take longer than usual; the nightly run on main will repopulate the cache under the new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)