### PR TITLE
[Test/tensorrt10] Fix SSAT lib gate and add issue #4850 regression case

### DIFF
--- a/tests/nnstreamer_filter_tensorrt10/runTest.sh
+++ b/tests/nnstreamer_filter_tensorrt10/runTest.sh
@@ -25,9 +25,9 @@ PATH_TO_PLUGIN="../../build"
 if [[ -d $PATH_TO_PLUGIN ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
     if [[ -d ${ini_path} ]]; then
-        check=$(ls ${ini_path} | grep tensorrt.so)
+        check=$(ls ${ini_path} | grep tensorrt10.so)
         if [[ ! $check ]]; then
-            echo "Cannot find TensorRT shared lib"
+            echo "Cannot find TensorRT10 shared lib"
             report
             exit
         fi
@@ -48,9 +48,9 @@ else
         fi
 
         if [[ -d ${value} ]]; then
-            check=$(ls ${value} | grep tensorrt.so)
+            check=$(ls ${value} | grep tensorrt10.so)
             if [[ ! $check ]]; then
-                echo "Cannot find TensorRT lib"
+                echo "Cannot find TensorRT10 lib"
                 report
                 exit
             fi
@@ -88,5 +88,25 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
 
 # Cleanup
 rm yolov5nu_result_*.log*
+
+## @brief Regression test for issue #4850: reading tensor_filter outputs across a
+##        queue boundary (fakesink dump=true maps and reads the buffer contents in
+##        the sink thread while the filter runs the next inference) segfaulted when
+##        the subplugin handed CUDA managed memory downstream. Multiple buffers are
+##        required to overlap downstream CPU reads with an active GPU inference.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+    filesrc location=${PATH_TO_IMAGE} ! \
+    pngdec ! \
+    videoscale ! \
+    imagefreeze num-buffers=8 ! \
+    videoconvert ! \
+    video/x-raw,width=224,height=224,format=RGB,framerate=30/1 ! \
+    tensor_converter ! \
+    tensor_transform mode=transpose option=1:2:0:3 ! \
+    tensor_transform mode=arithmetic option=typecast:float32,div:255 ! \
+    tensor_filter framework=tensorrt10 model=${PATH_TO_MODEL} ! \
+    queue ! \
+    fakesink dump=true sync=false" \
+    2 0 0 $PERFORMANCE
 
 report

--- a/tests/nnstreamer_filter_tensorrt10/runTest.sh
+++ b/tests/nnstreamer_filter_tensorrt10/runTest.sh
@@ -50,7 +50,7 @@ else
         if [[ -d ${value} ]]; then
             check=$(ls ${value} | grep tensorrt10.so)
             if [[ ! $check ]]; then
-                echo "Cannot find TensorRT10 lib"
+                echo "Cannot find TensorRT10 shared lib"
                 report
                 exit
             fi


### PR DESCRIPTION
## What this does

**1. Fix the SSAT library gate.**
`tests/nnstreamer_filter_tensorrt10/runTest.sh` gated test execution on `grep tensorrt.so`, which matches the old TensorRT subplugin (`libnnstreamer_filter_tensorrt.so`) but never matches `libnnstreamer_filter_tensorrt10.so` (as a regex, `tensorrt.so` requires exactly one character between `tensorrt` and `so`). As a result the tensorrt10 SSAT suite was keyed to the wrong library. Both branches of the check — the build-dir branch and the `/etc/nnstreamer.ini` branch — now gate on `tensorrt10.so`.

**2. Add a regression SSAT case for #4850.**
New case runs the tensorrt10 filter with its outputs consumed across a `queue` by `fakesink dump=true`:

```
... tensor_filter framework=tensorrt10 model=yolov5nu_224.onnx ! queue ! fakesink dump=true sync=false
```

`fakesink dump=true` maps and reads the buffer contents in the sink thread while the filter is already running the next inference — the exact pattern reported in #4850 that segfaulted when the subplugin handed CUDA managed memory downstream (invalid CPU access on systems without `concurrentManagedAccess`: Windows, WSL2, pre-Pascal GPUs). `imagefreeze num-buffers=8` produces multiple buffers so downstream CPU reads overlap an active GPU inference; a single buffer would not exercise the race.

## Notes

- The regression case is expected to pass together with the fix in #4854 (on affected systems it reproduces the segfault without that fix).
- Related: #4850, #4854

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Merge order

This PR must be merged **after** #4854 (the actual fix for #4850). On machines that build TensorRT 10 support, the new regression case reproduces the #4850 segfault until #4854 lands. Shared CI does not build tensorrt10 (`tensorrt_support 0` in the spec; no tensorrt lane in GitHub Actions), so CI is unaffected either way.
