### PR TITLE
[CI] Build and test the llamacpp tensor-filter in GitHub Actions

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -50,7 +50,6 @@ jobs:
         sudo cp llama-prebuilt/build/bin/*.so /usr/local/lib/
         sudo cp llama-prebuilt/llama.cpp-${LLAMA_VERSION}/include/*.h /usr/local/include/
         sudo cp llama-prebuilt/llama.cpp-${LLAMA_VERSION}/ggml/include/*.h /usr/local/include/
-        sudo ln -sf /usr/local/lib/libggml-cpu-x64.so /usr/local/lib/libggml-cpu.so
 
         mkdir -p ~/llama-backends
         cp llama-prebuilt/build/bin/libggml-*.so ~/llama-backends/

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -32,11 +32,61 @@ jobs:
         sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update && sudo apt-get install -y ssat libpaho-mqtt-dev
         sudo apt-get install -y valgrind gstreamer1.0-tools gstreamer1.0-plugins-good gstreamer1.0-plugins-base libgtest-dev libpng-dev libc6-dbg binutils-x86-64-linux-gnu-dbg valgrind-dbg
         pip install meson ninja
+    - name: install llama.cpp for the llamacpp tensor-filter
+      if: env.rebuild == '1' && matrix.os == 'ubuntu-22.04'
+      run: |
+        # Install a pinned prebuilt llama.cpp release (x64 only) so that the
+        # llamacpp tensor-filter and its unit tests are built and run here.
+        # llama.cpp does not ship a dev package or pkg-config file, and ggml
+        # searches dynamic backends relative to the executable rather than
+        # FHS paths (ggml-org/ggml#1120); hence the hand-written llama.pc
+        # here and the backend copy into build/tests/ after the build.
+        LLAMA_VERSION="b6569"
+        curl -fsSL -o llama-bin.zip "https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_VERSION}/llama-${LLAMA_VERSION}-bin-ubuntu-x64.zip"
+        curl -fsSL -o llama-src.zip "https://github.com/ggml-org/llama.cpp/archive/refs/tags/${LLAMA_VERSION}.zip"
+        unzip -q llama-bin.zip -d llama-prebuilt
+        unzip -q llama-src.zip -d llama-prebuilt
+
+        sudo cp llama-prebuilt/build/bin/*.so /usr/local/lib/
+        sudo cp llama-prebuilt/llama.cpp-${LLAMA_VERSION}/include/*.h /usr/local/include/
+        sudo cp llama-prebuilt/llama.cpp-${LLAMA_VERSION}/ggml/include/*.h /usr/local/include/
+        sudo ln -sf /usr/local/lib/libggml-cpu-x64.so /usr/local/lib/libggml-cpu.so
+
+        mkdir -p ~/llama-backends
+        cp llama-prebuilt/build/bin/libggml-*.so ~/llama-backends/
+
+        sudo mkdir -p /usr/local/lib/pkgconfig
+        cat << 'EOF' | sudo tee /usr/local/lib/pkgconfig/llama.pc
+        prefix=/usr/local
+        exec_prefix=${prefix}
+        libdir=${prefix}/lib
+        includedir=${prefix}/include
+
+        Name: llama
+        Description: C/C++ inference of LLaMA-family models
+        Version: 0.0.6569
+        Libs: -L${libdir} -lggml -lggml-base -lllama
+        Cflags: -I${includedir}
+        EOF
+        sudo ldconfig
+        rm -rf llama-bin.zip llama-src.zip llama-prebuilt/
+
+        mkdir -p tests/test_models/models
+        curl -fsSL -o tests/test_models/models/TinyStories-656K-Q2_K.gguf \
+          "https://huggingface.co/tensorblock/TinyStories-656K-GGUF/resolve/main/TinyStories-656K-Q2_K.gguf"
+        echo "5a798ebc1cad921e0ce639b2f10c4bcce492654a79d4b4ca52bd0268416f6b87  tests/test_models/models/TinyStories-656K-Q2_K.gguf" | sha256sum -c
     - name: build and unit test
       if: env.rebuild == '1'
       run: |
         meson setup build/
         meson compile -C build/
+
+        if [ '${{ matrix.os }}' == 'ubuntu-22.04' ]; then
+          # Fail loudly if meson stopped detecting llama.cpp; otherwise the
+          # llamacpp tests would silently vanish from this job.
+          test -f build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_llamacpp.so
+          cp ~/llama-backends/libggml-*.so build/tests/
+        fi
 
         sudo mkdir -m 777 /cores
         sudo bash -c 'echo "/cores/coredump" > /proc/sys/kernel/core_pattern'

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -44,6 +44,10 @@ jobs:
         LLAMA_VERSION="b6569"
         curl -fsSL -o llama-bin.zip "https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_VERSION}/llama-${LLAMA_VERSION}-bin-ubuntu-x64.zip"
         curl -fsSL -o llama-src.zip "https://github.com/ggml-org/llama.cpp/archive/refs/tags/${LLAMA_VERSION}.zip"
+        echo "52cc91b7b0a0d8e40bc79f7049a0b03c9055ac90ddcdf9f1f7307c5f3939634e  llama-bin.zip" | sha256sum -c
+        # Auto-generated source archive: its checksum is stable in practice but
+        # not permanently guaranteed by GitHub; update the hash if it changes.
+        echo "25c8a7c5f5f8411659ccfa7c24caacc5f7d7a36ea758d120e2429a888612d447  llama-src.zip" | sha256sum -c
         unzip -q llama-bin.zip -d llama-prebuilt
         unzip -q llama-src.zip -d llama-prebuilt
 
@@ -63,10 +67,11 @@ jobs:
 
         Name: llama
         Description: C/C++ inference of LLaMA-family models
-        Version: 0.0.6569
+        Version: 0.0.0
         Libs: -L${libdir} -lggml -lggml-base -lllama
         Cflags: -I${includedir}
         EOF
+        sudo sed -i "s/^Version: .*/Version: 0.0.${LLAMA_VERSION#b}/" /usr/local/lib/pkgconfig/llama.pc
         sudo ldconfig
         rm -rf llama-bin.zip llama-src.zip llama-prebuilt/
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_llamacpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_llamacpp.cc
@@ -298,6 +298,10 @@ TensorFilterLlamaCpp::configure_instance (const GstTensorFilterProperties *prop)
     throw std::runtime_error ("Failed to create llama context");
   }
 
