### PR TITLE
[Filter/TVM] Fix model_path leak on configure_instance failure paths

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tvm.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tvm.cc
@@ -99,16 +99,17 @@ tvm_subplugin::tvm_subplugin ()
 void
 tvm_subplugin::cleanup () noexcept
 {
+  g_free (model_path);
+  model_path = nullptr;
+
   if (empty_model)
     return;
-  g_free (model_path);
 
   input_tensor_list.clear ();
   output_tensor_list.clear ();
   gst_tensors_info_free (std::addressof (inputInfo));
   gst_tensors_info_free (std::addressof (outputInfo));
 
-  model_path = nullptr;
   empty_model = true;
 }
 

--- a/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
+++ b/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
@@ -39,7 +39,9 @@ class NNStreamerFilterTVMTest : public ::testing::Test
   const GstTensorFilterFramework *sp;
   const gchar *wrong_model_files[2];
   const gchar *proper_model_files[2];
+  const gchar *invalid_model_files[2];
   gchar *model_file;
+  gchar *invalid_model_file;
   gchar *pipeline;
   GstElement *gstpipe;
   GstElement *sink_handle;
@@ -47,16 +49,25 @@ class NNStreamerFilterTVMTest : public ::testing::Test
   GstTensorMemory output;
 
   /**
+   * @brief Get the absolute path of a file in tests/test_models
+   */
+  gchar *GetTestModelPath (const gchar *subdir, const gchar *filename)
+  {
+    const gchar *src_root = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+    g_autofree gchar *root_path = src_root ? g_strdup (src_root) : g_get_current_dir ();
+
+    return g_build_filename (root_path, "tests", "test_models", subdir, filename, NULL);
+  }
+
+  /**
    * @brief Set the model file for testing
    */
   gchar *SetModelFile ()
   {
-    const gchar *src_root = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
-    g_autofree gchar *root_path = src_root ? g_strdup (src_root) : g_get_current_dir ();
     g_autofree gchar *model_name
         = g_strdup_printf ("tvm_add_one_%s%s_", ARCH, NNSTREAMER_SO_FILE_EXTENSION);
 
-    return g_build_filename (root_path, "tests", "test_models", "models", model_name, NULL);
+    return GetTestModelPath ("models", model_name);
   }
 
   public:
@@ -64,13 +75,14 @@ class NNStreamerFilterTVMTest : public ::testing::Test
    * @brief Construct a new NNStreamerFilterTVMTest object
    */
   NNStreamerFilterTVMTest ()
-      : sp (nullptr), model_file (nullptr), pipeline (nullptr),
-        gstpipe (nullptr), sink_handle (nullptr)
+      : sp (nullptr), model_file (nullptr), invalid_model_file (nullptr),
+        pipeline (nullptr), gstpipe (nullptr), sink_handle (nullptr)
   {
     input.data = output.data = nullptr;
     input.size = output.size = 0;
     wrong_model_files[0] = wrong_model_files[1] = nullptr;
     proper_model_files[0] = proper_model_files[1] = nullptr;
+    invalid_model_files[0] = invalid_model_files[1] = nullptr;
   }
 
   /**
@@ -97,6 +109,10 @@ class NNStreamerFilterTVMTest : public ::testing::Test
     proper_model_files[0] = model_file;
     proper_model_files[1] = NULL;
 
+    invalid_model_file = GetTestModelPath ("labels", "labels.txt");
+    invalid_model_files[0] = invalid_model_file;
+    invalid_model_files[1] = NULL;
+
     input.size = output.size = 0;
     input.data = nullptr;
     output.data = nullptr;
@@ -110,6 +126,7 @@ class NNStreamerFilterTVMTest : public ::testing::Test
   void TearDown () override
   {
     g_free (model_file);
+    g_free (invalid_model_file);
     g_free (pipeline);
 
     g_clear_object (&gstpipe);
@@ -184,6 +201,28 @@ TEST_F (NNStreamerFilterTVMTest, openClose00)
   sp->close (&prop, &data);
 
   /* double close */
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Negative case with a file that exists but is not a tvm module
+ */
+TEST_F (NNStreamerFilterTVMTest, openClose01_n)
+{
+  int ret;
+  void *data = NULL;
+  GstTensorFilterProperties prop;
+
+  ASSERT_TRUE (g_file_test (invalid_model_file, G_FILE_TEST_IS_REGULAR));
+  EXPECT_NE (sp, nullptr);
+
+  /* Test */
+  SetFilterProperty (&prop, invalid_model_files);
+  ret = sp->open (&prop, &data);
+  EXPECT_NE (ret, 0);
+  EXPECT_EQ (data, nullptr);
+
+  /* close after failed open */
   sp->close (&prop, &data);
 }
 


### PR DESCRIPTION
`tvm_subplugin::cleanup()` starts with `if (empty_model) return;`, but `configure_instance()` assigns `model_path = g_strdup (prop->model_files[0])` *before* the calls that can throw, and `empty_model` is only cleared at the very end of a successful configure. Every throw in between calls `cleanup()`, hits the early return, and leaks the duplicated path.

The affected throw sites, all after the `g_strdup`:
- `tvm::runtime::Module::LoadFromFile()` on a file that exists but is not a tvm module
- the `get_input == nullptr` and `get_output == nullptr` guards
- either `convert_dtype()` failure

**Changes proposed in this PR:**
- Move `g_free (model_path); model_path = nullptr;` above the `empty_model` guard in `cleanup()`, so the path is released regardless of how far configure got. `model_path` is initialised to `nullptr` in the constructor and reset here, so the now-unconditional `g_free` is safe for the close-before-open and double-close calls the existing tests make.
- Add `openClose01_n`, opening a file that exists but is not a tvm module (`test_models/labels/labels.txt`). The existing negative cases (`openClose00_n`, `launch00_n`) pass a nonexistent `temp.so` and are rejected earlier by the `g_file_test (…, G_FILE_TEST_IS_REGULAR)` check, so no current test reaches the leaking path at all.

Found while reviewing #4873, which adds an SSAT suite whose `3_n` case is the first test in the tree to exercise `LoadFromFile()` throwing. The two PRs are independent and touch disjoint files. This one is not required for #4873 to be correct — the leak is pre-existing and one `g_strdup` per failed configure — but it is worth fixing before the path starts being exercised regularly.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped (needs a tvm-enabled build; verified in CI)
2. Run test: [ ]Passed [ ]Failed [*]Skipped (same)

**How to evaluate:**
1. Build with `-Dtvm-support=enabled`.
2. Run `unittest_filter_tvm`; `openClose01_n` should pass, and should fail on `sp->open()` returning 0 if the exception handling ever regresses.
3. Under valgrind or ASAN, `openClose01_n` shows a definite loss of the model path string without this fix and none with it.
