### PR TITLE
[Test] Wait for the sink buffer before tearing down single-buffer filter pipelines

### DIFF
--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -2677,6 +2677,70 @@ TEST (commonUtil, errorMessage)
 }
 
 /**
+ * @brief Thread body that bumps the counter after a short delay.
+ */
+static gpointer
+bump_counter (gpointer user_data)
+{
+  guint *count = (guint *) user_data;
+
+  g_usleep (TEST_DEFAULT_SLEEP_TIME * 3);
+  *count = 1U;
+
+  return NULL;
+}
+
+/**
+ * @brief Test that an already-satisfied count returns without waiting.
+ */
+TEST (commonUtil, waitPipelineProcessBuffers)
+{
+  guint count = 3U;
+  gint64 elapsed_us;
+  gint64 start_us = g_get_monotonic_time ();
+
+  EXPECT_TRUE (wait_pipeline_process_buffers (&count, 3U, TEST_TIMEOUT_LIMIT_MS));
+
+  elapsed_us = g_get_monotonic_time () - start_us;
+  EXPECT_LT (elapsed_us, (gint64) TEST_DEFAULT_SLEEP_TIME);
+}
+
+/**
+ * @brief Test that the count reached from another thread is observed.
+ */
+TEST (commonUtil, waitPipelineProcessBuffersAsync)
+{
+  guint count = 0U;
+  GThread *worker = g_thread_new ("bump", bump_counter, &count);
+
+  ASSERT_TRUE (worker != NULL);
+
+  EXPECT_TRUE (wait_pipeline_process_buffers (&count, 1U, TEST_TIMEOUT_LIMIT_MS));
+  EXPECT_GE (count, 1U);
+
+  g_thread_join (worker);
+}
+
+/**
+ * @brief Test that a count which is never reached fails on timeout.
+ * @note The filter unit tests rely on FALSE here to catch a buffer that never
+ *       arrives; a helper that reported success would make them vacuous again.
+ */
+TEST (commonUtil, waitPipelineProcessBuffers_n)
+{
+  guint count = 0U;
+  const guint timeout_ms = 100U;
+  gint64 elapsed_ms;
+  gint64 start_us = g_get_monotonic_time ();
+
+  EXPECT_FALSE (wait_pipeline_process_buffers (&count, 1U, timeout_ms));
+
+  elapsed_ms = (g_get_monotonic_time () - start_us) / 1000;
+  EXPECT_GE (elapsed_ms, (gint64) timeout_ms);
+  EXPECT_LT (elapsed_ms, (gint64) TEST_TIMEOUT_LIMIT_MS);
+}
+
+/**
  * @brief Main function for unit test.
  */
 int

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -2707,8 +2707,8 @@ TEST (commonUtil, waitPipelineProcessBuffers)
     best_us = MIN (best_us, g_get_monotonic_time () - start_us);
   }
 
-  /* One un-preempted run is enough to show the helper checks before sleeping.
-     Widening the bound instead would hide the very tick it has to detect. */
+  /** One un-preempted run is enough to show the helper checks before sleeping.
+   *  Widening the bound instead would hide the very tick it has to detect. */
   EXPECT_LT (best_us, (gint64) TEST_DEFAULT_SLEEP_TIME);
 }
 

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -2685,7 +2685,7 @@ bump_counter (gpointer user_data)
   guint *count = (guint *) user_data;
 
   g_usleep (TEST_DEFAULT_SLEEP_TIME * 3);
-  *count = 1U;
+  g_atomic_int_set (count, 1U);
 
   return NULL;
 }

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -2685,7 +2685,7 @@ bump_counter (gpointer user_data)
   guint *count = (guint *) user_data;
 
   g_usleep (TEST_DEFAULT_SLEEP_TIME * 3);
-  g_atomic_int_set (count, 1U);
+  g_atomic_int_inc (count);
 
   return NULL;
 }
