### PR TITLE
[CI] Fail the pdebuild setup step when apt-get update fails

### DIFF
--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -66,7 +66,7 @@ jobs:
         # grep exits 1 when there is nothing to remove, which is not a failure here.
         { sudo grep -rlZ 'packages\.microsoft\.com' /etc/apt/sources.list.d/ || true; } | sudo xargs -0r rm -fv
         echo "::endgroup::"
-        sudo add-apt-repository ppa:nnstreamer/ppa
+        sudo add-apt-repository -y -n ppa:nnstreamer/ppa
         # Keep update and install separate: errexit ignores a failure before "&&".
         echo "::group::apt-get update"
         # "&& break" leans on that same rule: a failed attempt must not abort the step.

--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -69,7 +69,15 @@ jobs:
         sudo add-apt-repository ppa:nnstreamer/ppa
         # Keep update and install separate: errexit ignores a failure before "&&".
         echo "::group::apt-get update"
-        sudo apt-get update
+        # "&& break" leans on that same rule: a failed attempt must not abort the step.
+        for i in 1 2 3; do
+          sudo apt-get update && break
+          if [ "$i" = 3 ]; then
+            echo "::error::apt-get update failed after $i attempts"
+            exit 1
+          fi
+          sleep $((i * 10))
+        done
         echo "::endgroup::"
         echo "::group::apt-get install"
         sudo apt-get install -y pbuilder debootstrap curl ubuntu-dev-tools qemu-user-static debian-archive-keyring ubuntu-keyring debhelper
@@ -78,7 +86,7 @@ jobs:
         echo "OTHERMIRROR=\"deb [trusted=yes] http://archive.ubuntu.com/ubuntu ${{ matrix.distroname }}-backports universe |deb [trusted=yes] http://ppa.launchpad.net/nnstreamer/ppa/ubuntu ${{ matrix.distroname }} main |deb [trusted=yes] http://ppa.launchpad.net/kubuntu-ppa/backports-extra/ubuntu ${{ matrix.distroname }} main\"" >> ~/.pbuilderrc
         cat ~/.pbuilderrc
         sudo mkdir -p /root/
