### PR TITLE
[Filter/TensorRT10] Fix resource leak when configuration fails midway

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
@@ -598,13 +598,16 @@ tensorrt10_subplugin::loadModel (const GstTensorFilterProperties *prop)
 
       // Allocate only for input, memory for output is allocated in the invoke method.
       allocBuffer (&tensorrt10_tensor_info.buffer, tensorrt10_tensor_info.buffer_size);
+
+      // Register the buffer before any call that may throw so that
+      // cleanup() can release it on a partial-configuration failure.
+      _tensorrt10_input_tensor_infos.push_back (tensorrt10_tensor_info);
+
       if (!_Context->setInputTensorAddress (
               tensorrt10_tensor_info.name, tensorrt10_tensor_info.buffer)) {
         ml_loge ("Unable to set input tensor address");
         throw std::runtime_error ("Unable to set input tensor address");
       }
-
-      _tensorrt10_input_tensor_infos.push_back (tensorrt10_tensor_info);
 
     } else if (tensorrt10_tensor_info.mode == nvinfer1::TensorIOMode::kOUTPUT) {
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
@@ -206,6 +206,7 @@ tensorrt10_subplugin::cleanup ()
     cudaFree (tensorrt10_tensor_info.buffer);
     tensorrt10_tensor_info.buffer = nullptr;
   }