@@ -2696,13 +2696,20 @@ bump_counter (gpointer user_data)
 TEST (commonUtil, waitPipelineProcessBuffers)
 {
   guint count = 3U;
-  gint64 elapsed_us;
-  gint64 start_us = g_get_monotonic_time ();
+  gint64 best_us = G_MAXINT64;
+  guint i;
 
-  EXPECT_TRUE (wait_pipeline_process_buffers (&count, 3U, TEST_TIMEOUT_LIMIT_MS));
+  for (i = 0; i < 5U; ++i) {
+    gint64 start_us = g_get_monotonic_time ();
 
-  elapsed_us = g_get_monotonic_time () - start_us;
-  EXPECT_LT (elapsed_us, (gint64) TEST_DEFAULT_SLEEP_TIME);
+    EXPECT_TRUE (wait_pipeline_process_buffers (&count, 3U, TEST_TIMEOUT_LIMIT_MS));
+
+    best_us = MIN (best_us, g_get_monotonic_time () - start_us);
+  }
+
+  /* One un-preempted run is enough to show the helper checks before sleeping.
+     Widening the bound instead would hide the very tick it has to detect. */
+  EXPECT_LT (best_us, (gint64) TEST_DEFAULT_SLEEP_TIME);
 }
 
 /**

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -283,7 +283,8 @@ if gtest_dep.found()
       install_dir: unittest_install_dir
     )
 
-    test('unittest_filter_tensorflow2_lite', unittest_filter_tensorflow2_lite, env: testenv)
+    test('unittest_filter_tensorflow2_lite', unittest_filter_tensorflow2_lite,
+      timeout: 120, env: testenv)
   endif
 
   if have_python3
@@ -406,7 +407,7 @@ if gtest_dep.found()
       install_dir: unittest_install_dir
     )
 
-    test('unittest_filter_onnxruntime', unittest_filter_onnxruntime, env: testenv)
+    test('unittest_filter_onnxruntime', unittest_filter_onnxruntime, timeout: 120, env: testenv)
   endif
 
   # LiteRT unittest
@@ -418,7 +419,7 @@ if gtest_dep.found()
       install_dir: unittest_install_dir
     )
 
-    test('unittest_filter_litert', unittest_filter_litert, env: testenv)
+    test('unittest_filter_litert', unittest_filter_litert, timeout: 120, env: testenv)
   endif
 
   # LLAMACPP unittest

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -137,6 +137,18 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 }
 
 /**
+ * @brief Signal to count invocations of tensor_sink
+ */
+static void
+count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  guint *count = (guint *) user_data;
+  UNUSED (element);
+  UNUSED (buffer);
+  (*count)++;
+}
+
+/**
  * @brief Check the litert subplugin is registered.
  */
 TEST (nnstreamerFilterLiteRT, checkExistence)
@@ -630,11 +642,16 @@ TEST (nnstreamerFilterLiteRT, floatModelResult)
   ASSERT_TRUE (sink_handle != nullptr);
 
   guint8 is_float = 1;
+  guint count = 0U;
   g_signal_connect (sink_handle, "new-data", (GCallback) check_output, &is_float);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_output, &count);
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT * 10),
       0);
+  EXPECT_TRUE (wait_pipeline_process_buffers (&count, 1U, TEST_TIMEOUT_LIMIT_MS));
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  EXPECT_GE (count, 1U);
 
   gst_object_unref (sink_handle);
   gst_object_unref (gstpipe);
@@ -664,11 +681,16 @@ TEST (nnstreamerFilterLiteRT, quantModelResult)
   ASSERT_TRUE (sink_handle != nullptr);
 
   guint8 is_float = 0;
+  guint count = 0U;
   g_signal_connect (sink_handle, "new-data", (GCallback) check_output, &is_float);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_output, &count);
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT * 10),
       0);
+  EXPECT_TRUE (wait_pipeline_process_buffers (&count, 1U, TEST_TIMEOUT_LIMIT_MS));
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  EXPECT_GE (count, 1U);
 
   gst_object_unref (sink_handle);
   gst_object_unref (gstpipe);

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -138,6 +138,10 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 
 /**
  * @brief Signal to count invocations of tensor_sink
+ * @note Connect this after check_output. GObject runs same-stage handlers in
+ *       connection order, so a satisfied count implies the golden comparison
+ *       for that buffer has already run; connecting it first would let the
+ *       waiter tear the pipeline down before check_output had a say.
  */
 static void
 count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
@@ -145,7 +149,7 @@ count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
   guint *count = (guint *) user_data;
   UNUSED (element);
   UNUSED (buffer);
