### PR TITLE
[Filter/llamacpp] Fix the sync-mode test stall and treat a zero-token generation as valid

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_llamacpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_llamacpp.cc
@@ -234,6 +234,10 @@ TensorFilterLlamaCpp::parseCustomProperties (const GstTensorFilterProperties *pr
   }
 
   /* validate properties */
+  if (n_predict < 0) {
+    throw std::invalid_argument (
+        "Number of tokens to predict should not be negative (0 generates nothing).");
+  }
   if (n_ctx < 0) {
     throw std::invalid_argument ("Context length should be a positive value (or 0 from model).");
   }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_llamacpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_llamacpp.cc
@@ -498,10 +498,11 @@ TensorFilterLlamaCpp::generateTokens (GstTensorFilterProperties *prop,
     n_processed++;
   }
 
-  if (!prop->invoke_async) {
-    if (output_accumulated.empty ())
-      ml_logd ("Generated no token for the given prompt (n_predict: %d).", n_predict);
+  /* n_remain is untouched only when not a single token was emitted. */
+  if (n_remain == n_predict)
+    ml_logd ("Generated no token for the given prompt (n_predict: %d).", n_predict);
 
+  if (!prop->invoke_async) {
     /* Final output for synchronous mode is created here. */
     if (!createOutputTensor (prop, output, output_accumulated)) {
       throw std::runtime_error ("Failed to create output tensor while generating tokens");

--- a/ext/nnstreamer/tensor_filter/tensor_filter_llamacpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_llamacpp.cc
@@ -359,6 +359,9 @@ TensorFilterLlamaCpp::invoke (const GstTensorMemory *input, GstTensorMemory *out
 /**
  * @brief Create output tensor
  *
+ * An empty @a buf is a valid input; it yields a one-byte tensor holding the
+ * string terminator, which is how a zero-token generation is represented.
+ *
  * The memory allocated for the output tensor data using g_strndup()
  * must be freed by the caller of this function to avoid memory leaks.
  */
@@ -368,7 +371,7 @@ TensorFilterLlamaCpp::createOutputTensor (GstTensorFilterProperties *prop,
 {
   GstTensorInfo *_info;
 
-  if (buf.empty () || output == nullptr || prop == nullptr) {
+  if (output == nullptr || prop == nullptr) {
     ml_loge ("Invalid arguments passed to createOutputTensor");
     return false;
   }
@@ -432,6 +435,10 @@ TensorFilterLlamaCpp::updateOutput (GstTensorFilterProperties *prop,
  * If invoke_async is true, each token is dispatched asynchronously using
  * nnstreamer_filter_dispatch_output_async(); otherwise, the result is stored in
  * output. GstTensorMemory is freed by nnstreamer; do not free it manually.
+ *
+ * Generating no token at all (the first sampled token is end-of-generation, or
+ * num_predict is zero) is a valid result, not an error; in synchronous mode it
+ * produces an empty output so that every input still yields one output.
  */
 void
 TensorFilterLlamaCpp::generateTokens (GstTensorFilterProperties *prop,
@@ -492,6 +499,9 @@ TensorFilterLlamaCpp::generateTokens (GstTensorFilterProperties *prop,
   }
 
   if (!prop->invoke_async) {
+    if (output_accumulated.empty ())
+      ml_logd ("Generated no token for the given prompt (n_predict: %d).", n_predict);
+
     /* Final output for synchronous mode is created here. */
     if (!createOutputTensor (prop, output, output_accumulated)) {
       throw std::runtime_error ("Failed to create output tensor while generating tokens");

--- a/ext/nnstreamer/tensor_filter/tensor_filter_llamacpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_llamacpp.cc
@@ -738,7 +738,8 @@ void
 TensorFilterLlamaCpp::init_filter_llama ()
 {
   registered = tensor_filter_subplugin::register_subplugin<TensorFilterLlamaCpp> ();
-  nnstreamer_filter_set_custom_property_desc (name, "num_predict", "Number of tokens to predict",
+  nnstreamer_filter_set_custom_property_desc (name, "num_predict",
+      "Number of tokens to predict, non-negative (0 generates nothing)",
       "num_gpu_layers", "Number of layers to offload to the GPU", "context_length",
       "Context size for KV cache", "batch_size", "Logical maximum batch size",
       "top_k", "Top-K sampling parameter", "top_p", "Top-P sampling parameter",

--- a/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
+++ b/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
@@ -416,9 +416,13 @@ TEST_F (NNStreamerFilterLlamaCppTest, zeroTokenGenerationSync_p)
  * @brief Test case for a zero-token generation in asynchronous mode.
  *
  * Asynchronous mode dispatches one sample per generated token, so generating
- * nothing must dispatch nothing: each input is left with only the output the
- * invoke itself produces. Pinning the count keeps a future change to the
- * dispatch path from silently emitting a sample per empty generation.
+ * nothing must dispatch nothing. Two inputs still yield exactly two samples:
+ * tensor_filter pushes one buffer per invoke_dynamic() call whatever the
+ * sub-plugin dispatches on top, which is the same structural invariant that
+ * makes singleInputMultipleOutputsAsync_p expect eleven samples for ten
+ * predicted tokens. The count is therefore an invariant, not a timing
+ * measurement, and pinning it keeps a future change to the dispatch path from
+ * silently emitting a sample per empty generation.
  */
 TEST_F (NNStreamerFilterLlamaCppTest, zeroTokenGenerationAsync_p)
 {

--- a/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
+++ b/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
@@ -329,6 +329,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, singleInputSingleOutputSync_p)
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_TRUE (wait_for_samples (1));
+  EXPECT_FALSE (pipeline_error);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1);
@@ -570,6 +571,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, combinedSamplingSync_p)
   EXPECT_TRUE (data_push ("Hello my name is"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_TRUE (wait_for_samples (1));
+  EXPECT_FALSE (pipeline_error);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1);
@@ -653,6 +655,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, contextSaveLoad_p)
   EXPECT_TRUE (data_push ("Hello my name is John. I like programming and AI."));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_TRUE (wait_for_samples (1));
+  EXPECT_FALSE (pipeline_error);
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1);
 
@@ -670,6 +673,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, contextSaveLoad_p)
   EXPECT_TRUE (data_push ("What did I just say about myself?"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_TRUE (wait_for_samples (1));
+  EXPECT_FALSE (pipeline_error);
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1);
 
@@ -700,6 +704,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, contextFileNotFound_n)
   EXPECT_TRUE (data_push ("Hello my name is John."));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_TRUE (wait_for_samples (1));
+  EXPECT_FALSE (pipeline_error);
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1); /* Should work with fresh context */
 }
@@ -722,6 +727,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, contextInvalidSavePath_n)
   EXPECT_TRUE (data_push ("Hello my name is John."));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_TRUE (wait_for_samples (1));
+  EXPECT_FALSE (pipeline_error);
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1); /* Should work even if save fails */
 
@@ -744,6 +750,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, applyLoraAdapter_p)
   EXPECT_TRUE (data_push ("Can you translate 'Hello world' into Korean?"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_TRUE (wait_for_samples (1));
+  EXPECT_FALSE (pipeline_error);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1); /* In sync mode, expect one sample for the entire output */

--- a/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
+++ b/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
@@ -340,7 +340,6 @@ TEST_F (NNStreamerFilterLlamaCppTest, singleInputSingleOutputSync_p)
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1);
-  EXPECT_GT (max_sample_size, 1U);
 }
 
 /**

--- a/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
+++ b/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
@@ -65,7 +65,7 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
   GstElement *pipeline, *appsrc, *appsink, *tensor_filter;
   gchar *model;
   LoRAPaths *lora_paths;
-  guint *new_sample_count;
+  gint *new_sample_count;
   gsize max_sample_size;
   gboolean pipeline_error;
   gboolean skip_test;
@@ -122,7 +122,7 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
   void SetUp () override
   {
     /* Track the number of async callback invocations. */
-    new_sample_count = g_new0 (guint, 1);
+    new_sample_count = g_new0 (gint, 1);
     max_sample_size = 0;
     pipeline_error = FALSE;
   }
@@ -151,7 +151,7 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
     GstMapInfo map;
 
     if (self && self->new_sample_count)
-      (*self->new_sample_count)++;
+      g_atomic_int_inc (self->new_sample_count);
 
     sample = gst_app_sink_pull_sample (GST_APP_SINK (sink));
     if (sample) {
@@ -202,6 +202,8 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
      * a running time - a PTS minutes into the future. A synchronizing sink
      * then holds the buffer and the sample never arrives. These tests measure
      * generation, not playback, so clock synchronization has no place here.
+     * The converter behaviour itself is tracked as issue #4898; revisit this
+     * once that is fixed.
      */
     g_object_set (G_OBJECT (appsink), "emit-signals", TRUE, "sync", FALSE, NULL);
     g_signal_connect (appsink, "new-sample", G_CALLBACK (new_sample_cb), this);
@@ -294,14 +296,14 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
   {
     guint waited_ms = 0;
 
-    while (*new_sample_count < expected && waited_ms < timeout_ms) {
+    while ((guint) g_atomic_int_get (new_sample_count) < expected && waited_ms < timeout_ms) {
       if (poll_pipeline_error ())
         break;
       g_usleep (10000);
       waited_ms += 10;
     }
 
-    if (*new_sample_count < expected)
+    if ((guint) g_atomic_int_get (new_sample_count) < expected)
       return FALSE;
 
     g_usleep (100000);
@@ -411,6 +413,29 @@ TEST_F (NNStreamerFilterLlamaCppTest, zeroTokenGenerationSync_p)
 }
 
 /**
+ * @brief Test case for a zero-token generation in asynchronous mode.
+ *
+ * Asynchronous mode dispatches one sample per generated token, so generating
+ * nothing must dispatch nothing: each input is left with only the output the
+ * invoke itself produces. Pinning the count keeps a future change to the
+ * dispatch path from silently emitting a sample per empty generation.
+ */
+TEST_F (NNStreamerFilterLlamaCppTest, zeroTokenGenerationAsync_p)
+{
+  skip_llamacpp_tc ("zeroTokenGenerationAsync_p");
+
+  ASSERT_TRUE (create_pipeline (model, TRUE, "num_predict:0"));
+  EXPECT_TRUE (data_push ("Hello my name is"));
+  EXPECT_TRUE (data_push ("What is AI?"));
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_TRUE (wait_for_samples (2));
+  EXPECT_FALSE (pipeline_error);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (*new_sample_count, 2);
+}
+
+/**
  * @brief Test case for tensor_filter llama-cpp plugin with invalidNumPredict_n
  */
 TEST_F (NNStreamerFilterLlamaCppTest, invalidNumPredict_n)
@@ -434,6 +459,29 @@ TEST_F (NNStreamerFilterLlamaCppTest, invalidModel_n)
 
   ASSERT_TRUE (create_pipeline (NULL, TRUE, "num_predict:10"));
   EXPECT_NE (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+}
+
+/**
+ * @brief Test case for a negative num_predict.
+ *
+ * llama.cpp spells "generate until the context is full" as -1, which this
+ * sub-plugin does not implement: the loop would simply never run. Since an
+ * empty generation is now a valid result rather than an error, such a
+ * misconfiguration would otherwise pass silently, so it is rejected up front.
+ */
+TEST_F (NNStreamerFilterLlamaCppTest, negativeNumPredict_n)
+{
+  skip_llamacpp_tc ("negativeNumPredict_n");
+
+  ASSERT_TRUE (create_pipeline (model, TRUE, "num_predict:-1"));
+  /**
+   * -ESTRPIPE, not merely non-zero: a pipeline that is never fed also fails to
+   * reach PLAYING, but with -ETIME once preroll times out. Only the stricter
+   * value distinguishes "the sub-plugin rejected the property" from "nothing
+   * ever arrived", so this stays a regression test for the rejection itself.
+   */
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT),
+      -ESTRPIPE);
 }
 
 /**
@@ -681,7 +729,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, contextSaveLoad_p)
 
   /* Second pipeline: load context */
   clear_pipeline ();
-  *new_sample_count = 0;
+  g_atomic_int_set (new_sample_count, 0);
 
   g_autofree gchar *custom_str2 = g_strdup_printf (
       "num_predict:20,context_length:512,load_ctx:%s", context_file);

--- a/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
+++ b/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
@@ -8,6 +8,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <errno.h>
 #include <gst/app/gstappsink.h>
 #include <gst/app/gstappsrc.h>
 #include <gst/gst.h>
@@ -437,21 +438,6 @@ TEST_F (NNStreamerFilterLlamaCppTest, zeroTokenGenerationAsync_p)
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 2);
-}
-
-/**
- * @brief Test case for tensor_filter llama-cpp plugin with invalidNumPredict_n
- */
-TEST_F (NNStreamerFilterLlamaCppTest, invalidNumPredict_n)
-{
-  skip_llamacpp_tc ("invalidNumPredict_n");
-
-  ASSERT_TRUE (create_pipeline (model, TRUE, "num_predict:0"));
-  EXPECT_TRUE (data_push ("Hello my name is"));
-  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
-  g_usleep (100000);
-
-  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 }
 
 /**

--- a/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
+++ b/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
@@ -57,34 +57,6 @@ typedef struct {
   } while (0)
 
 /**
- * @brief Callback function for appsink element to pull sample and print the output text from llamacpp plugin
- */
-static GstFlowReturn
-new_sample_cb (GstElement *sink, gpointer user_data)
-{
-  GstSample *sample;
-  GstBuffer *buffer;
-  GstMapInfo map;
-
-  if (user_data) {
-    guint *count = (guint *) user_data;
-    (*count)++;
-  }
-
-  sample = gst_app_sink_pull_sample (GST_APP_SINK (sink));
-  if (sample) {
-    buffer = gst_sample_get_buffer (sample);
-    if (gst_buffer_map (buffer, &map, GST_MAP_READ)) {
-      g_print ("%.*s", (int) map.size, (char *) map.data);
-      gst_buffer_unmap (buffer, &map);
-    }
-    gst_sample_unref (sample);
-    return GST_FLOW_OK;
-  }
-  return GST_FLOW_ERROR;
-}
-
-/**
  * @brief Test fixture class for tensor_filter llama-cpp plugin unit tests.
  */
 class NNStreamerFilterLlamaCppTest : public ::testing::Test
@@ -94,6 +66,7 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
   gchar *model;
   LoRAPaths *lora_paths;
   guint *new_sample_count;
+  gsize max_sample_size;
   gboolean pipeline_error;
   gboolean skip_test;
   gboolean skip_lora_test;
@@ -115,6 +88,7 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
     appsink = nullptr;
     tensor_filter = nullptr;
     new_sample_count = nullptr;
+    max_sample_size = 0;
     pipeline_error = FALSE;
 
     model = g_build_filename (
@@ -149,6 +123,7 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
   {
     /* Track the number of async callback invocations. */
     new_sample_count = g_new0 (guint, 1);
+    max_sample_size = 0;
     pipeline_error = FALSE;
   }
 
@@ -159,6 +134,38 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
   {
     clear_pipeline ();
     g_clear_pointer (&new_sample_count, g_free);
+  }
+
+  /**
+   * @brief Callback for appsink to pull a sample, print the generated text and
+   *        record the sample count and the largest payload seen.
+   *
+   * The payload size matters because a zero-token generation is expected to
+   * arrive as a one-byte, terminator-only buffer rather than not at all.
+   */
+  static GstFlowReturn new_sample_cb (GstElement *sink, gpointer user_data)
+  {
+    NNStreamerFilterLlamaCppTest *self = (NNStreamerFilterLlamaCppTest *) user_data;
+    GstSample *sample;
+    GstBuffer *buffer;
+    GstMapInfo map;
+
+    if (self && self->new_sample_count)
+      (*self->new_sample_count)++;
+
+    sample = gst_app_sink_pull_sample (GST_APP_SINK (sink));
+    if (sample) {
+      buffer = gst_sample_get_buffer (sample);
+      if (gst_buffer_map (buffer, &map, GST_MAP_READ)) {
+        g_print ("%.*s", (int) map.size, (char *) map.data);
+        if (self && map.size > self->max_sample_size)
+          self->max_sample_size = map.size;
+        gst_buffer_unmap (buffer, &map);
+      }
+      gst_sample_unref (sample);
+      return GST_FLOW_OK;
+    }
+    return GST_FLOW_ERROR;
   }
 
   /**
@@ -189,7 +196,7 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
     g_return_val_if_fail (appsink != nullptr, FALSE);
 
     g_object_set (G_OBJECT (appsink), "emit-signals", TRUE, NULL);
-    g_signal_connect (appsink, "new-sample", G_CALLBACK (new_sample_cb), new_sample_count);
+    g_signal_connect (appsink, "new-sample", G_CALLBACK (new_sample_cb), this);
     return TRUE;
   }
 
@@ -333,6 +340,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, singleInputSingleOutputSync_p)
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 1);
+  EXPECT_GT (max_sample_size, 1U);
 }
 
 /**
@@ -391,6 +399,8 @@ TEST_F (NNStreamerFilterLlamaCppTest, zeroTokenGenerationSync_p)
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 2);
+  /* Both samples carry the string terminator and nothing else. */
+  EXPECT_EQ (max_sample_size, 1U);
 }
 
 /**

--- a/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
+++ b/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
@@ -195,7 +195,15 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
     appsink = gst_bin_get_by_name (GST_BIN (pipeline), "appsink");
     g_return_val_if_fail (appsink != nullptr, FALSE);
 
-    g_object_set (G_OBJECT (appsink), "emit-signals", TRUE, NULL);
+    /**
+     * Do not gate rendering on the clock. tensor_converter timestamps a
+     * buffer that carries no PTS from the clock, and while the element's
+     * base time is still unset that yields an absolute clock time instead of
+     * a running time - a PTS minutes into the future. A synchronizing sink
+     * then holds the buffer and the sample never arrives. These tests measure
+     * generation, not playback, so clock synchronization has no place here.
+     */
+    g_object_set (G_OBJECT (appsink), "emit-signals", TRUE, "sync", FALSE, NULL);
     g_signal_connect (appsink, "new-sample", G_CALLBACK (new_sample_cb), this);
     return TRUE;
   }