+  /* n_ctx 0 means the model default; sync it for the trimming guard in generateTokens() */
+  if (n_ctx == 0)
+    n_ctx = (int) llama_n_ctx (ctx);
+
   if (!load_ctx_path.empty ()) {
     if (std::filesystem::exists (load_ctx_path)) {
       if (!loadContextFromFile (load_ctx_path)) {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -418,7 +418,7 @@ if gtest_dep.found()
       install_dir: unittest_install_dir
     )
 
-    test('unittest_filter_llamacpp', unittest_filter_llamacpp, env: testenv)
+    test('unittest_filter_llamacpp', unittest_filter_llamacpp, timeout: 60, env: testenv)
   endif
 
   # Run unittest_trainer

--- a/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
+++ b/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
@@ -213,6 +213,30 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
     ret = gst_app_src_push_buffer (GST_APP_SRC (appsrc), buffer);
     return (ret == GST_FLOW_OK);
   }
+
+  /**
+   * @brief Wait until the appsink has received the expected number of samples.
+   *        After the count is reached, a short grace period lets unexpected
+   *        extra samples arrive so that exact-count assertions can catch them.
+   * @param expected Number of samples to wait for.
+   * @param timeout_ms Maximum wait time in milliseconds.
+   * @return TRUE if the expected count was reached before the timeout.
+   */
+  gboolean wait_for_samples (guint expected, guint timeout_ms = 10000U)
+  {
+    guint waited_ms = 0;
+
+    while (*new_sample_count < expected && waited_ms < timeout_ms) {
+      g_usleep (10000);
+      waited_ms += 10;
+    }
+
+    if (*new_sample_count < expected)
+      return FALSE;
+
+    g_usleep (100000);
+    return TRUE;
+  }
 };
 
 /**
@@ -232,7 +256,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, singleInputMultipleOutputsAsync_p)
   ASSERT_TRUE (create_pipeline (model, TRUE, "num_predict:10"));
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (11));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_GT (*new_sample_count, 10);
@@ -248,7 +272,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, singleInputSingleOutputSync_p)
   ASSERT_TRUE (create_pipeline (model, FALSE, "num_predict:10"));
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (1));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1);
@@ -265,7 +289,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, multipleInputsMultipleOutputsAsync_p)
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_TRUE (data_push ("What is AI?"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (1500000);
+  EXPECT_TRUE (wait_for_samples (16));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_GT (*new_sample_count, 15);
@@ -282,7 +306,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, multipleInputsSingleOutputSync_p)
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_TRUE (data_push ("What is AI?"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (1000000);
+  EXPECT_TRUE (wait_for_samples (2));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 2);
@@ -352,7 +376,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, singleInputCombinedSampling_p)
   ASSERT_TRUE (create_pipeline (model, TRUE, "num_predict:30,top_k:50,top_p:0.9,temperature:0.7"));
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (11));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_GT (*new_sample_count, 10);
@@ -369,7 +393,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, singleInputAllSamplingOptions_p)
       "num_predict:30,top_k:40,top_p:0.9,typical_p:0.9,temperature:0.7"));
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (11));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_GT (*new_sample_count, 10);
@@ -385,7 +409,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, singleInputTypicalPTempSampling_p)
   ASSERT_TRUE (create_pipeline (model, TRUE, "num_predict:30,typical_p:0.9,temperature:0.7"));
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (11));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_GT (*new_sample_count, 10);
@@ -401,7 +425,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, invalidTopKValue_n)
   ASSERT_TRUE (create_pipeline (model, TRUE, "num_predict:10,top_k:0"));
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (11));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_GT (*new_sample_count, 10);
@@ -417,7 +441,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, invalidTopPValue_n)
   ASSERT_TRUE (create_pipeline (model, TRUE, "num_predict:10,top_p:1.0"));
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (11));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_GT (*new_sample_count, 10);
@@ -433,7 +457,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, invalidTypicalPValue_n)
   ASSERT_TRUE (create_pipeline (model, TRUE, "num_predict:10,typical_p:1.0"));
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (11));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_GT (*new_sample_count, 10);
@@ -449,7 +473,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, invalidTemperatureValue_n)
   ASSERT_TRUE (create_pipeline (model, TRUE, "num_predict:10,temperature:-1.0"));
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (11));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_GT (*new_sample_count, 10);
@@ -465,7 +489,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, combinedSamplingSync_p)
   ASSERT_TRUE (create_pipeline (model, FALSE, "num_predict:30,top_k:20,top_p:0.7,temperature:0.7"));
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (1));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1);
@@ -482,7 +506,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, contextContinuationInConversation_p)
   EXPECT_TRUE (data_push ("Hello my name is John. I like programming and AI."));
   EXPECT_TRUE (data_push ("What did I just say about myself?"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (2));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 2);
@@ -503,7 +527,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, cacheTrimmingTrigger_p)
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_TRUE (data_push ("What is AI?"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (1000000);
+  EXPECT_TRUE (wait_for_samples (11));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_GT (*new_sample_count, 10);
@@ -547,7 +571,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, contextSaveLoad_p)
 
   EXPECT_TRUE (data_push ("Hello my name is John. I like programming and AI."));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (1));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1);
 
@@ -564,7 +588,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, contextSaveLoad_p)
 
   EXPECT_TRUE (data_push ("What did I just say about myself?"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (1));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1);
 
@@ -594,7 +618,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, contextFileNotFound_n)
   /* Should work normally with fresh context */
   EXPECT_TRUE (data_push ("Hello my name is John."));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (1));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1); /* Should work with fresh context */
 }