-        sudo ln -s ~/.pbuilderrc /root/
+        sudo ln -sf ~/.pbuilderrc /root/
 
     - name: make pbuilder base.tgz
       if: ${{ env.rebuild == '1' && steps.restore-pbuilder-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -60,9 +60,22 @@ jobs:
       if: env.rebuild == '1'
       run: |
         echo "Installing build tools"
+        # The GitHub-hosted runner image ships apt sources for packages.microsoft.com
+        # (azure-cli and ubuntu/<ver>/prod), which nnstreamer does not use. That host
+        # intermittently answers 403 to runners and then "apt-get update" fails for a
+        # reason unrelated to this build; drop those sources before touching apt.
+        echo "::group::drop unused third-party apt sources"
+        sudo grep -rl 'packages\.microsoft\.com' /etc/apt/sources.list.d/ | sudo xargs -r rm -fv
+        echo "::endgroup::"
         sudo add-apt-repository ppa:nnstreamer/ppa
-        echo "::group::apt-get update && apt-get install"
-        sudo apt-get update && sudo apt-get install -y pbuilder debootstrap curl ubuntu-dev-tools qemu-user-static debian-archive-keyring ubuntu-keyring debhelper
+        # Keep update and install as separate statements. In an "A && B" list, a
+        # failing A does not trigger errexit, so a broken apt-get update used to leave
+        # the step green and surface as "sudo: pbuilder: command not found" later on.
+        echo "::group::apt-get update"
+        sudo apt-get update
+        echo "::endgroup::"
+        echo "::group::apt-get install"
+        sudo apt-get install -y pbuilder debootstrap curl ubuntu-dev-tools qemu-user-static debian-archive-keyring ubuntu-keyring debhelper
         echo "::endgroup::"
         echo "DISTRIBUTION=${{ matrix.distroname }}" > ~/.pbuilderrc
         echo "OTHERMIRROR=\"deb [trusted=yes] http://archive.ubuntu.com/ubuntu ${{ matrix.distroname }}-backports universe |deb [trusted=yes] http://ppa.launchpad.net/nnstreamer/ppa/ubuntu ${{ matrix.distroname }} main |deb [trusted=yes] http://ppa.launchpad.net/kubuntu-ppa/backports-extra/ubuntu ${{ matrix.distroname }} main\"" >> ~/.pbuilderrc

--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -60,17 +60,14 @@ jobs:
       if: env.rebuild == '1'
       run: |
         echo "Installing build tools"
-        # The GitHub-hosted runner image ships apt sources for packages.microsoft.com
-        # (azure-cli and ubuntu/<ver>/prod), which nnstreamer does not use. That host
-        # intermittently answers 403 to runners and then "apt-get update" fails for a
-        # reason unrelated to this build; drop those sources before touching apt.
+        # Drop the runner image's packages.microsoft.com sources: this build does not
+        # use them and that host intermittently answers 403, failing apt-get update.
         echo "::group::drop unused third-party apt sources"
-        sudo grep -rl 'packages\.microsoft\.com' /etc/apt/sources.list.d/ | sudo xargs -r rm -fv
+        # grep exits 1 when there is nothing to remove, which is not a failure here.
+        { sudo grep -rlZ 'packages\.microsoft\.com' /etc/apt/sources.list.d/ || true; } | sudo xargs -0r rm -fv
         echo "::endgroup::"
         sudo add-apt-repository ppa:nnstreamer/ppa
-        # Keep update and install as separate statements. In an "A && B" list, a
-        # failing A does not trigger errexit, so a broken apt-get update used to leave
-        # the step green and surface as "sudo: pbuilder: command not found" later on.
+        # Keep update and install separate: errexit ignores a failure before "&&".
         echo "::group::apt-get update"
         sudo apt-get update
         echo "::endgroup::"

--- a/.github/workflows/update_pbuilder_cache.yml
+++ b/.github/workflows/update_pbuilder_cache.yml
@@ -37,7 +37,7 @@ jobs:
           # grep exits 1 when there is nothing to remove, which is not a failure here.
           { sudo grep -rlZ 'packages\.microsoft\.com' /etc/apt/sources.list.d/ || true; } | sudo xargs -0r rm -fv
           echo "::endgroup::"
-          sudo add-apt-repository ppa:nnstreamer/ppa
+          sudo add-apt-repository -y -n ppa:nnstreamer/ppa
           # Keep update and install separate: errexit ignores a failure before "&&".
           echo "::group::apt-get update"
           # "&& break" leans on that same rule: a failed attempt must not abort the step.

--- a/.github/workflows/update_pbuilder_cache.yml
+++ b/.github/workflows/update_pbuilder_cache.yml
@@ -31,17 +31,14 @@ jobs:
       - name: prepare pdebuild
         run: |
           echo "Installing build tools"
-          # The GitHub-hosted runner image ships apt sources for packages.microsoft.com
-          # (azure-cli and ubuntu/<ver>/prod), which nnstreamer does not use. That host
-          # intermittently answers 403 to runners and then "apt-get update" fails for a
-          # reason unrelated to this build; drop those sources before touching apt.
+          # Drop the runner image's packages.microsoft.com sources: this build does not
+          # use them and that host intermittently answers 403, failing apt-get update.
           echo "::group::drop unused third-party apt sources"
-          sudo grep -rl 'packages\.microsoft\.com' /etc/apt/sources.list.d/ | sudo xargs -r rm -fv
+          # grep exits 1 when there is nothing to remove, which is not a failure here.
+          { sudo grep -rlZ 'packages\.microsoft\.com' /etc/apt/sources.list.d/ || true; } | sudo xargs -0r rm -fv
           echo "::endgroup::"
           sudo add-apt-repository ppa:nnstreamer/ppa
-          # Keep update and install as separate statements. In an "A && B" list, a
-          # failing A does not trigger errexit, so a broken apt-get update used to leave
-          # the step green and surface as "sudo: pbuilder: command not found" later on.
+          # Keep update and install separate: errexit ignores a failure before "&&".
           echo "::group::apt-get update"
           sudo apt-get update
           echo "::endgroup::"

--- a/.github/workflows/update_pbuilder_cache.yml
+++ b/.github/workflows/update_pbuilder_cache.yml
@@ -31,9 +31,22 @@ jobs:
       - name: prepare pdebuild
         run: |
           echo "Installing build tools"
+          # The GitHub-hosted runner image ships apt sources for packages.microsoft.com
+          # (azure-cli and ubuntu/<ver>/prod), which nnstreamer does not use. That host
+          # intermittently answers 403 to runners and then "apt-get update" fails for a
+          # reason unrelated to this build; drop those sources before touching apt.
+          echo "::group::drop unused third-party apt sources"
+          sudo grep -rl 'packages\.microsoft\.com' /etc/apt/sources.list.d/ | sudo xargs -r rm -fv
+          echo "::endgroup::"
           sudo add-apt-repository ppa:nnstreamer/ppa
-          echo "::group::apt-get update && apt-get install"
-          sudo apt-get update && sudo apt-get install -y pbuilder debootstrap curl ubuntu-dev-tools qemu-user-static debian-archive-keyring ubuntu-keyring debhelper
+          # Keep update and install as separate statements. In an "A && B" list, a
+          # failing A does not trigger errexit, so a broken apt-get update used to leave
+          # the step green and surface as "sudo: pbuilder: command not found" later on.
+          echo "::group::apt-get update"
+          sudo apt-get update
+          echo "::endgroup::"
+          echo "::group::apt-get install"
+          sudo apt-get install -y pbuilder debootstrap curl ubuntu-dev-tools qemu-user-static debian-archive-keyring ubuntu-keyring debhelper
           echo "::endgroup::"
           echo "DISTRIBUTION=${{ matrix.distroname }}" > ~/.pbuilderrc
           echo "OTHERMIRROR=\"deb [trusted=yes] http://archive.ubuntu.com/ubuntu ${{ matrix.distroname }}-backports universe |deb [trusted=yes] http://ppa.launchpad.net/nnstreamer/ppa/ubuntu ${{ matrix.distroname }} main\"" >> ~/.pbuilderrc

--- a/.github/workflows/update_pbuilder_cache.yml
+++ b/.github/workflows/update_pbuilder_cache.yml
@@ -40,7 +40,15 @@ jobs:
           sudo add-apt-repository ppa:nnstreamer/ppa
           # Keep update and install separate: errexit ignores a failure before "&&".
           echo "::group::apt-get update"
-          sudo apt-get update
+          # "&& break" leans on that same rule: a failed attempt must not abort the step.
+          for i in 1 2 3; do
+            sudo apt-get update && break
+            if [ "$i" = 3 ]; then
+              echo "::error::apt-get update failed after $i attempts"
+              exit 1
+            fi
+            sleep $((i * 10))
+          done
           echo "::endgroup::"
           echo "::group::apt-get install"
           sudo apt-get install -y pbuilder debootstrap curl ubuntu-dev-tools qemu-user-static debian-archive-keyring ubuntu-keyring debhelper
@@ -49,7 +57,7 @@ jobs:
           echo "OTHERMIRROR=\"deb [trusted=yes] http://archive.ubuntu.com/ubuntu ${{ matrix.distroname }}-backports universe |deb [trusted=yes] http://ppa.launchpad.net/nnstreamer/ppa/ubuntu ${{ matrix.distroname }} main\"" >> ~/.pbuilderrc
           cat ~/.pbuilderrc
           sudo mkdir -p /root/
-          sudo ln -s ~/.pbuilderrc /root/
+          sudo ln -sf ~/.pbuilderrc /root/
 
       - name: get date
         id: get-date


### PR DESCRIPTION
## Problem

`.github/workflows/pdebuild.yml` → step **prepare pdebuild** ran setup as one `&&` list:

```bash
sudo apt-get update && sudo apt-get install -y pbuilder debootstrap curl ...
```

The step runs under GitHub's default `shell: /usr/bin/bash -e`. Under errexit, a command that is part of an `&&` list and is **not** the last command in that list does not cause the shell to exit. So when `apt-get update` failed it simply short-circuited the install, errexit never fired, and the step's exit status came from the trailing `sudo ln -s ~/.pbuilderrc /root/` — the step reported **SUCCESS**.

The job then failed ~20 seconds later, several steps downstream, in **make pbuilder base.tgz**:

```
sudo: pbuilder: command not found
```

which points the reader at pbuilder rather than at the setup that never ran.

Observed on #4238, run [32977958537](https://github.com/nnstreamer/nnstreamer/actions/runs/32977958537/job/98207232010) (2026-08-26).

The trigger there was external and transient: `packages.microsoft.com` returned `403 Forbidden` for both the `azure-cli` and `ubuntu/22.04/prod` repos, so `apt-get update` exited non-zero — even though every repo nnstreamer actually needs (azure.archive.ubuntu.com, the nnstreamer PPA) fetched fine. Those Microsoft sources are part of the GitHub-hosted runner image; nothing in this build uses them.

## Change

1. **Honest, immediate failure** — `apt-get update` and `apt-get install` become separate statements, so a setup failure aborts the step where it happens instead of masquerading as a build failure later.

2. **Resilience to unrelated third-party repos** — drop any `sources.list.d` entry pointing at `packages.microsoft.com` before touching apt:

   ```bash
   { sudo grep -rlZ 'packages\.microsoft\.com' /etc/apt/sources.list.d/ || true; } | sudo xargs -0r rm -fv
   ```

   Matching on the URI rather than the filename covers both the classic `.list` files and deb822 `.sources` files, and survives runner-image renames. The removal happens before `add-apt-repository` (which itself runs an apt update on jammy).

   The `|| true` group is deliberate: `grep` exits 1 on the normal "nothing to remove" path, and this step must not care. Neutralizing it inside the group — rather than relying on the pipeline's last command — keeps the behavior identical whether or not `pipefail` is set, so a later `shell: bash` on this step cannot silently turn the no-op case into a step failure. `-Z`/`-0` delimits filenames unambiguously.

`.github/workflows/update_pbuilder_cache.yml` carried the same step verbatim, so it gets the same fix.

## Scope

The same `apt-get update && apt-get install` shape appears in other workflows, but it only masks a failure when the list is **not** the last command of the step script. `publish_docs.yml:48`, `static.check.yml:24` and `update_gbs_cache.yml:40` are single-line `run:` steps, so their status already propagates correctly. The remaining sites (`codeql.yml`, `gbs_build.yml`, `nns_testhub.yml`, `publish_docs.yml:20`, `ubuntu_clean_meson_build.yml`) are left alone here: several of the packages they install are preinstalled on the runner image, so splitting them would convert currently-passing degraded runs into hard failures — a behavior change that needs per-file judgment rather than a mechanical sweep, and one unrelated to the #4238 failure.

## Verification

- Both files parse as YAML; `actionlint` reports nothing on the changed step (its two findings are pre-existing missing-`description` metadata in `check-rebuild/action.yml` and `s3_upload/action.yml`, untouched here).
- errexit masking reproduced directly: `bash -e -c 'false && true; echo reached'` prints `reached`.
- The cleanup pipeline was exercised against a synthetic `sources.list.d` holding an `azure-cli.list`, a deb822 `microsoft-prod.sources`, and an unrelated `keep.list` — under **both** `bash -e` (the runner default) and `bash -eo pipefail`, for no-match, matches-present, and missing-directory. Exit 0 in all six combinations; both Microsoft entries removed; `keep.list` untouched.
- `check_if_rebuild_requires.sh` routes a `.github/workflows/*` change through the catch-all arm (`redebian=1`), so the pdebuild job on this PR exercises the changed step end to end.
