### PR TITLE
[Join] Forward EOS only after every sinkpad has ended

### DIFF
--- a/gst/join/gstjoin.c
+++ b/gst/join/gstjoin.c
@@ -19,6 +19,9 @@
  * N streams should not operate at the same time.
  * All capabilities (input stream i and output stream) should be the same.
  * For example, If one sinkpad is receiving buffer, the others should be stopped.
+ * As an N-to-1 element, join ends its output stream only after every sinkpad
+ * has received EOS, so a sinkpad that is never linked keeps the output stream
+ * alive.
  * <refsect2>
  * <title>Example launch line</title>
  * gst-launch-1.0 ... (input stream 0) ! join.sink_0 \
@@ -98,6 +101,8 @@ struct _GstJoinPad
 
   GstSegment segment;           /* the current segment on the pad */
   guint32 segment_seqnum;       /* sequence number of the current segment */
+
+  gboolean eos;                 /* TRUE if the pad has received EOS */
 };
 
 /**
@@ -162,7 +167,40 @@ gst_join_pad_reset (GstJoinPad * pad)
 {
   GST_OBJECT_LOCK (pad);
   gst_segment_init (&pad->segment, GST_FORMAT_UNDEFINED);
+  pad->eos = FALSE;
   GST_OBJECT_UNLOCK (pad);
+}
+
+/**
+ * @brief Withdraw the EOS of the given sink pad from the collected EOS state.
+ * @note must be called with the JOIN_LOCK
+ */
+static void
+gst_join_pad_clear_eos (GstJoin * sel, GstJoinPad * pad)
+{
+  if (pad->eos) {
+    pad->eos = FALSE;
+    if (sel->eos_count > 0)
+      sel->eos_count--;
+  }
+}
+
+/**
+ * @brief Reset the EOS state of every sink pad.
+ * @note must be called with the JOIN_LOCK
+ */
+static void
+gst_join_reset (GstJoin * sel)
+{
+  GList *walk;
+
+  GST_OBJECT_LOCK (sel);
+  for (walk = GST_ELEMENT_CAST (sel)->sinkpads; walk; walk = walk->next)
+    gst_join_pad_reset (GST_JOIN_PAD_CAST (walk->data));
+  GST_OBJECT_UNLOCK (sel);
+
+  sel->eos_count = 0;
+  sel->eos_sent = FALSE;
 }
 
 /**
@@ -284,6 +322,33 @@ gst_join_pad_event (GstPad * pad, GstObject * parent, GstEvent * event)
           &selpad->segment);
       break;
     }
+    case GST_EVENT_EOS:
+    {
+      /**
+       * Join is an N-to-1 element, so the output stream ends only after every
+       * input stream has ended. Forwarding EOS as soon as the pad that happens
+       * to be active receives it makes the downstream elements discard the
+       * buffers that the other, still running, input streams are about to push.
+       */
+      if (!selpad->eos) {
+        selpad->eos = TRUE;
+        sel->eos_count++;
+      }
+
+      forward = (!sel->eos_sent && sel->eos_count >= sel->n_pads);
+      if (forward)
+        sel->eos_sent = TRUE;
+
+      GST_DEBUG_OBJECT (pad, "EOS received (%u of %u sink pads), %s",
+          sel->eos_count, sel->n_pads,
+          forward ? "forwarding" : "waiting for the other sink pads");
+      break;
+    }
+    case GST_EVENT_FLUSH_STOP:
+      /* The stream restarts after a flush, so drop the collected EOS state. */
+      gst_join_pad_clear_eos (sel, selpad);
+      sel->eos_sent = FALSE;
+      break;
     default:
       break;
   }
@@ -424,6 +489,9 @@ static void gst_join_get_property (GObject * object,
     guint prop_id, GValue * value, GParamSpec * pspec);
 static GstPad *gst_join_request_new_pad (GstElement * element,
     GstPadTemplate * templ, const gchar * unused, const GstCaps * caps);
