### PR TITLE
[Edge] Add custom property (takeover of #4700)

### DIFF
--- a/gst/edge/edge_common.c
+++ b/gst/edge/edge_common.c
@@ -63,22 +63,23 @@ gst_edge_parse_custom_props (nns_edge_h edge_h, const gchar * custom_props)
       const gchar *key = g_strstrip (kv[0]);
       const gchar *value = g_strstrip (kv[1]);
 
-      if (*key && *value) {
+      if (!*key) {
+        nns_logw ("Ignored a custom property with an empty key.");
+        all_set = FALSE;
+      } else if (!*value) {
+        nns_logw ("Ignored custom property '%s' with an empty value.", key);
+        all_set = FALSE;
+      } else {
         int ret = nns_edge_set_info (edge_h, key, value);
 
         if (NNS_EDGE_ERROR_NONE != ret) {
-          nns_logw ("Failed to set custom property '%s:%s' (error %d).",
-              key, value, ret);
+          nns_logw ("Failed to set custom property '%s' (error %d).", key, ret);
           all_set = FALSE;
         }
-      } else {
-        nns_logw ("Ignored custom property token '%s' with empty key or value.",
-            tokens[i]);
-        all_set = FALSE;
       }
     } else if (kv[0] && *g_strstrip (kv[0])) {
-      nns_logw ("Ignored malformed custom property token '%s'. "
-          "Expected key:value form.", tokens[i]);
+      nns_logw ("Ignored malformed custom property '%s'. "
+          "Expected key:value form.", kv[0]);
       all_set = FALSE;
     }
     g_strfreev (kv);

--- a/gst/edge/edge_common.c
+++ b/gst/edge/edge_common.c
@@ -64,7 +64,7 @@ gst_edge_parse_custom_props (nns_edge_h edge_h, const gchar * custom_props)
       const gchar *value = g_strstrip (kv[1]);
 
       if (!*key) {
-        nns_logw ("Ignored a custom property with an empty key.");
+        nns_logw ("Ignored custom property #%u with an empty key.", i + 1);
         all_set = FALSE;
       } else if (!*value) {
         nns_logw ("Ignored custom property '%s' with an empty value.", key);
@@ -78,8 +78,8 @@ gst_edge_parse_custom_props (nns_edge_h edge_h, const gchar * custom_props)
         }
       }
     } else if (kv[0] && *g_strstrip (kv[0])) {
-      nns_logw ("Ignored malformed custom property '%s'. "
-          "Expected key:value form.", kv[0]);
+      nns_logw ("Ignored malformed custom property #%u. "
+          "Expected key:value form.", i + 1);
       all_set = FALSE;
     }
     g_strfreev (kv);

--- a/gst/edge/edge_common.c
+++ b/gst/edge/edge_common.c
@@ -15,6 +15,7 @@
 #endif
 
 #include "edge_common.h"
+#include "nnstreamer_log.h"
 
 /**
  * @brief register GEnumValue array for edge protocol property handling
@@ -39,4 +40,50 @@ gst_edge_get_connect_type (void)
   }
 
   return protocol;
+}
+
+/**
+ * @brief Parse custom properties and set them on the edge handle.
+ */
+gboolean
+gst_edge_parse_custom_props (nns_edge_h edge_h, const gchar * custom_props)
+{
+  gchar **tokens;
+  guint i;
+  gboolean all_set = TRUE;
+
+  g_return_val_if_fail (edge_h != NULL, FALSE);
+  g_return_val_if_fail (custom_props != NULL, FALSE);
+
+  tokens = g_strsplit (custom_props, ",", -1);
+  for (i = 0; tokens[i]; i++) {
+    gchar **kv = g_strsplit (tokens[i], ":", 2);
+
+    if (g_strv_length (kv) == 2) {
+      const gchar *key = g_strstrip (kv[0]);
+      const gchar *value = g_strstrip (kv[1]);
+
+      if (*key && *value) {
+        int ret = nns_edge_set_info (edge_h, key, value);
+
+        if (NNS_EDGE_ERROR_NONE != ret) {
+          nns_logw ("Failed to set custom property '%s:%s' (error %d).",
+              key, value, ret);
+          all_set = FALSE;
+        }
+      } else {
+        nns_logw ("Ignored custom property token '%s' with empty key or value.",
+            tokens[i]);
+        all_set = FALSE;
+      }
+    } else if (kv[0] && *g_strstrip (kv[0])) {
+      nns_logw ("Ignored malformed custom property token '%s'. "
+          "Expected key:value form.", tokens[i]);
+      all_set = FALSE;
+    }
+    g_strfreev (kv);
+  }
+  g_strfreev (tokens);
+
+  return all_set;
 }

--- a/gst/edge/edge_common.h
+++ b/gst/edge/edge_common.h
@@ -34,5 +34,17 @@ G_BEGIN_DECLS
  */
 GType gst_edge_get_connect_type (void);
 
+/**
+ * @brief Parse custom properties and set them on the edge handle.
+ * @param[in] edge_h The edge handle to set the parsed options on.
+ * @param[in] custom_props Comma-separated key:value pairs, e.g. "key1:val1,key2:val2".
+ *            A value may contain ':' (e.g. "QUEUE_SIZE:10:OLD"); only the first
+ *            ':' separates the key from the value. Whitespace around keys and
+ *            values is trimmed and empty tokens are ignored.
+ * @return TRUE if all non-empty tokens were parsed and set successfully.
+ *         Malformed tokens or rejected keys are logged and skipped.
+ */
+gboolean gst_edge_parse_custom_props (nns_edge_h edge_h, const gchar * custom_props);
+
 G_END_DECLS
 #endif /* __GST_EDGE_H__ */