@@ -616,7 +640,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, contextInvalidSavePath_n)
   /* Should work normally even if save fails */
   EXPECT_TRUE (data_push ("Hello my name is John."));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
+  EXPECT_TRUE (wait_for_samples (1));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1); /* Should work even if save fails */
 
@@ -638,7 +662,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, applyLoraAdapter_p)
 
   EXPECT_TRUE (data_push ("Can you translate 'Hello world' into Korean?"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (1000000); /* Wait for inference to complete */
+  EXPECT_TRUE (wait_for_samples (1));
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1); /* In sync mode, expect one sample for the entire output */


### PR DESCRIPTION
## What

Make the llamacpp tensor-filter actually built and tested in CI, and fix the two defects this new coverage immediately exposed.

Currently no GitHub Action installs llama.cpp, so meson silently disables the filter and `unittest_filter_llamacpp` never runs — while llama.cpp related changes (properties, LoRA loading, context save/load) keep landing on main without any CI coverage.

## Commits

1. **[CI] Build and test the llamacpp tensor-filter in GitHub Actions** — install a pinned prebuilt llama.cpp release (**b6569**) into `/usr/local` in the ubuntu-22.04 x64 job: hand-written `llama.pc` (llama.cpp ships no dev package; meson needs `dependency('llama')`), ggml backends copied next to test binaries (ggml searches backends relative to the executable, ggml-org/ggml#1120), TinyStories-656K model (~540 KiB) downloaded with sha256 verification, and a post-build assertion that `libnnstreamer_filter_llamacpp.so` exists so silently broken detection fails loudly. The arm job is untouched (no arm64 Linux prebuilts).
2. **[Filter/llama.cpp] Sync n_ctx with the actual context size** — with no `context_length` given, the member `n_ctx` stayed 0 while llama.cpp used the model default; the KV-cache trimming guard then fired on *every* invoke and wiped the whole cache (`n_keep = 0`), breaking context continuity and failing `multipleInputsSingleOutputSync_p` in the first CI run of this PR.
3. **[Test/llama.cpp] Poll for samples instead of fixed sleeps** — every count assertion relied on a hard-coded `g_usleep` after PLAYING; replaced with a bounded polling helper (plus a short grace period so exact-count assertions still catch extra samples). Removes the CI-runner timing flakiness and shortens the happy path.
4. **[CI] Drop unused libggml-cpu symlink** — review feedback; the prebuilt is a `GGML_BACKEND_DL` build, the generic-name symlink is never referenced.

## Relationship to #4775

Supersedes #4775 (author unresponsive since 2025-12; the PR is in conflict with main). Its test-code and filter-code changes already landed on main separately (e1265fa8, 2c625a01, 7b5726ff); this PR re-scopes the remaining CI portion onto current main. Deltas from the original: extraction into a separate directory instead of clobbering `build/`, `curl -f`, sha256 model verification, the build assertion, adjustment to the current `[ubuntu-22.04, ubuntu-22.04-arm]` matrix — plus the two fixes above that the new coverage surfaced.

**When this PR is merged, #4775 should be closed** (GitHub does not auto-close superseded PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)