### PR TITLE
[Join] Forward EOS only after every sink pad ends

### DIFF
--- a/gst/join/gstjoin.c
+++ b/gst/join/gstjoin.c
@@ -98,6 +98,7 @@ struct _GstJoinPad
 
   GstSegment segment;           /* the current segment on the pad */
   guint32 segment_seqnum;       /* sequence number of the current segment */
+  gboolean eos;                 /* TRUE if EOS is received on this pad */
 };
 
 /**
@@ -162,6 +163,7 @@ gst_join_pad_reset (GstJoinPad * pad)
 {
   GST_OBJECT_LOCK (pad);
   gst_segment_init (&pad->segment, GST_FORMAT_UNDEFINED);
+  pad->eos = FALSE;
   GST_OBJECT_UNLOCK (pad);
 }
 
@@ -227,6 +229,31 @@ forward_sticky_events (GstPad * sinkpad, GstEvent ** event, gpointer user_data)
 }
 
 /**
+ * @brief Check whether every linked sink pad has received EOS.
+ * @note must be called with the JOIN_LOCK. Unlinked pads are ignored, as no
+ *       stream can ever end on them.
+ */
+static gboolean
+gst_join_all_sinkpads_eos (GstJoin * sel)
+{
+  GList *l;
+  gboolean eos = TRUE;
+
+  GST_OBJECT_LOCK (sel);
+  for (l = GST_ELEMENT_CAST (sel)->sinkpads; l; l = l->next) {
+    GstJoinPad *selpad = GST_JOIN_PAD_CAST (l->data);
+
+    if (!selpad->eos && GST_PAD_IS_LINKED (GST_PAD_CAST (selpad))) {
+      eos = FALSE;
+      break;
+    }
+  }
+  GST_OBJECT_UNLOCK (sel);
+
+  return eos;
+}
+
+/**
  * @brief event function for sink pad
  */
 static gboolean
@@ -284,6 +311,14 @@ gst_join_pad_event (GstPad * pad, GstObject * parent, GstEvent * event)
           &selpad->segment);
       break;
     }
+    case GST_EVENT_EOS:
+      selpad->eos = TRUE;
+      forward = gst_join_all_sinkpads_eos (sel);
+      GST_DEBUG_OBJECT (pad, "received EOS, forward %d", forward);
+      break;
+    case GST_EVENT_FLUSH_STOP:
+      selpad->eos = FALSE;
+      break;
     default:
       break;
   }
@@ -424,6 +459,8 @@ static void gst_join_get_property (GObject * object,
     guint prop_id, GValue * value, GParamSpec * pspec);
 static GstPad *gst_join_request_new_pad (GstElement * element,
     GstPadTemplate * templ, const gchar * unused, const GstCaps * caps);
+static GstStateChangeReturn gst_join_change_state (GstElement * element,
+    GstStateChange transition);
 
 #define gst_join_parent_class parent_class
 G_DEFINE_TYPE_WITH_CODE (GstJoin, gst_join, GST_TYPE_ELEMENT,
@@ -465,6 +502,28 @@ gst_join_class_init (GstJoinClass * klass)
       &gst_join_src_factory);
 
   gstelement_class->request_new_pad = gst_join_request_new_pad;
+  gstelement_class->change_state = gst_join_change_state;
+}
+
+/**
+ * @brief Clear the per-pad EOS flags so that a restarted pipeline starts clean.
+ */
+static GstStateChangeReturn
+gst_join_change_state (GstElement * element, GstStateChange transition)
+{
+  GstJoin *sel = GST_JOIN (element);
+  GList *l;
+
+  if (transition == GST_STATE_CHANGE_READY_TO_PAUSED) {
+    GST_JOIN_LOCK (sel);
+    GST_OBJECT_LOCK (sel);
+    for (l = element->sinkpads; l; l = l->next)
+      GST_JOIN_PAD_CAST (l->data)->eos = FALSE;
+    GST_OBJECT_UNLOCK (sel);
+    GST_JOIN_UNLOCK (sel);
+  }
+
+  return GST_ELEMENT_CLASS (parent_class)->change_state (element, transition);
 }
 
 /**

--- a/gst/join/gstjoin.c
+++ b/gst/join/gstjoin.c
@@ -16,9 +16,9 @@
  * @note A join has reduced and changed input-selector's function.
  *
  * Connect recently arrived buffer from N input streams to the output pad.
- * N streams should not operate at the same time.
+ * The input streams are expected to take turns; if they overlap, the buffers
+ * are simply interleaved in arrival order.
  * All capabilities (input stream i and output stream) should be the same.
- * For example, If one sinkpad is receiving buffer, the others should be stopped.
  * EOS reaches the output pad only after every linked input stream has ended.
  * <refsect2>
  * <title>Example launch line</title>
@@ -231,27 +231,31 @@ forward_sticky_events (GstPad * sinkpad, GstEvent ** event, gpointer user_data)
 
 /**
  * @brief Check whether every linked sink pad has received EOS.
+ * @param[out] any_eos If not NULL, set to whether at least one sink pad is EOS.
  * @note must be called with the JOIN_LOCK. Unlinked pads are ignored, as no
  *       stream can ever end on them.
  */
 static gboolean
