### PR TITLE
[CI] Fix check-rebuild on macOS and the orc-disabled werror build

### DIFF
--- a/.github/actions/check-rebuild/action.yml
+++ b/.github/actions/check-rebuild/action.yml
@@ -14,16 +14,11 @@ runs:
         tmpfile=$(mktemp)
         git show --pretty="format:" --name-only --diff-filter=AMRC ${{ github.event.pull_request.head.sha}} -${{ github.event.pull_request.commits }} | sort | uniq | awk NF > ${tmpfile}
         echo "changed_file_list=${tmpfile}" >> "$GITHUB_ENV"
-        # Use grep -c instead of "grep | wc -l": the BSD wc on macOS pads its
-        # output with leading spaces, which made `env.rebuild == '1'` always
-        # false there (macOS jobs silently skipped every build step).
-        # Check the script status separately: a script failure must fail this
-        # step instead of silently producing rebuild=0 and skipping the job.
-        out=$(bash .github/actions/check-rebuild/check_if_rebuild_requires.sh ${tmpfile} ${{ inputs.mode }}) || {
-          echo "::error::check_if_rebuild_requires.sh failed"
-          exit 1
-        }
-        rebuild=$(printf '%s\n' "$out" | grep -c "REBUILD=YES" || true)
+        # get_rebuild_flag.sh prints 0 or 1 and exits nonzero on checker
+        # failure, which fails this "sh -e" step instead of silently
+        # skipping the job. It is also exercised by
+        # test_check_if_rebuild_requires.sh in the Static checks workflow.
+        rebuild=$(bash .github/actions/check-rebuild/get_rebuild_flag.sh ${tmpfile} ${{ inputs.mode }})
         echo "Rebuild required: ${rebuild}"
         echo "rebuild=${rebuild}" >> "$GITHUB_ENV"
       shell: sh

--- a/.github/actions/check-rebuild/action.yml
+++ b/.github/actions/check-rebuild/action.yml
@@ -17,7 +17,13 @@ runs:
         # Use grep -c instead of "grep | wc -l": the BSD wc on macOS pads its
         # output with leading spaces, which made `env.rebuild == '1'` always
         # false there (macOS jobs silently skipped every build step).
-        rebuild=`bash .github/actions/check-rebuild/check_if_rebuild_requires.sh ${tmpfile} ${{ inputs.mode }} | grep -c "REBUILD=YES" || true`
+        # Check the script status separately: a script failure must fail this
+        # step instead of silently producing rebuild=0 and skipping the job.
+        out=$(bash .github/actions/check-rebuild/check_if_rebuild_requires.sh ${tmpfile} ${{ inputs.mode }}) || {
+          echo "::error::check_if_rebuild_requires.sh failed"
+          exit 1
+        }
+        rebuild=$(printf '%s\n' "$out" | grep -c "REBUILD=YES" || true)
         echo "Rebuild required: ${rebuild}"
         echo "rebuild=${rebuild}" >> "$GITHUB_ENV"
       shell: sh

--- a/.github/actions/check-rebuild/action.yml
+++ b/.github/actions/check-rebuild/action.yml
@@ -14,7 +14,10 @@ runs:
         tmpfile=$(mktemp)
         git show --pretty="format:" --name-only --diff-filter=AMRC ${{ github.event.pull_request.head.sha}} -${{ github.event.pull_request.commits }} | sort | uniq | awk NF > ${tmpfile}
         echo "changed_file_list=${tmpfile}" >> "$GITHUB_ENV"
-        rebuild=`bash .github/actions/check-rebuild/check_if_rebuild_requires.sh ${tmpfile} ${{ inputs.mode }} | grep "REBUILD=YES" | wc -l`
+        # Use grep -c instead of "grep | wc -l": the BSD wc on macOS pads its
+        # output with leading spaces, which made `env.rebuild == '1'` always
+        # false there (macOS jobs silently skipped every build step).
+        rebuild=`bash .github/actions/check-rebuild/check_if_rebuild_requires.sh ${tmpfile} ${{ inputs.mode }} | grep -c "REBUILD=YES" || true`
         echo "Rebuild required: ${rebuild}"
         echo "rebuild=${rebuild}" >> "$GITHUB_ENV"
       shell: sh

--- a/.github/actions/check-rebuild/check_if_rebuild_requires.sh
+++ b/.github/actions/check-rebuild/check_if_rebuild_requires.sh
@@ -15,8 +15,8 @@
 #                  android: check if jni rebuild is required
 #                  build (default): check if general meson rebuild is required.
 
-if [ -z $1 ]; then
-  echo "::error The argument (file path) is not given."
+if [ ! -f "$1" ]; then
+  echo "::error The argument (file path) is not given or is not a file."
   exit 1
 fi
 

