### PR TITLE
[Test] fix float max-search init in filter unit tests

### DIFF
--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -97,6 +97,18 @@ fill_tensors_config_for_test (GstTensorsConfig *conf1, GstTensorsConfig *conf2)
 }
 
 /**
+ * @brief Test argmax_float with all-negative values (e.g. raw logits)
+ */
+TEST (commonUtil, argmaxFloatAllNegative)
+{
+  const gfloat values[] = { -3.0f, -1.5f, -0.25f, -2.0f };
+
+  EXPECT_EQ (argmax_float (values, 4), 2U);
+  EXPECT_EQ (argmax_float (values, 2), 1U);
+  EXPECT_EQ (argmax_float (values, 0), 0U);
+}
+
+/**
  * @brief Test for int32 type string.
  */
 TEST (commonGetTensorType, failure_n)

--- a/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
+++ b/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
@@ -484,6 +484,18 @@ get_argmax (T *array, size_t size)
 }
 
 /**
+ * @brief Test get_argmax with all-negative values (e.g. raw logits)
+ */
+TEST (nnstreamerFilterArmnn, argmaxAllNegative)
+{
+  float values[] = { -3.0f, -1.5f, -0.25f, -2.0f };
+
+  EXPECT_EQ (get_argmax<float> (values, 4), 2U);
+  EXPECT_EQ (get_argmax<float> (values, 2), 1U);
+  EXPECT_EQ (get_argmax<float> (values, 0), 0U);
+}
+
+/**
  * @brief Test armnn subplugin with successful invoke for tflite advanced model
  */
 TEST (nnstreamerFilterArmnn, invokeAdvanced)

--- a/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
+++ b/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
@@ -467,8 +467,13 @@ size_t
 get_argmax (T *array, size_t size)
 {
   size_t idx, max_idx = 0;
-  T max_value = 0;
-  for (idx = 0; idx < size; idx++) {
+  T max_value;
+
+  if (size == 0)
+    return 0;
+
+  max_value = array[0];
+  for (idx = 1; idx < size; idx++) {
     if (max_value < array[idx]) {
       max_idx = idx;
       max_value = array[idx];

--- a/tests/nnstreamer_filter_onnxruntime/unittest_filter_onnxruntime.cc
+++ b/tests/nnstreamer_filter_onnxruntime/unittest_filter_onnxruntime.cc
@@ -86,25 +86,6 @@ _SetFilterProp (GstTensorFilterProperties *prop, const gchar *name, const gchar 
 }
 
 /**
- * @brief internal function to find the index of the maximum float value
- */
-static guint
-_argmax_float (const gfloat *values, guint num)
-{
-  guint idx, max_idx = 0U;
-  gfloat max_value = -G_MAXFLOAT;
-
-  for (idx = 0; idx < num; ++idx) {
-    if (values[idx] > max_value) {
-      max_value = values[idx];
-      max_idx = idx;
-    }
-  }
-
-  return max_idx;
-}
-
-/**
  * @brief Signal to validate the result in tensor_sink
  */
 static void
@@ -135,7 +116,7 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
   } else if (is_float == 1) {
     gfloat *output = (gfloat *) info_res.data;
 
-    max_idx = _argmax_float (output, info_res.size / sizeof (gfloat));
+    max_idx = argmax_float (output, info_res.size / sizeof (gfloat));
   }
 
   gst_memory_unmap (mem_res, &info_res);
@@ -145,14 +126,15 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 }
 
 /**
- * @brief Test _argmax_float with all-negative values (e.g. raw logits)
+ * @brief Test argmax_float with all-negative values (e.g. raw logits)
  */
 TEST (nnstreamerFilterOnnxRuntime, argmaxFloatAllNegative)
 {
   const gfloat values[] = { -3.0f, -1.5f, -0.25f, -2.0f };
 
-  EXPECT_EQ (_argmax_float (values, 4), 2U);
-  EXPECT_EQ (_argmax_float (values, 2), 1U);
+  EXPECT_EQ (argmax_float (values, 4), 2U);
+  EXPECT_EQ (argmax_float (values, 2), 1U);
+  EXPECT_EQ (argmax_float (values, 0), 0U);
 }
 
 /**

--- a/tests/nnstreamer_filter_onnxruntime/unittest_filter_onnxruntime.cc
+++ b/tests/nnstreamer_filter_onnxruntime/unittest_filter_onnxruntime.cc
@@ -86,6 +86,25 @@ _SetFilterProp (GstTensorFilterProperties *prop, const gchar *name, const gchar 
 }
 
 /**
+ * @brief internal function to find the index of the maximum float value
+ */
+static guint
+_argmax_float (const gfloat *values, guint num)
+{
+  guint idx, max_idx = 0U;
+  gfloat max_value = -G_MAXFLOAT;
+
+  for (idx = 0; idx < num; ++idx) {
+    if (values[idx] > max_value) {
+      max_value = values[idx];
+      max_idx = idx;
+    }
+  }
+
+  return max_idx;
+}
+
+/**
  * @brief Signal to validate the result in tensor_sink
  */
 static void
@@ -115,20 +134,25 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
     }
   } else if (is_float == 1) {
     gfloat *output = (gfloat *) info_res.data;
-    gfloat max_value = G_MINFLOAT;
 
-    for (idx = 0; idx < (info_res.size / sizeof (gfloat)); ++idx) {
-      if (output[idx] > max_value) {
-        max_value = output[idx];
-        max_idx = idx;
-      }
-    }
+    max_idx = _argmax_float (output, info_res.size / sizeof (gfloat));
   }
 
   gst_memory_unmap (mem_res, &info_res);
   gst_memory_unref (mem_res);
 
   EXPECT_EQ (max_idx, 951U);
