### PR TITLE
[Test/Plugins] Type-correct orc 64-bit buffers for macOS

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -28,7 +28,7 @@ jobs:
           brew install cask
     - name: install minimal requirements
       if: env.rebuild == '1'
-      run: brew install meson ninja pkg-config cmake libffi glib gstreamer numpy json-glib googletest
+      run: brew install meson ninja pkg-config cmake libffi glib gstreamer numpy json-glib googletest orc
     - name: install LiteRT SDK
       if: env.rebuild == '1'
       run: |
@@ -69,18 +69,30 @@ jobs:
         echo "LITERT_ROOT=$LITERT_ROOT" >> $GITHUB_ENV
     - name: meson build
       if: env.rebuild == '1'
-      # orcc-support is disabled: the orc test code in unittest_plugins.cc
-      # does not compile on macOS (orc_int64 is long while int64_t is
-      # long long); it never has, hidden until now by the check-rebuild bug
-      # that skipped every step of this job.
+      # orcc-support is required rather than auto-detected: building the orc
+      # paths here is what keeps the orc test code compiling on macOS, where
+      # int64_t is long long while orc_int64 is long. Auto-detection would
+      # silently drop that coverage if orc went missing from the image.
       run: |
-        meson setup build -Dorcc-support=disabled
+        meson setup build -Dorcc-support=enabled
         meson compile -C build
     - name: check litert subplugin built
       if: env.rebuild == '1'
       run: |
         ls build/ext/nnstreamer/tensor_filter/ | grep litert
         test -f build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_litert.dylib || test -f build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_litert.so
+    - name: run tensor_transform orc unit tests
+      if: env.rebuild == '1'
+      # the orc entry points directly, the typecast and arithmetic cases that
+      # route through them when acceleration is on, and properties01, which
+      # compares the element's acceleration default against the test's own
+      # HAVE_ORC and so catches the two being built with orc disagreeing
+      run: |
+        meson test -C build unittest_plugins -v --test-args='--gtest_filter=testTensorTransform.orc*:testTensorTransform.typecast_*_accel:testTensorTransform.arithmetic*Accel:testTensorTransform.properties01'
+        # a filter that matches nothing, or that quietly stops matching some of
+        # the cases, still exits 0; require the whole set to have run
+        ran=$(sed -nE 's/^\[  PASSED  \] ([0-9]+) tests?\.$/\1/p' build/meson-logs/testlog.txt | tail -1)
+        test "${ran:-0}" -ge 34
     - name: run litert unit tests
       if: env.rebuild == '1'
       run: |

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -3772,7 +3772,39 @@ TEST (testTensorConverter, flexToStaticInvalidBuffer2_n)
 }
 
 #ifdef HAVE_ORC
+#include <type_traits>
+
 #include "nnstreamer-orc.h"
+
+/**
+ * @brief Deduce the element type an orc constant-operand function works on.
+ *
+ * Declared only, and used in unevaluated context, to recover the buffer type
+ * from an orc prototype without spelling out its ORC_RESTRICT qualifier.
+ */
+template <typename T> T test_orc_elem_type (void (*orc_func) (T *, int, int));
+
+/**
+ * @brief Buffer element types for the 64-bit orc test cases.
+ *
+ * orcc emits its own orc_intNN typedefs, and their C99 branch is not taken in
+ * C++, where __STDC_VERSION__ is undefined, so on LP64 orc_int64 falls back to
+ * long. That is the same type as int64_t on Linux but not on macOS, where
+ * int64_t is long long; the two are distinct types to the compiler even though
+ * both are 64 bits wide, so buffers spelled int64_t cannot be passed to the orc
+ * entry points there. Taking the types from the prototypes themselves keeps
+ * these buffers correct under either convention by construction, rather than
+ * naming a type that only happens to match on one of them. New orc test code
+ * should use them too; int64_t/uint64_t buffers compile on Linux but break the
+ * macOS build.
+ */
+typedef decltype (test_orc_elem_type (nns_orc_add_c_s64)) orc_s64_elem;
+typedef decltype (test_orc_elem_type (nns_orc_add_c_u64)) orc_u64_elem;
+
+static_assert (sizeof (orc_s64_elem) == 8 && sizeof (orc_u64_elem) == 8,
+    "orc 64-bit buffers must be 64 bits wide");
+static_assert (std::is_signed<orc_s64_elem>::value && std::is_unsigned<orc_u64_elem>::value,
+    "orc 64-bit buffer signedness must match the s64/u64 prototypes");
 
 /**
  * @brief Test for tensor_transform orc functions (add constant value)
@@ -3903,7 +3935,7 @@ TEST (testTensorTransform, orcAdd)
   }
 
   /* add constant s64 */
