### PR TITLE
[Test/datarepo] fix flaky fps30ReadFlexibleTensors

### DIFF
--- a/tests/nnstreamer_datarepo/unittest_datareposrc.cc
+++ b/tests/nnstreamer_datarepo/unittest_datareposrc.cc
@@ -714,7 +714,7 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
    * the expected duration from the frames actually read.
    */
   ASSERT_GT (sync_count, 0);
-  ASSERT_GT (no_sync_count, 0);
+  EXPECT_EQ (sync_count, no_sync_count);
 
   /* sync=true paces the playback with the framerate stored in the json file */
   EXPECT_GT (sync_time, (sync_count / (gdouble) fps) * 0.7);

--- a/tests/nnstreamer_datarepo/unittest_datareposrc.cc
+++ b/tests/nnstreamer_datarepo/unittest_datareposrc.cc
@@ -636,8 +636,10 @@ error:
 TEST (datareposrc, fps30ReadFlexibleTensors)
 {
   gint fps = 30;
+  gint sync_count = 0, no_sync_count = 0;
+  GCallback handler = G_CALLBACK (new_data_cb);
   guint64 start_time, end_time;
-  gdouble elapsed_time;
+  gdouble sync_time, no_sync_time;
   GstElement *tensor_sink;
   GstBus *bus;
   GMainLoop *loop;
@@ -648,6 +650,10 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
   create_flexible_tensors_test_file (fps, file_index);
   GstElement *pipeline = gst_parse_launch (str_pipeline, NULL);
   ASSERT_NE (pipeline, nullptr);
+
+  tensor_sink = gst_bin_get_by_name (GST_BIN (pipeline), "tensor_sink0");
+  ASSERT_NE (tensor_sink, nullptr);
+  g_signal_connect (tensor_sink, "new-data", (GCallback) handler, &sync_count);
 
   loop = g_main_loop_new (NULL, FALSE);
   bus = gst_pipeline_get_bus (GST_PIPELINE (pipeline));
@@ -662,11 +668,9 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
 
   setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT);
   end_time = g_get_monotonic_time ();
-  elapsed_time = (end_time - start_time) / (double) G_USEC_PER_SEC;
+  sync_time = (end_time - start_time) / (double) G_USEC_PER_SEC;
 
-  g_print ("Elapsed time: %.6f second\n", elapsed_time);
-  EXPECT_LT (0.8, elapsed_time);
-
+  g_clear_pointer (&tensor_sink, gst_object_unref);
   g_clear_pointer (&pipeline, gst_object_unref);
   g_main_loop_unref (loop);
 
@@ -680,7 +684,9 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
   g_clear_pointer (&bus, gst_object_unref);
 
   tensor_sink = gst_bin_get_by_name (GST_BIN (pipeline), "tensor_sink0");
+  ASSERT_NE (tensor_sink, nullptr);
   g_object_set (GST_OBJECT (tensor_sink), "sync", FALSE, NULL);
+  g_signal_connect (tensor_sink, "new-data", (GCallback) handler, &no_sync_count);
 
   start_time = g_get_monotonic_time ();
 
@@ -689,10 +695,7 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
 
   setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT);
   end_time = g_get_monotonic_time ();
-  elapsed_time = (end_time - start_time) / (double) G_USEC_PER_SEC;
-
-  g_print ("Elapsed time: %.6f second\n", elapsed_time);
-  EXPECT_LT (elapsed_time, 0.05);
+  no_sync_time = (end_time - start_time) / (double) G_USEC_PER_SEC;
 
   g_clear_pointer (&tensor_sink, gst_object_unref);
   g_clear_pointer (&pipeline, gst_object_unref);
@@ -700,6 +703,23 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
 
   g_remove ("flexible1.json");
   g_remove ("flexible1.data");