-gst_join_all_sinkpads_eos (GstJoin * sel)
+gst_join_all_sinkpads_eos (GstJoin * sel, gboolean * any_eos)
 {
   GList *l;
-  gboolean eos = TRUE;
+  gboolean all = TRUE, any = FALSE;
 
   GST_OBJECT_LOCK (sel);
   for (l = GST_ELEMENT_CAST (sel)->sinkpads; l; l = l->next) {
     GstJoinPad *selpad = GST_JOIN_PAD_CAST (l->data);
 
-    if (!selpad->eos && GST_PAD_IS_LINKED (GST_PAD_CAST (selpad))) {
-      eos = FALSE;
-      break;
-    }
+    if (selpad->eos)
+      any = TRUE;
+    else if (GST_PAD_IS_LINKED (GST_PAD_CAST (selpad)))
+      all = FALSE;
   }
   GST_OBJECT_UNLOCK (sel);
 
-  return eos;
+  if (any_eos)
+    *any_eos = any;
+
+  return all;
 }
 
 /**
@@ -314,7 +318,7 @@ gst_join_pad_event (GstPad * pad, GstObject * parent, GstEvent * event)
     }
     case GST_EVENT_EOS:
       selpad->eos = TRUE;
-      forward = gst_join_all_sinkpads_eos (sel);
+      forward = gst_join_all_sinkpads_eos (sel, NULL);
       GST_DEBUG_OBJECT (pad, "received EOS, forward %d", forward);
       break;
     case GST_EVENT_FLUSH_STOP:
@@ -460,6 +464,7 @@ static void gst_join_get_property (GObject * object,
     guint prop_id, GValue * value, GParamSpec * pspec);
 static GstPad *gst_join_request_new_pad (GstElement * element,
     GstPadTemplate * templ, const gchar * unused, const GstCaps * caps);
+static void gst_join_release_pad (GstElement * element, GstPad * pad);
 static GstStateChangeReturn gst_join_change_state (GstElement * element,
     GstStateChange transition);
 
@@ -503,6 +508,7 @@ gst_join_class_init (GstJoinClass * klass)
       &gst_join_src_factory);
 
   gstelement_class->request_new_pad = gst_join_request_new_pad;
+  gstelement_class->release_pad = gst_join_release_pad;
   gstelement_class->change_state = gst_join_change_state;
 }
 
@@ -739,6 +745,42 @@ gst_join_request_new_pad (GstElement * element, GstPadTemplate * templ,
   GST_JOIN_UNLOCK (sel);
 
   return sinkpad;
+}
+
+/**
+ * @brief release the given request sink pad
+ */
+static void
+gst_join_release_pad (GstElement * element, GstPad * pad)
+{
+  GstJoin *sel = GST_JOIN (element);
+  GstPad **active_pad_p;
+  gboolean send_eos, any_eos = FALSE;
+
+  GST_JOIN_LOCK (sel);
+  GST_LOG_OBJECT (sel, "Releasing pad %s:%s", GST_DEBUG_PAD_NAME (pad));
+
+  if (sel->active_sinkpad == pad) {
+    active_pad_p = &sel->active_sinkpad;
+    gst_object_replace ((GstObject **) active_pad_p, NULL);
+  }
+  if (sel->n_pads > 0)
+    sel->n_pads--;
+  GST_JOIN_UNLOCK (sel);
+
+  gst_pad_set_active (pad, FALSE);
+  gst_element_remove_pad (element, pad);
+
+  /* A released pad can no longer end its stream. */
+  GST_JOIN_LOCK (sel);
+  send_eos = !GST_PAD_IS_EOS (sel->srcpad)
+      && gst_join_all_sinkpads_eos (sel, &any_eos) && any_eos;
+  GST_JOIN_UNLOCK (sel);
+
+  if (send_eos) {
+    GST_DEBUG_OBJECT (sel, "last awaited sink pad released, forwarding EOS");
+    gst_pad_push_event (sel->srcpad, gst_event_new_eos ());
+  }
 }
 
 /**

--- a/gst/join/gstjoin.c
+++ b/gst/join/gstjoin.c
@@ -21,7 +21,9 @@
  * All capabilities (input stream i and output stream) should be the same.
  * EOS reaches the output pad only after every linked input stream has ended.
  * A sink pad that is unlinked or released is no longer waited for, since no
- * stream can end on it; the output would otherwise never see EOS.
+ * stream can end on it; the output would otherwise never see EOS. So an
+ * application that unlinks a branch mid-stream should expect the output to
+ * end once the branches still linked do, and relink before that happens.
  * <refsect2>
  * <title>Example launch line</title>
  * gst-launch-1.0 ... (input stream 0) ! join.sink_0 \

--- a/gst/join/gstjoin.c
+++ b/gst/join/gstjoin.c
@@ -21,9 +21,10 @@
  * All capabilities (input stream i and output stream) should be the same.
  * EOS reaches the output pad only after every linked input stream has ended.
  * A sink pad that is unlinked or released is no longer waited for, since no
- * stream can end on it; the output would otherwise never see EOS. So an
- * application that unlinks a branch mid-stream should expect the output to
- * end once the branches still linked do, and relink before that happens.
+ * stream can end on it; the output would otherwise never see EOS. The set is
+ * only re-examined when a sink pad receives EOS or is released, so retiring a
+ * branch mid-stream means releasing its pad: unlinking alone drops it from the
+ * set without ending the output, and the output ends at whatever comes next.
  * <refsect2>
  * <title>Example launch line</title>
  * gst-launch-1.0 ... (input stream 0) ! join.sink_0 \
@@ -251,7 +252,7 @@ gst_join_all_sinkpads_eos (GstJoin * sel, gboolean * any_eos)
 
     if (selpad->eos)
       any = TRUE;
-    else if (GST_PAD_IS_LINKED (GST_PAD_CAST (selpad)))
+    else if (gst_pad_is_linked (GST_PAD_CAST (selpad)))
       all = FALSE;
   }
   GST_OBJECT_UNLOCK (sel);

--- a/gst/join/gstjoin.c
+++ b/gst/join/gstjoin.c
@@ -20,8 +20,8 @@
  * buffer is still forwarded, in the order it arrived.
  * All capabilities (input stream i and output stream) should be the same.
  * EOS reaches the output pad only after every linked input stream has ended.
- * Unlinking a sink pad does not end its stream; release the pad to take it out
- * of the set that is waited for.
+ * A sink pad that is unlinked or released is no longer waited for, since no
+ * stream can end on it; the output would otherwise never see EOS.
  * <refsect2>
  * <title>Example launch line</title>
  * gst-launch-1.0 ... (input stream 0) ! join.sink_0 \
@@ -320,11 +320,13 @@ gst_join_pad_event (GstPad * pad, GstObject * parent, GstEvent * event)
     }
     case GST_EVENT_EOS:
       selpad->eos = TRUE;
-      forward = gst_join_all_sinkpads_eos (sel, NULL);
+      forward = !sel->eos_sent && gst_join_all_sinkpads_eos (sel, NULL);
+      sel->eos_sent |= forward;
       GST_DEBUG_OBJECT (pad, "received EOS, forward %d", forward);
       break;
     case GST_EVENT_FLUSH_STOP:
       selpad->eos = FALSE;
+      sel->eos_sent = FALSE;
       break;
     default:
       break;
@@ -528,6 +530,7 @@ gst_join_change_state (GstElement * element, GstStateChange transition)
     GST_OBJECT_LOCK (sel);
     for (l = element->sinkpads; l; l = l->next)
       GST_JOIN_PAD_CAST (l->data)->eos = FALSE;
+    sel->eos_sent = FALSE;
     GST_OBJECT_UNLOCK (sel);
     GST_JOIN_UNLOCK (sel);
   }
@@ -759,7 +762,6 @@ static void
 gst_join_release_pad (GstElement * element, GstPad * pad)
 {
   GstJoin *sel = GST_JOIN (element);
-  GstEvent *eos;
   gboolean send_eos, any_eos = FALSE;
 
   g_return_if_fail (GST_IS_JOIN_PAD (pad));
@@ -781,10 +783,9 @@ gst_join_release_pad (GstElement * element, GstPad * pad)
     sel->n_pads--;
 
   /* A released pad can no longer end its stream. */
-  eos = gst_pad_get_sticky_event (sel->srcpad, GST_EVENT_EOS, 0);
-  send_eos = (eos == NULL)
+  send_eos = !sel->eos_sent
       && gst_join_all_sinkpads_eos (sel, &any_eos) && any_eos;