--- a/.github/actions/check-rebuild/get_rebuild_flag.sh
+++ b/.github/actions/check-rebuild/get_rebuild_flag.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# @file: get_rebuild_flag.sh
+# @brief    Print 1 if the given changed-file list requires a rebuild, else 0.
+# @see      https://github.com/nnstreamer/nnstreamer
+# @author   MyungJoo Ham <myungjoo.ham@samsung.com>
+#
+# Argument 1 ($1): the file containing the list of changed files.
+# Argument 2 ($2): build mode to be checked (see check_if_rebuild_requires.sh).
+#
+# Exits nonzero if the checker fails, so that the calling CI step (run under
+# "sh -e") turns red instead of silently skipping the job.
+# "grep -c" is used instead of "grep | wc -l": the BSD wc on macOS pads its
+# output with leading spaces, which made the `env.rebuild == '1'` step
+# conditions always false there (macOS jobs silently skipped every build step).
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+out=$(bash "${SCRIPT_DIR}/check_if_rebuild_requires.sh" "$1" "$2") || {
+  echo "::error::check_if_rebuild_requires.sh failed" >&2
+  exit 1
+}
+printf '%s\n' "$out" | grep -c "REBUILD=YES" || true

--- a/.github/actions/check-rebuild/test_check_if_rebuild_requires.sh
+++ b/.github/actions/check-rebuild/test_check_if_rebuild_requires.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# @file: test_check_if_rebuild_requires.sh
+# @brief    Self-test for check_if_rebuild_requires.sh and the action.yml step pattern.
+# @see      https://github.com/nnstreamer/nnstreamer
+# @author   MyungJoo Ham <myungjoo.ham@samsung.com>
+#
+# Runs the same "out=$(...) || exit; grep -c ... || true" pattern as
+# .github/actions/check-rebuild/action.yml under "sh -e", which is how GitHub
+# executes composite "shell: sh" steps. This keeps the REBUILD=NO path and the
+# fail-closed error path exercised by CI on every PR.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+CHECKER="${SCRIPT_DIR}/check_if_rebuild_requires.sh"
+failed=0
+
+# run_step <file-list-path> <mode>: emulate the action.yml step under sh -e.
+run_step() {
+  sh -ec '
+    out=$(bash "$1" "$2" "$3") || {
+      echo "::error::check_if_rebuild_requires.sh failed" >&2
+      exit 1
+    }
+    printf "%s\n" "$out" | grep -c "REBUILD=YES" || true
+  ' sh "$CHECKER" "$1" "$2"
+}
+
+# expect_rebuild <expected 0|1> <mode> <changed-file>...
+expect_rebuild() {
+  expected=$1
+  mode=$2
+  shift 2
+  list=$(mktemp)
+  printf '%s\n' "$@" > "$list"
+  if actual=$(run_step "$list" "$mode") && [ "$actual" = "$expected" ]; then
+    echo "PASS: mode=${mode} files=[$*] rebuild=${actual}"
+  else
+    echo "FAIL: mode=${mode} files=[$*] expected=${expected} got=${actual:-<step failed>}"
+    failed=1
+  fi
+  rm -f "$list"
+}
+
+# A source change triggers a rebuild in every mode.
+for mode in build gbs debian android; do
+  expect_rebuild 1 "$mode" "gst/nnstreamer/nnstreamer_plugin_api_impl.c"
+done
+
+# Docs-only changes must skip every mode (this is the REBUILD=NO / "|| true"
+# path that lets docs-only PRs pass all 8 consuming workflows).
+for mode in build gbs debian android; do
+  expect_rebuild 0 "$mode" "README.md" "docs/logo.png"
+done
+
+# Mode-specific arms.
+expect_rebuild 1 gbs "packaging/nnstreamer.spec"
+expect_rebuild 0 build "packaging/nnstreamer.spec"
+expect_rebuild 1 debian "debian/rules"
+expect_rebuild 0 android "debian/rules"
+expect_rebuild 1 android "jni/Android.mk"
+expect_rebuild 0 gbs "jni/Android.mk"
+
+# A checker failure must fail the step instead of silently yielding rebuild=0.
+if run_step "/nonexistent/file-list" build > /dev/null 2>&1; then
+  echo "FAIL: a missing file list must fail the step"
+  failed=1
+else
+  echo "PASS: a missing file list fails the step"
+fi
+
+exit ${failed}

--- a/.github/actions/check-rebuild/test_check_if_rebuild_requires.sh
+++ b/.github/actions/check-rebuild/test_check_if_rebuild_requires.sh
@@ -8,26 +8,21 @@
 # @see      https://github.com/nnstreamer/nnstreamer
 # @author   MyungJoo Ham <myungjoo.ham@samsung.com>
 #