--- a/gst/edge/edge_common.h
+++ b/gst/edge/edge_common.h
@@ -40,9 +40,12 @@ GType gst_edge_get_connect_type (void);
  * @param[in] custom_props Comma-separated key:value pairs, e.g. "key1:val1,key2:val2".
  *            A value may contain ':' (e.g. "QUEUE_SIZE:10:OLD"); only the first
  *            ':' separates the key from the value. Whitespace around keys and
- *            values is trimmed and empty tokens are ignored.
- * @return TRUE if all non-empty tokens were parsed and set successfully.
- *         Malformed tokens or rejected keys are logged and skipped.
+ *            values is trimmed.
+ * @return TRUE if every token was applied. Empty or whitespace-only tokens
+ *         (e.g. from a trailing comma) are silently ignored and do not affect
+ *         the result. Tokens without ':', with an empty key or value, or
+ *         rejected by nns_edge_set_info() are logged, skipped, and make the
+ *         return value FALSE.
  */
 gboolean gst_edge_parse_custom_props (nns_edge_h edge_h, const gchar * custom_props);
 

--- a/gst/edge/edge_common.h
+++ b/gst/edge/edge_common.h
@@ -46,7 +46,8 @@ GType gst_edge_get_connect_type (void);
  *         the result. Tokens without ':', with an empty key or value, or
  *         rejected by nns_edge_set_info() are logged, skipped, and make the
  *         return value FALSE. Option values may carry credentials of a custom
- *         connection library, so only keys are logged.
+ *         connection library, so a rejected option is named by its key, or by
+ *         its position when no key could be parsed out of it.
  */
 gboolean gst_edge_parse_custom_props (nns_edge_h edge_h, const gchar * custom_props);
 

--- a/gst/edge/edge_common.h
+++ b/gst/edge/edge_common.h
@@ -45,7 +45,8 @@ GType gst_edge_get_connect_type (void);
  *         (e.g. from a trailing comma) are silently ignored and do not affect
  *         the result. Tokens without ':', with an empty key or value, or
  *         rejected by nns_edge_set_info() are logged, skipped, and make the
- *         return value FALSE.
+ *         return value FALSE. Option values may carry credentials of a custom
+ *         connection library, so only keys are logged.
  */
 gboolean gst_edge_parse_custom_props (nns_edge_h edge_h, const gchar * custom_props);
 

--- a/gst/edge/edge_sink.c
+++ b/gst/edge/edge_sink.c
@@ -153,7 +153,7 @@ gst_edgesink_class_init (GstEdgeSinkClass * klass)
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_CUSTOM_PROPS,
       g_param_spec_string ("custom-props", "Custom connection props",
-          "User defined custom connection properties. Set the options in key:value form and divide them by , for multiple options. The options are applied when the element starts.",
+          "User defined custom connection properties. Set the options in key:value form and divide them by , for multiple options. The options are applied when the element starts, after the dedicated properties, so a key that duplicates one of them (e.g. TOPIC) overrides it.",
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   gst_element_class_add_pad_template (gstelement_class,
@@ -416,7 +416,7 @@ gst_edgesink_start (GstBaseSink * basesink)
     if (!gst_edge_parse_custom_props (self->edge_h, self->custom_props)) {
       GST_ELEMENT_WARNING (self, RESOURCE, SETTINGS,
           ("Some custom-props options were not applied."),
-          ("custom-props: %s", self->custom_props));
+          ("The rejected keys are in the debug log."));
     }
   }
 

--- a/gst/edge/edge_sink.c
+++ b/gst/edge/edge_sink.c
@@ -153,7 +153,7 @@ gst_edgesink_class_init (GstEdgeSinkClass * klass)
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_CUSTOM_PROPS,
       g_param_spec_string ("custom-props", "Custom connection props",
-          "User defined custom connection properties. Set the options in key:value form and divide them by , for multiple options.",
+          "User defined custom connection properties. Set the options in key:value form and divide them by , for multiple options. The options are applied when the element starts.",
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   gst_element_class_add_pad_template (gstelement_class,
@@ -412,8 +412,13 @@ gst_edgesink_start (GstBaseSink * basesink)
   if (self->topic)
     nns_edge_set_info (self->edge_h, "TOPIC", self->topic);
 
-  if (self->custom_props)
-    gst_edge_parse_custom_props (self->edge_h, self->custom_props);
+  if (self->custom_props) {
+    if (!gst_edge_parse_custom_props (self->edge_h, self->custom_props)) {
+      GST_ELEMENT_WARNING (self, RESOURCE, SETTINGS,
+          ("Some custom-props options were not applied."),
+          ("custom-props: %s", self->custom_props));
+    }
+  }
 
   nns_edge_set_event_callback (self->edge_h, _nns_edge_event_cb, self);
 

--- a/gst/edge/edge_sink.c
+++ b/gst/edge/edge_sink.c
@@ -416,7 +416,7 @@ gst_edgesink_start (GstBaseSink * basesink)
     if (!gst_edge_parse_custom_props (self->edge_h, self->custom_props)) {
       GST_ELEMENT_WARNING (self, RESOURCE, SETTINGS,
           ("Some custom-props options were not applied."),
-          ("The rejected keys are in the debug log."));
+          ("The rejected options are in the debug log."));
     }
   }
 

--- a/gst/edge/edge_sink.c
+++ b/gst/edge/edge_sink.c
@@ -10,6 +10,22 @@
  * @bug     No known bugs
  *
  */
