### PR TITLE
[Filter] unnecessary strdup

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -1590,10 +1590,10 @@ _gtfc_setprop_CUSTOM (GstTensorFilterPrivate * priv,
           (priv->fw, prop, priv->privateData, CUSTOM_PROP, &data);
       if (status == 0) {
         g_free_const (prop->custom_properties);
-        prop->custom_properties = g_value_dup_string (value);
+        prop->custom_properties = data.custom_properties;
+      } else {
+        g_free_const (data.custom_properties);
       }
-
-      g_free_const (data.custom_properties);
     }
   }
 


### PR DESCRIPTION
Code clean, remove unnecessary strdup while updating custom property string.
