### PR TITLE
[Test/datarepo] Fix flaky datarepo unit tests under parallel CI runs

### DIFF
--- a/tests/nnstreamer_datarepo/unittest_datareposink.cc
+++ b/tests/nnstreamer_datarepo/unittest_datareposink.cc
@@ -665,6 +665,7 @@ int
 main (int argc, char **argv)
 {
   int result = -1;
+  gchar *work_dir;
 
   try {
     testing::InitGoogleTest (&argc, argv);
@@ -674,11 +675,17 @@ main (int argc, char **argv)
 
   gst_init (&argc, &argv);
 
+  /* These tests write fixed file names, which unittest_datareposrc also uses. */
+  /* Enter after InitGoogleTest, which anchors --gtest_output to the start directory. */
+  work_dir = enterPrivateWorkDir ();
+
   try {
     result = RUN_ALL_TESTS ();
   } catch (...) {
     g_warning ("catch `testing::internal::GoogleTestFailureException`");
   }
+
+  leavePrivateWorkDir (&work_dir);
 
   return result;
 }

--- a/tests/nnstreamer_datarepo/unittest_datareposrc.cc
+++ b/tests/nnstreamer_datarepo/unittest_datareposrc.cc
@@ -637,11 +637,12 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
 {
   gint fps = 30;
   guint64 start_time, end_time;
-  gdouble elapsed_time;
+  gdouble elapsed_time, stream_duration;
   GstElement *tensor_sink;
   GstBus *bus;
   GMainLoop *loop;
   gint file_index = 1;
+  gint buffer_count = 0, no_sync_count = 0;
   const gchar *str_pipeline
       = "datareposrc location=flexible1.data json=flexible1.json ! queue ! tensor_sink name=tensor_sink0 sync=true";
 
@@ -655,6 +656,10 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
   gst_bus_add_watch (bus, bus_callback, loop);
   g_clear_pointer (&bus, gst_object_unref);
 
+  tensor_sink = gst_bin_get_by_name (GST_BIN (pipeline), "tensor_sink0");
+  ASSERT_NE (tensor_sink, nullptr);
+  g_signal_connect (tensor_sink, "new-data", G_CALLBACK (new_data_cb), &buffer_count);
+
   start_time = g_get_monotonic_time ();
 
   setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT);
@@ -664,9 +669,20 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
   end_time = g_get_monotonic_time ();
   elapsed_time = (end_time - start_time) / (double) G_USEC_PER_SEC;
 
-  g_print ("Elapsed time: %.6f second\n", elapsed_time);
-  EXPECT_LT (0.8, elapsed_time);
+  /**
+   * @brief The writer pipeline does not store a fixed number of samples: join
+   * forwards EOS from the pad that delivered the last buffer, so the remaining
+   * sources are cut off at a point that depends on scheduling. Derive the
+   * expected play time from the samples that were actually read. Fewer than a
+   * third of the 30 samples means the writer, not the timing, is broken.
+   */
+  ASSERT_GE (buffer_count, 10);
+  stream_duration = (buffer_count - 1) / (gdouble) fps;
 
+  g_print ("Elapsed time: %.6f second (%d buffers)\n", elapsed_time, buffer_count);
+  EXPECT_LT (stream_duration * 0.9, elapsed_time);
+
+  g_clear_pointer (&tensor_sink, gst_object_unref);
   g_clear_pointer (&pipeline, gst_object_unref);
   g_main_loop_unref (loop);
 
@@ -680,7 +696,9 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
   g_clear_pointer (&bus, gst_object_unref);
 
   tensor_sink = gst_bin_get_by_name (GST_BIN (pipeline), "tensor_sink0");
+  ASSERT_NE (tensor_sink, nullptr);
   g_object_set (GST_OBJECT (tensor_sink), "sync", FALSE, NULL);
+  g_signal_connect (tensor_sink, "new-data", G_CALLBACK (new_data_cb), &no_sync_count);
 
   start_time = g_get_monotonic_time ();
 
@@ -691,8 +709,10 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
   end_time = g_get_monotonic_time ();
   elapsed_time = (end_time - start_time) / (double) G_USEC_PER_SEC;
 
-  g_print ("Elapsed time: %.6f second\n", elapsed_time);
-  EXPECT_LT (elapsed_time, 0.05);
+  g_print ("Elapsed time: %.6f second (%d buffers)\n", elapsed_time, no_sync_count);
+  EXPECT_EQ (no_sync_count, buffer_count);
+  /* Without sync the same samples are read without waiting for the clock. */
+  EXPECT_LT (elapsed_time, stream_duration * 0.5);
 
   g_clear_pointer (&tensor_sink, gst_object_unref);
   g_clear_pointer (&pipeline, gst_object_unref);
@@ -1147,6 +1167,7 @@ int
 main (int argc, char **argv)
 {
   int result = -1;
+  gchar *work_dir;
 
   try {
     testing::InitGoogleTest (&argc, argv);
@@ -1156,11 +1177,17 @@ main (int argc, char **argv)
 
   gst_init (&argc, &argv);
 
+  /* These tests write fixed file names, which unittest_datareposink also uses. */
+  /* Enter after InitGoogleTest, which anchors --gtest_output to the start directory. */
+  work_dir = enterPrivateWorkDir ();
+
   try {
     result = RUN_ALL_TESTS ();
   } catch (...) {
     g_warning ("catch `testing::internal::GoogleTestFailureException`");
   }
+
+  leavePrivateWorkDir (&work_dir);
 
   return result;
 }

--- a/tests/unittest_util.c
+++ b/tests/unittest_util.c
@@ -92,6 +92,99 @@ void removeTempFile (char **file_name)
 }
 
 /**
+ * @brief Remove a directory with everything in it.
+ */
+static void
+removeDirRecursive (const gchar * path)
+{
+  GDir *dir;
+  const gchar *name;
+
+  dir = g_dir_open (path, 0, NULL);
+  if (dir == NULL)
+    return;
+
+  while ((name = g_dir_read_name (dir)) != NULL) {
+    gchar *child = g_build_filename (path, name, NULL);
+
+    if (g_file_test (child, G_FILE_TEST_IS_DIR)
+        && !g_file_test (child, G_FILE_TEST_IS_SYMLINK))
+      removeDirRecursive (child);
+    else
+      g_remove (child);
+
+    g_free (child);
+  }
+
+  g_dir_close (dir);
+  g_rmdir (path);
+}
+
+static gchar *private_work_dir_origin = NULL; /**< Directory to return to. */
+
+/**
+ * @brief Enter a private working directory for the calling test binary.
+ * @return the new working directory, or NULL if the move failed
+ */
+gchar *
+enterPrivateWorkDir (void)
+{
+  gchar *work_dir;
+  gchar *cwd = g_get_current_dir ();
+
+  /* Tests locate their data with this, falling back to a relative path. */
+  if (g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH") == NULL) {
+    gchar *root = g_build_filename (cwd, "..", NULL);
+
+    g_setenv ("NNSTREAMER_SOURCE_ROOT_PATH", root, TRUE);
+    g_free (root);
+  }
+
+  work_dir = g_dir_make_tmp ("nnstreamer_unittest_workdir_XXXXXX", NULL);
+  if (work_dir == NULL) {
+    g_warning ("failed to create a private working directory, "
+               "tests sharing file names may interfere with each other");
+    g_free (cwd);
+    return NULL;
+  }
+
+  if (g_chdir (work_dir) != 0) {
+    g_warning ("failed to enter the private working directory %s, "
+               "tests sharing file names may interfere with each other", work_dir);
+    g_rmdir (work_dir);
+    g_free (work_dir);
+    g_free (cwd);
+    return NULL;
+  }
+
+  g_free (private_work_dir_origin);
+  private_work_dir_origin = cwd;
+
+  return work_dir;
+}
+
+/**
+ * @brief Return to the entry directory and remove the private working directory.
+ */
+void
+leavePrivateWorkDir (gchar ** work_dir)
+{
+  if (work_dir == NULL || *work_dir == NULL)
+    return;
+
+  /* Move out of the directory before removing it; both steps are best effort. */
+  if (private_work_dir_origin != NULL)
+    (void) g_chdir (private_work_dir_origin);
+
+  removeDirRecursive (*work_dir);
+
+  g_free (private_work_dir_origin);
+  private_work_dir_origin = NULL;
+  g_free (*work_dir);
+  *work_dir = NULL;
+}
+
+/**
  * @brief Wait until the pipeline processing the buffers
  * @return TRUE on success, FALSE when a time-out occurs
  */

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -51,6 +51,29 @@ extern gchar * getTempFilename (void);
 extern void removeTempFile (char **file_name);
 
 /**
+ * @brief Enter a private working directory for the calling test binary.
+ * @details meson runs test binaries in parallel with the build directory as
+ *          their working directory, so binaries that create files with fixed
+ *          names overwrite and delete each other's files. Call this before
+ *          running the tests to give the process a directory of its own.
+ *          NNSTREAMER_SOURCE_ROOT_PATH is made absolute first, so that test
+ *          data is still found after the move.
+ * @note Call this after testing::InitGoogleTest(), which resolves a relative
+ *       --gtest_output against the directory the test was started from.
+ *       Entering earlier would write the report into the private directory,
+ *       which leavePrivateWorkDir() then removes.
+ * @return the new working directory, or NULL if the move failed
+ *         (should be released with leavePrivateWorkDir)
+ */
+extern gchar * enterPrivateWorkDir (void);
+
+/**
+ * @brief Return to the directory enterPrivateWorkDir() was called from and
+ *        remove the private working directory with its contents.
+ */
+extern void leavePrivateWorkDir (gchar **work_dir);
+
+/**
  * @brief Wait until the pipeline processing the buffers
  * @return TRUE on success, FALSE when a time-out occurs
  */


### PR DESCRIPTION
## The problem

Two datarepo unit tests fail intermittently on shared CI runners and take unrelated PRs down with them:

- `datareposink.writeFlexibleTensors_n` — `Expected: (file_info) != (nullptr)` at `unittest_datareposink.cc:578`
- `datareposrc.fps30ReadFlexibleTensors` — `Expected: (0.8) < (elapsed_time), actual: 0.8 vs 0.758597` at `unittest_datareposrc.cc:668`

Both were seen on 2026-08-26 within minutes of each other on two different PRs, and the `ubuntu-22.04-arm` variant of the same job passed.

## Reproduction

```
meson test -C build unittest_datareposink unittest_datareposrc --repeat 12
```

**12 of 24 runs failed**, with exactly the two assertions above. The same command with `--num-processes 1`: **12/12 passed**. The trigger is concurrency, and there are two independent causes.

### Cause 1 — the two binaries share a working directory

`meson test` runs test binaries in parallel with the build directory as their working directory. Both datarepo binaries have their own `create_image_test_file()` writing the *same* names (`img_%02d.png`, `img.json`), and both `g_remove()` them when done. Each deletes the images the other is feeding to `multifilesrc`.

That explains the NULL `file_info` precisely: with the images gone, `multifilesrc` errors out before caps ever reach `datareposink`, and the sink opens its output file in `PAUSED_TO_PLAYING` (`gst_data_repo_sink_open_file()`, which also requires `data_type` from `set_caps`), so `flexible.data` is never created.

The two binaries share more than the images — `unittest_datareposrc.cc` also reads bare `flexible.json` and `sparse.data`, which only `unittest_datareposink` ever writes — so this PR isolates the whole file namespace rather than renaming the known collisions. The helper lives in `unittest_util` because any test binary writing fixed names has the same exposure.

### Cause 2 — a wall-clock assertion over a variable number of samples

`create_flexible_tensors_test_file()` joins three `videotestsrc` branches (10 buffers each). `join` forwards EOS from whichever sinkpad is currently active (`gst_join_pad_event()`: `forward = (pad == active_sinkpad)`), so when a branch's EOS wins the race the other branches are cut off. Probing the fixture directly:

| condition | total_samples written |
|---|---|
| idle | 30, 30, 30, 30, 30, 30, 30, 30 |
| all cores loaded | 30, 28, 30, 17, 21, 30, 24, 22, 25, 26 |

The test assumed 30 samples at 30 fps (last PTS = 0.967 s) and compared against a hardcoded `0.8`. With 24 samples the stream is only 0.767 s long, so the assertion fails — which is exactly the 0.758597 s the CI log recorded. The `EXPECT_LT (elapsed_time, 0.05)` on the unsynced run had the same shape of problem in the other direction.

The fix counts the buffers actually read and derives the expected play time from them, so the test measures the framerate behaviour it is meant to measure regardless of how much the fixture wrote.

## Verification

| scenario | before | after |
|---|---|---|
| `--repeat 12`, parallel | 12/24 fail | **24/24 pass** |
| `--repeat 20`, all cores saturated | — | **40/40 pass** (buffer counts 18–30 in that run; the old assertion would have failed 11 times) |
| full local suite | — | **no regressions** (checks the shared `unittest_util` change) |

## Not in this PR

The `join` EOS behaviour in cause 2 is a real data-loss path for any pipeline that merges concurrent streams, not just this fixture. Changing when `join` forwards EOS is an element behaviour change that deserves its own PR and review, so this PR only makes the tests independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)