+
+/**
+ * SECTION:element-edgesink
+ *
+ * Publish incoming streams to the connected edge devices.
+ * <refsect2>
+ * <title>Example launch line</title>
+ * gst-launch-1.0 videotestsrc ! edgesink port=0
+ * gst-launch-1.0 videotestsrc ! edgesink port=0 custom-props="QUEUE_SIZE:10:OLD"
+ *
+ * The custom-props property passes comma-separated key:value options to the
+ * nnstreamer-edge handle, e.g. queue policy or options of a custom connection
+ * library given by custom-lib. Only the first ':' separates a key from its
+ * value, so a value itself may contain ':'.
+ * </refsect2>
+ */
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -241,11 +257,9 @@ gst_edgesink_set_property (GObject * object, guint prop_id,
       self->custom_lib = g_value_dup_string (value);
       break;
     case PROP_CUSTOM_PROPS:
-    {
       g_free (self->custom_props);
       self->custom_props = g_value_dup_string (value);
       break;
-    }
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -353,23 +367,6 @@ _nns_edge_event_cb (nns_edge_event_h event_h, void *user_data)
 }
 
 /**
- * @brief Parse edge custom properties.
- */
-static void
-_edgesink_parse_custom_props (GstEdgeSink *self)
-{
-  gchar **str_ops = g_strsplit_set (self->custom_props, ",", -1);
-  guint i, num = g_strv_length (str_ops);
-
-  for (i = 0; i < num; i++) {
-    gchar **str_op = g_strsplit (str_ops[i], ":", -1);
-    nns_edge_set_info (self->edge_h, str_op[0], str_op[1]);
-    g_strfreev (str_op);
-  }
-  g_strfreev (str_ops);
-}
-
-/**
  * @brief start processing of edgesink
  */
 static gboolean
@@ -416,7 +413,7 @@ gst_edgesink_start (GstBaseSink * basesink)
     nns_edge_set_info (self->edge_h, "TOPIC", self->topic);
 
   if (self->custom_props)
-    _edgesink_parse_custom_props (self);
+    gst_edge_parse_custom_props (self->edge_h, self->custom_props);
 
   nns_edge_set_event_callback (self->edge_h, _nns_edge_event_cb, self);
 

--- a/gst/edge/edge_sink.c
+++ b/gst/edge/edge_sink.c
@@ -43,6 +43,7 @@ enum
   PROP_WAIT_CONNECTION,
   PROP_CONNECTION_TIMEOUT,
   PROP_CUSTOM_LIB,
+  PROP_CUSTOM_PROPS,
 
   PROP_LAST
 };
@@ -134,6 +135,10 @@ gst_edgesink_class_init (GstEdgeSinkClass * klass)
       g_param_spec_string ("custom-lib", "Custom connection lib path",
           "User defined custom connection lib path.",
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_CUSTOM_PROPS,
+      g_param_spec_string ("custom-props", "Custom connection props",
+          "User defined custom connection properties. Set the options in key:value form and divide them by , for multiple options.",
+          "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   gst_element_class_add_pad_template (gstelement_class,
       gst_static_pad_template_get (&sinktemplate));
@@ -180,6 +185,7 @@ gst_edgesink_init (GstEdgeSink * self)
   self->wait_connection = FALSE;
   self->connection_timeout = 0;
   self->custom_lib = NULL;
+  self->custom_props = NULL;
   self->is_connected = FALSE;
   self->edge_h = NULL;
   g_mutex_init (&self->lock);
@@ -234,6 +240,12 @@ gst_edgesink_set_property (GObject * object, guint prop_id,
       g_free (self->custom_lib);
       self->custom_lib = g_value_dup_string (value);
       break;
+    case PROP_CUSTOM_PROPS:
+    {
+      g_free (self->custom_props);
+      self->custom_props = g_value_dup_string (value);
+      break;
+    }
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -277,6 +289,9 @@ gst_edgesink_get_property (GObject * object, guint prop_id, GValue * value,
     case PROP_CUSTOM_LIB:
       g_value_set_string (value, self->custom_lib);
       break;
+    case PROP_CUSTOM_PROPS:
+      g_value_set_string (value, self->custom_props);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -295,6 +310,7 @@ gst_edgesink_finalize (GObject * object)
   g_clear_pointer (&self->dest_host, g_free);
   g_clear_pointer (&self->topic, g_free);
   g_clear_pointer (&self->custom_lib, g_free);
+  g_clear_pointer (&self->custom_props, g_free);
 
   g_mutex_clear (&self->lock);
   g_cond_clear (&self->cond);
@@ -334,6 +350,23 @@ _nns_edge_event_cb (nns_edge_event_h event_h, void *user_data)
   }
 
   return ret;
+}
+
+/**
+ * @brief Parse edge custom properties.
+ */
+static void
+_edgesink_parse_custom_props (GstEdgeSink *self)
+{
+  gchar **str_ops = g_strsplit_set (self->custom_props, ",", -1);
+  guint i, num = g_strv_length (str_ops);
+
+  for (i = 0; i < num; i++) {
+    gchar **str_op = g_strsplit (str_ops[i], ":", -1);
+    nns_edge_set_info (self->edge_h, str_op[0], str_op[1]);
+    g_strfreev (str_op);
+  }
+  g_strfreev (str_ops);
 }
 
 /**
@@ -381,6 +414,9 @@ gst_edgesink_start (GstBaseSink * basesink)
   }
   if (self->topic)
     nns_edge_set_info (self->edge_h, "TOPIC", self->topic);
+
+  if (self->custom_props)
+    _edgesink_parse_custom_props (self);
 
   nns_edge_set_event_callback (self->edge_h, _nns_edge_event_cb, self);
 

--- a/gst/edge/edge_sink.h
+++ b/gst/edge/edge_sink.h
@@ -55,6 +55,7 @@ struct _GstEdgeSink
   guint64 connection_timeout;
 
   gchar *custom_lib;
+  gchar *custom_props;
   gboolean is_connected;
   GMutex lock;
   GCond cond;

--- a/gst/edge/edge_src.c
+++ b/gst/edge/edge_src.c
@@ -38,6 +38,7 @@ enum
   PROP_CONNECT_TYPE,
   PROP_TOPIC,
   PROP_CUSTOM_LIB,
+  PROP_CUSTOM_PROPS,
 
   PROP_LAST
 };
@@ -115,6 +116,10 @@ gst_edgesrc_class_init (GstEdgeSrcClass * klass)
       g_param_spec_string ("custom-lib", "Custom connection lib path",
           "User defined custom connection lib path.",
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_CUSTOM_PROPS,
+      g_param_spec_string ("custom-props", "Custom connection props",
+          "User defined custom connection properties. Set the options in key:value form and divide them by , for multiple options.",
+          "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   gst_element_class_add_pad_template (gstelement_class,
       gst_static_pad_template_get (&srctemplate));
@@ -164,6 +169,7 @@ gst_edgesrc_init (GstEdgeSrc * self)
   self->connect_type = DEFAULT_CONNECT_TYPE;
   self->playing = FALSE;
   self->custom_lib = NULL;
+  self->custom_props = NULL;
   self->edge_h = NULL;
 }
 
@@ -204,6 +210,12 @@ gst_edgesrc_set_property (GObject * object, guint prop_id, const GValue * value,
       g_free (self->custom_lib);
       self->custom_lib = g_value_dup_string (value);
       break;
+    case PROP_CUSTOM_PROPS:
+    {
+      g_free (self->custom_props);
+      self->custom_props = g_value_dup_string (value);
+      break;
+    }
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -241,6 +253,9 @@ gst_edgesrc_get_property (GObject * object, guint prop_id, GValue * value,
     case PROP_CUSTOM_LIB:
       g_value_set_string (value, self->custom_lib);
       break;
+    case PROP_CUSTOM_PROPS:
+      g_value_set_string (value, self->custom_props);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -259,6 +274,7 @@ gst_edgesrc_class_finalize (GObject * object)
   g_clear_pointer (&self->dest_host, g_free);
   g_clear_pointer (&self->topic, g_free);
   g_clear_pointer (&self->custom_lib, g_free);
+  g_clear_pointer (&self->custom_props, g_free);
 
   if (self->msg_queue) {
     while ((data_h = g_async_queue_try_pop (self->msg_queue))) {
@@ -344,6 +360,23 @@ _nns_edge_event_cb (nns_edge_event_h event_h, void *user_data)
 }
 
 /**
+ * @brief Parse edge custom properties.
+ */
+static void
+_edgesrc_parse_custom_props (GstEdgeSrc *self)
+{
+  gchar **str_ops = g_strsplit_set (self->custom_props, ",", -1);
+  guint i, num = g_strv_length (str_ops);
+
+  for (i = 0; i < num; i++) {
+    gchar **str_op = g_strsplit (str_ops[i], ":", -1);
+    nns_edge_set_info (self->edge_h, str_op[0], str_op[1]);
+    g_strfreev (str_op);
+  }
+  g_strfreev (str_ops);
+}
+
+/**
  * @brief start edgesrc, called when state changed null to ready
  */
 static gboolean
@@ -381,6 +414,9 @@ gst_edgesrc_start (GstBaseSrc * basesrc)
   }
   if (self->topic)
     nns_edge_set_info (self->edge_h, "TOPIC", self->topic);