+  _tensorrt10_input_tensor_infos.clear ();
 
   if (_model_path != nullptr) {
     g_free (_model_path);
@@ -214,6 +215,7 @@ tensorrt10_subplugin::cleanup ()
 
   if (_stream) {
     cudaStreamDestroy (_stream);
+    _stream = nullptr;
   }
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
@@ -179,6 +179,8 @@ const accl_hw tensorrt10_subplugin::hw_list[] = {};
  */
 tensorrt10_subplugin::tensorrt10_subplugin () : tensor_filter_subplugin ()
 {
+  gst_tensors_info_init (std::addressof (_inputTensorMeta));
+  gst_tensors_info_init (std::addressof (_outputTensorMeta));
 }
 
 /**
@@ -189,13 +191,14 @@ tensorrt10_subplugin::~tensorrt10_subplugin ()
   cleanup ();
 }
 
+/**
+ * @brief Release the resources allocated by this instance.
+ * @note Safe to call on a partially configured instance; every resource
+ *       released here is either initialized in the constructor or guarded.
+ */
 void
 tensorrt10_subplugin::cleanup ()
 {
-  if (!_configured) {
-    return;
-  }
-
   gst_tensors_info_free (&_inputTensorMeta);
   gst_tensors_info_free (&_outputTensorMeta);
 

--- a/tests/nnstreamer_filter_tensorrt10/runTest.sh
+++ b/tests/nnstreamer_filter_tensorrt10/runTest.sh
@@ -87,8 +87,8 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
     1 0 0 $PERFORMANCE
 
 # Negative test: unsupported model file extension.
-# configure_instance() throws in loadModel() after partial allocation;
-# the instance must be cleaned up gracefully without crash or leak.
+# configure_instance() throws in loadModel() before the cuda stream and
+# input buffers are allocated; exercises the _model_path cleanup path.
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
     videotestsrc num_buffers=1 ! \
     videoconvert ! \

--- a/tests/nnstreamer_filter_tensorrt10/runTest.sh
+++ b/tests/nnstreamer_filter_tensorrt10/runTest.sh
@@ -86,6 +86,30 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
     multifilesink location=yolov5nu_result_%1d.log" \
     1 0 0 $PERFORMANCE
 
+# Negative test: unsupported model file extension.
+# configure_instance() throws in loadModel() after partial allocation;
+# the instance must be cleaned up gracefully without crash or leak.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+    videotestsrc num_buffers=1 ! \
+    videoconvert ! \
+    video/x-raw,width=224,height=224,format=RGB,framerate=0/1 ! \
+    tensor_converter ! \
+    tensor_filter framework=tensorrt10 model=${PATH_TO_LABEL} ! \
+    fakesink" \
+    2_n 0 1 $PERFORMANCE
+
+# Negative test: invalid custom property.
+# configure_instance() throws before loadModel(); the partially
+# configured instance must be cleaned up gracefully.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+    videotestsrc num_buffers=1 ! \
+    videoconvert ! \
+    video/x-raw,width=224,height=224,format=RGB,framerate=0/1 ! \
+    tensor_converter ! \
+    tensor_filter framework=tensorrt10 model=${PATH_TO_MODEL} custom=InvalidProp:1 ! \
+    fakesink" \
+    3_n 0 1 $PERFORMANCE
+
 # Cleanup
 rm yolov5nu_result_*.log*
 

--- a/tests/nnstreamer_filter_tensorrt10/runTest.sh
+++ b/tests/nnstreamer_filter_tensorrt10/runTest.sh
@@ -86,30 +86,6 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
     multifilesink location=yolov5nu_result_%1d.log" \
     1 0 0 $PERFORMANCE
 
-# Negative test: unsupported model file extension.
-# configure_instance() throws in loadModel() before the cuda stream and
-# input buffers are allocated; exercises the _model_path cleanup path.
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
-    videotestsrc num_buffers=1 ! \
-    videoconvert ! \
-    video/x-raw,width=224,height=224,format=RGB,framerate=0/1 ! \
-    tensor_converter ! \
-    tensor_filter framework=tensorrt10 model=${PATH_TO_LABEL} ! \
-    fakesink" \
-    2_n 0 1 $PERFORMANCE
-
-# Negative test: invalid custom property.
-# configure_instance() throws before loadModel(); the partially
-# configured instance must be cleaned up gracefully.
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
-    videotestsrc num_buffers=1 ! \
-    videoconvert ! \
-    video/x-raw,width=224,height=224,format=RGB,framerate=0/1 ! \
-    tensor_converter ! \
-    tensor_filter framework=tensorrt10 model=${PATH_TO_MODEL} custom=InvalidProp:1 ! \
-    fakesink" \
-    3_n 0 1 $PERFORMANCE
-
 # Cleanup
 rm yolov5nu_result_*.log*
 
@@ -132,5 +108,29 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
     queue ! \
     fakesink dump=true sync=false" \
     2 0 0 $PERFORMANCE
+
+# Negative test: unsupported model file extension.
+# configure_instance() throws in loadModel() before the cuda stream and
+# input buffers are allocated; exercises the _model_path cleanup path.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+    videotestsrc num_buffers=1 ! \
+    videoconvert ! \
+    video/x-raw,width=224,height=224,format=RGB,framerate=0/1 ! \
+    tensor_converter ! \
+    tensor_filter framework=tensorrt10 model=${PATH_TO_LABEL} ! \
+    fakesink" \
+    3_n 0 1 $PERFORMANCE
+
+# Negative test: invalid custom property.
+# configure_instance() throws before loadModel(); the partially
+# configured instance must be cleaned up gracefully.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+    videotestsrc num_buffers=1 ! \
+    videoconvert ! \
+    video/x-raw,width=224,height=224,format=RGB,framerate=0/1 ! \
+    tensor_converter ! \
+    tensor_filter framework=tensorrt10 model=${PATH_TO_MODEL} custom=InvalidProp:1 ! \
+    fakesink" \
+    4_n 0 1 $PERFORMANCE
 
 report


### PR DESCRIPTION
## What this fixes

`tensorrt10_subplugin::cleanup()` returned early when `_configured` was false, but `_configured` is only set at the very end of `configure_instance()`. If `loadModel()` throws after partial allocation, the destructor runs `cleanup()` on an unconfigured instance and leaks:

- `_model_path` (`g_strdup`'ed before `loadModel()` is called)
- the CUDA stream created by `cudaStreamCreate()`
- the input device buffers allocated by `allocBuffer()` (`cudaMallocManaged`)

## Changes

1. Initialize `_inputTensorMeta` / `_outputTensorMeta` with `gst_tensors_info_init()` in the constructor. Previously they stayed uninitialized until `convertTensorsInfo()` ran at the end of `loadModel()`, so unconditionally calling `gst_tensors_info_free()` on a partially configured instance would have read uninitialized memory.
2. Remove the early return in `cleanup()` so all resources are freed unconditionally. This is safe: `cudaFree(NULL)` and `g_free(NULL)` are no-ops, and `_stream` already has an `if` guard.

## Relation to #4829

This fix only takes full effect together with #4829, which makes `cpp_open()` delete the subplugin instance when `configure_instance()` throws. Without that, the leaked instance's destructor never runs at all; with it but without this change, the destructor runs and `cleanup()` still skips freeing. The two are complementary and independent to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Relation to #4861 (merge order)

#4861 fixes the SSAT lib gate in `tests/nnstreamer_filter_tensorrt10/runTest.sh` (the current `grep tensorrt.so` does not match `libnnstreamer_filter_tensorrt10.so`, so the script silently skips on tensorrt10-only builds) and adds a regression case at the end of the same file. The tests added here depend on that gate fix to actually run, and both PRs touch the same hunk range.

**Update: #4861 has been merged and this PR is now rebased on top of it** (gate fix inherited; the negative tests are reordered after the #4850 regression case and renumbered to 3_n/4_n).