+static void gst_join_release_pad (GstElement * element, GstPad * pad);
+static GstStateChangeReturn gst_join_change_state (GstElement * element,
+    GstStateChange transition);
 
 #define gst_join_parent_class parent_class
 G_DEFINE_TYPE_WITH_CODE (GstJoin, gst_join, GST_TYPE_ELEMENT,
@@ -465,6 +533,8 @@ gst_join_class_init (GstJoinClass * klass)
       &gst_join_src_factory);
 
   gstelement_class->request_new_pad = gst_join_request_new_pad;
+  gstelement_class->release_pad = gst_join_release_pad;
+  gstelement_class->change_state = gst_join_change_state;
 }
 
 /**
@@ -482,6 +552,8 @@ gst_join_init (GstJoin * sel)
   sel->active_sinkpad = NULL;
   sel->padcount = 0;
   sel->have_group_id = TRUE;
+  sel->eos_count = 0;
+  sel->eos_sent = FALSE;
 
   g_mutex_init (&sel->lock);
   g_cond_init (&sel->cond);
@@ -679,6 +751,67 @@ gst_join_request_new_pad (GstElement * element, GstPadTemplate * templ,
   GST_JOIN_UNLOCK (sel);
 
   return sinkpad;
+}
+
+/**
+ * @brief release the given request sink pad
+ */
+static void
+gst_join_release_pad (GstElement * element, GstPad * pad)
+{
+  GstJoin *sel = GST_JOIN (element);
+  gboolean send_eos = FALSE;
+
+  GST_JOIN_LOCK (sel);
+  GST_LOG_OBJECT (sel, "Releasing pad %s:%s", GST_DEBUG_PAD_NAME (pad));
+
+  gst_join_pad_clear_eos (sel, GST_JOIN_PAD_CAST (pad));
+
+  if (sel->active_sinkpad == pad) {
+    gst_object_unref (sel->active_sinkpad);
+    sel->active_sinkpad = NULL;
+  }
+
+  if (sel->n_pads > 0)
+    sel->n_pads--;
+
+  /**
+   * The streams left behind may have ended already while this pad was still
+   * around; in that case this release is what completes the aggregation.
+   */
+  if (!sel->eos_sent && sel->n_pads > 0 && sel->eos_count >= sel->n_pads)
+    sel->eos_sent = send_eos = TRUE;
+
+  GST_JOIN_UNLOCK (sel);
+
+  gst_pad_set_active (pad, FALSE);
+  gst_element_remove_pad (element, pad);
+
+  if (send_eos) {
+    GST_DEBUG_OBJECT (sel, "All remaining sink pads are EOS, forwarding EOS");
+    gst_pad_push_event (sel->srcpad, gst_event_new_eos ());
+  }
+}
+
+/**
+ * @brief handle the state change of join element
+ */
+static GstStateChangeReturn
+gst_join_change_state (GstElement * element, GstStateChange transition)
+{
+  GstJoin *sel = GST_JOIN (element);
+
+  switch (transition) {
+    case GST_STATE_CHANGE_READY_TO_PAUSED:
+      GST_JOIN_LOCK (sel);
+      gst_join_reset (sel);
+      GST_JOIN_UNLOCK (sel);
+      break;
+    default:
+      break;
+  }
+
+  return GST_ELEMENT_CLASS (parent_class)->change_state (element, transition);
 }
 
 /**

--- a/gst/join/gstjoin.h
+++ b/gst/join/gstjoin.h
@@ -42,6 +42,8 @@ struct _GstJoin
   GstPad *active_sinkpad;
   guint n_pads;                 /* number of pads */
   guint padcount;               /* sequence number for pads */