-# Runs the same "out=$(...) || exit; grep -c ... || true" pattern as
-# .github/actions/check-rebuild/action.yml under "sh -e", which is how GitHub
-# executes composite "shell: sh" steps. This keeps the REBUILD=NO path and the
-# fail-closed error path exercised by CI on every PR.
+# Runs get_rebuild_flag.sh -- the same script action.yml invokes -- under
+# "sh -e", which is how GitHub executes composite "shell: sh" steps. This
+# keeps the REBUILD=NO path and the fail-closed error path exercised by CI
+# on every PR.
 
 set -u
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-CHECKER="${SCRIPT_DIR}/check_if_rebuild_requires.sh"
+FLAG_SCRIPT="${SCRIPT_DIR}/get_rebuild_flag.sh"
 failed=0
 
 # run_step <file-list-path> <mode>: emulate the action.yml step under sh -e.
 run_step() {
-  sh -ec '
-    out=$(bash "$1" "$2" "$3") || {
-      echo "::error::check_if_rebuild_requires.sh failed" >&2
-      exit 1
-    }
-    printf "%s\n" "$out" | grep -c "REBUILD=YES" || true
-  ' sh "$CHECKER" "$1" "$2"
+  sh -ec 'rebuild=$(bash "$1" "$2" "$3"); printf "%s\n" "$rebuild"' \
+    sh "$FLAG_SCRIPT" "$1" "$2"
 }
 
 # expect_rebuild <expected 0|1> <mode> <changed-file>...

--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -144,6 +144,9 @@ jobs:
         # Originally from "pr-prebuild-signed-off-by"
         run: |
           bash .github/workflows/static.check.scripts/signed-off-by.sh ${{ github.event.pull_request.commits }}
+      - name: /Checker/ check-rebuild action self-test
+        run: |
+          bash .github/actions/check-rebuild/test_check_if_rebuild_requires.sh
       - name: /Checker/ shellcheck for shell scripts
         # Originally from "pr-prebuild-shellcheck"
         run: |

--- a/.github/workflows/ubuntu_clean_llvm_build.yml
+++ b/.github/workflows/ubuntu_clean_llvm_build.yml
@@ -41,6 +41,11 @@ jobs:
       if: env.rebuild == '1'
     - run: meson test -C build/ -v
       if: env.rebuild == '1'
+    - name: build with orcc-support disabled
+      if: env.rebuild == '1'
+      run: |
+        meson setup build-noorc/ -Dorcc-support=disabled
+        meson compile -C build-noorc/
     - uses: actions/upload-artifact@v4
       if: failure()
       with:

--- a/.github/workflows/ubuntu_clean_llvm_build.yml
+++ b/.github/workflows/ubuntu_clean_llvm_build.yml
@@ -46,8 +46,13 @@ jobs:
       run: |
         meson setup build-noorc/ -Dorcc-support=disabled
         meson compile -C build-noorc/
+      env:
+        CC: clang
+        CXX: clang++
     - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: Meson_LLVM_Testlog
-        path: build/meson-logs/testlog.txt
+        path: |
+          build/meson-logs/testlog.txt
+          build-noorc/meson-logs/meson-log.txt

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -1309,6 +1309,8 @@ gst_tensor_transform_typecast (GstTensorTransform * filter,
     orc_typecast (inptr, outptr, num, in_info->type, out_info->type);
     return GST_FLOW_OK;
   }
+#else
+  UNUSED (filter);
 #endif
 
   in_element_size = gst_tensor_get_element_size (in_info->type);


### PR DESCRIPTION
Self-contained fixes split out of #4855 per its review, so that reactivating the macOS CI job can land and be observed independently of the LiteRT feature (and reverted independently if the job turns out to be unstable):

1. **`.github/actions/check-rebuild`**: the rebuild flag was computed with `grep | wc -l`; BSD `wc` on macOS pads its output with leading spaces, so the padded value never matched the `env.rebuild == '1'` step conditions. **Every step of the macOS job has been silently skipped since the action was introduced** — the job "passed" in ~15 seconds without building anything. `grep -c` prints an unpadded count on all platforms (the check script emits exactly one `REBUILD=YES|NO` line, so the count is always 0 or 1).

2. **`gst/nnstreamer/elements/gsttensor_transform.c`**: in `gst_tensor_transform_typecast()`, the `filter` parameter is used only inside the `HAVE_ORC` block, so building with `-Dorcc-support=disabled` fails under the default werror (`-Werror=unused-parameter`). Mark it `UNUSED` in the non-orc path. This is the configuration that **#4855 will use for the macOS job** (the orc test code in `unittest_plugins.cc` does not compile on macOS — tracked in #4862). Note that the current macOS job builds *with* orc (brew's gstreamer pulls it in), so this fix is exercised by the new non-orc gate below, not by the macOS job on this PR.

3. **Review follow-ups (see the review comments below)**:
   - check-rebuild no longer fails open: an error from `check_if_rebuild_requires.sh` turns the step red instead of silently producing `rebuild=0` and skipping the job, and the script rejects a missing/unreadable file-list argument.
   - The Ubuntu LLVM workflow gains a `-Dorcc-support=disabled` configure-and-compile gate (with clang, like its sibling steps) so the non-orc build path is covered by CI from now on.
   - `test_check_if_rebuild_requires.sh` exercises the checker's YES/NO decision for every mode plus the exact `sh -e` step pattern of `action.yml` (including the `REBUILD=NO`/`|| true` path and the fail-closed error path), and runs in the **Static checks** workflow — which is not gated on the rebuild flag, so these paths are verified by CI on every PR, including this one.

Effect to watch after merge: the macOS job starts doing real builds for the first time, and docs-only PRs must still skip cleanly across all 8 workflows using check-rebuild. The LiteRT-specific macOS steps arrive with #4855, which will rebase on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