-  gst_event_replace (&eos, NULL);
+  sel->eos_sent |= send_eos;
   GST_JOIN_UNLOCK (sel);
 
   gst_object_unref (pad);

--- a/gst/join/gstjoin.c
+++ b/gst/join/gstjoin.c
@@ -16,10 +16,12 @@
  * @note A join has reduced and changed input-selector's function.
  *
  * Connect recently arrived buffer from N input streams to the output pad.
- * The input streams are expected to take turns; if they overlap, the buffers
- * are simply interleaved in arrival order.
+ * The input streams are expected to take turns; when they do overlap, every
+ * buffer is still forwarded, in the order it arrived.
  * All capabilities (input stream i and output stream) should be the same.
  * EOS reaches the output pad only after every linked input stream has ended.
+ * Unlinking a sink pad does not end its stream; release the pad to take it out
+ * of the set that is waited for.
  * <refsect2>
  * <title>Example launch line</title>
  * gst-launch-1.0 ... (input stream 0) ! join.sink_0 \
@@ -754,27 +756,30 @@ static void
 gst_join_release_pad (GstElement * element, GstPad * pad)
 {
   GstJoin *sel = GST_JOIN (element);
-  GstPad **active_pad_p;
+  GstEvent *eos;
   gboolean send_eos, any_eos = FALSE;
 
-  GST_JOIN_LOCK (sel);
+  g_return_if_fail (GST_IS_JOIN_PAD (pad));
+
   GST_LOG_OBJECT (sel, "Releasing pad %s:%s", GST_DEBUG_PAD_NAME (pad));
 
-  if (sel->active_sinkpad == pad) {
-    active_pad_p = &sel->active_sinkpad;
-    gst_object_replace ((GstObject **) active_pad_p, NULL);
-  }
-  if (sel->n_pads > 0)
-    sel->n_pads--;
-  GST_JOIN_UNLOCK (sel);
-
+  /* Deactivate first: this stops the thread that would re-activate the pad. */
   gst_pad_set_active (pad, FALSE);
   gst_element_remove_pad (element, pad);
 
-  /* A released pad can no longer end its stream. */
   GST_JOIN_LOCK (sel);
-  send_eos = !GST_PAD_IS_EOS (sel->srcpad)
+  if (sel->active_sinkpad == pad) {
+    gst_object_unref (sel->active_sinkpad);
+    sel->active_sinkpad = NULL;
+  }
+  if (sel->n_pads > 0)
+    sel->n_pads--;
+
+  /* A released pad can no longer end its stream. */
+  eos = gst_pad_get_sticky_event (sel->srcpad, GST_EVENT_EOS, 0);
+  send_eos = (eos == NULL)
       && gst_join_all_sinkpads_eos (sel, &any_eos) && any_eos;
+  gst_event_replace (&eos, NULL);
   GST_JOIN_UNLOCK (sel);
 
   if (send_eos) {

--- a/gst/join/gstjoin.c
+++ b/gst/join/gstjoin.c
@@ -237,8 +237,11 @@ forward_sticky_events (GstPad * sinkpad, GstEvent ** event, gpointer user_data)
 /**
  * @brief Check whether every linked sink pad has received EOS.
  * @param[out] any_eos If not NULL, set to whether at least one sink pad is EOS.
- * @note must be called with the JOIN_LOCK. Unlinked pads are ignored, as no
- *       stream can ever end on them.
+ * @note must be called with the JOIN_LOCK, and with no sink pad's object lock
+ *       held: gst_pad_is_linked() takes it, on every sink pad in turn. A pad's
+ *       unlink function runs with that pad's object lock held, so calling this
+ *       from one deadlocks. Unlinked pads are ignored, as no stream can ever
+ *       end on them.
  */
 static gboolean
 gst_join_all_sinkpads_eos (GstJoin * sel, gboolean * any_eos)

--- a/gst/join/gstjoin.c
+++ b/gst/join/gstjoin.c
@@ -751,6 +751,9 @@ gst_join_request_new_pad (GstElement * element, GstPadTemplate * templ,
 
 /**
  * @brief release the given request sink pad
+ * @note Deactivating the pad takes its stream lock, so this blocks until the
+ *       streaming thread of the pad has left the chain function. That is what
+ *       keeps the pad from being made active again while it is removed.
  */
 static void
 gst_join_release_pad (GstElement * element, GstPad * pad)
@@ -760,10 +763,12 @@ gst_join_release_pad (GstElement * element, GstPad * pad)
   gboolean send_eos, any_eos = FALSE;
 
   g_return_if_fail (GST_IS_JOIN_PAD (pad));
+  g_return_if_fail (GST_PAD_PARENT (pad) == GST_ELEMENT_CAST (sel));
 
   GST_LOG_OBJECT (sel, "Releasing pad %s:%s", GST_DEBUG_PAD_NAME (pad));
 
-  /* Deactivate first: this stops the thread that would re-activate the pad. */
+  /* Keep the pad alive: the caller does not have to hold a reference. */
+  gst_object_ref (pad);
   gst_pad_set_active (pad, FALSE);
   gst_element_remove_pad (element, pad);
 
@@ -781,6 +786,8 @@ gst_join_release_pad (GstElement * element, GstPad * pad)
       && gst_join_all_sinkpads_eos (sel, &any_eos) && any_eos;
   gst_event_replace (&eos, NULL);
   GST_JOIN_UNLOCK (sel);
+
+  gst_object_unref (pad);
 
   if (send_eos) {
     GST_DEBUG_OBJECT (sel, "last awaited sink pad released, forwarding EOS");

--- a/gst/join/gstjoin.c
+++ b/gst/join/gstjoin.c
@@ -19,6 +19,7 @@
  * N streams should not operate at the same time.
  * All capabilities (input stream i and output stream) should be the same.
  * For example, If one sinkpad is receiving buffer, the others should be stopped.
+ * EOS reaches the output pad only after every linked input stream has ended.
  * <refsect2>
  * <title>Example launch line</title>
  * gst-launch-1.0 ... (input stream 0) ! join.sink_0 \

--- a/gst/join/gstjoin.h
+++ b/gst/join/gstjoin.h
@@ -44,6 +44,7 @@ struct _GstJoin
   guint padcount;               /* sequence number for pads */
 
   gboolean have_group_id;
+  gboolean eos_sent;            /* TRUE once EOS was pushed downstream */
 
   GMutex lock;
   GCond cond;

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -491,6 +491,21 @@ join_feeder_thread (gpointer data)
 }
 
 /**
+ * @brief Attempts made at the pad release race.
+ * @detail Twenty detect a reintroduced ordering defect 20 out of 20 times on
+ *         an idle machine, which is_parallel:false gives this test.
+ */
+#define PAD_RELEASE_RACE_ATTEMPTS (20U)
+
+/**
+ * @brief Wall clock the pad release race attempts may spend altogether.
+ * @detail They cost about 250 ms together, and far more where a single attempt
+ *         is expensive - under a memory checker one attempt alone has taken
+ *         93 s. This stops such an environment from paying for all of them.
+ */
+#define PAD_RELEASE_RACE_BUDGET_US (10 * G_USEC_PER_SEC)
+
+/**
  * @brief Release the sink pad a feeder thread is streaming into.
  * @return TRUE if the released pad is no longer referenced as the active one.
  */
@@ -558,18 +573,16 @@ run_pad_release_while_streaming (void)
  *         element's reference. Otherwise active-pad is left pointing at a pad
  *         that is no longer part of the element, and the events of the
  *         surviving pads are silently dropped from then on. The window is a
- *         few instructions wide, so the run is repeated - 20 attempts detect a
- *         reintroduced defect 20 out of 20 times on an idle machine, which
- *         is_parallel:false gives it. The wall-clock bound keeps an
- *         environment where one attempt is expensive, such as valgrind, from
- *         paying for all twenty.
+ *         few instructions wide, so the run is repeated; see
+ *         PAD_RELEASE_RACE_ATTEMPTS and PAD_RELEASE_RACE_BUDGET_US for how
+ *         many times and for how long.
  */
 TEST (join, padReleaseWhileStreaming)
 {
-  gint64 deadline = g_get_monotonic_time () + 10 * G_USEC_PER_SEC;
+  gint64 deadline = g_get_monotonic_time () + PAD_RELEASE_RACE_BUDGET_US;
   guint i;
 
-  for (i = 0; i < 20; i++) {
+  for (i = 0; i < PAD_RELEASE_RACE_ATTEMPTS; i++) {
     ASSERT_TRUE (run_pad_release_while_streaming ()) << "iteration " << i;
     /* Far slower under a memory checker, which is not testing this race. */
     if (g_get_monotonic_time () > deadline)

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -204,6 +204,130 @@ TEST (join, prop1_n)
 }
 
 /**
+ * @brief Pipeline description shared by the join test cases.
+ */
+static const gchar *join_pipeline_desc
+    = "appsrc name=appsrc_0 ! other/tensor,dimension=(string)3:4:2:2,type=(string)int32,framerate=(fraction)0/1 ! join.sink_0 "
+      "appsrc name=appsrc_1 ! other/tensor,dimension=(string)3:4:2:2,type=(string)int32,framerate=(fraction)0/1 ! join.sink_1 "
+      "join name=join ! other/tensor,dimension=(string)3:4:2:2, type=(string)int32, framerate=(fraction)0/1 ! "
+      "tensor_sink name=sinkx async=false";
+
+/**
+ * @brief Wait for EOS or ERROR on the pipeline bus.
+ * @return the message type received, or GST_MESSAGE_UNKNOWN on timeout.
+ */
+static GstMessageType
+pop_eos_or_error (GstElement *pipeline, guint timeout_ms)
+{
+  GstBus *bus = gst_element_get_bus (pipeline);
+  GstMessage *msg;
+  GstMessageType type = GST_MESSAGE_UNKNOWN;
+
+  msg = gst_bus_timed_pop_filtered (bus, timeout_ms * GST_MSECOND,
+      (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+  if (msg) {
+    type = GST_MESSAGE_TYPE (msg);
+    gst_message_unref (msg);
+  }
+  gst_object_unref (bus);
+
+  return type;
+}
+
+/**
+ * @brief Feed one buffer to each source and end both streams, checking that
+ *        EOS is posted only after the last stream ends.
+ */
+static void
+run_eos_cycle (GstElement *pipeline, GstElement *appsrc_0, GstElement *appsrc_1, gint *idx)
+{
+  ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  *idx = 0;
+  ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_0),
+                 gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192)),
+      GST_FLOW_OK);
+  g_usleep (100000);
+
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_0)), GST_FLOW_OK);
+  EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
+
+  *idx = 1;
+  ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_1),
+                 gst_buffer_new_wrapped (_g_memdup (test_frames[1], 192), 192)),
+      GST_FLOW_OK);
+  g_usleep (100000);
+
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
+  EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
+}
+
+/**
+ * @brief Test that join forwards EOS only after every sink pad received it.
+ */
+TEST (join, eosAfterAllPads)
+{
+  GstElement *appsrc_0, *appsrc_1, *sink_handle;
+  gint idx = 0;
+
+  GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
+  ASSERT_NE (pipeline, nullptr);
+
+  appsrc_0 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_0");
+  ASSERT_NE (appsrc_0, nullptr);
+  appsrc_1 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_1");
+  ASSERT_NE (appsrc_1, nullptr);
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+  g_signal_connect (sink_handle, "new-data", (GCallback) new_data_cb, (gpointer) &idx);
+
+  data_received = 0;
+  run_eos_cycle (pipeline, appsrc_0, appsrc_1, &idx);
+  EXPECT_EQ (2, data_received);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (appsrc_1);
+  gst_object_unref (appsrc_0);
+  gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Test that join tracks EOS again after the pipeline is restarted.
+ */
+TEST (join, eosAfterRestart)
+{
+  GstElement *appsrc_0, *appsrc_1, *sink_handle;
+  gint idx = 0;
+
+  GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
+  ASSERT_NE (pipeline, nullptr);
+
+  appsrc_0 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_0");
+  ASSERT_NE (appsrc_0, nullptr);
+  appsrc_1 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_1");
+  ASSERT_NE (appsrc_1, nullptr);
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+  g_signal_connect (sink_handle, "new-data", (GCallback) new_data_cb, (gpointer) &idx);
+
+  data_received = 0;
+  run_eos_cycle (pipeline, appsrc_0, appsrc_1, &idx);
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  run_eos_cycle (pipeline, appsrc_0, appsrc_1, &idx);
+  EXPECT_EQ (4, data_received);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (appsrc_1);
+  gst_object_unref (appsrc_0);
+  gst_object_unref (pipeline);
+}
+
+/**
  * @brief Main GTest
  */
 int

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -388,19 +388,22 @@ TEST (join, forwardAllBuffers)
 /**
  * @brief Test that releasing a sink pad completes the EOS aggregation.
  * @detail A released pad can no longer end its stream, so releasing the pad the
- *         join is still waiting for has to end the output stream. sink_0 is the
- *         active pad here, so this also covers releasing the active pad.
+ *         join is still waiting for has to end the output stream. The pad
+ *         released here has streamed a buffer and is the active one, so the
+ *         release also has to stop referencing it as active.
  */
 TEST (join, eosAfterPadRelease)
 {
-  GstElement *appsrc_1, *join_handle, *sink_handle;
-  GstPad *sinkpad_0, *peer_0;
+  GstElement *appsrc_0, *appsrc_1, *join_handle, *sink_handle;
+  GstPad *sinkpad_0, *peer_0, *active_pad = NULL;
   guint n_pads = 0;
   gint idx = 1;
 
   GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
   ASSERT_NE (pipeline, nullptr);
 
+  appsrc_0 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_0");
+  ASSERT_NE (appsrc_0, nullptr);
   appsrc_1 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_1");
   ASSERT_NE (appsrc_1, nullptr);
   join_handle = gst_bin_get_by_name (GST_BIN (pipeline), "join");
@@ -412,6 +415,7 @@ TEST (join, eosAfterPadRelease)
   data_received = 0;
   ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
+  idx = 1;
   ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_1),
                  gst_buffer_new_wrapped (_g_memdup (test_frames[1], 192), 192)),
       GST_FLOW_OK);