+  guint eos_count;              /* number of sink pads that have received EOS */
+  gboolean eos_sent;            /* TRUE if EOS has been forwarded downstream */
 
   gboolean have_group_id;
 

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -148,6 +148,220 @@ TEST (join, normal0)
 }
 
 /**
+ * @brief Callback counting the buffers that reached the sink.
+ */
+static void
+count_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  guint *received = (guint *) user_data;
+  (void) element;
+  (void) buffer;
+
+  (*received)++;
+}
+
+/**
+ * @brief Wait for the EOS (or an error) message of the given pipeline.
+ * @return TRUE if EOS was received before the time-out.
+ */
+static gboolean
+wait_pipeline_eos (GstElement *pipeline, guint timeout_ms)
+{
+  GstBus *bus = gst_element_get_bus (pipeline);
+  GstMessage *msg;
+  gboolean got_eos = FALSE;
+
+  if (bus == NULL)
+    return FALSE;
+
+  msg = gst_bus_timed_pop_filtered (bus, timeout_ms * GST_MSECOND,
+      (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+  if (msg != NULL) {
+    got_eos = (GST_MESSAGE_TYPE (msg) == GST_MESSAGE_EOS);
+    gst_message_unref (msg);
+  }
+
+  gst_object_unref (bus);
+  return got_eos;
+}
+
+/**
+ * @brief Test that EOS of one sink pad does not cut off the other streams.
+ * @detail Join is an N-to-1 element, so the buffers of every input stream
+ *         should be forwarded until all of them have ended. Before the EOS
+ *         aggregation was added, the EOS of the sink pad that happened to be
+ *         active was forwarded right away and the downstream elements dropped
+ *         everything the remaining streams pushed afterwards.
+ */
+TEST (join, eosAggregation)
+{
+  guint received = 0;
+  guint i;
+  GstElement *pipeline, *appsrc_0, *appsrc_1, *sink_handle;
+  GstBuffer *buf;
+
+  gchar *str_pipeline = g_strdup (
+      "appsrc name=appsrc_0 ! other/tensor,dimension=(string)3:4:2:2,type=(string)int32,framerate=(fraction)0/1 ! join.sink_0 "
+      "appsrc name=appsrc_1 ! other/tensor,dimension=(string)3:4:2:2,type=(string)int32,framerate=(fraction)0/1 ! join.sink_1 "
+      "join name=join ! other/tensor,dimension=(string)3:4:2:2, type=(string)int32, framerate=(fraction)0/1 ! "
+      "tensor_sink name=sinkx async=false sync=false");
+
+  pipeline = gst_parse_launch (str_pipeline, NULL);
+  g_free (str_pipeline);
+  ASSERT_NE (pipeline, nullptr);
+
+  appsrc_0 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_0");
+  ASSERT_NE (appsrc_0, nullptr);
+  appsrc_1 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_1");
+  ASSERT_NE (appsrc_1, nullptr);
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  /* sink_0 pushes first, so it becomes the active pad. */
+  buf = gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192);
+  EXPECT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_0), buf), GST_FLOW_OK);
+  EXPECT_TRUE (wait_pipeline_process_buffers (&received, 1, TEST_TIMEOUT_LIMIT_MS));
+
+  /* The active pad ends first; the other stream must not be cut off. */
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_0)), GST_FLOW_OK);
+  EXPECT_FALSE (wait_pipeline_eos (pipeline, 200));
+
+  for (i = 0; i < 3; i++) {
+    buf = gst_buffer_new_wrapped (_g_memdup (test_frames[1], 192), 192);
+    EXPECT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_1), buf), GST_FLOW_OK);
+  }
+  EXPECT_TRUE (wait_pipeline_process_buffers (&received, 4, TEST_TIMEOUT_LIMIT_MS));
+  EXPECT_EQ (4U, received);
+
+  /* Once every sink pad is EOS, EOS is forwarded downstream. */
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
+  EXPECT_TRUE (wait_pipeline_eos (pipeline, TEST_TIMEOUT_LIMIT_MS));
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (4U, received);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (appsrc_0);
+  gst_object_unref (appsrc_1);
+  gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Test that a join of N finite sources delivers every buffer downstream.
+ * @detail This is the pipeline shape used by the datarepo test fixtures. The
+ *         three branches run in their own streaming threads, so which sink pad
+ *         is active when the first branch ends is a race; no buffer may be lost
+ *         because of it.
+ */
+TEST (join, forwardAllBuffers)
+{
+  const guint num_srcs = 3;
+  const guint num_buffers = 10;
+  guint received = 0;
+  guint i;
+  GstElement *pipeline, *sink_handle;
+  GString *desc = g_string_new (NULL);
+
+  for (i = 0; i < num_srcs; i++) {
+    g_string_append_printf (desc,
+        "videotestsrc num-buffers=%u ! "
+        "video/x-raw,format=RGB,width=64,height=48,framerate=30/1 ! "
+        "tensor_converter ! queue ! join0.sink_%u ",
+        num_buffers, i);
+  }
+  /* qos=false: a late-buffer QoS event would make upstream drop frames. */
+  g_string_append (desc,
+      "join name=join0 ! tensor_sink name=sinkx sync=false qos=false async=false");
+
+  pipeline = gst_parse_launch (desc->str, NULL);
+  g_string_free (desc, TRUE);
+  ASSERT_NE (pipeline, nullptr);
+
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_TRUE (wait_pipeline_eos (pipeline, TEST_TIMEOUT_LIMIT_MS));
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  EXPECT_EQ (num_srcs * num_buffers, received);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Test that releasing a sink pad completes the EOS aggregation.
+ * @detail A sink pad that is gone can no longer deliver EOS, so releasing the
+ *         last pad the join is still waiting for has to end the output stream.
+ */
+TEST (join, releasePadAfterEos)
+{
+  guint received = 0;
+  guint n_pads = 0;
+  GstElement *pipeline, *appsrc_0, *join_handle, *sink_handle;
+  GstBuffer *buf;
+  GstPad *sinkpad_1, *peer_1;
+
+  gchar *str_pipeline = g_strdup (
+      "appsrc name=appsrc_0 ! other/tensor,dimension=(string)3:4:2:2,type=(string)int32,framerate=(fraction)0/1 ! join.sink_0 "
+      "appsrc name=appsrc_1 ! other/tensor,dimension=(string)3:4:2:2,type=(string)int32,framerate=(fraction)0/1 ! join.sink_1 "
+      "join name=join ! other/tensor,dimension=(string)3:4:2:2, type=(string)int32, framerate=(fraction)0/1 ! "
+      "tensor_sink name=sinkx async=false sync=false");
+
+  pipeline = gst_parse_launch (str_pipeline, NULL);
+  g_free (str_pipeline);
+  ASSERT_NE (pipeline, nullptr);
+
+  appsrc_0 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_0");
+  ASSERT_NE (appsrc_0, nullptr);
+  join_handle = gst_bin_get_by_name (GST_BIN (pipeline), "join");
+  ASSERT_NE (join_handle, nullptr);
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  buf = gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192);
+  EXPECT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_0), buf), GST_FLOW_OK);
+  EXPECT_TRUE (wait_pipeline_process_buffers (&received, 1, TEST_TIMEOUT_LIMIT_MS));
+
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_0)), GST_FLOW_OK);
+  EXPECT_FALSE (wait_pipeline_eos (pipeline, 200));
+
+  /* sink_1 never gets EOS; dropping the pad has to complete the aggregation. */
+  sinkpad_1 = gst_element_get_static_pad (join_handle, "sink_1");
+  ASSERT_NE (sinkpad_1, nullptr);
+  peer_1 = gst_pad_get_peer (sinkpad_1);
+  if (peer_1 != NULL) {
+    gst_pad_unlink (peer_1, sinkpad_1);
+    gst_object_unref (peer_1);
+  }
+  gst_element_release_request_pad (join_handle, sinkpad_1);
+  gst_object_unref (sinkpad_1);
+
+  EXPECT_TRUE (wait_pipeline_eos (pipeline, TEST_TIMEOUT_LIMIT_MS));
+
+  g_object_get (join_handle, "n-pads", &n_pads, NULL);
+  EXPECT_EQ (1U, n_pads);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (1U, received);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (join_handle);
+  gst_object_unref (appsrc_0);
+  gst_object_unref (pipeline);
+}
+
+/**
  * @brief Test get property with invalid parameter
  */
 TEST (join, prop0_n)