+  if (self->custom_props) {
+    _edgesrc_parse_custom_props (self);
+  }
 
   nns_edge_set_event_callback (self->edge_h, _nns_edge_event_cb, self);
 

--- a/gst/edge/edge_src.c
+++ b/gst/edge/edge_src.c
@@ -134,7 +134,7 @@ gst_edgesrc_class_init (GstEdgeSrcClass * klass)
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_CUSTOM_PROPS,
       g_param_spec_string ("custom-props", "Custom connection props",
-          "User defined custom connection properties. Set the options in key:value form and divide them by , for multiple options. The options are applied when the element starts.",
+          "User defined custom connection properties. Set the options in key:value form and divide them by , for multiple options. The options are applied when the element starts, after the dedicated properties, so a key that duplicates one of them (e.g. TOPIC) overrides it.",
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   gst_element_class_add_pad_template (gstelement_class,
@@ -415,7 +415,7 @@ gst_edgesrc_start (GstBaseSrc * basesrc)
     if (!gst_edge_parse_custom_props (self->edge_h, self->custom_props)) {
       GST_ELEMENT_WARNING (self, RESOURCE, SETTINGS,
           ("Some custom-props options were not applied."),
-          ("custom-props: %s", self->custom_props));
+          ("The rejected keys are in the debug log."));
     }
   }
 

--- a/gst/edge/edge_src.c
+++ b/gst/edge/edge_src.c
@@ -415,7 +415,7 @@ gst_edgesrc_start (GstBaseSrc * basesrc)
     if (!gst_edge_parse_custom_props (self->edge_h, self->custom_props)) {
       GST_ELEMENT_WARNING (self, RESOURCE, SETTINGS,
           ("Some custom-props options were not applied."),
-          ("The rejected keys are in the debug log."));
+          ("The rejected options are in the debug log."));
     }
   }
 

--- a/gst/edge/edge_src.c
+++ b/gst/edge/edge_src.c
@@ -10,6 +10,22 @@
  * @bug     No known bugs
  *
  */
