### PR TITLE
[Test] Install the SSAT suites that were missing from unittest-nnstreamer

### DIFF
--- a/.github/workflows/static.check.scripts/ssat-install-list.sh
+++ b/.github/workflows/static.check.scripts/ssat-install-list.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# @file     ssat-install-list.sh
+# @brief    Keep the install_subdir list in tests/meson.build in sync with the SSAT suites
+# @see      https://github.com/nnstreamer/nnstreamer
+# @author   MyungJoo Ham <myungjoo.ham@samsung.com>
+#
+# The list that fills the unittest-nnstreamer package is hand-maintained, so a new
+# tests/<suite>/runTest.sh can be added without ever being shipped, and an entry can
+# outlive the directory it names. Both happened. This checks the two directions.
+#
+
+meson_file="tests/meson.build"
+
+# Suites deliberately absent from the package. Keep the reason next to the name.
+#   codegen: runs tools/development/nnstreamerCodeGenCustomFilter.py and compiles
+#            against gst/nnstreamer through ../../ paths that only a source tree has.
+not_installed=("codegen")
+
+if [ ! -f "${meson_file}" ]; then
+  echo "::error::${meson_file} not found. Run this from the repository root."
+  exit 1
+fi
+
+failed=0
+installed=$(grep -vE '^[[:space:]]*#' "${meson_file}" | grep -oE "install_subdir\('[^']+'" | cut -d"'" -f2)
+
+# Every SSAT suite should be installed, unless it is listed above.
+while IFS= read -r script; do
+  suite=$(basename "$(dirname "${script}")")
+
+  skip=0
+  for exempt in "${not_installed[@]}"; do
+    if [ "${suite}" = "${exempt}" ]; then skip=1; break; fi
+  done
+  [ ${skip} -eq 1 ] && continue
+
+  if ! echo "${installed}" | grep -qxF "${suite}"; then
+    echo "::error::tests/${suite} has a runTest.sh but is missing from ${meson_file}, so it will not reach the unittest-nnstreamer package. Add install_subdir('${suite}', install_dir: unittest_install_dir), or add it to not_installed in $0 with the reason."
+    failed=1
+  fi
+done < <(find tests -mindepth 2 -maxdepth 2 -name runTest.sh)
+
+# Every entry should name a directory that exists.
+for suite in ${installed}; do
+  if [ ! -d "tests/${suite}" ]; then
+    echo "::error::${meson_file} installs '${suite}', but tests/${suite} does not exist."
+    failed=1
+  fi
+done
+
+if [ ${failed} -ne 0 ]; then
+  exit 1
+fi
+
+echo "The SSAT install list in ${meson_file} is in sync."

--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -175,6 +175,20 @@ jobs:
           else
             echo "Skipped: $selftest is not in this branch's tree and this PR does not remove it."
           fi
+      - name: /Checker/ SSAT install list is in sync
+        # Same guard as the check-rebuild self-test above: the step list comes
+        # from the merge ref while the checkout is the PR head, so a branch that
+        # predates this script would fail with "No such file or directory".
+        run: |
+          checker=.github/workflows/static.check.scripts/ssat-install-list.sh
+          if [ -f "$checker" ]; then
+            bash "$checker"
+          elif git show --pretty="format:" --name-only --no-renames --diff-filter=D ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | grep -qxF "$checker"; then
+            echo "::error::This PR removes $checker; remove its workflow step too, or restore the script (also update this step if the script moved)."
+            exit 1
+          else
+            echo "Skipped: $checker is not in this branch's tree and this PR does not remove it."
+          fi
       - name: /Checker/ shellcheck for shell scripts
         # Originally from "pr-prebuild-shellcheck"
         run: |

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -452,7 +452,10 @@ tensor_filter_ext_enabled = tflite_support_is_available or \
     pytorch_support_is_available or caffe2_support_is_available or \
     nnfw_runtime_support_is_available or get_option('enable-edgetpu') or \
     mvncsdk2_support_is_available or get_option('enable-openvino') or \