--- a/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
+++ b/tests/nnstreamer_filter_llamacpp/unittest_filter_llamacpp.cc
@@ -94,6 +94,7 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
   gchar *model;
   LoRAPaths *lora_paths;
   guint *new_sample_count;
+  gboolean pipeline_error;
   gboolean skip_test;
   gboolean skip_lora_test;
 
@@ -114,6 +115,7 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
     appsink = nullptr;
     tensor_filter = nullptr;
     new_sample_count = nullptr;
+    pipeline_error = FALSE;
 
     model = g_build_filename (
         root_path, "tests", "test_models", "models", LLAMACPP_TEST_MODEL, NULL);
@@ -147,6 +149,7 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
   {
     /* Track the number of async callback invocations. */
     new_sample_count = g_new0 (guint, 1);
+    pipeline_error = FALSE;
   }
 
   /**
@@ -215,9 +218,59 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
   }
 
   /**
+   * @brief Drain the pipeline bus and latch whether the pipeline has failed.
+   *
+   * A sub-plugin that fails to invoke makes tensor_filter post an
+   * "invoke-failure" application message and return GST_FLOW_ERROR, which
+   * appsrc turns into a bus error. Without this check such a failure is
+   * indistinguishable from a slow inference: both end up as a wait timeout.
+   *
+   * @return TRUE if the pipeline has posted an error so far.
+   */
+  gboolean poll_pipeline_error ()
+  {
+    GstBus *bus;
+    GstMessage *msg;
+
+    if (pipeline == nullptr)
+      return pipeline_error;
+
+    bus = gst_element_get_bus (pipeline);
+    if (bus == nullptr)
+      return pipeline_error;
+
+    while ((msg = gst_bus_pop_filtered (bus,
+                (GstMessageType) (GST_MESSAGE_ERROR | GST_MESSAGE_APPLICATION)))
+           != NULL) {
+      if (GST_MESSAGE_TYPE (msg) == GST_MESSAGE_ERROR) {
+        GError *err = NULL;
+
+        gst_message_parse_error (msg, &err, NULL);
+        g_printerr ("Pipeline error: %s\n", err ? err->message : "unknown");
+        g_clear_error (&err);
+        pipeline_error = TRUE;
+      } else {
+        const GstStructure *s = gst_message_get_structure (msg);
+
+        if (s && gst_structure_has_name (s, "nnstreamer-message")
+            && g_strcmp0 (gst_structure_get_string (s, "type"), "invoke-failure") == 0) {
+          g_printerr ("Invoke failure: %s\n",
+              GST_STR_NULL (gst_structure_get_string (s, "message")));
+          pipeline_error = TRUE;
+        }
+      }
+      gst_message_unref (msg);
+    }
+    gst_object_unref (bus);
+
+    return pipeline_error;
+  }
+
+  /**
    * @brief Wait until the appsink has received the expected number of samples.
    *        After the count is reached, a short grace period lets unexpected
    *        extra samples arrive so that exact-count assertions can catch them.
+   *        The wait is aborted early if the pipeline reports a failure.
    * @param expected Number of samples to wait for.
    * @param timeout_ms Maximum wait time in milliseconds.
    * @return TRUE if the expected count was reached before the timeout.
@@ -227,6 +280,8 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
     guint waited_ms = 0;
 
     while (*new_sample_count < expected && waited_ms < timeout_ms) {
+      if (poll_pipeline_error ())
+        break;
       g_usleep (10000);
       waited_ms += 10;
     }
@@ -235,6 +290,7 @@ class NNStreamerFilterLlamaCppTest : public ::testing::Test
       return FALSE;
 
     g_usleep (100000);
+    poll_pipeline_error ();
     return TRUE;
   }
 };
@@ -307,6 +363,30 @@ TEST_F (NNStreamerFilterLlamaCppTest, multipleInputsSingleOutputSync_p)
   EXPECT_TRUE (data_push ("What is AI?"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_TRUE (wait_for_samples (2));
+  EXPECT_FALSE (pipeline_error);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_EQ (*new_sample_count, 2);
+}
+
+/**
+ * @brief Test case for a generation that produces no token at all.
+ *
+ * A zero-token generation is a valid result: the filter must still hand one
+ * (empty) output to the pipeline so that every input yields exactly one sample.
+ * This is the deterministic form of the intermittent stall where the model
+ * sampled end-of-generation as the very first token of the second prompt.
+ */
+TEST_F (NNStreamerFilterLlamaCppTest, zeroTokenGenerationSync_p)
+{
+  skip_llamacpp_tc ("zeroTokenGenerationSync_p");
+
+  ASSERT_TRUE (create_pipeline (model, FALSE, "num_predict:0"));
+  EXPECT_TRUE (data_push ("Hello my name is"));
+  EXPECT_TRUE (data_push ("What is AI?"));
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_TRUE (wait_for_samples (2));
+  EXPECT_FALSE (pipeline_error);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 2);
@@ -507,6 +587,7 @@ TEST_F (NNStreamerFilterLlamaCppTest, contextContinuationInConversation_p)
   EXPECT_TRUE (data_push ("What did I just say about myself?"));
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_TRUE (wait_for_samples (2));
+  EXPECT_FALSE (pipeline_error);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (*new_sample_count, 2);