+}
+
+/**
+ * @brief Test _argmax_float with all-negative values (e.g. raw logits)
+ */
+TEST (nnstreamerFilterOnnxRuntime, argmaxFloatAllNegative)
+{
+  const gfloat values[] = { -3.0f, -1.5f, -0.25f, -2.0f };
+
+  EXPECT_EQ (_argmax_float (values, 4), 2U);
+  EXPECT_EQ (_argmax_float (values, 2), 1U);
 }
 
 /**

--- a/tests/nnstreamer_filter_onnxruntime/unittest_filter_onnxruntime.cc
+++ b/tests/nnstreamer_filter_onnxruntime/unittest_filter_onnxruntime.cc
@@ -101,7 +101,7 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
   ASSERT_TRUE (mapped);
 
   gint is_float = (gint) * ((guint8 *) user_data);
-  guint idx, max_idx = 0U;
+  gsize idx, max_idx = 0U;
 
   if (is_float == 0) {
     guint8 *output = (guint8 *) info_res.data;
@@ -123,18 +123,6 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
   gst_memory_unref (mem_res);
 
   EXPECT_EQ (max_idx, 951U);
-}
-
-/**
- * @brief Test argmax_float with all-negative values (e.g. raw logits)
- */
-TEST (nnstreamerFilterOnnxRuntime, argmaxFloatAllNegative)
-{
-  const gfloat values[] = { -3.0f, -1.5f, -0.25f, -2.0f };
-
-  EXPECT_EQ (argmax_float (values, 4), 2U);
-  EXPECT_EQ (argmax_float (values, 2), 1U);
-  EXPECT_EQ (argmax_float (values, 0), 0U);
 }
 
 /**

--- a/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
+++ b/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
@@ -84,7 +84,7 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
   ASSERT_TRUE (mapped);
 
   gint is_float = (gint) * ((guint8 *) user_data);
-  guint idx, max_idx = 0U;
+  gsize idx, max_idx = 0U;
 
   if (is_float == 0) {
     guint8 *output = (guint8 *) info_res.data;
@@ -108,18 +108,6 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 
   gst_memory_unmap (mem_res, &info_res);
   gst_memory_unref (mem_res);
-}
-
-/**
- * @brief Test argmax_float with all-negative values (e.g. raw logits)
- */
-TEST (nnstreamerFilterTensorFlow2Lite, argmaxFloatAllNegative)
-{
-  const gfloat values[] = { -3.0f, -1.5f, -0.25f, -2.0f };
-
-  EXPECT_EQ (argmax_float (values, 4), 2U);
-  EXPECT_EQ (argmax_float (values, 2), 1U);
-  EXPECT_EQ (argmax_float (values, 0), 0U);
 }
 
 /**

--- a/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
+++ b/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
@@ -69,25 +69,6 @@ _GetOrangePngFilePath (gchar **input_file)
 }
 
 /**
- * @brief internal function to find the index of the maximum float value
- */
-static guint
-_argmax_float (const gfloat *values, guint num)
-{
-  guint idx, max_idx = 0U;
-  gfloat max_value = -G_MAXFLOAT;
-
-  for (idx = 0; idx < num; ++idx) {
-    if (values[idx] > max_value) {
-      max_value = values[idx];
-      max_idx = idx;
-    }
-  }
-
-  return max_idx;
-}
-
-/**
  * @brief Signal to validate the result in tensor_sink
  */
 static void
