### PR TITLE
[Packaging] Add an unversioned gcc fallback to Build-Depends

### DIFF
--- a/.github/workflows/static.check.scripts/debian-control.sh
+++ b/.github/workflows/static.check.scripts/debian-control.sh
@@ -50,7 +50,7 @@ extract_clauses() {
     /^[[:space:]]*#/ { next }
     /^[[:space:]]*$/ { collecting = 0; next }
     /^[A-Za-z0-9][A-Za-z0-9-]*:/ {
-      collecting = ($0 ~ /^Build-Depends(-Arch|-Indep)?:/)
+      collecting = (tolower($0) ~ /^build-depends(-arch|-indep)?:/)
       if (!collecting) { next }
       if (started) { printf "," }
       started = 1

--- a/.github/workflows/static.check.scripts/debian-control.sh
+++ b/.github/workflows/static.check.scripts/debian-control.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# @file     debian-control.sh
+# @brief    Verify that debian/control* build-dependencies stay satisfiable.
+# @see      https://github.com/nnstreamer/nnstreamer
+# @author   MyungJoo Ham <myungjoo.ham@samsung.com>
+#
+# Ubuntu 25.04 and later, and every current Debian release, dropped gcc-5
+# through gcc-9 from their archives. A Build-Depends alternative group that
+# names only version-suffixed toolchain packages therefore becomes
+# unsatisfiable on a new distro, and the PPA source build parks in
+# "Dependency wait" instead of failing loudly, so no package is ever
+# published for that series. Require an unversioned alternative, which the
+# distro default compiler always provides.
+#
+# Argument ($@): control files to check. Defaults to the repository's
+#                debian/control* when no argument is given.
+#
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../../.." && pwd)
+failed=0
+
+# Toolchain packages whose version-suffixed form leaves distro archives as
+# the compiler ages out.
+TOOLCHAIN_RE='^(gcc|g\+\+|cpp|clang|clang\+\+|llvm)-[0-9]+(\.[0-9]+)*$'
+PKGNAME_RE='^[a-z0-9][a-z0-9+.-]*$'
+
+##
+# @brief Print a string with its runs of whitespace collapsed into single spaces.
+# @param $1 string to normalize
+squeeze() {
+  echo "$1" | awk '{ $1 = $1; print }'
+}
+
+##
+# @brief Print the Build-Depends* fields of a control file, one clause per line.
+# @param $1 path of the control file
+extract_clauses() {
+  awk '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*$/ { collecting = 0; next }
+    /^[A-Za-z0-9][A-Za-z0-9-]*:/ {
+      collecting = ($0 ~ /^Build-Depends(-Arch|-Indep)?:/)
+      if (!collecting) { next }
+      sub(/^[^:]*:/, "")
+    }
+    collecting { printf "%s ", $0 }
+    END { printf "\n" }
+  ' "$1" | tr ',' '\n'
+}
+
+##
+# @brief Report the build dependencies of one control file that cannot hold.
+# @param $1 path of the control file
+check_file() {
+  local file=$1
+  local clause alt name toolchain_only alt_count
+
+  if [ ! -f "$file" ]; then
+    echo "::error::$file does not exist."
+    failed=1
+    return
+  fi
+
+  while IFS= read -r clause; do
+    clause=$(echo "$clause" | tr -d '\r' | sed -e 's/([^)]*)//g' -e 's/\[[^]]*\]//g' -e 's/<[^>]*>//g')
+    if [ -z "$(echo "$clause" | tr -d '[:space:]')" ]; then
+      continue
+    fi
+
+    toolchain_only=1
+    alt_count=0
+    while IFS= read -r alt; do
+      name=$(echo "$alt" | awk '{print $1}')
+      if [ -z "$name" ]; then
+        continue
+      fi
+      alt_count=$((alt_count + 1))
+      if ! echo "$name" | grep -Eq "$PKGNAME_RE"; then
+        echo "::error::$file: invalid package name '$name' in build dependency '$(squeeze "$clause")'."
+        failed=1
+      fi
+      if ! echo "$name" | grep -Eq "$TOOLCHAIN_RE"; then
+        toolchain_only=0
+      fi
+    done < <(echo "$clause" | tr '|' '\n')
+
+    if [ "$alt_count" -gt 0 ] && [ "$toolchain_only" -eq 1 ]; then
+      echo "::error::$file: '$(squeeze "$clause")' lists only version-suffixed toolchain packages, which distros eventually drop. Add an unversioned alternative such as '| gcc'."
+      failed=1
+    fi
+  done < <(extract_clauses "$file")
+}
+
+files=("$@")
+if [ "${#files[@]}" -eq 0 ]; then
+  mapfile -t files < <(find "${REPO_ROOT}/debian" -maxdepth 1 -type f -name 'control*' 2>/dev/null | sort)
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "::error::No debian control file to check."
+  exit 1
+fi
+
+for file in "${files[@]}"; do
+  echo "Checking $file"
+  check_file "$file"
+done
+
+if [ "$failed" -ne 0 ]; then
+  echo "::error::The debian control build-dependency check has failed."
+  exit 1
+fi
+
+echo "The debian control build-dependency check has passed."

--- a/.github/workflows/static.check.scripts/debian-control.sh
+++ b/.github/workflows/static.check.scripts/debian-control.sh
@@ -27,7 +27,8 @@ REPO_ROOT=$(cd "${SCRIPT_DIR}/../../.." && pwd)
 failed=0
 
 # Toolchain packages whose version-suffixed form leaves distro archives as
-# the compiler ages out.
+# the compiler ages out. Matched against the bare name, with any multiarch
+# qualifier such as :native already stripped.
 TOOLCHAIN_RE='^(gcc|g\+\+|cpp|clang|clang\+\+|llvm)-[0-9]+(\.[0-9]+)*$'
 PKGNAME_RE='^[a-z0-9][a-z0-9+.-]*$'
 
@@ -78,6 +79,7 @@ check_file() {
     alt_count=0
     while IFS= read -r alt; do
       name=$(echo "$alt" | awk '{print $1}')
+      name=${name%%:*}
       if [ -z "$name" ]; then
         continue
       fi

--- a/.github/workflows/static.check.scripts/debian-control.sh
+++ b/.github/workflows/static.check.scripts/debian-control.sh
@@ -41,6 +41,9 @@ squeeze() {
 
 ##
 # @brief Print the Build-Depends* fields of a control file, one clause per line.
+#        A separator is emitted between fields because the last dependency of
+#        a field needs no trailing comma, and without it the field would run
+#        into the next one and hide a group inside the merged clause.
 # @param $1 path of the control file
 extract_clauses() {
   awk '
@@ -49,6 +52,8 @@ extract_clauses() {
     /^[A-Za-z0-9][A-Za-z0-9-]*:/ {
       collecting = ($0 ~ /^Build-Depends(-Arch|-Indep)?:/)
       if (!collecting) { next }
+      if (started) { printf "," }
+      started = 1
       sub(/^[^:]*:/, "")
     }
     collecting { printf "%s ", $0 }

--- a/.github/workflows/static.check.scripts/test_debian_control.sh
+++ b/.github/workflows/static.check.scripts/test_debian_control.sh
@@ -107,6 +107,25 @@ Build-Depends: GCC-9 | GCC,
  ninja-build
 Standards-Version: 3.9.6'
 
+expect_checker 1 "a group in Build-Depends-Indep is not hidden by the field before it" \
+'Source: nnstreamer
+Build-Depends: ninja-build
+Build-Depends-Indep: gcc-9 | gcc-8
+Standards-Version: 3.9.6'
+
+expect_checker 1 "a group in Build-Depends is not hidden by the field after it" \
+'Source: nnstreamer
+Build-Depends: gcc-9 | gcc-8
+Build-Depends-Arch: ninja-build
+Standards-Version: 3.9.6'
+
+expect_checker 0 "several Build-Depends fields without a versioned-only group pass" \
+'Source: nnstreamer
+Build-Depends: gcc-9 | gcc
+Build-Depends-Arch: ninja-build
+Build-Depends-Indep: doxygen
+Standards-Version: 3.9.6'
+
 expect_checker 0 "fields after Build-Depends are not scanned" \
 'Source: nnstreamer
 Build-Depends: gcc-9 | gcc

--- a/.github/workflows/static.check.scripts/test_debian_control.sh
+++ b/.github/workflows/static.check.scripts/test_debian_control.sh
@@ -126,6 +126,12 @@ Build-Depends-Arch: ninja-build
 Build-Depends-Indep: doxygen
 Standards-Version: 3.9.6'
 
+expect_checker 1 "a field name is matched regardless of case" \
+'Source: nnstreamer
+build-depends: gcc-9 | gcc-8,
+ ninja-build
+Standards-Version: 3.9.6'
+
 expect_checker 0 "fields after Build-Depends are not scanned" \
 'Source: nnstreamer
 Build-Depends: gcc-9 | gcc

--- a/.github/workflows/static.check.scripts/test_debian_control.sh
+++ b/.github/workflows/static.check.scripts/test_debian_control.sh
@@ -82,6 +82,18 @@ Build-Depends: gcc-13 | gcc,
  pytorch <!nocheck> | libtorch-dev | gcc
 Standards-Version: 3.9.6'
 
+expect_checker 1 "a multiarch qualifier does not hide a versioned-only group" \
+'Source: nnstreamer
+Build-Depends: gcc-13:native | gcc-12:native,
+ ninja-build
+Standards-Version: 3.9.6'
+
+expect_checker 0 "a multiarch qualifier on the fallback is accepted" \
+'Source: nnstreamer
+Build-Depends: gcc-13:native | gcc:native,
+ ninja-build
+Standards-Version: 3.9.6'
+
 expect_checker 0 "a comment inside the field does not terminate it" \
 'Source: nnstreamer
 Build-Depends: gcc-9 | gcc,

--- a/.github/workflows/static.check.scripts/test_debian_control.sh
+++ b/.github/workflows/static.check.scripts/test_debian_control.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# @file     test_debian_control.sh
+# @brief    Self-test for debian-control.sh.
+# @see      https://github.com/nnstreamer/nnstreamer
+# @author   MyungJoo Ham <myungjoo.ham@samsung.com>
+#
+# Pins the properties that make the checker worth running. The compiler
+# clause as it stood before #4848, naming only version-suffixed gcc
+# packages, must fail; the same clause carrying an unversioned fallback must
+# pass. Without the first the checker could accept everything unnoticed;
+# without the second it could reject every control file. A gcc-13/gcc-12
+# pair is checked too, so the rule is not read as a list of the specific
+# compilers that happened to age out. The repository's own control files run
+# last, which keeps the shipped tree covered even when no fixture changes.
+#
+# The checker is invoked with stdin closed, matching how GitHub runs it, so
+# that a future reader-of-stdin bug fails here instead of hanging.
+#
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../../.." && pwd)
+CHECKER="${SCRIPT_DIR}/debian-control.sh"
+workdir=$(mktemp -d)
+failed=0
+
+trap 'rm -rf "$workdir"' EXIT
+
+##
+# @brief Run the checker on a generated control file and compare the exit status.
+# @param $1 expected exit status, 0 or 1
+# @param $2 description used for the fixture name and the report line
+# @param $3 body of the control file
+expect_checker() {
+  local expected=$1 desc=$2 body=$3
+  local target actual
+
+  target="${workdir}/$(echo "$desc" | tr -c 'a-zA-Z0-9' '_')"
+  printf '%s\n' "$body" > "$target"
+
+  bash "$CHECKER" "$target" > /dev/null 2>&1 < /dev/null
+  actual=$?
+  if [ $actual -ne 0 ]; then
+    actual=1
+  fi
+
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: ${desc} (exit ${actual})"
+  else
+    echo "FAIL: ${desc} expected exit ${expected}, got ${actual}"
+    failed=1
+  fi
+}
+
+expect_checker 1 "versioned-only gcc clause is rejected" \
+'Source: nnstreamer
+Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
+ ninja-build, meson (>=0.62.0)
+Standards-Version: 3.9.6'
+
+expect_checker 0 "unversioned gcc fallback is accepted" \
+'Source: nnstreamer
+Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4) | gcc,
+ ninja-build, meson (>=0.62.0)
+Standards-Version: 3.9.6'
+
+expect_checker 1 "a newer versioned-only pair is rejected as well" \
+'Source: nnstreamer
+Build-Depends: gcc-13 | gcc-12,
+ ninja-build
+Standards-Version: 3.9.6'
+
+expect_checker 0 "arch and profile qualifiers do not confuse the parser" \
+'Source: nnstreamer
+Build-Depends: gcc-13 | gcc,
+ libprotobuf-dev [amd64 arm64 armhf],
+ pytorch <!nocheck> | libtorch-dev | gcc
+Standards-Version: 3.9.6'
+
+expect_checker 0 "a comment inside the field does not terminate it" \
+'Source: nnstreamer
+Build-Depends: gcc-9 | gcc,
+# Please list more neural network frameworks as Debian includes them.
+ ninja-build
+Standards-Version: 3.9.6'
+
+expect_checker 1 "an invalid package name is rejected" \
+'Source: nnstreamer
+Build-Depends: GCC-9 | GCC,
+ ninja-build
+Standards-Version: 3.9.6'
+
+expect_checker 0 "fields after Build-Depends are not scanned" \
+'Source: nnstreamer
+Build-Depends: gcc-9 | gcc
+Standards-Version: 3.9.6
+
+Package: nnstreamer
+Depends: gcc-9 | gcc-8
+Description: not a build dependency'
+
+echo "Checking the control files shipped in this repository"
+if (cd "$REPO_ROOT" && bash "$CHECKER") < /dev/null; then
+  echo "PASS: the repository control files satisfy the checker"
+else
+  echo "FAIL: the repository control files do not satisfy the checker"
+  failed=1
+fi
+
+if [ "$failed" -ne 0 ]; then
+  echo "::error::test_debian_control.sh has failed."
+  exit 1
+fi
+
+echo "test_debian_control.sh has passed."

--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -189,6 +189,32 @@ jobs:
           else
             echo "Skipped: $checker is not in this branch's tree and this PR does not remove it."
           fi
+      - name: /Checker/ debian control build dependencies
+        # Checks debian/control* rather than $changed_file_list, so it needs
+        # the same merge-ref guard as the steps above.
+        run: |
+          checker=.github/workflows/static.check.scripts/debian-control.sh
+          if [ -f "$checker" ]; then
+            bash "$checker"
+          elif git show --pretty="format:" --name-only --no-renames --diff-filter=D ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | grep -qxF "$checker"; then
+            echo "::error::This PR removes $checker; remove its workflow step too, or restore the script (also update this step if the script moved)."
+            exit 1
+          else
+            echo "Skipped: $checker is not in this branch's tree and this PR does not remove it."
+          fi
+      - name: /Checker/ debian-control self-test
+        # Runs a repository script unrelated to $changed_file_list, so it
+        # needs the same merge-ref guard as the step above.
+        run: |
+          selftest=.github/workflows/static.check.scripts/test_debian_control.sh
+          if [ -f "$selftest" ]; then
+            bash "$selftest"
+          elif git show --pretty="format:" --name-only --no-renames --diff-filter=D ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | grep -qxF "$selftest"; then
+            echo "::error::This PR removes $selftest; remove its workflow step too, or restore the script (also update this step if the script moved)."
+            exit 1
+          else
+            echo "Skipped: $selftest is not in this branch's tree and this PR does not remove it."
+          fi
       - name: /Checker/ shellcheck for shell scripts
         # Originally from "pr-prebuild-shellcheck"
         run: |

--- a/Documentation/getting-started-ubuntu-ppa.md
+++ b/Documentation/getting-started-ubuntu-ppa.md
@@ -14,6 +14,21 @@ $ sudo apt-add-repository ppa:nnstreamer
 $ sudo apt install nnstreamer
 ```
 
+### Supported Ubuntu releases
+
+The PPA does not carry a build for every Ubuntu release. If `apt` reports
+
+```
+E: The repository '.../ppa/ubuntu <codename> Release' does not have a Release file.
+```
+
+then your release has no packages in the PPA. The
+[PPA page](https://launchpad.net/~nnstreamer/+archive/ubuntu/ppa) lists the
+series that are currently published; if the release you need is missing,
+please file an issue. In the meantime you may build the packages yourself with
+[Ubuntu: Pbuilder / Pdebuild](getting-started-ubuntu-debuild.md) or
+[Linux generic: build with meson and ninja](getting-started-meson-build.md).
+
 ### Additional plugins available
 
 * nnstreamer-caffe2 : Allows to use caffe2 models in a pipeline. (From pytorch 1.3.1 by default)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: nnstreamer
 Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
-Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
+Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4) | gcc,
  ninja-build, meson (>=0.62.0), debhelper (>=9), nnstreamer-edge-dev,
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev, libjson-glib-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,

--- a/debian/control.debian
+++ b/debian/control.debian
@@ -2,7 +2,7 @@ Source: nnstreamer
 Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
-Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
+Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4) | gcc,
  ninja-build, meson (>=0.49), debhelper (>=9), nnstreamer-edge-dev,
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,

--- a/debian/control.ubuntu.ppa
+++ b/debian/control.ubuntu.ppa
@@ -2,7 +2,7 @@ Source: nnstreamer
 Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
-Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
+Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4) | gcc,
  ninja-build, meson (>=0.49), debhelper (>=9), nnstreamer-edge-dev,
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev, libjson-glib-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,


### PR DESCRIPTION
Addresses the repository side of #4848.

## Problem

`ppa:nnstreamer` publishes nothing newer than noble (24.04), so `apt update` on
a newer Ubuntu fails with `does not have a Release file`. The reason is in
`debian/control`:

```
Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
```

Ubuntu 25.04 and later carry **none** of `gcc-5`..`gcc-9`, and neither does any
current Debian release, so the clause is unsatisfiable there:

| series | gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 | gcc |
|---|---|---|---|---|---|---|
| xenial 16.04 | – | – | – | – | 5.4.0 | 4:5.3.1 |
| bionic 18.04 | – | 8.4.0 | 7.5.0 | 6.5.0 | 5.5.0 | 4:7.4.0 |
| focal 20.04 | 9.4.0 | 8.4.0 | 7.5.0 | – | – | 4:9.3.0 |
| jammy 22.04 | 9.5.0 | – | – | – | – | 4:11.2.0 |
| noble 24.04 | 9.5.0 | – | – | – | – | 4:13.2.0 |
| **plucky 25.04** | – | – | – | – | – | 4:14.2.0 |
| **resolute 26.04** | – | – | – | – | – | 4:15.2.0 |
| bookworm / trixie / sid | – | – | – | – | – | 12.2 / 14.2 / 16.1 |

The `nnstreamer-daily` recipe already targets Plucky, and its build parks in
`Dependency wait — Missing build dependencies: gcc-9` instead of failing
loudly, so no package is ever published for the series.

## Change

Append an unversioned `gcc` alternative to all three control files
(`debian/rules` swaps them in per vendor, so leaving one behind would let the
source build and the binary build disagree).

## Why this is safe on existing releases

- On xenial through noble an earlier alternative is still installable, so
  resolution is unchanged there.
- Where the fallback does take effect it changes nothing about what is built.
  `gcc-9` was never the compiler: the PPA build logs show meson selecting `cc`,
  the distro default gcc.

  ```
  [noble]  Setting up gcc-9 (9.5.0-6ubuntu2) ...
  [noble]  C compiler for the host machine: cc (gcc 13.3.0 ...)
  [jammy]  Setting up gcc-9 (9.5.0-1ubuntu1~22.04) ...
  [jammy]  C compiler for the host machine: cc (gcc 11.4.0 ...)
  ```

  The only practical effect is that `gcc-9` and its three dependencies stop
  being installed into the build chroot, because `build-essential` already
  provides `gcc`.
- A core build on Ubuntu 25.04 with gcc 14.2 and `werror=true` was run to
  confirm the newer compiler is viable: 168/168 targets, no new warnings.
  Subplugins and unit tests were out of that run, since their build
  dependencies are not published for 25.04 yet.
- `packaging/nnstreamer.spec` has no versioned gcc `BuildRequires`, so Tizen is
  untouched. meson does not read `debian/control`.
- `debian/control` is part of the pbuilder cache key in `pdebuild.yml` and
  `update_pbuilder_cache.yml`; the key changes once and `restore-keys` covers
  the fallback.

## Regression test

`.github/workflows/static.check.scripts/debian-control.sh` rejects any
build-dependency alternative group made only of version-suffixed toolchain
packages. It fails on the tree as it stood before this PR:

```
::error::debian/control: 'gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5' lists only
version-suffixed toolchain packages, which distros eventually drop. Add an
unversioned alternative such as '| gcc'.
```

and passes after it. `test_debian_control.sh` pins both directions plus the
parser's handling of arch/profile qualifiers, in-field comments, and later
fields, and finally runs the checker against the shipped control files. Both
are wired into `static.check.yml` behind the same merge-ref guard the existing
self-test steps use.

The rule is not written around gcc-9 specifically: a future `gcc-13 | gcc-12`
is rejected the same way.

## Documentation

`Documentation/getting-started-ubuntu-ppa.md` now explains what the
`does not have a Release file` error means and where to check which series are
published, which is the message the reporter of #4848 hit.

## Not covered here

This is the repository half only. Publishing for a new series additionally
requires, on Launchpad:

1. the recipes to target the series (`nnstreamer-daily` currently lists
   Focal/Jammy/Noble/Plucky; no series newer than Plucky), and
2. the PPA dependency stack rebuilt for it — `ssat`, `nnstreamer-edge`,
   `tensorflow2-lite`, `edgetpu`, `openvino`, `onnxruntime`, `tvm`, `onert`.
   Several of these already list Plucky as a target but have never had a build
   requested; `onnxruntime-daily` has been failing on every series since
   2025-01-24.

Two related findings that are **not** addressed here, since their cause is
different:

- Jammy PPA builds have been in `Dependency wait` on `meson (>= 0.62.0)` since
  2025-12-19 (jammy ships 0.61.2); the last jammy publish is 2025-12-04.
- `debian/control.ubuntu.ppa` and `debian/control.debian` still declare
  `meson (>=0.49)` while `meson.build` requires `>=0.62.0`.

Note that Ubuntu 25.10 (questing), the release named in #4848, has since gone
end-of-life, so the practical target is now 26.04 LTS. The issue should stay
open until packages actually appear for a current series.