+
+  g_print ("Elapsed time: %.6f second (sync, %d frames), %.6f second (no sync, %d frames)\n",
+      sync_time, sync_count, no_sync_time, no_sync_count);
+
+  /**
+   * The number of frames in the test file is not fixed: the join element feeding
+   * datareposink forwards EOS from the pad that delivered the last buffer, so the
+   * remaining sources are cut off at a point that depends on scheduling. Derive
+   * the expected duration from the frames actually read.
+   */
+  ASSERT_GT (sync_count, 0);
+  ASSERT_GT (no_sync_count, 0);
+
+  /* sync=true paces the playback with the framerate stored in the json file */
+  EXPECT_GT (sync_time, (sync_count / (gdouble) fps) * 0.7);
+  /* sync=false reads the same frames without waiting for the clock */
+  EXPECT_LT (no_sync_time * 3, sync_time);
 }
 
 /**

--- a/tests/nnstreamer_datarepo/unittest_datareposrc.cc
+++ b/tests/nnstreamer_datarepo/unittest_datareposrc.cc
@@ -704,14 +704,14 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
   g_remove ("flexible1.json");
   g_remove ("flexible1.data");
 
-  g_print ("Elapsed time: %.6f second (sync, %d frames), %.6f second (no sync, %d frames)\n",
-      sync_time, sync_count, no_sync_time, no_sync_count);
+  g_print ("Elapsed time: %.6f s (sync), %.6f s (no sync), %d frames\n",
+      sync_time, no_sync_time, sync_count);
 
   /**
-   * The number of frames in the test file is not fixed: the join element feeding
-   * datareposink forwards EOS from the pad that delivered the last buffer, so the
-   * remaining sources are cut off at a point that depends on scheduling. Derive
-   * the expected duration from the frames actually read.
+   * The number of frames in the test file is not fixed: the join element
+   * feeding datareposink forwards EOS from the pad that delivered the last
+   * buffer, so the remaining sources are cut off at a point that depends on
+   * scheduling. Derive the expected duration from the frames actually read.
    */
   ASSERT_GT (sync_count, 0);
   EXPECT_EQ (sync_count, no_sync_count);


### PR DESCRIPTION
## Problem

`datareposrc.fps30ReadFlexibleTensors` fails intermittently in the Ubuntu meson CI job. Most recently on [run 32974102457](https://github.com/nnstreamer/nnstreamer/actions/runs/32974102457) for #4864, whose diff only touched unrelated test argmax helpers. The log shows:

```
Elapsed time: 0.758597 second
../tests/nnstreamer_datarepo/unittest_datareposrc.cc:668: Failure
```

## Root cause

The test asserted a hard-coded wall-clock lower bound (`EXPECT_LT (0.8, elapsed_time)`) on the `sync=true` run, which assumes the generated file always holds 30 frames (3 sources x `num-buffers=10`).

It does not. `create_flexible_tensors_test_file ()` feeds **three concurrent** `videotestsrc` into `join`, but `join` forwards events only from the pad that delivered the last buffer:

https://github.com/nnstreamer/nnstreamer/blob/main/gst/join/gstjoin.c — `forward = (pad == active_sinkpad);`

So the first EOS that arrives while its pad is active is forwarded downstream, `datareposink` finalizes the file, and the remaining sources are cut off. How many frames land in the file depends on thread scheduling. This is consistent with `join`'s documented contract — *"N streams should not operate at the same time... If one sinkpad is receiving buffer, the others should be stopped"* — which the helper does not honour, so this is a test-side issue rather than a `join` defect.

`datareposrc` timestamps frame *i* at `(i-1)/fps`, so the last of N frames renders at `(N-2)/fps`:

| frames stored | expected elapsed | vs. 0.8 s bound |
|---|---|---|
| 30 | 0.933 s | passes |
| 25 | 0.767 s | **fails** (matches the observed 0.7586 s) |

## Fix

Count the frames each run actually delivers via the `new-data` signal and derive the expectation from that instead of a magic constant:

- **synced run** must take at least 70% of the stream duration (`frames / fps`). Since the sink waits for every timestamp, elapsed is always >= `(N-2)/fps`, so this holds deterministically for any N >= 7 — and N is never below 10, because the source that emits the terminating EOS has necessarily pushed all 10 of its buffers. Machine load can only make elapsed larger, never smaller.
- **unsynced run** is now compared against the synced run instead of an absolute `0.05 s` bound, so it no longer depends on the runner being fast in absolute terms. For the typical 25-30 frame file this allows ~0.26-0.31 s where the observed value is ~0.02 s.

Both properties the test verified are preserved: `sync=true` is paced by the framerate stored in the json, and `sync=false` is far faster.

## Scope notes

- Test-only change, confined to one test function; no production code touched.
- Assertions moved after the cleanup so a failure cannot leak the pipeline.
- The deeper question of whether `join` should aggregate EOS across all pads (rather than relying on callers to serialize their sources) is left alone deliberately — it would change element behaviour for every `join` user and is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)