-  (*count)++;
+  g_atomic_int_inc (count);
 }
 
 /**

--- a/tests/nnstreamer_filter_onnxruntime/unittest_filter_onnxruntime.cc
+++ b/tests/nnstreamer_filter_onnxruntime/unittest_filter_onnxruntime.cc
@@ -127,6 +127,10 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 
 /**
  * @brief Signal to count invocations of tensor_sink
+ * @note Connect this after check_output. GObject runs same-stage handlers in
+ *       connection order, so a satisfied count implies the golden comparison
+ *       for that buffer has already run; connecting it first would let the
+ *       waiter tear the pipeline down before check_output had a say.
  */
 static void
 count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
@@ -134,7 +138,7 @@ count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
   guint *count = (guint *) user_data;
   UNUSED (element);
   UNUSED (buffer);
-  (*count)++;
+  g_atomic_int_inc (count);
 }
 
 /**

--- a/tests/nnstreamer_filter_onnxruntime/unittest_filter_onnxruntime.cc
+++ b/tests/nnstreamer_filter_onnxruntime/unittest_filter_onnxruntime.cc
@@ -126,6 +126,18 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 }
 
 /**
+ * @brief Signal to count invocations of tensor_sink
+ */
+static void
+count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  guint *count = (guint *) user_data;
+  UNUSED (element);
+  UNUSED (buffer);
+  (*count)++;
+}
+
+/**
  * @brief Negative test case with invalid model file path
  */
 TEST (nnstreamerFilterOnnxRuntime, openClose00)
@@ -379,28 +391,22 @@ TEST (nnstreamerFilterOnnxRuntime, floatModelResult)
   ASSERT_TRUE (sink_handle != nullptr);
 
   guint8 is_float = 1;
+  guint count = 0U;
 
   g_signal_connect (sink_handle, "new-data", (GCallback) check_output, &is_float);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_output, &count);
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT * 10),
       0);
 
+  EXPECT_TRUE (wait_pipeline_process_buffers (&count, 1U, TEST_TIMEOUT_LIMIT_MS));
+
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  EXPECT_GE (count, 1U);
 
   gst_object_unref (sink_handle);
   gst_object_unref (gstpipe);
-}
-
-/**
- * @brief Signal to count invocations of tensor_sink
- */
-static void
-count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
-{
-  guint *count = (guint *) user_data;
-  UNUSED (element);
-  UNUSED (buffer);
-  (*count)++;
 }
 
 /**
@@ -434,6 +440,8 @@ TEST (nnstreamerFilterOnnxRuntime, quantModelLaunch00)
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT * 10),
       0);
+
+  EXPECT_TRUE (wait_pipeline_process_buffers (&count, 1U, TEST_TIMEOUT_LIMIT_MS));
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 

--- a/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
+++ b/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
@@ -111,6 +111,18 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 }
 
 /**
+ * @brief Signal to count invocations of tensor_sink
+ */
+static void
+count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  guint *count = (guint *) user_data;
+  UNUSED (element);
+  UNUSED (buffer);
+  (*count)++;
+}
+
+/**
  * @brief Negative case to launch gst pipeline: wrong dimension
  */
 TEST (nnstreamerFilterTensorFlow2Lite, launch0_n)
@@ -184,13 +196,19 @@ TEST (nnstreamerFilterTensorFlow2Lite, quantModelResult)
   ASSERT_TRUE (sink_handle != nullptr);
 
   guint8 *is_float = (guint8 *) g_malloc0 (1);
+  guint count = 0U;
   *is_float = 0;
   g_signal_connect (sink_handle, "new-data", (GCallback) check_output, is_float);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_output, &count);
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT * 10),
       0);
 
+  EXPECT_TRUE (wait_pipeline_process_buffers (&count, 1U, TEST_TIMEOUT_LIMIT_MS));
+
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  EXPECT_GE (count, 1U);
 
   gst_object_unref (sink_handle);
   gst_object_unref (gstpipe);
@@ -224,13 +242,19 @@ TEST (nnstreamerFilterTensorFlow2Lite, floatModelResult)
   ASSERT_TRUE (sink_handle != nullptr);
 
   guint8 *is_float = (guint8 *) g_malloc0 (1);
+  guint count = 0U;
   *is_float = 1;
   g_signal_connect (sink_handle, "new-data", (GCallback) check_output, is_float);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_output, &count);
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT * 10),
       0);
 
