### PR TITLE
[Doc] Correct the macOS build instructions

### DIFF
--- a/Documentation/getting-started-macos.md
+++ b/Documentation/getting-started-macos.md
@@ -24,6 +24,9 @@ $ brew tap nnstreamer/neural-network
 $ brew install nnstreamer
 ```
 
+This installs the latest tagged release, not the `main` branch. Build from
+source if you need changes that are not in a release yet.
+
 ## Building from source
 
 Note that most frameworks will be disabled during the configuration, if you 
@@ -33,7 +36,7 @@ please provide a pull request with an update of this doc!
 Install the necessary dependencies:
 
 ```bash
-$ brew install meson ninja pkg-config cmake libffi glib \
+$ brew install meson ninja pkg-config cmake libffi glib json-glib \
     gstreamer gst-plugins-base gst-plugins-good numpy
 ```
 
@@ -54,20 +57,21 @@ Optionally checkout a recent version more stable than the main branch, for
 instance:
 
 ```bash
-$ git checkout v2.1.1
+$ git checkout v2.6.0
 ```
 
 Configure the build with [meson](https://mesonbuild.com):
 
 ```bash
-$ meson build \
-    --prefix=/usr/local \
+$ meson setup build \
+    --prefix=$(brew --prefix) \
     -Dwerror=false -Denable-test=false
 ```
 
-The target files will be installed in `/usr/local/lib/gstreamer-1.0`, 
-`/usr/local/lib/nnstreamer`, `/usr/local/include/nnstreamer` and 
-`/usr/local/etc/`.
+`brew --prefix` is `/opt/homebrew` on Apple silicon and `/usr/local` on Intel.
+The target files will be installed in `$(brew --prefix)/lib/gstreamer-1.0`, 
+`$(brew --prefix)/lib/nnstreamer`, `$(brew --prefix)/include/nnstreamer` and 
+`$(brew --prefix)/etc/`.
 
 Finally build and install using [ninja](https://ninja-build.org/):
 

--- a/Documentation/getting-started-macos.md
+++ b/Documentation/getting-started-macos.md
@@ -53,11 +53,11 @@ $ git clone https://github.com/nnstreamer/nnstreamer.git
 $ cd nnstreamer
 ```
 
-Optionally checkout a recent version more stable than the main branch, for 
-instance:
+Optionally checkout the most recent release, which is more stable than the
+main branch:
 
 ```bash
-$ git checkout v2.6.0
+$ git checkout $(git tag --sort=-v:refname --list 'v*' | head -n 1)
 ```
 
 Configure the build with [meson](https://mesonbuild.com):


### PR DESCRIPTION
Related to #4430.

#4430 is really a defect in the Homebrew tap (the formula is pinned to v2.0.0,
which builds with `cpp_std=c++14`, while Homebrew's protobuf now pulls in
abseil, and abseil has required C++17 since LTS 20240116). That is fixed in
nnstreamer/homebrew-neural-network#21.

While confirming that, the macOS manual this repository ships turned out to
have defects of its own, two of which stop a reader outright:

- `git checkout v2.1.1` names a tag that **does not exist**. The releases are
  v2.0.0, v2.0.1, v2.2.0, v2.4.0, v2.4.2, v2.4.4 and v2.6.0.
- `--prefix=/usr/local` is the Intel Homebrew prefix. On Apple silicon — the
  machine in the bug report — the prefix is `/opt/homebrew`, so following the
  manual installs the plugin where GStreamer will not find it.
  `$(brew --prefix)` is correct on both architectures.

Smaller corrections in the same pass:

- `meson build` is the pre-0.55 spelling and now emits a deprecation warning;
  `meson setup build` is the current form.
- `json-glib` added to the dependency line: it is what enables datarepo
  support, and nnstreamer's own macOS CI installs it.
- The Homebrew section did not say that the formula tracks tagged releases
  rather than `main`.

## Testing

Documentation only — no functional change, so per the test-case policy in
CLAUDE.md there is no test to add. The two substantive claims are checkable
without a macOS machine: `git tag` in this repository shows that `v2.1.1` does
not exist, and Homebrew's prefix on Apple silicon is `/opt/homebrew`, which is
also what `.github/workflows/macos.yaml` builds against.