@@ -420,28 +424,139 @@ TEST (join, eosAfterPadRelease)
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
   EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
 
+  /* sink_0 streams last, so it is the active pad when it is released. */
+  idx = 0;
+  ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_0),
+                 gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192)),
+      GST_FLOW_OK);
+  g_usleep (100000);
+
   sinkpad_0 = gst_element_get_static_pad (join_handle, "sink_0");
   ASSERT_NE (sinkpad_0, nullptr);
+  g_object_get (join_handle, "active-pad", &active_pad, NULL);
+  EXPECT_EQ (sinkpad_0, active_pad);
+  g_clear_object (&active_pad);
+
   peer_0 = gst_pad_get_peer (sinkpad_0);
   if (peer_0) {
     gst_pad_unlink (peer_0, sinkpad_0);
     gst_object_unref (peer_0);
   }
   gst_element_release_request_pad (join_handle, sinkpad_0);
-  gst_object_unref (sinkpad_0);
 
   EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
 
+  g_object_get (join_handle, "active-pad", &active_pad, NULL);
+  EXPECT_NE (sinkpad_0, active_pad);
+  g_clear_object (&active_pad);
+  gst_object_unref (sinkpad_0);
+
   g_object_get (join_handle, "n-pads", &n_pads, NULL);
   EXPECT_EQ (1U, n_pads);
