### PR TITLE
[Filter/dali] Fix resource leaks in cleanup()

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_dali.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_dali.cc
@@ -199,17 +199,18 @@ dali_subplugin::~dali_subplugin ()
 void
 dali_subplugin::cleanup ()
 {
-  if (!configured) {
-    return;
-  }
-
   if (_pipeline_handle) {
     daliDeletePipeline (&_pipeline_handle);
     _pipeline_handle = nullptr;
   }
 
+  g_free (_pipeline_path);
+  _pipeline_path = nullptr;
+
   gst_tensors_info_free (&_inputTensorMeta);
   gst_tensors_info_free (&_outputTensorMeta);
+  _nns_input_name = nullptr;
+  _nns_output_name = nullptr;
 
   configured = false;
 }


### PR DESCRIPTION
## What

Fixes resource leaks in `dali_subplugin::cleanup()`:

1. `_pipeline_path` (allocated with `g_strdup()` in `loadPipeline()`) was never freed anywhere, leaking on every close.
2. The `if (!configured) return;` guard skipped all cleanup when `configure_instance()` threw before its last line, where `configured` is set. #4829 (still open; this PR should land after it) makes the framework delete the instance when open fails, so the destructor then runs on such partially-configured instances and must release whatever was acquired — not just `_pipeline_handle` and `_pipeline_path`, but also the two `GstTensorsInfo` metas that `configure_instance()` copies from the filter properties before any of its throw sites.

## How

Drop the guard and free `_pipeline_path`. Every free in `cleanup()` is null-safe on a never-configured instance: members are value-initialized (`{}`), tensor metas are initialized in the constructor, and `_pipeline_handle` is checked before `daliDeletePipeline()`.

`cleanup()` is now fully idempotent, which is what makes dropping the guard safe: `gst_tensors_info_free()` re-initializes the metas, and every raw pointer member — including the `_nns_input_name`/`_nns_output_name` aliases into the tensor metas — is reset to `nullptr`, so no member points at freed memory after `cleanup()` returns.

Identified during the (AI-assisted) review of #4829; the `_pipeline_path` leak is pre-existing and independent of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
