### PR TITLE
[CI] Repair the prohibited-words checker and pin it with a self-test

### DIFF
--- a/.github/workflows/static.check.scripts/prohibited-words.sh
+++ b/.github/workflows/static.check.scripts/prohibited-words.sh
@@ -88,7 +88,7 @@ if [[ -n "${target_files/[ ]*\n/}" ]]; then
   cat ${bad_words_log_file}
 
   # Step 3: Count prohibited words from variable result_content
-  result_count=$(cat ${bad_word_log_file} | grep -c '^' )
+  result_count=$(wc -l < ${bad_words_log_file})
 
   # Step 4: change a value of the check result
   if [[ $result_count -gt 0 ]]; then

--- a/.github/workflows/static.check.scripts/prohibited-words.txt
+++ b/.github/workflows/static.check.scripts/prohibited-words.txt
@@ -1,3 +1,2 @@
 samsung.net
 FUCK
-file

--- a/.github/workflows/static.check.scripts/test_prohibited_words.sh
+++ b/.github/workflows/static.check.scripts/test_prohibited_words.sh
@@ -3,7 +3,7 @@
 ##
 # Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
 #
-# @file: test_prohibited_words.sh
+# @file     test_prohibited_words.sh
 # @brief    Self-test for prohibited-words.sh and its word list.
 # @see      https://github.com/nnstreamer/nnstreamer
 # @author   MyungJoo Ham <myungjoo.ham@samsung.com>
@@ -53,8 +53,9 @@ expect_checker() {
   fi
 }
 
-# Every listed word must actually fail the checker.
-while read -r word; do
+# Every listed word must actually fail the checker. The || [[ -n ]] guard keeps
+# a last line without a trailing newline from being skipped silently.
+while read -r word || [[ -n "$word" ]]; do
   word=${word%$'\r'}
   [[ -z "$word" ]] && continue
   expect_checker 1 "prohibited word ${word}" "A line that mentions ${word} inline."

--- a/.github/workflows/static.check.scripts/test_prohibited_words.sh
+++ b/.github/workflows/static.check.scripts/test_prohibited_words.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# @file: test_prohibited_words.sh
+# @brief    Self-test for prohibited-words.sh and its word list.
+# @see      https://github.com/nnstreamer/nnstreamer
+# @author   MyungJoo Ham <myungjoo.ham@samsung.com>
+#
+# Runs prohibited-words.sh the same way static.check.yml does, from the
+# repository root with a changed-file list. Two properties are pinned: a
+# prohibited word must fail the checker, and ordinary prose must not. The
+# first would have caught the checker silently passing on every input; the
+# second keeps an over-broad entry from turning the word list into a gate
+# that rejects nearly every PR.
+#
+# The checker is invoked with stdin closed, matching how GitHub runs it, so
+# that a future reader-of-stdin bug fails here instead of hanging.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../../.." && pwd)
+CHECKER="${SCRIPT_DIR}/prohibited-words.sh"
+WORD_LIST="${SCRIPT_DIR}/prohibited-words.txt"
+workdir=$(mktemp -d)
+failed=0
+
+trap 'rm -rf "$workdir"' EXIT
+
+# expect_checker <expected 0|1> <description> <content>
+# Writes content to a markdown file, runs the checker on it from the repo
+# root, and compares the exit status.
+expect_checker() {
+  local expected=$1 desc=$2 content=$3
+  local target list actual
+
+  target="${workdir}/$(echo "$desc" | tr -c 'a-zA-Z0-9' '_').md"
+  printf '%s\n' "$content" > "$target"
+  list=$(mktemp -p "$workdir")
+  printf '%s\n' "$target" > "$list"
+
+  (cd "$REPO_ROOT" && bash "$CHECKER" "$list") > /dev/null 2>&1 < /dev/null
+  actual=$?
+  [[ $actual -ne 0 ]] && actual=1
+
+  if [[ "$actual" == "$expected" ]]; then
+    echo "PASS: ${desc} (exit ${actual})"
+  else
+    echo "FAIL: ${desc} expected exit ${expected}, got ${actual}"
+    failed=1
+  fi
+}
+
+# Every listed word must actually fail the checker.
+while read -r word; do
+  word=${word%$'\r'}
+  [[ -z "$word" ]] && continue
+  expect_checker 1 "prohibited word ${word}" "A line that mentions ${word} inline."
+done < "$WORD_LIST"
+
+# Ordinary prose must pass. These sentences use the vocabulary that a
+# repository-wide word list is most likely to over-match on.
+expect_checker 0 "plain prose" "This file describes how to build and test the plugin."
+expect_checker 0 "code-ish prose" "Open the file, read the header, then close the file descriptor."
+
+# An empty changed-file list is a no-op, not a failure.
+empty_list=$(mktemp -p "$workdir")
+: > "$empty_list"
+if (cd "$REPO_ROOT" && bash "$CHECKER" "$empty_list") > /dev/null 2>&1 < /dev/null; then
+  echo "PASS: empty file list"
+else
+  echo "FAIL: empty file list expected exit 0"
+  failed=1
+fi
+
+if [[ "$failed" != "0" ]]; then
+  echo "::error test_prohibited_words.sh failed."
+  exit 1
+fi
+echo "test_prohibited_words.sh: all checks passed."