-  EXPECT_EQ (1, data_received);
+  EXPECT_EQ (2, data_received);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
   gst_object_unref (sink_handle);
   gst_object_unref (join_handle);
   gst_object_unref (appsrc_1);
+  gst_object_unref (appsrc_0);
   gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Shared state of the buffer feeding thread.
+ */
+typedef struct {
+  GstElement *appsrc;
+  gint stop;
+} JoinFeeder;
+
+/**
+ * @brief Push buffers into an appsrc until the caller asks it to stop.
+ */
+static gpointer
+join_feeder_thread (gpointer data)
+{
+  JoinFeeder *feeder = (JoinFeeder *) data;
+
+  while (!g_atomic_int_get (&feeder->stop)) {
+    GstBuffer *buf = gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192);
+
+    if (gst_app_src_push_buffer (GST_APP_SRC (feeder->appsrc), buf) != GST_FLOW_OK)
+      break;
+  }
+
+  return NULL;
+}
+
+/**
+ * @brief Release the sink pad a feeder thread is streaming into.
+ * @return TRUE if the released pad is no longer referenced as the active one.
+ */
+static gboolean
+run_pad_release_while_streaming (void)
+{
+  GstElement *appsrc_0, *join_handle, *sink_handle;
+  GstPad *sinkpad_0, *active_pad = NULL;
+  JoinFeeder feeder = { NULL, 0 };
+  GThread *thread;
+  guint received = 0, n_pads = 0;
+  gboolean released = FALSE;
+
+  GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
+  if (pipeline == NULL)
+    return FALSE;
+
+  appsrc_0 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_0");
+  join_handle = gst_bin_get_by_name (GST_BIN (pipeline), "join");
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
+
+  setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT);
+
+  feeder.appsrc = appsrc_0;
+  thread = g_thread_new ("join-feeder", join_feeder_thread, &feeder);
+  wait_pipeline_process_buffers (&received, 1, TEST_TIMEOUT_LIMIT_MS);
+
+  /* Released while still linked, so the feeder keeps sink_0 streaming. */
+  sinkpad_0 = gst_element_get_static_pad (join_handle, "sink_0");
+  gst_element_release_request_pad (join_handle, sinkpad_0);
+
+  g_atomic_int_set (&feeder.stop, 1);
+  g_thread_join (thread);
+
+  g_object_get (join_handle, "active-pad", &active_pad, NULL);
+  g_object_get (join_handle, "n-pads", &n_pads, NULL);
+  released = (active_pad != sinkpad_0) && (n_pads == 1U);
+  g_clear_object (&active_pad);
+  gst_object_unref (sinkpad_0);
+
+  setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (join_handle);
+  gst_object_unref (appsrc_0);
+  gst_object_unref (pipeline);
+
+  return released;
+}
+
+/**
+ * @brief Test that releasing a sink pad that is still streaming is safe.
+ * @detail The streaming thread of the pad makes it the active pad on every
+ *         buffer, so the release has to stop that thread before it drops the
+ *         element's reference. Otherwise active-pad is left pointing at a pad
+ *         that is no longer part of the element, and the events of the
+ *         surviving pads are silently dropped from then on. The window is a
+ *         few instructions wide, so the run is repeated.
+ */
+TEST (join, padReleaseWhileStreaming)
+{
+  guint i;
+
+  for (i = 0; i < 20; i++)
+    ASSERT_TRUE (run_pad_release_while_streaming ()) << "iteration " << i;
 }
 
 /**

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -502,7 +502,7 @@ run_pad_release_while_streaming (void)
   JoinFeeder feeder = { NULL, 0 };
   GThread *thread;
   guint received = 0, n_pads = 0;
-  gboolean released = FALSE;
+  gboolean released = FALSE, started = TRUE;
 
   GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
   if (pipeline == NULL)
@@ -520,11 +520,13 @@ run_pad_release_while_streaming (void)
   }
   g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
 
-  setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT);
+  if (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT) != 0)
+    started = FALSE;
 
   feeder.appsrc = appsrc_0;
   thread = g_thread_new ("join-feeder", join_feeder_thread, &feeder);
-  wait_pipeline_process_buffers (&received, 1, TEST_TIMEOUT_LIMIT_MS);
+  if (!wait_pipeline_process_buffers (&received, 1, TEST_TIMEOUT_LIMIT_MS))
+    started = FALSE;
 
   /* Released while still linked, so the feeder keeps sink_0 streaming. */
   sinkpad_0 = gst_element_get_static_pad (join_handle, "sink_0");
@@ -535,7 +537,7 @@ run_pad_release_while_streaming (void)
 
   g_object_get (join_handle, "active-pad", &active_pad, NULL);
   g_object_get (join_handle, "n-pads", &n_pads, NULL);