-    mxnet_support_is_available
+    mxnet_support_is_available or litert_support_is_available or \
+    onnxruntime_support_is_available or tensorrt_support_is_available or \
+    tensorrt10_support_is_available or tvm_support_is_available or \
+    lua_support_is_available
 if get_option('install-test') and tensor_filter_ext_enabled
   # host-only model generator scripts are not needed on target devices
   install_subdir('test_models', install_dir: unittest_install_dir,
@@ -462,13 +465,19 @@ endif
 
 # Install Unittest
 if get_option('install-test')
+  # tests/codegen is intentionally not installed: it runs tools/development/
+  # nnstreamerCodeGenCustomFilter.py and compiles against gst/nnstreamer via
+  # ../../ paths that exist only in the source tree.
   install_data('gen24bBMP.py', install_dir: unittest_install_dir)
   install_data('test_utils.py', install_dir: unittest_install_dir)
+  install_data('get_available_port.py', install_dir: unittest_install_dir)
+  install_subdir('gstreamer_join', install_dir: unittest_install_dir)
   install_subdir('nnstreamer_converter', install_dir: unittest_install_dir)
   install_subdir('nnstreamer_merge', install_dir: unittest_install_dir)
   install_subdir('nnstreamer_decoder', install_dir: unittest_install_dir)
   install_subdir('nnstreamer_decoder_boundingbox', install_dir: unittest_install_dir)
   install_subdir('nnstreamer_decoder_pose', install_dir: unittest_install_dir)
+  install_subdir('nnstreamer_decoder_tensor_region', install_dir: unittest_install_dir)
   install_subdir('nnstreamer_demux', install_dir: unittest_install_dir)
   install_subdir('nnstreamer_filter_custom', install_dir: unittest_install_dir)
   if tflite_support_is_available or tflite2_support_is_available
@@ -509,11 +518,31 @@ if get_option('install-test')
   if protobuf_support_is_available
     install_subdir('nnstreamer_protobuf', install_dir: unittest_install_dir)
   endif
-  if mxnet_support_is_available
-    install_subdir('unittest_filter_mxnet', install_dir: unittest_install_dir)
-  endif
   if executorch_support_is_available
     install_subdir('nnstreamer_filter_executorch', install_dir: unittest_install_dir)
+  endif
+  if litert_support_is_available
+    install_subdir('nnstreamer_filter_litert', install_dir: unittest_install_dir)
+  endif
+  if lua_support_is_available
+    install_subdir('nnstreamer_filter_lua', install_dir: unittest_install_dir)
+    # nnstreamer_sparse builds its sparse tensors with the lua filter
+    install_subdir('nnstreamer_sparse', install_dir: unittest_install_dir)
+  endif
+  if onnxruntime_support_is_available
+    install_subdir('nnstreamer_filter_onnxruntime', install_dir: unittest_install_dir)
+  endif
+  if tensorrt_support_is_available
+    install_subdir('nnstreamer_filter_tensorrt', install_dir: unittest_install_dir)
+  endif
+  if tensorrt10_support_is_available
+    install_subdir('nnstreamer_filter_tensorrt10', install_dir: unittest_install_dir)
+  endif
+  if tvm_support_is_available
+    install_subdir('nnstreamer_filter_tvm', install_dir: unittest_install_dir)
+  endif
+  if grpc_support_is_available
+    install_subdir('nnstreamer_grpc', install_dir: unittest_install_dir)
   endif
   install_subdir('nnstreamer_mux', install_dir: unittest_install_dir)
   install_subdir('nnstreamer_rate', install_dir: unittest_install_dir)
@@ -522,6 +551,7 @@ if get_option('install-test')
   install_subdir('nnstreamer_repo_lstm', install_dir: unittest_install_dir)
   install_subdir('nnstreamer_repo_rnn', install_dir: unittest_install_dir)
   install_subdir('nnstreamer_split', install_dir: unittest_install_dir)
+  install_subdir('nnstreamer_octet_stream', install_dir: unittest_install_dir)
   install_subdir('transform_arithmetic', install_dir: unittest_install_dir)
   install_subdir('transform_clamp', install_dir: unittest_install_dir)
   install_subdir('transform_dimchg', install_dir: unittest_install_dir)


### PR DESCRIPTION
`tests/meson.build` enumerates by hand which SSAT directories go into the `unittest-nnstreamer` package, and that list stopped being maintained around 2021. Twelve suites were absent, so on a target device they do not exist and cannot be run against the installed nnstreamer — even though the gtest binaries from the same directories *are* installed. This fixes the list and then stops it drifting again.

## Changes

**Install the eleven suites that were missing:** `nnstreamer_decoder_tensor_region`, `nnstreamer_filter_lua`, `nnstreamer_sparse`, `nnstreamer_filter_litert`, `nnstreamer_filter_onnxruntime`, `nnstreamer_filter_tensorrt`, `nnstreamer_filter_tensorrt10`, `nnstreamer_filter_tvm`, `nnstreamer_grpc`, `nnstreamer_octet_stream`, `gstreamer_join`. Framework-specific ones are gated on the matching `*_support_is_available` flag, following the `tflite`/`executorch` entries above them.

**Install `get_available_port.py`.** `nnstreamer_grpc/runTest.sh` invokes it as `../get_available_port.py`; without it that suite would *fail* rather than skip once installed.

**Leave `codegen` out**, with a comment saying why.

**Delete the mxnet entry.** It installed `unittest_filter_mxnet`, which is not a directory in this tree — the real one is `tests/nnstreamer_filter_mxnet`, and it has no `runTest.sh`, so there is no SSAT suite to install either way. It went unnoticed because it only fires when `mxnet_support_is_available`, which is never true in CI.

**Extend `tensor_filter_ext_enabled`** — which gates the `test_models` install — with litert, onnxruntime, tensorrt, tensorrt10, tvm and lua. Every suite added here reads from `../test_models`, so without this a build enabling only one of those frameworks would ship a suite without its fixtures. That variable is defined at `tests/meson.build:448` and used only at line 456, so widening it changes nothing else.

**Add a drift check.** The root cause is a hand-maintained list with nothing detecting divergence: no one was told to update it and CI stayed green while twelve entries went missing. `.github/workflows/static.check.scripts/ssat-install-list.sh` compares both directions — a suite with a `runTest.sh` that is not installed, and an entry naming a directory that does not exist — and carries `codegen` as an explicit exemption with its reason next to the name. The mxnet entry above is exactly what the second direction catches. The workflow step uses the same guard as the check-rebuild self-test, since the step list comes from the merge ref while the checkout is the PR head.

## How each suite was checked

Every candidate was inspected for references outside its own directory (ignoring `../test_models`, which is installed, and `../../build`, the build-mode probe):

| suite | external reference | verdict |
| --- | --- | --- |
| `gstreamer_join`, `octet_stream`, `sparse`, `filter_tensorrt`, `filter_tensorrt10`, `filter_tvm`, `filter_litert` | none | install |
| `filter_onnxruntime` | `../` only, inside a deliberately-invalid model path in a negative case | install |
| `decoder_tensor_region` | `../nnstreamer_decoder_boundingbox/{box_priors.txt,coco_labels_list.txt}` — installed unconditionally | install |
| `filter_lua` | `../nnstreamer_filter_python3/checkScaledTensor.py` — installed when `have_python3` | install |
| `grpc` | `../get_available_port.py` — **was not installed**; added here | install |
| `codegen` | `../../tools/development/nnstreamerCodeGenCustomFilter.py`, `../../gst/nnstreamer`, `../../gst/nnstreamer/include` | **exclude** |

`codegen` is the one that genuinely cannot work outside a source tree. `nnstreamer_sparse` is gated on lua rather than a converter flag because its own script says so: *"Check lua libraries are built. This test utilizes it for making 'sparse' dense tensors."* `nnstreamer_decoder_tensor_region` is unconditional because it runs no framework — its `PATH_TO_MODEL` is assigned and never used, and the pipeline feeds pre-dumped `mobilenet_ssd_tensor.{0,1}`.

The audit above covers `../`-relative references pointing outside `test_models`; it does not verify that fixtures *inside* `test_models` resolve. #4890 records one that does not (`tensorrt10` names `yolov5nu_224.onnx`, which is not in the tree) — pre-existing, but this PR is what puts that suite on devices.

## What this does and does not achieve

Nine of the eleven become runnable on a device. `filter_lua` and `sparse` do not: their build-directory probe ends with `echo "No build directory"; report; exit` rather than falling back to `/etc/nnstreamer.ini`, so from an installed tree they report no cases.

That shape is pre-existing — six suites already in the install list behave identically (`converter_python3`, `decoder_python3`, `filter_python3`, `flatbuf`, `flexbuf`, `protobuf`). Teaching all eight installed-mode discovery is a separate change, and doing it for only the two this PR happens to touch would be the same arbitrary partial fix that left this list stale. They are installed here regardless, since that later fix is only useful once the scripts ship.

One consequence worth noting: the `filter_lua` dependency on `checkScaledTensor.py` cannot bite today, because the script exits at the build-directory probe long before reaching that call. If `filter_lua` later gains the fallback, its install should be gated on `have_python3` as well.

## Scope and risk

No test logic changes, and nothing about how CI runs the suites changes — CI always executes them from the build tree, where discovery comes from `GST_PLUGIN_PATH` / `NNSTREAMER_CONF` / `NNSTREAMER_FILTERS` exported by `nnstreamer.spec` and `debian/rules`, not from this list. The only behavioural effect is the contents of the installed test package.

`%files unittests` globs the directory (`%{_prefix}/%{nnstbindir}/unittest-nnstreamer/tests`), so no packaging file needs to change. The package grows by about 1.1MB, ~924KB of which is the `mobilenet_ssd_tensor.*` fixtures in `decoder_tensor_region`; every other suite is 8-40KB.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped (both `-Dinstall-test=true` builds are green)
2. Run test: [ ]Passed [ ]Failed [*]Skipped (no test logic changed)

**How to evaluate:**
1. Build and install with `-Dinstall-test=true`, then confirm the eleven directories appear under `<prefix>/lib/nnstreamer/bin/unittest-nnstreamer/tests/` for the frameworks enabled in that build, and that `codegen` is absent.
2. Run `bash .github/workflows/static.check.scripts/ssat-install-list.sh` from the repository root; it should report the list is in sync. Delete an `install_subdir` entry, or point one at a non-existent directory, and it should fail with a message naming the fix.
3. Confirm CI's SSAT results are unchanged, since those runs never consult this list.