+
+/**
+ * SECTION:element-edgesrc
+ *
+ * Subscribe and receive streams from an edge device.
+ * <refsect2>
+ * <title>Example launch line</title>
+ * gst-launch-1.0 edgesrc dest-port=5001 ! fakesink
+ * gst-launch-1.0 edgesrc dest-port=5001 custom-props="QUEUE_SIZE:10:OLD" ! fakesink
+ *
+ * The custom-props property passes comma-separated key:value options to the
+ * nnstreamer-edge handle, e.g. queue policy or options of a custom connection
+ * library given by custom-lib. Only the first ':' separates a key from its
+ * value, so a value itself may contain ':'.
+ * </refsect2>
+ */
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -211,11 +227,9 @@ gst_edgesrc_set_property (GObject * object, guint prop_id, const GValue * value,
       self->custom_lib = g_value_dup_string (value);
       break;
     case PROP_CUSTOM_PROPS:
-    {
       g_free (self->custom_props);
       self->custom_props = g_value_dup_string (value);
       break;
-    }
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -360,23 +374,6 @@ _nns_edge_event_cb (nns_edge_event_h event_h, void *user_data)
 }
 
 /**
- * @brief Parse edge custom properties.
- */
-static void
-_edgesrc_parse_custom_props (GstEdgeSrc *self)
-{
-  gchar **str_ops = g_strsplit_set (self->custom_props, ",", -1);
-  guint i, num = g_strv_length (str_ops);
-
-  for (i = 0; i < num; i++) {
-    gchar **str_op = g_strsplit (str_ops[i], ":", -1);
-    nns_edge_set_info (self->edge_h, str_op[0], str_op[1]);
-    g_strfreev (str_op);
-  }
-  g_strfreev (str_ops);
-}
-
-/**
  * @brief start edgesrc, called when state changed null to ready
  */
 static gboolean
@@ -414,9 +411,8 @@ gst_edgesrc_start (GstBaseSrc * basesrc)
   }
   if (self->topic)
     nns_edge_set_info (self->edge_h, "TOPIC", self->topic);
-  if (self->custom_props) {
-    _edgesrc_parse_custom_props (self);
-  }
+  if (self->custom_props)
+    gst_edge_parse_custom_props (self->edge_h, self->custom_props);
 
   nns_edge_set_event_callback (self->edge_h, _nns_edge_event_cb, self);
 

--- a/gst/edge/edge_src.c
+++ b/gst/edge/edge_src.c
@@ -134,7 +134,7 @@ gst_edgesrc_class_init (GstEdgeSrcClass * klass)
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_CUSTOM_PROPS,
       g_param_spec_string ("custom-props", "Custom connection props",
-          "User defined custom connection properties. Set the options in key:value form and divide them by , for multiple options.",
+          "User defined custom connection properties. Set the options in key:value form and divide them by , for multiple options. The options are applied when the element starts.",
           "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   gst_element_class_add_pad_template (gstelement_class,
@@ -411,8 +411,13 @@ gst_edgesrc_start (GstBaseSrc * basesrc)
   }
   if (self->topic)
     nns_edge_set_info (self->edge_h, "TOPIC", self->topic);
-  if (self->custom_props)
-    gst_edge_parse_custom_props (self->edge_h, self->custom_props);
+  if (self->custom_props) {
+    if (!gst_edge_parse_custom_props (self->edge_h, self->custom_props)) {
+      GST_ELEMENT_WARNING (self, RESOURCE, SETTINGS,
+          ("Some custom-props options were not applied."),
+          ("custom-props: %s", self->custom_props));
+    }
+  }
 
   nns_edge_set_event_callback (self->edge_h, _nns_edge_event_cb, self);
 

--- a/gst/edge/edge_src.h
+++ b/gst/edge/edge_src.h
@@ -54,6 +54,7 @@ struct _GstEdgeSrc
   gboolean playing;
 
   gchar* custom_lib;
+  gchar* custom_props;
 };
 
 /**

--- a/gst/edge/edge_src.h
+++ b/gst/edge/edge_src.h
@@ -54,7 +54,7 @@ struct _GstEdgeSrc
   gboolean playing;
 
   gchar* custom_lib;
-  gchar* custom_props;
+  gchar *custom_props;
 };
 
 /**

--- a/tests/nnstreamer_edge/edge/unittest_edge.cc
+++ b/tests/nnstreamer_edge/edge/unittest_edge.cc
@@ -407,6 +407,83 @@ TEST (edgeCustom, sinkInvalidProp2_n)
 }
 
 /**
+ * @brief Ensure custom-props values reach the edge handle when edgesink starts.
+ */
+TEST (edgeCustom, sinkCustomProps)
+{
+  gchar *pipeline = nullptr;
+  GstElement *gstpipe = nullptr;
+  GstElement *edge_handle = nullptr;
+  GstEdgeSink *sink = nullptr;
+  char *val = nullptr;
+
+  /* Value with ':' and whitespace around tokens: split on the first ':' only, then strip. */
+  pipeline = g_strdup_printf (
+      "videotestsrc ! videoconvert ! videoscale ! "
+      "video/x-raw,width=320,height=240,format=RGB,framerate=10/1 ! "
+      "tensor_converter ! edgesink connect-type=CUSTOM custom-lib=%s "
+      "custom-props=\" PEER_ADDRESS : tcp://127.0.0.1:1883 , QUEUE_SIZE:5:OLD\" name=sinkx port=0",
+      CUSTOM_LIB_PATH);
+  gstpipe = gst_parse_launch (pipeline, nullptr);
+  ASSERT_NE (gstpipe, nullptr);
+
+  edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sinkx");
+  ASSERT_NE (edge_handle, nullptr);
+  sink = GST_EDGESINK_CAST (edge_handle);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  ASSERT_NE (sink->edge_h, (nns_edge_h) NULL);
+
+  EXPECT_EQ (nns_edge_get_info (sink->edge_h, "PEER_ADDRESS", &val), NNS_EDGE_ERROR_NONE);
+  EXPECT_STREQ ("tcp://127.0.0.1:1883", val);
+  g_free (val);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (edge_handle);
+  gst_object_unref (gstpipe);
+  g_free (pipeline);
+}
+
+/**
+ * @brief Malformed custom-props tokens must be skipped without crash and must not block start.
+ */
+TEST (edgeSink, customPropsMalformed_n)
+{
+  gchar *pipeline = nullptr;
+  GstElement *gstpipe = nullptr;
+  GstElement *edge_handle = nullptr;
+  GstEdgeSink *sink = nullptr;
+  char *val = nullptr;
+
+  /* Colon-less token, empty tokens, empty key, and empty value with a trailing comma. */
+  pipeline = g_strdup_printf (
+      "videotestsrc ! videoconvert ! videoscale ! "
+      "video/x-raw,width=320,height=240,format=RGB,framerate=10/1 ! "
+      "tensor_converter ! edgesink custom-props=\"foo,,topic:test_topic, : ,c:,:v,\" name=sinkx port=0");
+  gstpipe = gst_parse_launch (pipeline, nullptr);
+  ASSERT_NE (gstpipe, nullptr);
+
+  edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sinkx");
+  ASSERT_NE (edge_handle, nullptr);
+  sink = GST_EDGESINK_CAST (edge_handle);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  ASSERT_NE (sink->edge_h, (nns_edge_h) NULL);
+
+  /* The valid token amid the malformed ones must still be applied. */
+  EXPECT_EQ (nns_edge_get_info (sink->edge_h, "TOPIC", &val), NNS_EDGE_ERROR_NONE);
+  EXPECT_STREQ ("test_topic", val);
+  g_free (val);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (edge_handle);
+  gst_object_unref (gstpipe);
+  g_free (pipeline);
+}
+
+/**
  * @brief Test for edgesrc custom connection.
  */
 TEST (edgeCustom, srcNormal)