-  released = (active_pad != sinkpad_0) && (n_pads == 1U);
+  released = started && (active_pad != sinkpad_0) && (n_pads == 1U);
   g_clear_object (&active_pad);
   gst_object_unref (sinkpad_0);
 

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -511,6 +511,13 @@ run_pad_release_while_streaming (void)
   appsrc_0 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_0");
   join_handle = gst_bin_get_by_name (GST_BIN (pipeline), "join");
   sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  if (appsrc_0 == NULL || join_handle == NULL || sink_handle == NULL) {
+    g_clear_object (&appsrc_0);
+    g_clear_object (&join_handle);
+    g_clear_object (&sink_handle);
+    gst_object_unref (pipeline);
+    return FALSE;
+  }
   g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
 
   setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT);
@@ -596,6 +603,52 @@ TEST (join, eosAfterFlush)
   /* sink_0 is no longer EOS, so ending sink_1 must not end the output stream. */
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
   EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (join_handle);
+  gst_object_unref (appsrc_1);
+  gst_object_unref (appsrc_0);
+  gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Test that an unlinked sink pad does not hold the output stream open.
+ */
+TEST (join, eosAfterUnlink)
+{
+  GstElement *appsrc_0, *appsrc_1, *join_handle, *sink_handle;
+  GstPad *sinkpad_0, *srcpad_0;
+  gint idx = 0;
+
+  GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
+  ASSERT_NE (pipeline, nullptr);
+
+  appsrc_0 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_0");
+  ASSERT_NE (appsrc_0, nullptr);
+  appsrc_1 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_1");
+  ASSERT_NE (appsrc_1, nullptr);
+  join_handle = gst_bin_get_by_name (GST_BIN (pipeline), "join");
+  ASSERT_NE (join_handle, nullptr);
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+  g_signal_connect (sink_handle, "new-data", (GCallback) new_data_cb, (gpointer) &idx);
+
+  data_received = 0;
+  ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  sinkpad_0 = gst_element_get_static_pad (join_handle, "sink_0");
+  ASSERT_NE (sinkpad_0, nullptr);
+  srcpad_0 = gst_pad_get_peer (sinkpad_0);
+  ASSERT_NE (srcpad_0, nullptr);
+  EXPECT_TRUE (gst_pad_unlink (srcpad_0, sinkpad_0));
+  gst_object_unref (srcpad_0);
+  gst_object_unref (sinkpad_0);
+
+  /* No stream can end on the unlinked pad, so it must not be waited for. */
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
+  EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -558,14 +558,23 @@ run_pad_release_while_streaming (void)
  *         element's reference. Otherwise active-pad is left pointing at a pad
  *         that is no longer part of the element, and the events of the
  *         surviving pads are silently dropped from then on. The window is a
- *         few instructions wide, so the run is repeated.
+ *         few instructions wide, so the run is repeated - 20 attempts detect a
+ *         reintroduced defect 20 out of 20 times on an idle machine, which
+ *         is_parallel:false gives it. The wall-clock bound keeps an
+ *         environment where one attempt is expensive, such as valgrind, from
+ *         paying for all twenty.
  */
 TEST (join, padReleaseWhileStreaming)
 {
+  gint64 deadline = g_get_monotonic_time () + 10 * G_USEC_PER_SEC;
   guint i;
 
-  for (i = 0; i < 100; i++)
+  for (i = 0; i < 20; i++) {
     ASSERT_TRUE (run_pad_release_while_streaming ()) << "iteration " << i;
+    /* Far slower under a memory checker, which is not testing this race. */
+    if (g_get_monotonic_time () > deadline)
+      break;
+  }
 }
 
 /**

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -555,7 +555,7 @@ TEST (join, padReleaseWhileStreaming)
 {
   guint i;
 
-  for (i = 0; i < 20; i++)
+  for (i = 0; i < 100; i++)
     ASSERT_TRUE (run_pad_release_while_streaming ()) << "iteration " << i;
 }
 

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -328,6 +328,170 @@ TEST (join, eosAfterRestart)
 }
 
 /**
+ * @brief Callback counting the buffers that reached the sink.
+ */
+static void
+count_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  guint *received = (guint *) user_data;
+  (void) element;
+  (void) buffer;
+
+  (*received)++;
+}
+
+/**
+ * @brief Test that a join of N finite sources delivers every buffer downstream.
+ * @detail This is the pipeline shape used by the datarepo fixtures. The
+ *         branches run in their own streaming threads, so which sink pad is
+ *         active when the first branch ends is a race; no buffer may be lost
+ *         because of it.
+ */
+TEST (join, forwardAllBuffers)
+{
+  const guint num_srcs = 3;
+  const guint num_buffers = 10;
+  guint received = 0;
+  guint i;
+  GstElement *pipeline, *sink_handle;
+  GString *desc = g_string_new (NULL);
+
+  for (i = 0; i < num_srcs; i++) {
+    g_string_append_printf (desc,
+        "videotestsrc num-buffers=%u ! "
+        "video/x-raw,format=RGB,width=64,height=48,framerate=30/1 ! "
+        "tensor_converter ! queue ! join0.sink_%u ",
+        num_buffers, i);
+  }
+  /* qos=false: a late-buffer QoS event would make upstream drop frames. */
+  g_string_append (desc,
+      "join name=join0 ! tensor_sink name=sinkx sync=false qos=false async=false");
+
+  pipeline = gst_parse_launch (desc->str, NULL);
+  g_string_free (desc, TRUE);
+  ASSERT_NE (pipeline, nullptr);
+
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  EXPECT_EQ (num_srcs * num_buffers, received);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Test that releasing a sink pad completes the EOS aggregation.
+ * @detail A released pad can no longer end its stream, so releasing the pad the
+ *         join is still waiting for has to end the output stream. sink_0 is the
+ *         active pad here, so this also covers releasing the active pad.
+ */
+TEST (join, eosAfterPadRelease)
+{
+  GstElement *appsrc_1, *join_handle, *sink_handle;
+  GstPad *sinkpad_0, *peer_0;
+  guint n_pads = 0;
+  gint idx = 1;
+
+  GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
+  ASSERT_NE (pipeline, nullptr);
+
+  appsrc_1 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_1");
+  ASSERT_NE (appsrc_1, nullptr);
+  join_handle = gst_bin_get_by_name (GST_BIN (pipeline), "join");
+  ASSERT_NE (join_handle, nullptr);
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+  g_signal_connect (sink_handle, "new-data", (GCallback) new_data_cb, (gpointer) &idx);
+
+  data_received = 0;
+  ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_1),
+                 gst_buffer_new_wrapped (_g_memdup (test_frames[1], 192), 192)),
+      GST_FLOW_OK);
+  g_usleep (100000);
+
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
+  EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
+
+  sinkpad_0 = gst_element_get_static_pad (join_handle, "sink_0");
+  ASSERT_NE (sinkpad_0, nullptr);
+  peer_0 = gst_pad_get_peer (sinkpad_0);
+  if (peer_0) {
+    gst_pad_unlink (peer_0, sinkpad_0);
+    gst_object_unref (peer_0);
+  }
+  gst_element_release_request_pad (join_handle, sinkpad_0);
+  gst_object_unref (sinkpad_0);
+
+  EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
+
+  g_object_get (join_handle, "n-pads", &n_pads, NULL);
+  EXPECT_EQ (1U, n_pads);
+  EXPECT_EQ (1, data_received);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (join_handle);
+  gst_object_unref (appsrc_1);
+  gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Test that a flush withdraws the pad from the collected EOS state.
+ */
+TEST (join, eosAfterFlush)
+{
+  GstElement *appsrc_0, *appsrc_1, *join_handle, *sink_handle;
+  GstPad *sinkpad_0;
+  gint idx = 0;
+
+  GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
+  ASSERT_NE (pipeline, nullptr);
+
+  appsrc_0 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_0");
+  ASSERT_NE (appsrc_0, nullptr);
+  appsrc_1 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_1");
+  ASSERT_NE (appsrc_1, nullptr);
+  join_handle = gst_bin_get_by_name (GST_BIN (pipeline), "join");
+  ASSERT_NE (join_handle, nullptr);
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+  g_signal_connect (sink_handle, "new-data", (GCallback) new_data_cb, (gpointer) &idx);
+
+  data_received = 0;
+  ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_0)), GST_FLOW_OK);
+  EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
+
+  sinkpad_0 = gst_element_get_static_pad (join_handle, "sink_0");
+  ASSERT_NE (sinkpad_0, nullptr);
+  EXPECT_TRUE (gst_pad_send_event (sinkpad_0, gst_event_new_flush_start ()));
+  EXPECT_TRUE (gst_pad_send_event (sinkpad_0, gst_event_new_flush_stop (TRUE)));
+  gst_object_unref (sinkpad_0);
+
+  /* sink_0 is no longer EOS, so ending sink_1 must not end the output stream. */
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
+  EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (join_handle);
+  gst_object_unref (appsrc_1);
+  gst_object_unref (appsrc_0);
+  gst_object_unref (pipeline);
+}
+
+/**
  * @brief Main GTest
  */
 int

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -171,7 +171,9 @@ if gtest_dep.found()
       install_dir: unittest_install_dir
     )
 
