### PR TITLE
[Doc] Replace dead JCenter references with the daily release channel

### DIFF
--- a/Documentation/API-reference.md
+++ b/Documentation/API-reference.md
@@ -51,7 +51,7 @@ Note that this supports SingleShot/Pipeline subdomains and do not include traini
 - [Android sample app](https://github.com/nnstreamer/nnstreamer-example/tree/master/android/example_app/api-sample) uses JAVA APIs to implement Android-NNStreamer apps.
     - Note that the Android Sample Applications published via Google Play Store, [Source Code](https://github.com/nnstreamer/nnstreamer-example/tree/main/android/example_app), are developed before NNStreamer Java API. They use GStreamer functions.
 - [Implementation](https://github.com/nnstreamer/api/tree/main/java) (stable)
-- [Available at JCenter](https://bintray.com/beta/#/nnsuite/nnstreamer?tab=packages)
+- [Available at Daily Build Release](https://release.nnstreamer.com/#nnstreamer/latest/android/) (`nnstreamer.aar`)
 
 
 ### Python API is planned

--- a/Documentation/component-description.md
+++ b/Documentation/component-description.md
@@ -187,7 +187,7 @@ Note that test elements in /tests/ are not elements for applications. They exist
   - Tizen (since 5.5 M1) [Package Download](https://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified/latest/repos/standard/packages/) [Build & Release Infra](https://build.tizen.org/project/show/Tizen:Unified)
   - Ubuntu [Launchpad PPA](https://launchpad.net/~nnstreamer/+archive/ubuntu/ppa)
   - Yocto/OpenEmbedded [OpenEmbedded Layer, "meta-neural-network"](https://layers.openembedded.org/layerindex/branch/master/layer/meta-neural-network/)
-  - Android WIP: JCenter Repository & Daily Build Release
+  - Android [Daily Build Release](https://release.nnstreamer.com/#nnstreamer/latest/android/)
   - macOS WIP: Daily Build Release
 - [Test cases](https://github.com/nnstreamer/nnstreamer/tree/main/tests/): Mandatory unit test cases required to pass for each PR.
   - Used [SSAT](https://github.com/myungjoo/SSAT).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ neural network developers to manage neural network pipelines and their filters e
 - Ready: CI system ensures build-ability and unit-testing. Users may easily build and execute. However, we do not have automated release & deployment system for this instance.
 - Available: binary packages are released and deployed automatically and periodically along with CI tests.
 - [Daily Release](https://release.nnstreamer.com/#nnstreamer/latest/)
-- SDK Support: Tizen Studio (5.5 M2+) / Android Studio (JCenter, "nnstreamer")
+- SDK Support: Tizen Studio (5.5 M2+) / Android Studio (`nnstreamer.aar` from [Daily Release](https://release.nnstreamer.com/#nnstreamer/latest/android/))
 - [Enabled features of official releases](Documentation/features-per-distro.md)
 
 


### PR DESCRIPTION
## What

Three docs still send Android users to JCenter/bintray, which has served nothing since bintray shut down in 2021:

| Location | Before |
| --- | --- |
| `Documentation/API-reference.md:54` | `[Available at JCenter](https://bintray.com/beta/#/nnsuite/nnstreamer?tab=packages)` |
| `Documentation/component-description.md:190` | `Android WIP: JCenter Repository & Daily Build Release` |
| `README.md:43` | `Android Studio (JCenter, "nnstreamer")` |

All three now point at the daily build release instead.

## Why this target

There is no Maven/MavenCentral publication today — `jcenter`/`bintray`/`maven` appear nowhere in the build or publish configuration of either `nnstreamer` or `nnstreamer/api`, only in these stale doc strings. The real Android distribution is the daily build produced by `nnstreamer/api`'s `.github/workflows/daily-build-android.yml` and surfaced at release.nnstreamer.com.

Verified against the release bucket that `nnstreamer/latest/android/` currently holds `nnstreamer.aar`, `nnstreamer-lite.aar` and the matching native zips, so the artifact name quoted in the docs is the published one. `README.md:42` already links this same path from the publish table, so the three references are now consistent with it.

## Notes

- The `component-description.md` entry is reformatted to match the neighbouring Tizen / Ubuntu / Yocto rows (`- <Platform> [<Channel>](<url>)`).
- The `WIP` marker is dropped from that line. Unlike the macOS entry below it, which has no automated publication, Android arm64 is published automatically and is already marked *Available* with a build badge in the README table, so it belongs with the other live channels.
- `CHANGES:455` and `CHANGES:465` also mention JCenter, but those are historical 0.2/0.3-era release notes describing what was true at the time and are left untouched.

Documentation only; no functional change.

## Relation to #3495

This does **not** implement the JCenter → MavenCentral migration tracked by #3495. That issue asks for a MavenCentral repo, a domain rename and a publishing action — none of which this touches. #3495 stays open; this only stops the docs from advertising a dead channel in the meantime.

## Testing

No test is added: the change is three markdown strings with no build, packaging or code surface. Both changed `Documentation/*.md` files are listed in `Documentation/hotdoc/sitemap.txt`, so they flow into the published doc site; the links are ordinary inline markdown and render like the surrounding entries.

Ran locally against the changed files:

- `static.check.scripts/prohibited-words.sh` — pass
- `git diff --check` — clean, no CRLF introduced
- Confirmed no `jcenter`/`bintray` reference remains in any `*.md`

I looked at wiring a permanent guard (adding `bintray`/`jcenter` to `prohibited-words.txt`) and deliberately did not, for a reason worth recording separately: that checker cannot fail today. See the review discussion below.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