--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -162,6 +162,19 @@ jobs:
           else
             echo "Skipped: $selftest is not in this branch's tree and this PR does not remove it."
           fi
+      - name: /Checker/ prohibited-words self-test
+        # Runs a repository script unrelated to $changed_file_list, so it
+        # needs the same merge-ref guard as the step above.
+        run: |
+          selftest=.github/workflows/static.check.scripts/test_prohibited_words.sh
+          if [ -f "$selftest" ]; then
+            bash "$selftest"
+          elif git show --pretty="format:" --name-only --no-renames --diff-filter=D ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | grep -qxF "$selftest"; then
+            echo "::error::This PR removes $selftest; remove its workflow step too, or restore the script (also update this step if the script moved)."
+            exit 1
+          else
+            echo "Skipped: $selftest is not in this branch's tree and this PR does not remove it."
+          fi
       - name: /Checker/ shellcheck for shell scripts
         # Originally from "pr-prebuild-shellcheck"
         run: |


### PR DESCRIPTION
## The checker cannot fail today

`/Checker/ prohibited words` in `static.check.yml` runs `prohibited-words.sh`, whose Step 3 is:

```sh
bad_words_log_file=$(mktemp)                                        # line 74
$bad_words_sw $bad_words_rules $target_files > ${bad_words_log_file}  # line 85
cat ${bad_words_log_file}                                             # line 88
result_count=$(cat ${bad_word_log_file} | grep -c '^' )               # line 91
```

Line 91 reads `${bad_word_log_file}` — no `s`. The name is unset, so `cat` reads stdin rather than the grep output. Under Actions stdin is empty, `result_count` is always `0`, and the step always exits 0.

Reproduced locally on a file that does contain a listed word — grep prints the hit and the script still passes:

```
README.md:127:- [TAOS-CI config files for nnstreamer](.TAOS-CI).
There is no prohibited word found in this PR.
exit=0
```

Counting with `wc -l` fixes the name and removes the useless `cat` that let the failure hide behind a stdin read.

## Why the word list has to change at the same time

Repairing the count alone would turn the step red on nearly every PR. `prohibited-words.txt` listed `file`, and the rules are a plain `grep -f`:

- **337 of 392** files in the inspected extensions (`*.c *.h *.cpp *.hpp *.py *.sh *.php *.md`) contain `file`
- The `README.md` hit above is exactly that

`file` is not a prohibited word in any meaningful sense, so it is dropped. Remaining entries: `samsung.net`, `FUCK`.

**One consequence to be aware of.** With the checker actually working, `ext/nnstreamer/tensor_filter/vivante/tensor_filter_vivante.c:47` will fail the step if a future PR touches that file — its header comment cites an internal `github.sec.samsung.net` clone URL for Tizen packaging. That is the checker doing precisely what `samsung.net` is in the list for. I left it alone because rewriting that packaging pointer needs knowledge of where that repo lives now, which this change does not have. Merging this PR does not break anything today: the checker only inspects files changed in a PR.

## Regression test

`test_prohibited_words.sh` follows `.github/actions/check-rebuild/test_check_if_rebuild_requires.sh`, the self-test `static.check.yml` already runs, and is wired in next to it. It pins both properties that were broken:

| Property | Guards against |
| --- | --- |
| Every word in `prohibited-words.txt` must fail the checker | the counting bug fixed here |
| Ordinary prose must pass | an over-broad entry like `file` being re-added |

Both directions were verified by reintroducing each defect:

```
# with the misspelled variable restored
FAIL: prohibited word samsung.net expected exit 1, got 0
FAIL: prohibited word FUCK expected exit 1, got 0

# with "file" put back in the word list
FAIL: plain prose expected exit 0, got 1
FAIL: code-ish prose expected exit 0, got 1
```

Because the test drives the checker through the same entry point CI uses, a future PR that breaks either property fails `Static checkers and verifiers` and cannot merge.

The checker is invoked with stdin closed, matching how GitHub runs it. Without that, restoring the `cat`-reads-stdin bug makes the test hang on a terminal instead of failing — the test would still not pass, but it would waste a CI slot rather than report.

## Local verification

- `test_prohibited_words.sh` — all checks pass; both regression injections fail it as shown above
- Repaired checker run against this PR's own changed files — exit 0
- `executable.sh` on the changed files — pass; new script committed `100644` like its siblings
- Staged blobs confirmed LF (0 CR bytes), `static.check.yml` re-parsed and the new step confirmed registered in `simple_script_checkers`

## Scope

Found while working on #4878, where `prohibited-words.txt` looked like the natural place to guard against dead JCenter/bintray links coming back. It could not serve that purpose, hence this repair. The two PRs are independent and touch disjoint files — this one deliberately does **not** add `bintray`/`jcenter` to the list, because doing so before #4878 lands would fail any PR touching the docs that still mention them.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