-  int64_t data_s64[array_size] = {
+  orc_s64_elem data_s64[array_size] = {
     0,
   };
 
@@ -3928,7 +3960,7 @@ TEST (testTensorTransform, orcAdd)
   }
 
   /* add constant u64 */
-  uint64_t data_u64[array_size] = {
+  orc_u64_elem data_u64[array_size] = {
     0,
   };
 
@@ -4122,7 +4154,7 @@ TEST (testTensorTransform, orcMul)
   }
 
   /* mul constant s64 */
-  int64_t data_s64[array_size] = {
+  orc_s64_elem data_s64[array_size] = {
     0,
   };
 
@@ -4147,7 +4179,7 @@ TEST (testTensorTransform, orcMul)
   }
 
   /* mul constant u64 */
-  uint64_t data_u64[array_size] = {
+  orc_u64_elem data_u64[array_size] = {
     0,
   };
 
@@ -4354,7 +4386,7 @@ TEST (testTensorTransform, orcConvS8)
   }
 
   /* convert s64 */
-  int64_t res_s64[array_size] = {
+  orc_s64_elem res_s64[array_size] = {
     0,
   };
 
@@ -4365,7 +4397,7 @@ TEST (testTensorTransform, orcConvS8)
   }
 
   /* convert u64 */
-  uint64_t res_u64[array_size] = {
+  orc_u64_elem res_u64[array_size] = {
     0,
   };
 
@@ -4481,7 +4513,7 @@ TEST (testTensorTransform, orcConvU8)
   }
 
   /* convert s64 */
-  int64_t res_s64[array_size] = {
+  orc_s64_elem res_s64[array_size] = {
     0,
   };
 
@@ -4492,7 +4524,7 @@ TEST (testTensorTransform, orcConvU8)
   }
 
   /* convert u64 */
-  uint64_t res_u64[array_size] = {
+  orc_u64_elem res_u64[array_size] = {
     0,
   };
 
@@ -4608,7 +4640,7 @@ TEST (testTensorTransform, orcConvS16)
   }
 
   /* convert s64 */
-  int64_t res_s64[array_size] = {
+  orc_s64_elem res_s64[array_size] = {
     0,
   };
 
@@ -4619,7 +4651,7 @@ TEST (testTensorTransform, orcConvS16)
   }
 
   /* convert u64 */
-  uint64_t res_u64[array_size] = {
+  orc_u64_elem res_u64[array_size] = {
     0,
   };
 
@@ -4735,7 +4767,7 @@ TEST (testTensorTransform, orcConvU16)
   }
 
   /* convert s64 */
-  int64_t res_s64[array_size] = {
+  orc_s64_elem res_s64[array_size] = {
     0,
   };
 
@@ -4746,7 +4778,7 @@ TEST (testTensorTransform, orcConvU16)
   }
 
   /* convert u64 */
-  uint64_t res_u64[array_size] = {
+  orc_u64_elem res_u64[array_size] = {
     0,
   };
 
@@ -4862,7 +4894,7 @@ TEST (testTensorTransform, orcConvS32)
   }
 
   /* convert s64 */
-  int64_t res_s64[array_size] = {
+  orc_s64_elem res_s64[array_size] = {
     0,
   };
 
@@ -4873,7 +4905,7 @@ TEST (testTensorTransform, orcConvS32)
   }
 
   /* convert u64 */
