### PR TITLE
[Decoder/Pose] fix max-score search initialization

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -773,7 +773,7 @@ pose_decode (void **pdata, const GstTensorsConfig * config,
   for (index = 0; index < pose_size; index++) {
     int maxX = 0;
     int maxY = 0;
-    float max = G_MINFLOAT;
+    float max = -G_MAXFLOAT;
     pose p;
     for (j = 0; j < grid_ysize; j++) {
       for (i = 0; i < grid_xsize; i++) {

--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -773,7 +773,7 @@ pose_decode (void **pdata, const GstTensorsConfig * config,
   for (index = 0; index < pose_size; index++) {
     int maxX = 0;
     int maxY = 0;
-    float max = -G_MAXFLOAT;
+    float max = -G_MAXFLOAT; /* not G_MINFLOAT, which is the smallest positive float */
     pose p;
     for (j = 0; j < grid_ysize; j++) {
       for (i = 0; i < grid_xsize; i++) {

--- a/tests/nnstreamer_decoder_pose/runTest.sh
+++ b/tests/nnstreamer_decoder_pose/runTest.sh
@@ -32,9 +32,6 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoc
 # TEST WITH MORE BUFFERS
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=20 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:128,div:255 ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 2 0 0 $PERFORMANCE
 
-# TEST WITH ALL-NEGATIVE HEATMAP VALUES (the max-score search should still work)
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:-256,div:255 ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 4 0 0 $PERFORMANCE
-
 echo "nose 1 2 3 4
 leftEye 0 2 3
 rightEye 0 1 4
@@ -57,5 +54,9 @@ rightAnkle 14" > pose_label.txt
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=20 ! videoconvert ! videoscale ! video/x-raw,width=17,height=17,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:128,div:255 ! tensor_split name=a tensorseg=1:17:17:1,2:17:17:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=17:17 option3=pose_label.txt option4=heatmap-only option5=ignored ! fakesink" 3 0 0 $PERFORMANCE
 
 rm pose_label.txt
+
+# TEST WITH ALL-NEGATIVE HEATMAP VALUES (path exercise only: the output is
+# not verified since keypoints with prob < 0.5 are never drawn)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:-256,div:255 ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 4 0 0 $PERFORMANCE
 
 report

--- a/tests/nnstreamer_decoder_pose/runTest.sh
+++ b/tests/nnstreamer_decoder_pose/runTest.sh
@@ -32,6 +32,9 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoc
 # TEST WITH MORE BUFFERS
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=20 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:128,div:255 ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 2 0 0 $PERFORMANCE
 
+# TEST WITH ALL-NEGATIVE HEATMAP VALUES (the max-score search should still work)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:-256,div:255 ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 4 0 0 $PERFORMANCE
+
 echo "nose 1 2 3 4
 leftEye 0 2 3
 rightEye 0 1 4


### PR DESCRIPTION
## What this fixes

The keypoint max-score search in `pose_decode ()` (ext/nnstreamer/tensor_decoder/tensordec-pose.c) initialized `max` with `G_MINFLOAT`, which is the smallest **positive** normalized float (~1.18e-38), not the most negative float. If every score in a keypoint's heatmap is negative — raw logits in heatmap-only mode, or subnormal sigmoid outputs (e.g., sigmoid(-100) ≈ 3.7e-44) in heatmap-offset mode — the argmax incorrectly stays at (0, 0) and `p.prob` is reported as `G_MINFLOAT` instead of the true maximum.

## Changes

- Initialize the search with `-G_MAXFLOAT` instead of `G_MINFLOAT`.
- Add an SSAT case in `tests/nnstreamer_decoder_pose/runTest.sh` driving all-negative float heatmap values through the decoder.

## Impact analysis

The bug is currently **latent**: `draw ()` filters out keypoints with `prob < 0.5`, which covers every all-negative case, so the rendered output is identical before and after this fix — i.e., zero regression risk. The fix corrects the argmax and the propagated `prob` so that future changes to the drawing threshold or prob usage do not inherit the wrong result. Because the observable output cannot distinguish buggy from fixed behavior through the current pipeline, a golden-output regression test is not applicable; the added SSAT case keeps the all-negative path exercised.

The same pattern was fixed in the filter unit tests in #4864. The remaining `G_MINFLOAT` in `ext/` (`box_properties/mobilenetssdpp.cc` `THRESHOLD_DEFAULT`) is an intentional threshold sentinel, not a max-search initializer, and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)