--- a/tests/unittest_util.c
+++ b/tests/unittest_util.c
@@ -14,13 +14,6 @@
 #include "unittest_util.h"
 
 /**
- * @ref https://github.com/nnstreamer/nnstreamer/commit/7f38acb78c26f0f144b6d6fe7fb887b7431d395b
- */
-#if !defined(ESTRPIPE)
-#define ESTRPIPE EPIPE
-#endif /* !defined(ESTRPIPE) */
-
-/**
  * @brief Set pipeline state, wait until it's done.
  * @return 0 success, -ESTRPIPE if failed, -ETIME if timeout happens.
  */

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -19,6 +19,15 @@
 #include <netinet/in.h>
 #include <gio/gio.h>
 
+/**
+ * @ref https://github.com/nnstreamer/nnstreamer/commit/7f38acb78c26f0f144b6d6fe7fb887b7431d395b
+ * @brief Defined here rather than in the .c so that callers comparing against
+ *        -ESTRPIPE see the same value setPipelineStateSync() returns.
+ */
+#if !defined(ESTRPIPE)
+#define ESTRPIPE EPIPE
+#endif /* !defined(ESTRPIPE) */
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */


### PR DESCRIPTION
Fixes #4883, though not by the mechanism the issue proposed — that hypothesis turned out to be wrong, and the real cause is in the test's own pipeline. Also fixes a separate filter defect found on the way.