-  uint64_t res_u64[array_size] = {
+  orc_u64_elem res_u64[array_size] = {
     0,
   };
 
@@ -4989,7 +5021,7 @@ TEST (testTensorTransform, orcConvU32)
   }
 
   /* convert s64 */
-  int64_t res_s64[array_size] = {
+  orc_s64_elem res_s64[array_size] = {
     0,
   };
 
@@ -5000,7 +5032,7 @@ TEST (testTensorTransform, orcConvU32)
   }
 
   /* convert u64 */
-  uint64_t res_u64[array_size] = {
+  orc_u64_elem res_u64[array_size] = {
     0,
   };
 
@@ -5041,7 +5073,7 @@ TEST (testTensorTransform, orcConvS64)
   const guint array_size = 10;
   guint i;
 
-  int64_t data_s64[array_size] = {
+  orc_s64_elem data_s64[array_size] = {
     0,
   };
 
@@ -5116,7 +5148,7 @@ TEST (testTensorTransform, orcConvS64)
   }
 
   /* convert s64 */
-  int64_t res_s64[array_size] = {
+  orc_s64_elem res_s64[array_size] = {
     0,
   };
 
@@ -5127,7 +5159,7 @@ TEST (testTensorTransform, orcConvS64)
   }
 
   /* convert u64 */
-  uint64_t res_u64[array_size] = {
+  orc_u64_elem res_u64[array_size] = {
     0,
   };
 
@@ -5168,7 +5200,7 @@ TEST (testTensorTransform, orcConvU64)
   const guint array_size = 10;
   guint i;
 
-  uint64_t data_u64[array_size] = {
+  orc_u64_elem data_u64[array_size] = {
     0,
   };
 
@@ -5243,7 +5275,7 @@ TEST (testTensorTransform, orcConvU64)
   }
 
   /* convert s64 */
-  int64_t res_s64[array_size] = {
+  orc_s64_elem res_s64[array_size] = {
     0,
   };
 
@@ -5254,7 +5286,7 @@ TEST (testTensorTransform, orcConvU64)
   }
 
   /* convert u64 */
-  uint64_t res_u64[array_size] = {
+  orc_u64_elem res_u64[array_size] = {
     0,
   };
 
@@ -5373,7 +5405,7 @@ TEST (testTensorTransform, orcConvF32)
   }
 
   /* convert s64 */
-  int64_t res_s64[array_size] = {
+  orc_s64_elem res_s64[array_size] = {
     0,
   };
 
@@ -5384,7 +5416,7 @@ TEST (testTensorTransform, orcConvF32)
   }
 
   /* convert u64 */
-  uint64_t res_u64[array_size] = {
+  orc_u64_elem res_u64[array_size] = {
     0,
   };
 
@@ -5504,7 +5536,7 @@ TEST (testTensorTransform, orcConvF64)
   }
 
   /* convert s64 */
-  int64_t res_s64[array_size] = {
+  orc_s64_elem res_s64[array_size] = {
     0,
   };
 
@@ -5515,7 +5547,7 @@ TEST (testTensorTransform, orcConvF64)
   }
 
   /* convert u64 */
-  uint64_t res_u64[array_size] = {
+  orc_u64_elem res_u64[array_size] = {
     0,
   };
 


### PR DESCRIPTION
## Problem

`tests/nnstreamer_plugins/unittest_plugins.cc` does not compile on macOS. Its
orc test cases declare the 64-bit buffers as `int64_t`/`uint64_t` and pass them
straight to the orc entry points, whose prototypes take `orc_int64`/`orc_uint64`.

orcc emits those typedefs into the generated header itself, and their C99 branch
is guarded by `__STDC_VERSION__`, which is undefined in C++. On LP64 the fallback
branch is taken:

```c
#if INT_MAX == LONG_MAX
typedef long long orc_int64;
#else
typedef long orc_int64;      /* <- taken on LP64 */
#endif
```

So in C++ `orc_int64` is `long`. On Linux `int64_t` is also `long`, which is why
this never showed up; on macOS `int64_t` is `long long`, a distinct type, and the
pointer conversion is a hard error.

Reproduced locally against the generated header (Linux, where `long long` is just
as distinct from `long` as it is on macOS):

```
error: invalid conversion from 'long long int*' to 'orc_int64*' {aka 'long int*'}
    8 |   nns_orc_add_c_s64 (s, 1, 4);
```

The production paths in `gst/nnstreamer/elements/gsttensor_transform.c` are not
affected: they cast to `gpointer` at the orc boundary, and they compile as C,
where orcc's typedefs do resolve to the fixed-width types.

## Change

- Derive the orc test buffer types from the orc prototypes themselves, by
  deducing the element type through a declared-only helper (`test_orc_elem_type`,
  which sidesteps having to spell out `ORC_RESTRICT`). Naming `orc_int64` directly
  would fix the build just as well and in fewer lines; deducing instead keeps the
  buffers tied to the prototypes rather than to a second name that has to be kept
  in sync with them, so they stay correct if orcc ever emits the parameter as the
  type declared in the `.orc` file rather than as its own typedef. No casts, no
  aliasing through a differently-spelled 64-bit type.
- Drop `-Dorcc-support=disabled` from the macOS CI job. It now passes
  `-Dorcc-support=enabled` rather than relying on auto-detection, so the coverage
  cannot silently vanish if orc leaves the runner image, and `orc` is added to
  the brew install list to guarantee `orcc` is present.
- Run the orc test cases on macOS, together with the `tensor_transform`
  `typecast_*_accel` and `arithmetic*Accel` cases that route through the orc entry
  points, and `properties01`. That last one compares the element's `acceleration`
  default against the macro the test derives from its *own* `HAVE_ORC`, so it does
  not fail merely because the default is FALSE -- what it catches is the element
  and the test being built with orc disagreeing, which is a new possibility now
  that both are built with orc on macOS.
- A gtest filter that matches nothing, or that quietly stops matching part of the
  set, still exits 0, so the step also requires the expected number of tests to
  have actually run.

## Verification

Local (WSL Ubuntu, orc 0.4.32):

- Reproduced the failure and confirmed the `orc_int64` form compiles, by
  compiling both spellings against the generated `nnstreamer-orc.h`.
- Confirmed the deduction really binds the buffers: all 26 declarations use the
  deduced typedefs and no `int64_t`/`uint64_t` array declaration remains in the orc
  section. The surviving `static_assert`s cover what deduction cannot -- a width or
  signedness change on the orc side -- rather than restating it.
- Built `unittest_plugins` with both GCC 11 and Clang 14 under the project's
  `werror=true` / `warning_level=2` defaults, with `-Dorcc-support=enabled`;
  no new warnings. Clang also compiles the orc-generated C cleanly, which is the
  relevant precedent for macOS.
- `meson test -C build`: 19/19 suites OK, `unittest_plugins` 138/138 tests pass.
- The filtered command the macOS job runs selects 34 tests (14 orc + 14 typecast
  accel + 5 arithmetic accel + `properties01`), all passing. The count guard was
  verified in all three directions: 34 passes, a filter selecting nothing (0) fails,
  and a filter selecting only part of the set (14) fails.
- `clang-format` clean under both v14 and the v16 used by the cpp-linter job.

## Notes

The macOS job also gains the orc code path in `gsttensor_transform.c`, which means
`acceleration` now defaults to TRUE in macOS builds, matching Linux. That is the
intent of the issue, and the tests the job now runs cover it.

On the limits of the guard: new orc test code written with `int64_t`/`uint64_t`
would still compile on Linux and still break on macOS. No construct in the file
can catch that on Linux, because on Linux those buffers really are correct. The
macOS build is the guard, which is why enabling orc there is part of this change
rather than a follow-up.

Fixes #4862