+  EXPECT_TRUE (wait_pipeline_process_buffers (&count, 1U, TEST_TIMEOUT_LIMIT_MS));
+
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  EXPECT_GE (count, 1U);
 
   gst_object_unref (sink_handle);
   gst_object_unref (gstpipe);

--- a/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
+++ b/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
@@ -112,6 +112,10 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 
 /**
  * @brief Signal to count invocations of tensor_sink
+ * @note Connect this after check_output. GObject runs same-stage handlers in
+ *       connection order, so a satisfied count implies the golden comparison
+ *       for that buffer has already run; connecting it first would let the
+ *       waiter tear the pipeline down before check_output had a say.
  */
 static void
 count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
@@ -119,7 +123,7 @@ count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
   guint *count = (guint *) user_data;
   UNUSED (element);
   UNUSED (buffer);
-  (*count)++;
+  g_atomic_int_inc (count);
 }
 
 /**


### PR DESCRIPTION
Fixes #4870.

## Problem

`nnstreamerFilterOnnxRuntime.quantModelLaunch00` asserts `count >= 1` immediately after driving the pipeline `PLAYING -> NULL`:

```c
EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, ...), 0);
EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, ...), 0);
EXPECT_GE (count, 1U);
```

`setPipelineStateSync (PLAYING)` returns when the *state change* completes, not when data has flowed. The single buffer from `filesrc ! pngdec ! ... ! tensor_filter ! tensor_sink` is still in flight when the teardown starts. On loaded runners the teardown wins and `new-data` never fires, producing the reported `actual: 0 vs 1`.

The same `PLAYING -> NULL` structure exists in five sibling tests that assert **nothing** about the buffer count. There the lost race is silent: `check_output`'s golden argmax comparison simply never runs and the test passes without verifying anything.

## Fix

Poll for the buffer between the two state transitions with the existing `wait_pipeline_process_buffers()` helper from `tests/unittest_util.h`, and assert the count. Buffer counting is done through a *second* `new-data` handler so `check_output` stays single-purpose.

| Test | Before | After |
| --- | --- | --- |
| onnxruntime `quantModelLaunch00` | asserts count, no wait → **flaky** | waits, asserts |
| onnxruntime `floatModelResult` | no count, no wait → **vacuous** | waits, asserts |
| tflite `quantModelResult` / `floatModelResult` | no count, no wait → **vacuous** | waits, asserts |
| litert `floatModelResult` / `quantModelResult` | no count, no wait → **vacuous** | waits, asserts |

## Evidence

The race is framework-independent, so it reproduces without any inference subplugin. A standalone program building the same pipeline shape (`filesrc ! pngdec ! videoconvert ! videoscale ! tensor_converter ! tensor_transform ! tensor_sink`), 60 iterations on a fully CPU-saturated machine:

```
WITHOUT wait: 46/60 iterations saw count==0
WITH    wait:  0/60 iterations saw count==0
```

That is both the reproduction of #4870 and the demonstration that the wait fixes it. It also quantifies the vacuous-pass hole: under load the golden check in the five sibling tests was skipped roughly 77% of the time.

## Test coverage

- The repaired assertions are themselves the regression tests — without the wait they fail under load (46/60 above), with it they pass.
- `wait_pipeline_process_buffers()` had **no coverage of its own** even though these tests now depend on its timeout contract. Added `commonUtil.waitPipelineProcessBuffers` (already-satisfied count returns immediately), `commonUtil.waitPipelineProcessBuffersAsync` (count reached from another thread is observed), and `commonUtil.waitPipelineProcessBuffers_n` (unreachable count returns `FALSE` after at least the timeout). A future change making the helper report success on timeout would otherwise quietly make every test above vacuous again — CI now fails instead.

## Verification performed locally

- `unittest_common`: **142/142 pass** (139 existing + 3 new).
- All four changed files compile with `-Wall -Wextra`, no new warnings; `wait_pipeline_process_buffers` resolves at link time.
- `clang-format --style=file`: clean on all four files.
- onnxruntime / tensorflow2-lite / litert are not installable in this environment, so those four test binaries were compile- and link-verified but not executed; CI provides the runtime signal.

## Scope

Test-only. No production code, no API, no architecture change — no documentation update applies. Split into two commits: the first is #4870 itself plus the helper coverage, the second is the identical hole in the tflite/litert siblings, so they can be evaluated independently.
