### PR TITLE
[Filter/LiteRT] Share one LiteRtEnvironment across filter instances

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -42,6 +42,7 @@
 #include <cstring>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -101,8 +102,15 @@ namespace
  * because the environment must outlive every model and compiled model created
  * from it, while instances open and close independently at pipeline state
  * changes.
+ *
+ * The lock is shared/exclusive because the two access patterns differ. Running
+ * several compiled models off one environment is the pattern upstream
+ * recommends, so invoke() only takes it in shared mode. Building and tearing
+ * down an instance's LiteRT object graph has no documented thread-safety
+ * contract, and before the environment was shared each instance built its own,
+ * so those paths take it exclusively to keep that guarantee.
  */
-std::mutex litert_env_lock;
+std::shared_mutex litert_env_lock;
 LiteRtEnvironment litert_env = nullptr;
 unsigned int litert_env_refs = 0;
 
@@ -114,7 +122,7 @@ unsigned int litert_env_refs = 0;
 LiteRtEnvironment
 litert_env_ref ()
 {
-  std::lock_guard<std::mutex> guard (litert_env_lock);
+  std::lock_guard<std::shared_mutex> guard (litert_env_lock);
 
   if (litert_env_refs == 0) {
     LiteRtEnvironment created = nullptr;
@@ -132,7 +140,7 @@ litert_env_ref ()
 void
 litert_env_unref ()
 {
-  std::lock_guard<std::mutex> guard (litert_env_lock);
+  std::lock_guard<std::shared_mutex> guard (litert_env_lock);
 
   if (litert_env_refs == 0 || --litert_env_refs > 0)
     return;
@@ -222,23 +230,28 @@ litert_subplugin::~litert_subplugin ()
 void
 litert_subplugin::cleanup ()
 {
-  for (auto &buf : input_buffers)
-    LiteRtDestroyTensorBuffer (buf);
-  input_buffers.clear ();
-  input_tensor_sizes.clear ();
-  for (auto &buf : output_buffers)
-    LiteRtDestroyTensorBuffer (buf);
-  output_buffers.clear ();
-  output_tensor_sizes.clear ();
+  {
+    std::lock_guard<std::shared_mutex> guard (litert_env_lock);
 
-  if (compiled_model != nullptr) {
-    LiteRtDestroyCompiledModel (compiled_model);
-    compiled_model = nullptr;
+    for (auto &buf : input_buffers)
+      LiteRtDestroyTensorBuffer (buf);
+    input_buffers.clear ();
+    input_tensor_sizes.clear ();
+    for (auto &buf : output_buffers)
+      LiteRtDestroyTensorBuffer (buf);
+    output_buffers.clear ();
+    output_tensor_sizes.clear ();
+
+    if (compiled_model != nullptr) {
+      LiteRtDestroyCompiledModel (compiled_model);
+      compiled_model = nullptr;
+    }
+    if (model != nullptr) {
+      LiteRtDestroyModel (model);
+      model = nullptr;
+    }
   }
-  if (model != nullptr) {
-    LiteRtDestroyModel (model);
-    model = nullptr;
-  }
+
   if (env != nullptr) {
     litert_env_unref ();
     env = nullptr;
@@ -648,6 +661,11 @@ litert_subplugin::configure_instance (const GstTensorFilterProperties *prop)
 
   try {
     env = litert_env_ref ();
+
+    /** Unwinding releases this before the handler below runs, so the
+     *  cleanup() there can take the lock again without deadlocking. */
+    std::lock_guard<std::shared_mutex> guard (litert_env_lock);
+
     LITERT_CHECK (LiteRtCreateModelFromFile (env, model_path, &model));
 
     signature_index = resolveSignature ();
@@ -695,6 +713,11 @@ litert_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
 
   if (input == nullptr || output == nullptr)
     throw std::invalid_argument ("Invoke called with a null tensor memory.");
+
+  /** Shared: concurrent invokes on distinct compiled models are the pattern
+   *  upstream recommends. This only blocks while another instance is being
+   *  configured or torn down on the same environment. */
+  std::shared_lock<std::shared_mutex> guard (litert_env_lock);
 
   /* Fill input buffers */
   for (i = 0; i < inputTensorMeta.num_tensors; ++i) {

--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -33,9 +33,6 @@
  *
  * @todo Zero-copy invoke by wrapping GstTensorMemory with
  *       LiteRtCreateTensorBufferFromHostMemory when alignment permits.
- * @todo Share one LiteRtEnvironment across instances. Each filter instance
- *       currently creates its own environment; with GPU/NPU accelerators
- *       that may mean one device context per instance.
  * @todo Support dynamic input dimensions (invoke_dynamic).
  * @todo Expose accelerator-specific opaque options (GPU precision, NPU
  *       compiler plugin paths, etc.).
@@ -44,6 +41,7 @@
 #include <cerrno>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -88,6 +86,62 @@ void _fini_filter_litert (void) __attribute__ ((destructor));
     }                                                                              \
   } while (0)
 
+namespace
+{
+/**
+ * @brief The process-wide LiteRtEnvironment shared by every filter instance.
+ *
+ * LiteRT binds accelerator device contexts (the GPU context, the dispatch and
+ * compiler-plugin libraries) to the environment, and upstream recommends
+ * sharing one environment when an application holds several compiled models.
+ * Nothing in it is per-instance here: accelerator selection is applied through
+ * LiteRtCreateOptions at compile time, not through the environment.
+ *
+ * It is reference counted rather than leaked as a create-once singleton
+ * because the environment must outlive every model and compiled model created
+ * from it, while instances open and close independently at pipeline state
+ * changes.
+ */
+std::mutex litert_env_lock;
+LiteRtEnvironment litert_env = nullptr;
+unsigned int litert_env_refs = 0;
+
+/**
+ * @brief Take a reference to the shared environment, creating it if needed.
+ * @return the shared environment; the caller must not destroy it
+ * @throw std::runtime_error if the environment cannot be created
+ */
+LiteRtEnvironment
+litert_env_ref ()
+{
+  std::lock_guard<std::mutex> guard (litert_env_lock);
+
+  if (litert_env_refs == 0) {
+    LiteRtEnvironment created = nullptr;
+    LITERT_CHECK (LiteRtCreateEnvironment (0, nullptr, &created));
+    litert_env = created;
+  }
+
+  ++litert_env_refs;
+  return litert_env;
+}
+
+/**
+ * @brief Drop a reference, destroying the environment along with the last one.
+ */
+void
+litert_env_unref ()
+{
+  std::lock_guard<std::mutex> guard (litert_env_lock);
+
+  if (litert_env_refs == 0 || --litert_env_refs > 0)
+    return;
+
+  LiteRtDestroyEnvironment (litert_env);
+  litert_env = nullptr;
+}
+} /* namespace */
+
 /** @brief litert subplugin class */
 class litert_subplugin final : public tensor_filter_subplugin
 {
@@ -117,7 +171,7 @@ class litert_subplugin final : public tensor_filter_subplugin
   std::string signature_key{}; /**< requested signature key; empty = default */
   LiteRtParamIndex signature_index{}; /**< resolved signature index */
 
-  LiteRtEnvironment env{};
+  LiteRtEnvironment env{}; /**< borrowed from the shared environment; never destroyed here */
   LiteRtModel model{};
   LiteRtCompiledModel compiled_model{};
 
@@ -186,7 +240,7 @@ litert_subplugin::cleanup ()
     model = nullptr;
   }
   if (env != nullptr) {
-    LiteRtDestroyEnvironment (env);
+    litert_env_unref ();
     env = nullptr;
   }
 
@@ -593,7 +647,7 @@ litert_subplugin::configure_instance (const GstTensorFilterProperties *prop)
   }
 
   try {
-    LITERT_CHECK (LiteRtCreateEnvironment (0, nullptr, &env));
+    env = litert_env_ref ();
     LITERT_CHECK (LiteRtCreateModelFromFile (env, model_path, &model));
 
     signature_index = resolveSignature ();

--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -103,19 +103,32 @@ namespace
  * from it, while instances open and close independently at pipeline state
  * changes.
  *
- * The lock is shared/exclusive because the two access patterns differ. Running
- * several compiled models off one environment is the pattern upstream
- * recommends, so invoke() only takes it in shared mode. Building and tearing
- * down an instance's LiteRT object graph has no documented thread-safety
- * contract, and before the environment was shared each instance built its own,
- * so those paths take it exclusively to keep that guarantee.
+ * The lock is shared/exclusive because the two access patterns differ.
+ * Building and tearing down an instance's LiteRT object graph takes it
+ * exclusively: before the environment was shared each instance built its own,
+ * so those paths could not interact, and LiteRT documents no contract that
+ * lets them interact now. invoke() takes it in shared mode instead, so
+ * inference is not serialized across instances.
  *
- * The cost is that instances are no longer fully independent: configuring or
- * tearing one down blocks invokes on all the others for the duration, and an
- * invoke in flight delays another instance's setup. Both are bounded by a
- * single model compile on a path that only runs at pipeline state changes,
- * which is the cheaper side of the trade against unsynchronized access to a
- * runtime whose internals cannot be audited.
+ * Note what upstream does and does not say. litert/cc/litert_environment.h
+ * ("In a case of having multiple CompiledModels, it is recommended to share
+ * the same Environment") sanctions the structure, not concurrent calls into
+ * it, and litert/cc/litert_compiled_model.h requires only that the
+ * environment outlive the compiled model and any execution running on it.
+ * Neither states a thread-safety contract. Concurrent invoke is therefore a
+ * reasoned choice, not a documented guarantee: serializing every inference in
+ * the process would be a far worse regression, and libLiteRt.so is a prebuilt
+ * binary, so no sanitizer can settle the question either. If environment-level
+ * state ever does prove unsafe under concurrent use, it will show up on
+ * GPU/NPU rather than on the CPU path CI exercises, and this is the comment to
+ * come back to.
+ *
+ * The costs: instances are no longer fully independent, since configuring or
+ * tearing one down blocks invokes on all the others and an invoke in flight
+ * delays another instance's setup - both bounded by a single model compile on
+ * a path that only runs at pipeline state changes. Every instance in the
+ * process also shares this lock's cache line, so with enough of them even
+ * readers serialize on that atomic.
  */
 std::shared_mutex litert_env_lock;
 LiteRtEnvironment litert_env = nullptr;
@@ -149,7 +162,14 @@ litert_env_unref ()
 {
   std::lock_guard<std::shared_mutex> guard (litert_env_lock);
 
-  if (litert_env_refs == 0 || --litert_env_refs > 0)
+  if (litert_env_refs == 0) {
+    /** Defensive, but never legitimate: it means some path released a
+     *  reference it did not hold, so say so instead of absorbing it. */
+    ml_loge ("Unbalanced LiteRT environment release; this is a bug.");
+    return;
+  }
+
+  if (--litert_env_refs > 0)
     return;
 
   LiteRtDestroyEnvironment (litert_env);
@@ -721,9 +741,10 @@ litert_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
   if (input == nullptr || output == nullptr)
     throw std::invalid_argument ("Invoke called with a null tensor memory.");
 
-  /** Shared: concurrent invokes on distinct compiled models are the pattern
-   *  upstream recommends. This only blocks while another instance is being
-   *  configured or torn down on the same environment. */
+  /** Shared, so inference is never serialized across instances; see the
+   *  shared-environment comment for why concurrent invoke is a reasoned
+   *  choice rather than a documented guarantee. This only blocks while
+   *  another instance is being configured or torn down. */
   std::shared_lock<std::shared_mutex> guard (litert_env_lock);
 
   /* Fill input buffers */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -109,6 +109,13 @@ namespace
  * down an instance's LiteRT object graph has no documented thread-safety
  * contract, and before the environment was shared each instance built its own,
  * so those paths take it exclusively to keep that guarantee.
+ *
+ * The cost is that instances are no longer fully independent: configuring or
+ * tearing one down blocks invokes on all the others for the duration, and an
+ * invoke in flight delays another instance's setup. Both are bounded by a
+ * single model compile on a path that only runs at pipeline state changes,
+ * which is the cheaper side of the trade against unsynchronized access to a
+ * runtime whose internals cannot be audited.
  */
 std::shared_mutex litert_env_lock;
 LiteRtEnvironment litert_env = nullptr;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -413,7 +413,7 @@ if gtest_dep.found()
   if litert_support_is_available
     unittest_filter_litert = executable('unittest_filter_litert',
       join_paths('nnstreamer_filter_litert', 'unittest_filter_litert.cc'),
-      dependencies: [nnstreamer_unittest_deps],
+      dependencies: [nnstreamer_unittest_deps, thread_dep],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )

--- a/tests/nnstreamer_filter_litert/runTest.sh
+++ b/tests/nnstreamer_filter_litert/runTest.sh
@@ -70,6 +70,7 @@ PATH_TO_MODEL="../test_models/models/mobilenet_v1_1.0_224_quant.tflite"
 PATH_TO_LABEL="../test_models/labels/labels.txt"
 PATH_TO_IMAGE="../test_models/data/orange.png"
 PATH_TO_CLASS="class.out.log"
+PATH_TO_CLASS1="class1.out.log"
 PATH_TO_CLASS2="class2.out.log"
 
 # Test 1: Positive. Golden classification result, same model and golden label
@@ -96,11 +97,14 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} !
 
 # Test 6: Positive. Two litert tensor_filter instances share the process-wide
 # LiteRtEnvironment; both branches, held open at the same time in the same
-# pipeline, must still produce the golden classification result.
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=litert model=${PATH_TO_MODEL} ! tensor_decoder mode=image_labeling option1=${PATH_TO_LABEL} ! filesink location=${PATH_TO_CLASS} t. ! queue ! tensor_filter framework=litert model=${PATH_TO_MODEL} ! tensor_decoder mode=image_labeling option1=${PATH_TO_LABEL} ! filesink location=${PATH_TO_CLASS2}" 6 0 0 $PERFORMANCE
-class=$(cat ${PATH_TO_CLASS})
+# pipeline, must still produce the golden classification result. Both
+# branches write their own log, removed first, so no earlier case output
+# can stand in for a branch that produced nothing.
+rm -f ${PATH_TO_CLASS1} ${PATH_TO_CLASS2}
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=litert model=${PATH_TO_MODEL} ! tensor_decoder mode=image_labeling option1=${PATH_TO_LABEL} ! filesink location=${PATH_TO_CLASS1} t. ! queue ! tensor_filter framework=litert model=${PATH_TO_MODEL} ! tensor_decoder mode=image_labeling option1=${PATH_TO_LABEL} ! filesink location=${PATH_TO_CLASS2}" 6 0 0 $PERFORMANCE
+class1=$(cat ${PATH_TO_CLASS1})
 class2=$(cat ${PATH_TO_CLASS2})
-[ "$class" = "orange" ] && [ "$class2" = "orange" ]
+[ "$class1" = "orange" ] && [ "$class2" = "orange" ]
 testResult $? 6 "Golden test comparison with two concurrent litert instances" 0 1
 
 report

--- a/tests/nnstreamer_filter_litert/runTest.sh
+++ b/tests/nnstreamer_filter_litert/runTest.sh
@@ -70,6 +70,7 @@ PATH_TO_MODEL="../test_models/models/mobilenet_v1_1.0_224_quant.tflite"
 PATH_TO_LABEL="../test_models/labels/labels.txt"
 PATH_TO_IMAGE="../test_models/data/orange.png"
 PATH_TO_CLASS="class.out.log"
+PATH_TO_CLASS2="class2.out.log"
 
 # Test 1: Positive. Golden classification result, same model and golden label
 # as the tensorflow2-lite SSAT tests; cross-runtime divergence fails here.
@@ -92,5 +93,14 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! videoc
 
 # Test 5: Negative. Unknown accelerator custom property must fail.
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! tensor_converter ! tensor_filter framework=litert model=${PATH_TO_MODEL} custom=Accelerators:tpu ! fakesink" 5_n 0 1 $PERFORMANCE
+
+# Test 6: Positive. Two litert tensor_filter instances share the process-wide
+# LiteRtEnvironment; both branches, held open at the same time in the same
+# pipeline, must still produce the golden classification result.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=litert model=${PATH_TO_MODEL} ! tensor_decoder mode=image_labeling option1=${PATH_TO_LABEL} ! filesink location=${PATH_TO_CLASS} t. ! queue ! tensor_filter framework=litert model=${PATH_TO_MODEL} ! tensor_decoder mode=image_labeling option1=${PATH_TO_LABEL} ! filesink location=${PATH_TO_CLASS2}" 6 0 0 $PERFORMANCE
+class=$(cat ${PATH_TO_CLASS})
+class2=$(cat ${PATH_TO_CLASS2})
+[ "$class" = "orange" ] && [ "$class2" = "orange" ]
+testResult $? 6 "Golden test comparison with two concurrent litert instances" 0 1
 
 report

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -18,6 +18,10 @@
 #include <glib/gstdio.h>
 #include <gst/gst.h>
 
+#include <atomic>
+#include <thread>
+#include <vector>
+
 #include <nnstreamer_plugin_api_filter.h>
 #include <nnstreamer_util.h>
 #include <tensor_common.h>
@@ -790,6 +794,167 @@ TEST (nnstreamerFilterLiteRT, reopenDifferentModel)
   sp->close (&prop, &data);
   gst_tensors_info_free (&in_info);
   gst_tensors_info_free (&out_info);
+}
+
+/**
+ * @brief Positive case: a second instance must survive the first instance's close.
+ *
+ * Both instances share the process-wide LiteRtEnvironment. If close() on the
+ * first instance destroyed that shared environment (instead of merely
+ * dropping a reference), the second instance's still-open compiled model
+ * would be left operating on a freed environment and its next invoke()
+ * would fail or crash.
+ */
+TEST (nnstreamerFilterLiteRT, sharedEnvMultiInstance)
+{
+  int ret;
+  void *data1 = NULL, *data2 = NULL;
+  GstTensorMemory input, output;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop1, prop2;
+  _SetFilterProp (&prop1, "litert", model_files);
+  _SetFilterProp (&prop2, "litert", model_files);
+
+  input.size = sizeof (float) * 224 * 224 * 3;
+  output.size = sizeof (float) * 1001;
+  input.data = g_malloc0 (input.size);
+  output.data = g_malloc (output.size);
+
+  /* two independent instances held open at the same time */
+  ret = sp->open (&prop1, &data1);
+  ASSERT_EQ (ret, 0);
+  ret = sp->open (&prop2, &data2);
+  ASSERT_EQ (ret, 0);
+
+  EXPECT_EQ (sp->invoke (NULL, &prop1, data1, &input, &output), 0);
+  EXPECT_EQ (sp->invoke (NULL, &prop2, data2, &input, &output), 0);
+
+  /* dropping the first instance must not tear down the shared environment */
+  sp->close (&prop1, &data1);
+
+  EXPECT_EQ (sp->invoke (NULL, &prop2, data2, &input, &output), 0)
+      << "The second instance failed after the first instance closed; the "
+         "shared LiteRtEnvironment was likely destroyed prematurely.";
+
+  g_free (input.data);
+  g_free (output.data);
+  sp->close (&prop2, &data2);
+}
+
+/**
+ * @brief Positive case: the shared environment must be recreated after the
+ * refcount drops to zero and a new instance is opened.
+ */
+TEST (nnstreamerFilterLiteRT, sharedEnvReacquire)
+{
+  int ret;
+  void *data = NULL;
+  GstTensorMemory input, output;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  input.size = sizeof (float) * 224 * 224 * 3;
+  output.size = sizeof (float) * 1001;
+  input.data = g_malloc0 (input.size);
+  output.data = g_malloc (output.size);
+
+  /* first instance: acquires, uses, and fully releases the shared env */
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+  EXPECT_EQ (sp->invoke (NULL, &prop, data, &input, &output), 0);
+  sp->close (&prop, &data);
+
+  /* second instance: must re-acquire (recreate) the shared env from scratch */
+  data = NULL;
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+  EXPECT_EQ (sp->invoke (NULL, &prop, data, &input, &output), 0)
+      << "Reopening after the refcount reached zero failed; the shared "
+         "LiteRtEnvironment was likely not recreated on re-acquire.";
+
+  g_free (input.data);
+  g_free (output.data);
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Worker routine for sharedEnvConcurrentOpen: open, invoke, close once.
+ * @param[in] model_files NULL-terminated array with a single model path
+ * @param[out] ok set to true on success; read by the joining thread only
+ */
+static void
+_sharedEnvWorker (const gchar **model_files, std::atomic<bool> *ok)
+{
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  if (sp == nullptr) {
+    *ok = false;
+    return;
+  }
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  GstTensorMemory input, output;
+  input.size = sizeof (float) * 224 * 224 * 3;
+  output.size = sizeof (float) * 1001;
+  input.data = g_malloc0 (input.size);
+  output.data = g_malloc (output.size);
+
+  void *data = NULL;
+  gboolean success = FALSE;
+
+  if (sp->open (&prop, &data) == 0) {
+    success = (sp->invoke (NULL, &prop, data, &input, &output) == 0);
+    sp->close (&prop, &data);
+  }
+
+  g_free (input.data);
+  g_free (output.data);
+
+  *ok = success;
+}
+
+/**
+ * @brief Positive case: concurrent open/invoke/close from multiple threads
+ * must not corrupt the mutex-guarded shared-environment refcount.
+ */
+TEST (nnstreamerFilterLiteRT, sharedEnvConcurrentOpen)
+{
+  const guint num_workers = 4U;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+
+  std::vector<std::atomic<bool>> results (num_workers);
+  for (auto &r : results)
+    r = false;
+
+  std::vector<std::thread> workers;
+  for (guint i = 0; i < num_workers; ++i)
+    workers.emplace_back (_sharedEnvWorker, model_files, &results[i]);
+
+  for (auto &w : workers)
+    w.join ();
+
+  for (guint i = 0; i < num_workers; ++i)
+    EXPECT_TRUE (results[i].load ()) << "Worker " << i << " failed under concurrent open/close.";
 }
 
 /**

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -1015,6 +1015,17 @@ TEST (nnstreamerFilterLiteRT, sharedEnvRefBalanceOnConfigureFailure)
   input.data = g_malloc0 (input.size);
   output.data = g_malloc (output.size);
 
+  /** Everything that can fail fatally is done before the log handler is
+   *  installed: a fatal assertion returns from the test on the spot, which
+   *  would leave the handler in place for every case that runs after. */
+  fd = g_file_open_tmp ("litert_garbage_XXXXXX.tflite", &garbage_file, NULL);
+  ASSERT_GE (fd, 0);
+  ASSERT_TRUE (g_file_set_contents (
+      garbage_file, "This is not a tflite flatbuffer at all.", -1, NULL));
+  g_close (fd, NULL);
+
+  const gchar *bad_model_files[] = { garbage_file, NULL };
+
   ret = sp->open (&prop, &data);
   ASSERT_EQ (ret, 0);
 
@@ -1029,13 +1040,6 @@ TEST (nnstreamerFilterLiteRT, sharedEnvRefBalanceOnConfigureFailure)
       << "A failed signature lookup disturbed an already-open instance.";
 
   /* fails in LiteRtCreateModelFromFile(), also after the reference is taken */
-  fd = g_file_open_tmp ("litert_garbage_XXXXXX.tflite", &garbage_file, NULL);
-  ASSERT_GE (fd, 0);
-  ASSERT_TRUE (g_file_set_contents (
-      garbage_file, "This is not a tflite flatbuffer at all.", -1, NULL));
-  g_close (fd, NULL);
-
-  const gchar *bad_model_files[] = { garbage_file, NULL };
   data_bad = NULL;
   _SetFilterProp (&prop_bad, "litert", bad_model_files);
   EXPECT_NE (sp->open (&prop_bad, &data_bad), 0);

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -962,14 +962,17 @@ TEST (nnstreamerFilterLiteRT, sharedEnvConcurrentOpen)
  * and tear down an instance on the shared environment.
  * @param[in] model_files NULL-terminated array with a single model path
  * @param[in] iterations how many open/close cycles to run
+ * @param[out] cycles incremented after each cycle so the caller can overlap it
  * @param[out] ok set to false if any cycle failed; read after join only
  */
 static void
-_sharedEnvChurn (const gchar **model_files, guint iterations, std::atomic<bool> *ok)
+_sharedEnvChurn (const gchar **model_files, guint iterations,
+    std::atomic<guint> *cycles, std::atomic<bool> *ok)
 {
   const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
   if (sp == nullptr) {
     *ok = false;
+    *cycles = iterations; /* do not leave the caller spinning */
     return;
   }
 
@@ -980,9 +983,11 @@ _sharedEnvChurn (const gchar **model_files, guint iterations, std::atomic<bool> 
     _SetFilterProp (&prop, "litert", model_files);
     if (sp->open (&prop, &data) != 0) {
       *ok = false;
+      *cycles = iterations;
       return;
     }
     sp->close (&prop, &data);
+    ++(*cycles);
   }
 }
 
@@ -993,10 +998,16 @@ _sharedEnvChurn (const gchar **model_files, guint iterations, std::atomic<bool> 
  * Configuration and teardown hold the environment lock exclusively while
  * invoke holds it in shared mode; this is the case that regresses if that
  * distinction is dropped.
+ *
+ * The overlap is structural rather than timing-dependent: this thread keeps
+ * invoking until the churn thread reports every cycle done, so the two are
+ * guaranteed to run against the shared environment at the same time however
+ * the scheduler interleaves them.
  */
 TEST (nnstreamerFilterLiteRT, sharedEnvInvokeDuringConfigure)
 {
   const guint iterations = 10U;
+  const guint max_invokes = 1000U;
   int ret;
   void *data = NULL;
   GstTensorMemory input, output;
@@ -1019,14 +1030,24 @@ TEST (nnstreamerFilterLiteRT, sharedEnvInvokeDuringConfigure)
   ret = sp->open (&prop, &data);
   ASSERT_EQ (ret, 0);
 
+  std::atomic<guint> cycles (0U);
   std::atomic<bool> churn_ok (true);
-  std::thread churn (_sharedEnvChurn, model_files, iterations, &churn_ok);
+  std::thread churn (_sharedEnvChurn, model_files, iterations, &cycles, &churn_ok);
 
-  for (guint i = 0; i < iterations; ++i)
-    EXPECT_EQ (sp->invoke (NULL, &prop, data, &input, &output), 0)
-        << "Invoke " << i << " failed while another instance was being configured.";
+  guint invokes = 0U;
+  gboolean invoke_ok = TRUE;
+
+  while (invokes < iterations || (cycles.load () < iterations && invokes < max_invokes)) {
+    if (sp->invoke (NULL, &prop, data, &input, &output) != 0) {
+      invoke_ok = FALSE;
+      break;
+    }
+    ++invokes;
+  }
 
   churn.join ();
+  EXPECT_TRUE (invoke_ok) << "Invoke " << invokes
+                          << " failed while another instance was being configured.";
   EXPECT_TRUE (churn_ok.load ()) << "Concurrent open/close churn failed.";
 
   g_free (input.data);

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -957,6 +957,102 @@ TEST (nnstreamerFilterLiteRT, sharedEnvConcurrentOpen)
     EXPECT_TRUE (results[i].load ()) << "Worker " << i << " failed under concurrent open/close.";
 }
 
+static std::atomic<int> _unbalanced_release_count (0);
+
+/**
+ * @brief GLib log handler counting the subplugin's unbalanced-release error.
+ * @param[in] domain log domain, forwarded to the default handler
+ * @param[in] level log level, forwarded to the default handler
+ * @param[in] message the log message to inspect
+ * @param[in] user_data unused, forwarded to the default handler
+ */
+static void
+_countUnbalancedRelease (const gchar *domain, GLogLevelFlags level,
+    const gchar *message, gpointer user_data)
+{
+  if (message != NULL
+      && g_strstr_len (message, -1, "Unbalanced LiteRT environment release") != NULL)
+    ++_unbalanced_release_count;
+
+  g_log_default_handler (domain, level, message, user_data);
+}
+
+/**
+ * @brief Positive case: a failed configure must release exactly the reference
+ * it took, leaving an already-open instance usable.
+ *
+ * Both failures below throw after litert_env_ref() has succeeded, which is the
+ * only asymmetric path in the reference count.
+ *
+ * The reference count itself is what is checked, via the error the subplugin
+ * logs when a release finds no reference outstanding. Asserting on invoke()
+ * instead would not work: destroying a LiteRtEnvironment while a compiled
+ * model built from it is still alive leaves that model usable on the CPU path
+ * this runs on, so an over-release is invisible in the output of a pipeline.
+ * The invoke() checks below therefore assert the user-visible property (a
+ * failed open does not disturb an open instance), not the leak itself.
+ */
+TEST (nnstreamerFilterLiteRT, sharedEnvRefBalanceOnConfigureFailure)
+{
+  int ret;
+  void *data = NULL, *data_bad = NULL;
+  GstTensorMemory input, output;
+  g_autofree gchar *model_file = NULL;
+  g_autofree gchar *garbage_file = NULL;
+  gint fd;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop, prop_bad;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  input.size = sizeof (float) * 224 * 224 * 3;
+  output.size = sizeof (float) * 1001;
+  input.data = g_malloc0 (input.size);
+  output.data = g_malloc (output.size);
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  _unbalanced_release_count = 0;
+  GLogFunc prev_handler = g_log_set_default_handler (_countUnbalancedRelease, NULL);
+
+  /* fails in resolveSignature(), after the environment reference is taken */
+  _SetFilterProp (&prop_bad, "litert", model_files, "Signature:no_such_signature_key");
+  EXPECT_NE (sp->open (&prop_bad, &data_bad), 0);
+
+  EXPECT_EQ (sp->invoke (NULL, &prop, data, &input, &output), 0)
+      << "A failed signature lookup disturbed an already-open instance.";
+
+  /* fails in LiteRtCreateModelFromFile(), also after the reference is taken */
+  fd = g_file_open_tmp ("litert_garbage_XXXXXX.tflite", &garbage_file, NULL);
+  ASSERT_GE (fd, 0);
+  ASSERT_TRUE (g_file_set_contents (
+      garbage_file, "This is not a tflite flatbuffer at all.", -1, NULL));
+  g_close (fd, NULL);
+
+  const gchar *bad_model_files[] = { garbage_file, NULL };
+  data_bad = NULL;
+  _SetFilterProp (&prop_bad, "litert", bad_model_files);
+  EXPECT_NE (sp->open (&prop_bad, &data_bad), 0);
+
+  EXPECT_EQ (sp->invoke (NULL, &prop, data, &input, &output), 0)
+      << "A failed model load disturbed an already-open instance.";
+
+  g_log_set_default_handler (prev_handler, NULL);
+  EXPECT_EQ (_unbalanced_release_count.load (), 0)
+      << "A failed configure released an environment reference it did not hold.";
+
+  g_unlink (garbage_file);
+  g_free (input.data);
+  g_free (output.data);
+  sp->close (&prop, &data);
+}
+
 /**
  * @brief Churn routine for sharedEnvInvokeDuringConfigure: repeatedly build
  * and tear down an instance on the shared environment.

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -1000,9 +1000,10 @@ _sharedEnvChurn (const gchar **model_files, guint iterations,
  * distinction is dropped.
  *
  * The overlap is structural rather than timing-dependent: this thread keeps
- * invoking until the churn thread reports every cycle done, so the two are
- * guaranteed to run against the shared environment at the same time however
- * the scheduler interleaves them.
+ * invoking until the churn thread reports every cycle done, so the two run
+ * against the shared environment at the same time however the scheduler
+ * interleaves them. An invoke bound guards against a wedged churn thread; it
+ * is reported when reached, since it shortens the overlap.
  */
 TEST (nnstreamerFilterLiteRT, sharedEnvInvokeDuringConfigure)
 {
@@ -1044,6 +1045,14 @@ TEST (nnstreamerFilterLiteRT, sharedEnvInvokeDuringConfigure)
     }
     ++invokes;
   }
+
+  /** Report a short overlap instead of letting it pass as a full one. Not an
+   *  assertion: hitting the bound means invoke is fast relative to a model
+   *  compile, which is not a defect. */
+  if (invoke_ok && invokes >= max_invokes && cycles.load () < iterations)
+    g_message ("sharedEnvInvokeDuringConfigure: reached the %u invoke bound "
+               "after %u of %u churn cycles; overlap was partial.",
+        max_invokes, cycles.load (), iterations);
 
   churn.join ();
   EXPECT_TRUE (invoke_ok) << "Invoke " << invokes

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -958,6 +958,83 @@ TEST (nnstreamerFilterLiteRT, sharedEnvConcurrentOpen)
 }
 
 /**
+ * @brief Churn routine for sharedEnvInvokeDuringConfigure: repeatedly build
+ * and tear down an instance on the shared environment.
+ * @param[in] model_files NULL-terminated array with a single model path
+ * @param[in] iterations how many open/close cycles to run
+ * @param[out] ok set to false if any cycle failed; read after join only
+ */
+static void
+_sharedEnvChurn (const gchar **model_files, guint iterations, std::atomic<bool> *ok)
+{
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  if (sp == nullptr) {
+    *ok = false;
+    return;
+  }
+
+  for (guint i = 0; i < iterations; ++i) {
+    GstTensorFilterProperties prop;
+    void *data = NULL;
+
+    _SetFilterProp (&prop, "litert", model_files);
+    if (sp->open (&prop, &data) != 0) {
+      *ok = false;
+      return;
+    }
+    sp->close (&prop, &data);
+  }
+}
+
+/**
+ * @brief Positive case: invoking one instance while other instances are built
+ * and torn down on the same shared environment must keep producing results.
+ *
+ * Configuration and teardown hold the environment lock exclusively while
+ * invoke holds it in shared mode; this is the case that regresses if that
+ * distinction is dropped.
+ */
+TEST (nnstreamerFilterLiteRT, sharedEnvInvokeDuringConfigure)
+{
+  const guint iterations = 10U;
+  int ret;
+  void *data = NULL;
+  GstTensorMemory input, output;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  input.size = sizeof (float) * 224 * 224 * 3;
+  output.size = sizeof (float) * 1001;
+  input.data = g_malloc0 (input.size);
+  output.data = g_malloc (output.size);
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  std::atomic<bool> churn_ok (true);
+  std::thread churn (_sharedEnvChurn, model_files, iterations, &churn_ok);
+
+  for (guint i = 0; i < iterations; ++i)
+    EXPECT_EQ (sp->invoke (NULL, &prop, data, &input, &output), 0)
+        << "Invoke " << i << " failed while another instance was being configured.";
+
+  churn.join ();
+  EXPECT_TRUE (churn_ok.load ()) << "Concurrent open/close churn failed.";
+
+  g_free (input.data);
+  g_free (output.data);
+  sp->close (&prop, &data);
+}
+
+/**
  * @brief Main gtest
  */
 int

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -991,6 +991,13 @@ _countUnbalancedRelease (const gchar *domain, GLogLevelFlags level,
  * this runs on, so an over-release is invisible in the output of a pipeline.
  * The invoke() checks below therefore assert the user-visible property (a
  * failed open does not disturb an open instance), not the leak itself.
+ *
+ * Do not reduce this to a single failing open: the repetition is what makes
+ * the log fire. An over-release on the first failure only walks the count
+ * down to zero, which is silent. It is the second failure, which finds the
+ * count at zero, builds a fresh environment, and then over-releases from one,
+ * that reaches a release with nothing outstanding. Verified by injecting a
+ * double release: two failures catch it, one does not.
  */
 TEST (nnstreamerFilterLiteRT, sharedEnvRefBalanceOnConfigureFailure)
 {


### PR DESCRIPTION
## What

Replaces the per-instance `LiteRtEnvironment` in the `litert` tensor_filter subplugin with a process-wide, reference-counted one, and serializes the paths that build and tear down LiteRT objects against it.

Resolves the **"Share one `LiteRtEnvironment` across instances"** item of #4869.

## Why

`configure_instance()` called `LiteRtCreateEnvironment()` per filter instance and `cleanup()` destroyed it. LiteRT binds accelerator device contexts to the environment, so a pipeline holding several `litert` filters ended up with one GPU/NPU device context per instance. Upstream documents the opposite expectation — an application holding multiple `CompiledModel`s is expected to share a single `Environment`, and that environment must outlive every compiled model created from it.

## How

- File-local `litert_env` / `litert_env_refs` guarded by `litert_env_lock`, with `litert_env_ref()` (creates on the first reference) and `litert_env_unref()` (destroys on the last).
- Reference counting rather than a create-once singleton, because the environment must outlive every model and compiled model derived from it while instances open and close independently at pipeline state changes. `cleanup()` drops the reference only after the compiled model and the model are destroyed.
- `litert_env_lock` is a **`std::shared_mutex`**, because the two access patterns differ:
  - **Exclusive** in `configure_instance()` and `cleanup()`, around model creation, compilation, tensor-buffer setup and destruction. Sharing one environment newly allows two threads to build LiteRT object graphs against it, which upstream gives no thread-safety contract for and which could not happen before. This restores the property that only one thread at a time manipulates a given environment's object graph.
  - **Shared** in `invoke()`. Running several compiled models off one environment is the pattern upstream recommends, so concurrent invokes stay concurrent; it only blocks while another instance is being configured or torn down.
- The guard in `configure_instance()` lives inside the `try` block, so unwinding releases it before the handler's `cleanup()` re-acquires — the acquisitions are sequential, never nested (`std::shared_mutex` is not recursive).
- `std::lock_guard`/`std::shared_lock` rather than the `G_LOCK_DEFINE_STATIC` used elsewhere in this directory, because `LITERT_CHECK` throws inside the critical section and RAII unlocking is required there.

**The trade is documented in the code**: instances are no longer fully independent — setup/teardown blocks invokes on the others, and an invoke in flight delays another instance's setup. Both are bounded by a single model compile on a path that only runs at pipeline state changes.

**No per-instance state was lost.** The environment is created with no options, and each instance's accelerator selection is applied through `LiteRtCreateOptions` at compile time, not through the environment — so instances with different `custom=Accelerators:` values remain independent. Removes the corresponding `@todo` from the file header.

## Tests

Four gtest cases in `tests/nnstreamer_filter_litert/unittest_filter_litert.cc`, each targeting a boundary that would otherwise break silently:

| Test | Regresses if |
|---|---|
| `sharedEnvMultiInstance` | closing one instance destroyed the environment out from under another still-open instance |
| `sharedEnvReacquire` | the environment was destroyed at refcount 0 but not recreated on the next acquire |
| `sharedEnvConcurrentOpen` | the refcount raced under 4 concurrent open/invoke/close threads |
| `sharedEnvInvokeDuringConfigure` | the shared/exclusive split were dropped — one instance invokes while another thread repeatedly opens and closes instances on the same environment |

The last one's overlap is structural, not timing-dependent: the churn thread publishes a cycle counter and the invoking thread runs until every cycle is reported done. An invoke bound guards against a wedged churn thread and is reported via `g_message` when reached, since it shortens the overlap; it is deliberately not an assertion, as a fast invoke is not a defect and failing on it would make the case flaky on a loaded runner.

Plus SSAT case 6 in `runTest.sh`: a `tee`-branched pipeline with two simultaneous `framework=litert` filters, both checked against the golden `orange` label.

These run in the two jobs that build the subplugin — `ubuntu_clean_meson_build` (ubuntu-22.04 x86_64) and `macos`, both gtest + SSAT. A `LiteRtEnvironment` handle is not observable from outside the subplugin, so no test can assert "exactly one environment exists"; these assert the refcount and locking boundaries instead, which is what a regression would actually break. (The LiteRT runtime logs `Creating LiteRT environment` once per creation, which is how sharing was confirmed by hand.)

## Verification

Built and run locally against the same LiteRT 2.2.0 SDK the CI jobs install:

| Check | Result |
|---|---|
| `unittest_filter_litert` | 25/25 pass |
| `--gtest_repeat=20` on the shared-env cases | clean, no flakiness |
| `ssat -n -p=1` in `tests/nnstreamer_filter_litert` | 9/9 cases pass |
| `-Db_sanitize=address,undefined` | clean |
| `-Db_sanitize=thread` | 0 warnings |
| Full `meson test -C build` | no new failures |

ThreadSanitizer covers the nnstreamer side and the lock discipline only: `libLiteRt.so` is a prebuilt binary from the pip wheel and is uninstrumented, so a race inside LiteRT would be invisible to it. That is precisely why the fix is structural serialization rather than "tested and nothing showed up".

All 18 CI checks pass. Confirmed from the Ubuntu job log that the litert cases genuinely executed rather than being skipped — 25/25 gtest and SSAT `9 passed among 9 cases` — which matters because this suite reports success with zero cases when the subplugin is absent.

## Scope

Confined to `tensor_filter_litert.cc`, its own tests, and one `thread_dep` line in `tests/meson.build` — no header, API, or runtime build change, so nothing outside `libnnstreamer_filter_litert` is affected.

Other #4869 items are deliberately **not** addressed here and that issue stays open for them:

- Tizen/Debian packaging and the Android consumer are blocked on external prerequisites (no `litert.pc` on those targets, no Android `libLiteRt.so` in CI).
- Accelerator-specific options are blocked on the upstream LiteRT C API stabilizing.
- Zero-copy invoke and dynamic input dimensions are untouched; their `@todo`s remain in the file.