@@ -427,6 +504,66 @@ TEST (edgeCustom, srcNormal)
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   g_usleep (100000);
+
+  gst_object_unref (gstpipe);
+  g_free (pipeline);
+}
+
+/**
+ * @brief Ensure custom-props values reach the edge handle when edgesrc starts.
+ */
+TEST (edgeCustom, srcCustomProps)
+{
+  gchar *pipeline = nullptr;
+  GstElement *gstpipe = nullptr;
+  GstElement *edge_handle = nullptr;
+  GstEdgeSrc *src = nullptr;
+  char *val = nullptr;
+
+  pipeline = g_strdup_printf ("edgesrc connect-type=CUSTOM custom-lib=%s "
+                              "custom-props=\" PEER_ADDRESS : tcp://127.0.0.1:1883 , QUEUE_SIZE:5:OLD\" name=srcx ! "
+                              "other/tensors,num_tensors=1,dimensions=3:320:240:1,types=uint8,format=static,framerate=30/1 ! "
+                              "tensor_sink",
+      CUSTOM_LIB_PATH);
+  gstpipe = gst_parse_launch (pipeline, nullptr);
+  ASSERT_NE (gstpipe, nullptr);
+
+  edge_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "srcx");
+  ASSERT_NE (edge_handle, nullptr);
+  src = GST_EDGESRC_CAST (edge_handle);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  ASSERT_NE (src->edge_h, (nns_edge_h) NULL);
+
+  EXPECT_EQ (nns_edge_get_info (src->edge_h, "PEER_ADDRESS", &val), NNS_EDGE_ERROR_NONE);
+  EXPECT_STREQ ("tcp://127.0.0.1:1883", val);
+  g_free (val);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (edge_handle);
+  gst_object_unref (gstpipe);
+  g_free (pipeline);
+}
+
+/**
+ * @brief Malformed custom-props tokens must be skipped without crash and must not block start.
+ */
+TEST (edgeCustom, srcCustomPropsMalformed_n)
+{
+  gchar *pipeline = nullptr;
+  GstElement *gstpipe = nullptr;
+
+  pipeline = g_strdup_printf ("edgesrc connect-type=CUSTOM custom-lib=%s "
+                              "custom-props=\"foo,,topic:test_topic, : ,c:,:v,\" name=srcx ! "
+                              "other/tensors,num_tensors=1,dimensions=3:320:240:1,types=uint8,format=static,framerate=30/1 ! "
+                              "tensor_sink",
+      CUSTOM_LIB_PATH);
+  gstpipe = gst_parse_launch (pipeline, nullptr);
+  ASSERT_NE (gstpipe, nullptr);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
   gst_object_unref (gstpipe);
   g_free (pipeline);

--- a/tests/nnstreamer_edge/edge/unittest_edge.cc
+++ b/tests/nnstreamer_edge/edge/unittest_edge.cc
@@ -30,17 +30,16 @@ _pop_custom_props_warning (GstElement *gstpipe, const gchar *elem_name)
   GstBus *bus;
   GstMessage *msg;
   GError *err = nullptr;
-  gchar *debug = nullptr;
   gboolean matched = FALSE;
 
   bus = gst_element_get_bus (gstpipe);
   while ((msg = gst_bus_pop_filtered (bus, GST_MESSAGE_WARNING)) != nullptr) {
-    gst_message_parse_warning (msg, &err, &debug);
+    gst_message_parse_warning (msg, &err, nullptr);
     matched = g_error_matches (err, GST_RESOURCE_ERROR, GST_RESOURCE_ERROR_SETTINGS)
               && g_strcmp0 (GST_OBJECT_NAME (GST_MESSAGE_SRC (msg)), elem_name) == 0
-              && debug && g_strstr_len (debug, -1, "custom-props: ") != nullptr;
+              && err->message
+              && g_strstr_len (err->message, -1, "custom-props") != nullptr;
     g_clear_error (&err);
-    g_clear_pointer (&debug, g_free);
     gst_message_unref (msg);
     if (matched)
       break;
@@ -481,7 +480,7 @@ TEST (edgeCustom, sinkCustomProps)
 /**
  * @brief Malformed custom-props tokens must be skipped without crash and must not block start.
  */
-TEST (edgeSink, customPropsMalformed_n)
+TEST (edgeCustom, sinkCustomPropsMalformed_n)
 {
   gchar *pipeline = nullptr;
   GstElement *gstpipe = nullptr;
@@ -493,7 +492,9 @@ TEST (edgeSink, customPropsMalformed_n)
   pipeline = g_strdup_printf (
       "videotestsrc ! videoconvert ! videoscale ! "
       "video/x-raw,width=320,height=240,format=RGB,framerate=10/1 ! "
-      "tensor_converter ! edgesink custom-props=\"foo,,topic:test_topic, : ,c:,:v,\" name=sinkx port=0");
+      "tensor_converter ! edgesink connect-type=CUSTOM custom-lib=%s "
+      "custom-props=\"foo,,topic:test_topic, : ,c:,:v,\" name=sinkx port=0",
+      CUSTOM_LIB_PATH);
   gstpipe = gst_parse_launch (pipeline, nullptr);
   ASSERT_NE (gstpipe, nullptr);
 
@@ -515,6 +516,32 @@ TEST (edgeSink, customPropsMalformed_n)
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
   gst_object_unref (edge_handle);
+  gst_object_unref (gstpipe);
+  g_free (pipeline);
+}
+
+/**
+ * @brief A well-formed option that the edge library refuses must be reported too.
+ */
+TEST (edgeCustom, sinkCustomPropsRejected_n)
+{
+  gchar *pipeline = nullptr;
+  GstElement *gstpipe = nullptr;
+
+  /* ID is a valid key:value pair, but nnstreamer-edge does not allow updating it. */
+  pipeline = g_strdup_printf ("videotestsrc ! videoconvert ! videoscale ! "
+                              "video/x-raw,width=320,height=240,format=RGB,framerate=10/1 ! "
+                              "tensor_converter ! edgesink connect-type=CUSTOM custom-lib=%s "
+                              "custom-props=\"ID:not_allowed\" name=sinkx port=0",
+      CUSTOM_LIB_PATH);
+  gstpipe = gst_parse_launch (pipeline, nullptr);
+  ASSERT_NE (gstpipe, nullptr);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_TRUE (_pop_custom_props_warning (gstpipe, "sinkx"));
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
   gst_object_unref (gstpipe);
   g_free (pipeline);
 }

--- a/tests/nnstreamer_edge/edge/unittest_edge.cc
+++ b/tests/nnstreamer_edge/edge/unittest_edge.cc
@@ -21,6 +21,36 @@ static int data_received;
 static const char *CUSTOM_LIB_PATH = "libnnstreamer-edge-custom-test.so";
 
 /**
+ * @brief Look for the warning that the given element posts for rejected custom-props options.
+ * @note Consumes the queued warning messages up to and including the matching one.
+ */
+static gboolean
+_pop_custom_props_warning (GstElement *gstpipe, const gchar *elem_name)
+{
+  GstBus *bus;
+  GstMessage *msg;
+  GError *err = nullptr;
+  gchar *debug = nullptr;
+  gboolean matched = FALSE;
+
+  bus = gst_element_get_bus (gstpipe);
+  while ((msg = gst_bus_pop_filtered (bus, GST_MESSAGE_WARNING)) != nullptr) {
+    gst_message_parse_warning (msg, &err, &debug);
+    matched = g_error_matches (err, GST_RESOURCE_ERROR, GST_RESOURCE_ERROR_SETTINGS)
+              && g_strcmp0 (GST_OBJECT_NAME (GST_MESSAGE_SRC (msg)), elem_name) == 0
+              && debug && g_strstr_len (debug, -1, "custom-props: ") != nullptr;
+    g_clear_error (&err);
+    g_clear_pointer (&debug, g_free);
+    gst_message_unref (msg);
+    if (matched)
+      break;
+  }
+  gst_object_unref (bus);
+
+  return matched;
+}
+
+/**
  * @brief Test for edgesink get and set properties.
  */
 TEST (edgeSink, properties0)
@@ -438,6 +468,9 @@ TEST (edgeCustom, sinkCustomProps)
   EXPECT_STREQ ("tcp://127.0.0.1:1883", val);
   g_free (val);
 
+  /* All options were valid, no warning should be posted. */
+  EXPECT_FALSE (_pop_custom_props_warning (gstpipe, "sinkx"));
+
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
   gst_object_unref (edge_handle);
@@ -475,6 +508,9 @@ TEST (edgeSink, customPropsMalformed_n)
   EXPECT_EQ (nns_edge_get_info (sink->edge_h, "TOPIC", &val), NNS_EDGE_ERROR_NONE);
   EXPECT_STREQ ("test_topic", val);
   g_free (val);
+
+  /* Rejected options must be reported on the bus. */
+  EXPECT_TRUE (_pop_custom_props_warning (gstpipe, "sinkx"));
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
@@ -539,6 +575,9 @@ TEST (edgeCustom, srcCustomProps)
   EXPECT_STREQ ("tcp://127.0.0.1:1883", val);
   g_free (val);
 
+  /* All options were valid, no warning should be posted. */
+  EXPECT_FALSE (_pop_custom_props_warning (gstpipe, "srcx"));
+
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
   gst_object_unref (edge_handle);
@@ -563,6 +602,10 @@ TEST (edgeCustom, srcCustomPropsMalformed_n)
   ASSERT_NE (gstpipe, nullptr);
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  /* Rejected options must be reported on the bus. */
+  EXPECT_TRUE (_pop_custom_props_warning (gstpipe, "srcx"));
+
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
   gst_object_unref (gstpipe);

--- a/tests/nnstreamer_edge/edge/unittest_edge.cc
+++ b/tests/nnstreamer_edge/edge/unittest_edge.cc
@@ -70,6 +70,11 @@ TEST (edgeSink, properties0)
   EXPECT_STREQ ("TEMP_TEST_TOPIC", str_val);
   g_free (str_val);
 
+  g_object_set (edge_handle, "custom-props", "custom1:prop1,custom2:prop2", NULL);
+  g_object_get (edge_handle, "custom-props", &str_val, NULL);
+  EXPECT_STREQ ("custom1:prop1,custom2:prop2", str_val);
+  g_free (str_val);
+
   gst_object_unref (edge_handle);
   gst_object_unref (gstpipe);
   g_free (pipeline);
@@ -136,6 +141,11 @@ TEST (edgeSrc, properties0)
   g_object_set (edge_handle, "topic", "TEMP_TEST_TOPIC", NULL);
   g_object_get (edge_handle, "topic", &str_val, NULL);
   EXPECT_STREQ ("TEMP_TEST_TOPIC", str_val);
+  g_free (str_val);
+
+  g_object_set (edge_handle, "custom-props", "custom1:prop1,custom2:prop2", NULL);
+  g_object_get (edge_handle, "custom-props", &str_val, NULL);
+  EXPECT_STREQ ("custom1:prop1,custom2:prop2", str_val);
   g_free (str_val);
 
   gst_object_unref (edge_handle);

--- a/tests/nnstreamer_edge/meson.build
+++ b/tests/nnstreamer_edge/meson.build
@@ -6,11 +6,14 @@ library('nnstreamer-edge-custom-test',
   install_dir: unittest_install_dir
 )
 
-# Headers only: linking the gstedge plugin module would leave the installed
-# test binary unable to resolve libgstedge.so (plugin dir is not in the loader path).
+# Headers only for the plugin: linking the gstedge plugin module would leave the
+# installed test binary unable to resolve libgstedge.so (plugin dir is not in the
+# loader path). libnnstreamer-edge itself is a regular library and is linked to
+# query edge handle info in the tests.
 unittest_edge = executable('unittest_edge',
   join_paths('edge', 'unittest_edge.cc'),
   dependencies: [nnstreamer_unittest_deps,
+    nnstreamer_edge_support_deps,
     gstedge_dep.partial_dependency(includes: true, compile_args: true)],
   install: get_option('install-test'),
   install_dir: unittest_install_dir


### PR DESCRIPTION
Takeover of #4700 by @gichan-jang, which has been inactive since March 2025 with changes requested and now conflicts with main. The original commit is preserved with the author's authorship and sign-off; fixes are stacked on top.

**1. [Edge] Add custom property** (author: @gichan-jang, rebased)
Adds the `custom-props` property to edgesink/edgesrc: comma-separated `key:value` options applied to the nnstreamer-edge handle at start(). The unrelated `nns_edge_connect()` call added to `gst_edgesink_start()` is dropped during the rebase: edgesink is a PUB node and the call broke the NULL-to-READY transition when the peer is not up yet (the regression flagged in the original review).

**2. [Edge] Harden custom-props parsing with a common helper**
Replaces the duplicated per-element parsers with `gst_edge_parse_custom_props()` in edge_common, fixing the review findings:
- Heap OOB read on empty tokens (e.g. trailing comma): `g_strsplit("")` returns an empty vector, so `str_op[1]` read out of bounds.
- Values containing `:` were silently truncated (e.g. `QUEUE_SIZE:10:OLD`); now split on the first `:` only.
- Whitespace is stripped; malformed tokens and rejected keys are logged and skipped instead of silently ignored.
- Adds example launch lines to the element boilerplates, as requested in the original review.

**3. [Test/Edge] Exercise custom-props parsing at element start**
The original tests only covered the GObject set/get round trip; the parser never ran. New state-change tests apply custom-props through start() and verify values on the edge handle via `nns_edge_get_info()` (PEER_ADDRESS through the custom test library), plus malformed-input tests (colon-less token, empty key/value, doubled/trailing commas) confirming no crash, start not blocked, and valid tokens still applied. `unittest_edge` now links libnnstreamer-edge (a regular library; the gstedge plugin module remains unlinked).

**4. [Edge] Surface custom-props parse failures on the element bus**
Posts `GST_ELEMENT_WARNING (RESOURCE, SETTINGS)` when some options were not applied, so applications see the failure on the bus rather than in console logs only. The helper's return-value contract is specified in its doxygen, and the property blurb notes when options are applied.

**5. [Test/Edge] Verify custom-props warnings on the pipeline bus**
Asserts that rejected options post that warning — matched on domain/code, the posting element's name, and the message text — and that fully valid options post none, so the warning path itself is covered by CI.

**6. [Edge] Keep custom-props values out of logs and the bus** (+ follow-up commit)
`custom-props` is the documented place for options of a custom connection library, so a value may be a token or credential. A rejected option is now named by its key — or by its position when the separator was mistyped and no key can be parsed out of it — and the bus warning no longer echoes the property string. Also documents that custom-props is applied after the dedicated properties and therefore overrides a duplicated key, covers the branch where a well-formed option is refused by `nns_edge_set_info()`, and switches the edgesink malformed-input test to the custom connection library so it no longer opens a real TCP listener.

Local test: `unittest_edge` 18/18 passed; gst-indent and `clang-format --dry-run -Werror` clean on the changed code.

When this PR is merged, #4700 will be commented and closed.

**Self evaluation:**
1. Build test: [x] Passed [ ] Failed [ ] Skipped
2. Run test: [x] Passed [ ] Failed [ ] Skipped

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>