## The actual cause of #4883

Pad probes through the failing pipeline show both buffers reaching `tensor_filter`, both leaving it, and both arriving at the appsink's sink pad — while the `new-sample` callback fires only once:

```
DBG filter_sink=2 filter_src=2 appsink_pad=2 cb=1 err=0
```

The filter is not involved. The second buffer carries a PTS about nineteen minutes in the future:

```
[PTS sink pts_ms=0.0        run_ms=<none>]     <- buffer 1, rendered
[PTS sink pts_ms=1151788.8  run_ms=1.4]        <- buffer 2, held until its PTS
```

appsink synchronises to the clock by default, so it holds buffer 2 until that presentation time. Nothing errors, nothing is dropped — the sample just never renders and the test waits out its 10 s ceiling. That is exactly the reported symptom, and it is why no `invoke-failure` or bus error ever appeared.

The future PTS comes from `_gst_tensor_converter_chain_timestamp()` ([gsttensor_converter.c#L824](https://github.com/nnstreamer/nnstreamer/blob/main/gst/nnstreamer/elements/gsttensor_converter.c#L824)). For a buffer with no PTS and no framerate in caps it computes:

```c
base = gst_element_get_base_time (GST_ELEMENT (self));
now  = gst_clock_get_time (clock);
pts  = (base < now) ? (now - base) : 0;
```

While the element's base time is still unset, `now - base` is the **absolute** clock time, not a running time. **That converter behaviour is a real defect in its own right and this PR deliberately does not touch it** — `tensor_converter` is in essentially every nnstreamer pipeline and that change deserves its own review. See the note at the end.

The fix here is the one that belongs in a test: these tests measure token generation, not real-time playback, so the sink has no business synchronising. `sync=false` is what the rest of this repo's test suite already does for its sinks.

### Reproduction and verification

The race is decided by whether buffer 2 is timestamped inside the window where base time is unset, which depends on how fast the first generation completes. Restricting the process to four cores makes it highly reproducible — note it is *not* monotonic in available CPU, which is what shows it to be a race rather than slowness:

| cores | `multipleInputsSingleOutputSync_p` failures |
|---|---|
| 1 | 4/20 |
| 2 | 0/20 |
| 4 | **16/20** |

At the 4-core condition, with this change: **0/20**. Whole suite over 12 runs: pristine `main` 4 failures, this branch 0. The async cases that were failing alongside it share the cause and are fixed by the same line.

## The separate filter defect

`createOutputTensor()` rejected an empty string, so `generateTokens()` threw whenever the sampler produced no token — first sampled token is end-of-generation, or `num_predict:0`. In synchronous mode that became `-EINVAL`, `GST_FLOW_ERROR`, and no output buffer for that input. An empty generation is a legitimate zero-token result; it now emits the one-byte terminator-only tensor, so every input still yields one output.

`num_predict:0` reaches that path deterministically and is the regression test. Against the unpatched filter it fails in 15 ms naming the cause:

```
Invoke failure: ... has failed with error code (-22).
[  FAILED  ] NNStreamerFilterLlamaCppTest.zeroTokenGenerationSync_p (15 ms)
```

This defect is real but was **not** what made #4883 flake — worth stating plainly, since the issue's Analysis section predicted it would be.

## Test changes

- `zeroTokenGenerationSync_p` (new): two sync prompts with `num_predict:0` must yield two samples, each exactly one byte, and no pipeline error.
- The fixture drains the bus for `GST_MESSAGE_ERROR` and nnstreamer's `invoke-failure` message, aborting the wait as soon as the pipeline fails. This is what proved the filter innocent: it stayed silent through every failure. #4883 asked for exactly this — "the assertion should distinguish 'second inference produced nothing' from 'second inference was slow'".
- `zeroTokenGenerationAsync_p` (new): the same input in async mode. Dispatch is per generated token, so generating nothing must dispatch nothing; the two samples are the one buffer `tensor_filter` pushes per `invoke_dynamic()` call, which is a structural invariant rather than a timing measurement.
- `negativeNumPredict_n` (new): `num_predict:-1` must be refused. It asserts `-ESTRPIPE`, not merely non-zero — a pipeline that is never fed also fails to reach PLAYING, with `-ETIME` after preroll times out, so the weaker assertion passes with or without the validation and tests nothing. Verified: 6 ms / `-ESTRPIPE` with the check, 10149 ms / `-ETIME` without.
- `new_sample_cb` became a static fixture member so it can record payload size, and counts atomically (`g_atomic_int_inc`), following `f888c072` on main.
- appsink `sync=false`.

A negative `num_predict` is now rejected in `parseCustomProperties()`, matching how `n_ctx` and `n_batch` are already validated. llama.cpp spells "generate until the context is full" as `-1`, which this sub-plugin does not implement; that used to surface loudly as `-EINVAL`, and would have gone silent once an empty generation became valid.

Otherwise no API or architecture change. `createOutputTensor()` is private with no other callers; the rest is test-only. No llamacpp documentation exists to update.

## Follow-up worth filing separately

`tensor_converter` stamping a buffer with an absolute clock time when base time is unset will stall **any** pipeline whose sink synchronises, not just this test. Fixing it means changing a core element used by nearly every nnstreamer pipeline, so I have kept it out of this PR rather than expanding the blast radius from one test file to the whole framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