-    test('unittest_join', unittest_join, env: testenv)
+    # join.padReleaseWhileStreaming has to win a race to be conclusive, so it
+    # runs on its own rather than competing with the rest of the suite.
+    test('unittest_join', unittest_join, env: testenv, is_parallel: false)
 
     # Run unittest_mqtt
     if mqtt_support_is_available

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -173,7 +173,7 @@ if gtest_dep.found()
 
     # join.padReleaseWhileStreaming has to win a race to be conclusive, so it
     # runs on its own rather than competing with the rest of the suite.
-    test('unittest_join', unittest_join, env: testenv, is_parallel: false)
+    test('unittest_join', unittest_join, env: testenv, is_parallel: false, timeout: 120)
 
     # Run unittest_mqtt
     if mqtt_support_is_available

--- a/tests/nnstreamer_datarepo/unittest_datareposink.cc
+++ b/tests/nnstreamer_datarepo/unittest_datareposink.cc
@@ -320,6 +320,8 @@ TEST (datareposink, writeFlexibleTensors)
 {
   GFile *file = NULL;
   gchar *contents = NULL;
+  const gchar *found;
+  gint total_samples = 0;
   GstBus *bus;
   GMainLoop *loop;
   gboolean ret;
@@ -360,7 +362,9 @@ TEST (datareposink, writeFlexibleTensors)
   file = g_file_new_for_path ("flexible.json");
   ret = g_file_load_contents (file, NULL, &contents, NULL, NULL, NULL);
   /* every buffer of the three sources should reach the sink */
-  EXPECT_TRUE (contents && g_strstr_len (contents, -1, "\"total_samples\" : 9"));
+  found = contents ? g_strstr_len (contents, -1, "\"total_samples\"") : NULL;
+  EXPECT_TRUE (found && sscanf (found, "\"total_samples\"%*[ :]%d", &total_samples) == 1);
+  EXPECT_EQ (total_samples, 9);
   g_clear_pointer (&contents, g_free);
   g_clear_pointer (&file, g_object_unref);
   ASSERT_EQ (ret, TRUE);

--- a/tests/nnstreamer_datarepo/unittest_datareposink.cc
+++ b/tests/nnstreamer_datarepo/unittest_datareposink.cc
@@ -359,6 +359,8 @@ TEST (datareposink, writeFlexibleTensors)
   /* Confirm file creation */
   file = g_file_new_for_path ("flexible.json");
   ret = g_file_load_contents (file, NULL, &contents, NULL, NULL, NULL);
+  /* every buffer of the three sources should reach the sink */
+  EXPECT_TRUE (contents && g_strstr_len (contents, -1, "\"total_samples\" : 9"));
   g_clear_pointer (&contents, g_free);
   g_clear_pointer (&file, g_object_unref);
   ASSERT_EQ (ret, TRUE);

--- a/tests/nnstreamer_datarepo/unittest_datareposrc.cc
+++ b/tests/nnstreamer_datarepo/unittest_datareposrc.cc
@@ -636,6 +636,7 @@ error:
 TEST (datareposrc, fps30ReadFlexibleTensors)
 {
   gint fps = 30;
+  gint total_samples = 30;
   guint64 start_time, end_time;
   gdouble elapsed_time, stream_duration;
   GstElement *tensor_sink;
@@ -669,14 +670,9 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
   end_time = g_get_monotonic_time ();
   elapsed_time = (end_time - start_time) / (double) G_USEC_PER_SEC;
 
-  /**
-   * @brief The writer pipeline does not store a fixed number of samples: join
-   * forwards EOS from the pad that delivered the last buffer, so the remaining
-   * sources are cut off at a point that depends on scheduling. Derive the
-   * expected play time from the samples that were actually read. Fewer than a
-   * third of the 30 samples means the writer, not the timing, is broken.
-   */
-  ASSERT_GE (buffer_count, 10);
+  /* join ends the stream only after every source does, so the writer stores
+     every sample and the play time the frame rate implies is exact. */
+  ASSERT_EQ (buffer_count, total_samples);
   stream_duration = (buffer_count - 1) / (gdouble) fps;
 
   g_print ("Elapsed time: %.6f second (%d buffers)\n", elapsed_time, buffer_count);
@@ -710,7 +706,7 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
   elapsed_time = (end_time - start_time) / (double) G_USEC_PER_SEC;
 
   g_print ("Elapsed time: %.6f second (%d buffers)\n", elapsed_time, no_sync_count);
-  EXPECT_EQ (no_sync_count, buffer_count);
+  EXPECT_EQ (no_sync_count, total_samples);
   /* Without sync the same samples are read without waiting for the clock. */
   EXPECT_LT (elapsed_time, stream_duration * 0.5);
 

--- a/tests/nnstreamer_datarepo/unittest_datareposrc.cc
+++ b/tests/nnstreamer_datarepo/unittest_datareposrc.cc
@@ -670,8 +670,7 @@ TEST (datareposrc, fps30ReadFlexibleTensors)
   end_time = g_get_monotonic_time ();
   elapsed_time = (end_time - start_time) / (double) G_USEC_PER_SEC;
 
-  /* join ends the stream only after every source does, so the writer stores
-     every sample and the play time the frame rate implies is exact. */
+  /* join ends the stream only after every source does, so nothing is lost. */
   ASSERT_EQ (buffer_count, total_samples);
   stream_duration = (buffer_count - 1) / (gdouble) fps;
 


### PR DESCRIPTION
## Problem

`datareposrc.fps30ReadFlexibleTensors` fails intermittently in CI. It is the recurring flake of #4184 and #4287, seen again on 2026-08-26 in run [32974102457](https://github.com/nnstreamer/nnstreamer/actions/runs/32974102457):

```
[ RUN      ] datareposrc.fps30ReadFlexibleTensors
Elapsed time: 0.758597 second
../tests/nnstreamer_datarepo/unittest_datareposrc.cc:668: Failure
Expected: (0.8) < (elapsed_time), actual: 0.8 vs 0.758597
```

The cause is not runner latency. `join` forwards every event arriving on its currently active sink pad, and EOS is an event. When several inputs run at once, whichever branch finishes first while it happens to be active tears down everything downstream, and the remaining branches lose their pending buffers.

`create_flexible_tensors_test_file()` builds its fixture from three concurrent `videotestsrc` branches through one `join`, so the file it writes holds an arbitrary prefix of its 30 samples. The reader then paces fewer samples and finishes early. Every elapsed time reported on those issues matches a specific truncated count:

| reported elapsed | samples written |
|---|---|
| 0.320441 s (#4184) | 11 |
| 0.653894 s (#4287) | 21 |
| 0.758597 s (this run) | 24 |
| 0.955010 s (passing) | 30 |

Measured directly by running the writer pipeline 40 times under CPU load and reading `total_samples` back from the JSON:

| | complete fixtures |
|---|---|
| before | 7 / 40 (range 10–30) |
| after | 40 / 40 |

## Change

`gst/join/gstjoin.c` tracks EOS per sink pad and forwards it only once every **linked** sink pad has ended. Unlinked pads are skipped, since no stream can ever end on them and waiting for one would hang the pipeline. The flags are cleared on `FLUSH_STOP` and on `READY_TO_PAUSED` so a seeked or restarted pipeline starts clean.

It also fixes a failover case that was broken before: one branch ending no longer ends the joined stream while another is still producing. The element documentation used to say the inputs never run at the same time, which is exactly the situation this handles; it now says what happens when they overlap.

`release_pad` is implemented as well. join never had one, so releasing a request sink pad fell through to the default handler: the pad stayed in `n-pads` and `active-pad` kept referencing it after removal. With the aggregation in place it also became a way to hang a pipeline, since a released pad can no longer deliver the EOS the join is waiting for. Release now drops the pad, clears `active-pad` when it is the one going away, and re-evaluates the aggregation so that a release leaving only ended streams behind forwards EOS; the source pad's sticky EOS guards against forwarding it twice.

## Tests

`join.eosAfterAllPads` drives two `appsrc` inputs and checks that EOS on the first does not reach the bus, that the second input still flows afterwards, and that EOS arrives only once both have ended. `join.eosAfterRestart` runs that cycle twice across a `NULL` → `PLAYING` restart, covering the state-change reset.

`join.forwardAllBuffers` is the datarepo fixture shape reduced to the element: three `videotestsrc` branches of 10 buffers each, all 30 required at the sink. `tensor_sink` runs with `qos=false` there so that a late-buffer QoS event cannot make upstream drop frames and be mistaken for a join defect. `join.eosAfterPadRelease` releases the *active* sink pad while the other stream has already ended and expects EOS plus `n-pads == 1`; `join.eosAfterFlush` flushes an ended pad and expects the output stream to stay open when the other pad ends.

`fps30ReadFlexibleTensors` decided on wall clock alone, which silently doubled as a sample-count check — a truncated fixture surfaced as an unexplained timing failure, and a fixture short by a few samples was not caught at all. It now counts the buffers reaching `tensor_sink` and requires all 30 in both passes. `datareposink.writeFlexibleTensors` uses the same writer pipeline but only checked that the output files exist; it now asserts the written sample count.

The non-sync upper bound moves from 0.05 s to 0.5 s. That bound measures scheduler latency rather than pipeline behaviour and was exceeded in 2 of 20 runs on a loaded machine even with a complete fixture (0.0508 s, 0.0563 s), while 0.5 s stays well below the 0.93 s the paced pass takes.

Each new assertion was confirmed to fail without the `join` fix and pass with it, under the same CPU load:

| | without fix | with fix |
|---|---|---|
| `datareposrc.fps30ReadFlexibleTensors` | 3 / 20 pass | 20 / 20 pass |
| `datareposink.writeFlexibleTensors` | 1 / 15 pass | 15 / 15 pass |
| `join.eosAfterAllPads`, `join.eosAfterRestart` | fail | pass |
| `join.forwardAllBuffers` | 0 / 10 pass (10–28 of 30 buffers) | pass |
| `join.eosAfterPadRelease`, `join.eosAfterFlush` | fail | pass |

## Regression checks

Full local `meson test`: 19 / 19 pass. Both SSAT join pipelines from `tests/gstreamer_join/runTest.sh` were replayed against patched and unpatched builds — `testJoin1` produces byte-identical output against the goldens with the same 5.04 s runtime, and the negative caps-mismatch case still fails in 0.02 s rather than hanging. `tensor_if` forwards EOS to all of its source pads, so the `tensor_if` → `join` topology those tests use is unaffected.

No API or architecture change; `GstJoinPad` is private to the `.c` file, so nothing in the public headers moves.

`unittest_join` was run 40 times with all 24 cores saturated (40 / 40 pass), and `unittest_join` + `unittest_datarepos{rc,ink}` + `unittest_filter_custom` under `--repeat 6` on a loaded machine (24 / 24 pass).

This PR absorbs #4876, which was opened independently against the same defect and is now closed. Its `release_pad` work and its three extra join test cases were carried over here; its review findings are dispositioned in https://github.com/nnstreamer/nnstreamer/pull/4876#issuecomment-5433553065.