@@ -118,7 +99,7 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
   } else if (is_float == 1) {
     gfloat *output = (gfloat *) info_res.data;
 
-    max_idx = _argmax_float (output, info_res.size / sizeof (gfloat));
+    max_idx = argmax_float (output, info_res.size / sizeof (gfloat));
   } else {
     ASSERT_TRUE (1 == 0);
   }
@@ -130,14 +111,15 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 }
 
 /**
- * @brief Test _argmax_float with all-negative values (e.g. raw logits)
+ * @brief Test argmax_float with all-negative values (e.g. raw logits)
  */
 TEST (nnstreamerFilterTensorFlow2Lite, argmaxFloatAllNegative)
 {
   const gfloat values[] = { -3.0f, -1.5f, -0.25f, -2.0f };
 
-  EXPECT_EQ (_argmax_float (values, 4), 2U);
-  EXPECT_EQ (_argmax_float (values, 2), 1U);
+  EXPECT_EQ (argmax_float (values, 4), 2U);
+  EXPECT_EQ (argmax_float (values, 2), 1U);
+  EXPECT_EQ (argmax_float (values, 0), 0U);
 }
 
 /**

--- a/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
+++ b/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
@@ -69,6 +69,25 @@ _GetOrangePngFilePath (gchar **input_file)
 }
 
 /**
+ * @brief internal function to find the index of the maximum float value
+ */
+static guint
+_argmax_float (const gfloat *values, guint num)
+{
+  guint idx, max_idx = 0U;
+  gfloat max_value = -G_MAXFLOAT;
+
+  for (idx = 0; idx < num; ++idx) {
+    if (values[idx] > max_value) {
+      max_value = values[idx];
+      max_idx = idx;
+    }
+  }
+
+  return max_idx;
+}
+
+/**
  * @brief Signal to validate the result in tensor_sink
  */
 static void
@@ -84,7 +103,7 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
   ASSERT_TRUE (mapped);
 
   gint is_float = (gint) * ((guint8 *) user_data);
-  guint idx, max_idx = -1;
+  guint idx, max_idx = 0U;
 
   if (is_float == 0) {
     guint8 *output = (guint8 *) info_res.data;
@@ -98,14 +117,8 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
     }
   } else if (is_float == 1) {
     gfloat *output = (gfloat *) info_res.data;
-    gfloat max_value = G_MINFLOAT;
 
-    for (idx = 0; idx < (info_res.size / sizeof (gfloat)); ++idx) {
-      if (output[idx] > max_value) {
-        max_value = output[idx];
-        max_idx = idx;
-      }
-    }
+    max_idx = _argmax_float (output, info_res.size / sizeof (gfloat));
   } else {
     ASSERT_TRUE (1 == 0);
   }
