### PR TITLE
[CI] Guard the check-rebuild self-test against stale PR branches

### DIFF
--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -146,11 +146,12 @@ jobs:
           bash .github/workflows/static.check.scripts/signed-off-by.sh ${{ github.event.pull_request.commits }}
       - name: /Checker/ check-rebuild action self-test
         # The step list comes from the merge ref while the checkout above is
-        # the PR head, so a branch older than this script would fail with
-        # "No such file or directory". Skip in that case: the head tree then
-        # has no self-test target to verify. Any future step that runs a
-        # repository script unrelated to $changed_file_list needs the same
-        # existence guard.
+        # the PR head, so a tree that lacks this script - whether the branch
+        # predates it or a rename/deletion left it out without updating this
+        # step - would fail with "No such file or directory". Skip only when
+        # this PR did not remove it (see the elif below); any future step
+        # that runs a repository script unrelated to $changed_file_list
+        # needs the same guard.
         run: |
           selftest=.github/actions/check-rebuild/test_check_if_rebuild_requires.sh
           if [ -f "$selftest" ]; then

--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -145,8 +145,18 @@ jobs:
         run: |
           bash .github/workflows/static.check.scripts/signed-off-by.sh ${{ github.event.pull_request.commits }}
       - name: /Checker/ check-rebuild action self-test
+        # The step list comes from the merge ref while the checkout above is
+        # the PR head, so a branch older than this script would fail with
+        # "No such file or directory". Skip in that case: the head tree then
+        # has no self-test target to verify. Any future step that runs a
+        # repository script unrelated to $changed_file_list needs the same
+        # existence guard.
         run: |
-          bash .github/actions/check-rebuild/test_check_if_rebuild_requires.sh
+          if [ -f .github/actions/check-rebuild/test_check_if_rebuild_requires.sh ]; then
+            bash .github/actions/check-rebuild/test_check_if_rebuild_requires.sh
+          else
+            echo "Skipped: this PR branch predates the check-rebuild self-test."
+          fi
       - name: /Checker/ shellcheck for shell scripts
         # Originally from "pr-prebuild-shellcheck"
         run: |

--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -152,8 +152,12 @@ jobs:
         # repository script unrelated to $changed_file_list needs the same
         # existence guard.
         run: |
-          if [ -f .github/actions/check-rebuild/test_check_if_rebuild_requires.sh ]; then
-            bash .github/actions/check-rebuild/test_check_if_rebuild_requires.sh
+          selftest=.github/actions/check-rebuild/test_check_if_rebuild_requires.sh
+          if [ -f "$selftest" ]; then
+            bash "$selftest"
+          elif git show --pretty="format:" --name-only --diff-filter=D ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | grep -qx "$selftest"; then
+            echo "::error::This PR deletes $selftest; remove its workflow step too or restore the script."
+            exit 1
           else
             echo "Skipped: this PR branch predates the check-rebuild self-test."
           fi

--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -155,11 +155,11 @@ jobs:
           selftest=.github/actions/check-rebuild/test_check_if_rebuild_requires.sh
           if [ -f "$selftest" ]; then
             bash "$selftest"
-          elif git show --pretty="format:" --name-only --diff-filter=D ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | grep -qx "$selftest"; then
-            echo "::error::This PR deletes $selftest; remove its workflow step too or restore the script."
+          elif git show --pretty="format:" --name-only --no-renames --diff-filter=D ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | grep -qxF "$selftest"; then
+            echo "::error::This PR removes $selftest; remove its workflow step too, or restore the script (also update this step if the script moved)."
             exit 1
           else
-            echo "Skipped: this PR branch predates the check-rebuild self-test."
+            echo "Skipped: $selftest is not in this branch's tree and this PR does not remove it."
           fi
       - name: /Checker/ shellcheck for shell scripts
         # Originally from "pr-prebuild-shellcheck"


### PR DESCRIPTION
## Problem

For `pull_request` events, GitHub takes the **workflow definition (step list) from the merge ref**, while `static.check.yml` checks out `${{ github.event.pull_request.head.sha }}` — the PR head tree. When main gains a new step that invokes a repository script (as happened with the check-rebuild self-test, b57d9654), every PR branched before that change fails the Static checks job with exit 127 (`No such file or directory`): the new step runs, but the script it invokes is not in the head tree.

Observed in practice on #4863, which had to rebase to get past it. Until rebased or updated, **every stale open PR fails Static checks the same way.**

## Fix

Run the self-test only if the script exists in the checked-out tree, with a skip notice otherwise. Skipping is semantically correct — a head tree that predates the self-test has no self-test target to verify — unlike the changed-file-based lint checkers, which are unaffected because their scripts long predate any open PR. A comment in the workflow documents that any future step running a repository script unrelated to `$changed_file_list` needs the same guard.

## Alternative considered (deferred)

Checking out the merge ref into a separate directory and running **all** repository scripts from there would close the entire hazard class (including step-argument vs. script-version mismatches), but it touches every checker step and changes which tree the scripts come from. If new checker steps become frequent, that restructure is the better long-term shape; for now the one-step guard fixes the only step with this failure mode at minimal risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)