### PR DESCRIPTION
## The problem

`gst_join_pad_event()` computes

```c
forward = (pad == active_sinkpad);
```

once, at the top, and applies it to **every** event — EOS included. `gst_join_pad_chain()` makes whichever pad pushed the most recent buffer the active one. So the fate of a branch's EOS depends on a race:

- if the branch is the active pad when its EOS arrives, EOS goes downstream **immediately** and the sink stops accepting data — the buffers the other branches are still pushing are dropped;
- otherwise the EOS is silently unref'd and nothing ever ends the output stream from that branch.

`join` is documented as an N-to-1 element, so neither is right: the output stream ends when *all* the input streams have ended.

## Measured impact

The fixture `create_flexible_tensors_test_file()` in `tests/nnstreamer_datarepo/unittest_datareposrc.cc` joins three `videotestsrc` branches of 10 buffers each into `datareposink`. Probing it directly (10 runs each):

| condition | `total_samples` written |
|---|---|
| idle | 30 ×10 |
| all cores loaded, before this PR | 26, 28, 27, 27, 30, 30, 28, 17, 28, 20 |
| all cores loaded, with this PR | 30 ×10 |

That non-determinism is the second cause analysed in #4874, which deliberately left the element alone and only made the tests independent of the sample count. This PR is the element-side fix; the two do not conflict.