@@ -114,6 +127,17 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 
   gst_memory_unmap (mem_res, &info_res);
   gst_memory_unref (mem_res);
+}
+
+/**
+ * @brief Test _argmax_float with all-negative values (e.g. raw logits)
+ */
+TEST (nnstreamerFilterTensorFlow2Lite, argmaxFloatAllNegative)
+{
+  const gfloat values[] = { -3.0f, -1.5f, -0.25f, -2.0f };
+
+  EXPECT_EQ (_argmax_float (values, 4), 2U);
+  EXPECT_EQ (_argmax_float (values, 2), 1U);
 }
 
 /**

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -76,6 +76,31 @@ extern guint
 get_available_port (void);
 
 /**
+ * @brief Find the index of the maximum value in a float array.
+ * Seeded with the first element so that all-negative arrays are handled.
+ * @return The index of the maximum value. 0 if num is 0.
+ */
+static inline guint
+argmax_float (const gfloat * values, guint num)
+{
+  guint idx, max_idx = 0U;
+  gfloat max_value;
+
+  if (num == 0U)
+    return 0U;
+
+  max_value = values[0];
+  for (idx = 1U; idx < num; ++idx) {
+    if (values[idx] > max_value) {
+      max_value = values[idx];
+      max_idx = idx;
+    }
+  }
+
+  return max_idx;
+}
+
+/**
  * @brief Wait until the pipeline saving the file
  * @return TRUE on success, FALSE when a time-out occurs
  */

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -80,10 +80,10 @@ get_available_port (void);
  * Seeded with the first element so that all-negative arrays are handled.
  * @return The index of the maximum value. 0 if num is 0.
  */
-static inline guint
-argmax_float (const gfloat * values, guint num)
+static inline gsize
+argmax_float (const gfloat * values, gsize num)
 {
-  guint idx, max_idx = 0U;
+  gsize idx, max_idx = 0U;
   gfloat max_value;
 
   if (num == 0U)


### PR DESCRIPTION
## What this fixes

The `check_output` callbacks of the onnxruntime and tensorflow2-lite filter unit tests initialized the float max search with `G_MINFLOAT`, which is the smallest **positive** normalized float (~1.18e-38), not the most negative float. If every model output were negative (e.g., raw logits instead of softmax scores), `max_idx` would incorrectly remain at its initial value and the test would pass/fail for the wrong reason.

## Changes

- Replace the `G_MINFLOAT`-seeded float max searches with a shared `argmax_float ()` helper in `tests/unittest_util.h`, seeded with the first element so all-negative (and -inf/NaN-only) arrays are handled uniformly. It takes and returns `gsize` so the callers' `info_res.size / sizeof (gfloat)` is never truncated.
- Fix the same bug class in the armnn unit test: `get_argmax<T> ()` seeded `max_value` with 0, which breaks argmax for all-negative float arrays. It now seeds with the first element and guards `size == 0`. It stays a separate template because it is generic over `T` and also serves the `uint8` path, where a 0 seed is a valid lower bound.
- Add regression tests covering all-negative inputs and the empty-array guard, which would have caught the original bug: `commonUtil.argmaxFloatAllNegative` in `unittest_common` for the shared helper (always built, so the coverage does not depend on any optional subplugin), and `nnstreamerFilterArmnn.argmaxAllNegative` for the armnn template.

## Scope notes

- Test-only change; no production code is touched (`tests/unittest_util.h` is a test-only shared header).
- The same pattern in `ext/nnstreamer/tensor_decoder/tensordec-pose.c` (production code) is fixed separately in #4866.
- `box_properties/mobilenetssdpp.cc` uses `G_MINFLOAT` as a default threshold sentinel, which is intentional and not changed.
- `tests/tizen_nnfw_runtime`'s `get_argmax ()` keeps its 0 seed: it is `guint8`-only, where 0 is a valid lower bound.
- The armnn unit test now builds and runs in CI as of #4867, so its regression test is exercised there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)