## The change

`gst/join/gstjoin.c`:

- each `GstJoinPad` carries an `eos` flag, the element carries `eos_count`/`eos_sent`, and the `GST_EVENT_EOS` case forwards EOS only when `eos_count == n_pads`. Buffers and all other events keep their existing pass-through behaviour.
- `GST_EVENT_FLUSH_STOP` withdraws the pad from the collected EOS state and clears `eos_sent`, and `READY_TO_PAUSED` resets it for every pad, so a flushing seek or a pipeline restart can end the stream again.
- `release_pad` is implemented (it was missing entirely). A released pad can no longer deliver EOS, so it is dropped from the count, and if the pads left behind have all ended, the release itself forwards EOS. It also decrements `n-pads` and clears `active-pad`, which previously leaked across a pad release.

The element documentation now states the aggregation rule, including its consequence: a requested sinkpad that is never linked keeps the output stream alive.

## Tests

Three new cases in `tests/gstreamer_join/unittest_join.cc`:

| test | what it pins down |
|---|---|
| `join.forwardAllBuffers` | 3 sources × 10 buffers ⇒ 30 buffers at the sink |
| `join.eosAggregation` | EOS on the active pad does not cut off the other stream, and EOS reaches the bus exactly once both pads are done |
| `join.releasePadAfterEos` | releasing the last awaited pad completes the aggregation |

Against the unpatched element all three fail, and `forwardAllBuffers` fails **10/10 even on an idle machine** (10–28 buffers instead of 30). `tensor_sink` is given `qos=false` there so that a late-buffer QoS event cannot make upstream drop frames — that is real GStreamer behaviour and would otherwise be counted as join's loss.

## Verification

| scenario | result |
|---|---|
| `unittest_join`, 40 runs, all 24 cores saturated | 40/40 pass |
| `unittest_join` + `unittest_datarepos{rc,ink}` + `unittest_filter_custom`, `--repeat 6` under load | 24/24 pass |
| full local `meson test` suite | 19/19 pass, no regressions |
| SSAT `tests/gstreamer_join/runTest.sh` pipelines run by hand | 1 and 2 reach EOS and match the goldens; 3_n still fails as expected |

The SSAT cases now produce one extra `testJoin*_4.log` (the branch that used to be cut off finishes); the script only compares indices 0–3 and removes `*.log` afterwards, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
