### PR TITLE
[Join] End the output when the last awaited sink pad is unlinked

### DIFF
--- a/gst/join/gstjoin.c
+++ b/gst/join/gstjoin.c
@@ -24,6 +24,8 @@
  * stream can end on it; the output would otherwise never see EOS. Either one
  * re-examines the set, so a branch may be retired mid-stream by unlinking it or
  * by releasing its pad, in any order with respect to the other streams ending.
+ * Retiring every branch without any of them having ended leaves the output
+ * open, as there is then no EOS to forward.
  * <refsect2>
  * <title>Example launch line</title>
  * gst-launch-1.0 ... (input stream 0) ! join.sink_0 \

--- a/gst/join/gstjoin.c
+++ b/gst/join/gstjoin.c
@@ -21,10 +21,9 @@
  * All capabilities (input stream i and output stream) should be the same.
  * EOS reaches the output pad only after every linked input stream has ended.
  * A sink pad that is unlinked or released is no longer waited for, since no
- * stream can end on it; the output would otherwise never see EOS. The set is
- * only re-examined when a sink pad receives EOS or is released, so retiring a
- * branch mid-stream means releasing its pad: unlinking alone drops it from the
- * set without ending the output, and the output ends at whatever comes next.
+ * stream can end on it; the output would otherwise never see EOS. Either one
+ * re-examines the set, so a branch may be retired mid-stream by unlinking it or
+ * by releasing its pad, in any order with respect to the other streams ending.
  * <refsect2>
  * <title>Example launch line</title>
  * gst-launch-1.0 ... (input stream 0) ! join.sink_0 \
@@ -240,7 +239,8 @@ forward_sticky_events (GstPad * sinkpad, GstEvent ** event, gpointer user_data)
  * @note must be called with the JOIN_LOCK, and with no sink pad's object lock
  *       held: gst_pad_is_linked() takes it, on every sink pad in turn. A pad's
  *       unlink function runs with that pad's object lock held, so calling this
- *       from one deadlocks. Unlinked pads are ignored, as no stream can ever
+ *       from one deadlocks; gst_join_sinkpad_unlinked() is where an unlink is
+ *       picked up instead. Unlinked pads are ignored, as no stream can ever
  *       end on them.
  */
 static gboolean
@@ -264,6 +264,35 @@ gst_join_all_sinkpads_eos (GstJoin * sel, gboolean * any_eos)
     *any_eos = any;
 
   return all;
+}
+
+/**
+ * @brief re-examine the EOS set once a sink pad has been unlinked
+ * @note Connected to the pad's "unlinked" signal rather than installed with
+ *       gst_pad_set_unlink_function(). gst_pad_unlink() calls the unlink
+ *       function while it still holds both pad object locks and before it
+ *       clears either peer, so a scan from there deadlocks on the pad it is
+ *       asked about and, once that is dodged, still reads the pad as linked.
+ *       The signal is emitted after both peers are cleared and both locks are
+ *       dropped, which is what gst_join_all_sinkpads_eos() needs.
+ */
+static void
+gst_join_sinkpad_unlinked (GstPad * pad, GstPad * peer, gpointer user_data)
+{
+  GstJoin *sel = GST_JOIN (user_data);
+  gboolean send_eos, any_eos = FALSE;
+  (void) peer;
+
+  GST_JOIN_LOCK (sel);
+  send_eos = !sel->eos_sent
+      && gst_join_all_sinkpads_eos (sel, &any_eos) && any_eos;
+  sel->eos_sent |= send_eos;
+  GST_JOIN_UNLOCK (sel);
+
+  if (send_eos) {
+    GST_DEBUG_OBJECT (pad, "last awaited sink pad unlinked, forwarding EOS");
+    gst_pad_push_event (sel->srcpad, gst_event_new_eos ());
+  }
 }
 
 /**
@@ -748,6 +777,8 @@ gst_join_request_new_pad (GstElement * element, GstPadTemplate * templ,
   gst_pad_set_chain_function (sinkpad, GST_DEBUG_FUNCPTR (gst_join_pad_chain));
   gst_pad_set_iterate_internal_links_function (sinkpad,
       GST_DEBUG_FUNCPTR (gst_join_pad_iterate_linked_pads));
+  g_signal_connect_object (sinkpad, "unlinked",
+      G_CALLBACK (gst_join_sinkpad_unlinked), sel, (GConnectFlags) 0);
 
   GST_OBJECT_FLAG_SET (sinkpad, GST_PAD_FLAG_PROXY_CAPS);
   GST_OBJECT_FLAG_SET (sinkpad, GST_PAD_FLAG_PROXY_ALLOCATION);

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -684,6 +684,199 @@ TEST (join, eosAfterUnlink)
 }
 
 /**
+ * @brief Test that unlinking the sink pad the join is waiting for ends the
+ *        output stream.
+ * @detail The reverse order of join.eosAfterUnlink. sink_0 is still linked and
+ *         carrying a stream when the other branch ends, so that EOS has to
+ *         wait; nothing further arrives on any pad, which leaves the unlink as
+ *         the only thing that can complete the set.
+ */
+TEST (join, eosAfterUnlinkLast)
+{
+  GstElement *appsrc_0, *appsrc_1, *join_handle, *sink_handle;
+  GstPad *sinkpad_0, *srcpad_0;
+  gint idx = 0;
+
+  GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
+  ASSERT_NE (pipeline, nullptr);
+
+  appsrc_0 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_0");
+  ASSERT_NE (appsrc_0, nullptr);
+  appsrc_1 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_1");
+  ASSERT_NE (appsrc_1, nullptr);
+  join_handle = gst_bin_get_by_name (GST_BIN (pipeline), "join");
+  ASSERT_NE (join_handle, nullptr);
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+  g_signal_connect (sink_handle, "new-data", (GCallback) new_data_cb, (gpointer) &idx);
+
+  data_received = 0;
+  ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  idx = 0;
+  ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_0),
+                 gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192)),
+      GST_FLOW_OK);
+  g_usleep (100000);
+
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
+  EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
+
+  sinkpad_0 = gst_element_get_static_pad (join_handle, "sink_0");
+  ASSERT_NE (sinkpad_0, nullptr);
+  srcpad_0 = gst_pad_get_peer (sinkpad_0);
+  ASSERT_NE (srcpad_0, nullptr);
+  EXPECT_TRUE (gst_pad_unlink (srcpad_0, sinkpad_0));
+  gst_object_unref (srcpad_0);
+  gst_object_unref (sinkpad_0);
+
+  EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
+  EXPECT_EQ (1, data_received);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (join_handle);
+  gst_object_unref (appsrc_1);
+  gst_object_unref (appsrc_0);
+  gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Test that unlinking a sink pad does not end a stream that is running.
+ * @detail Unlinking retires a branch; it does not end the output on its own.
+ *         With no stream ended anywhere there is nothing to forward, and the
+ *         surviving branch has to keep streaming afterwards.
+ */
+TEST (join, noEosOnUnlinkWhileRunning)
+{
+  GstElement *appsrc_0, *appsrc_1, *join_handle, *sink_handle;
+  GstPad *sinkpad_0, *srcpad_0;
+  gint idx = 0;
+
+  GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
+  ASSERT_NE (pipeline, nullptr);
+
+  appsrc_0 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_0");
+  ASSERT_NE (appsrc_0, nullptr);
+  appsrc_1 = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc_1");
+  ASSERT_NE (appsrc_1, nullptr);
+  join_handle = gst_bin_get_by_name (GST_BIN (pipeline), "join");
+  ASSERT_NE (join_handle, nullptr);
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+  g_signal_connect (sink_handle, "new-data", (GCallback) new_data_cb, (gpointer) &idx);
+
+  data_received = 0;
+  ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  idx = 0;
+  ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_0),
+                 gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192)),
+      GST_FLOW_OK);
+  g_usleep (100000);
+
+  sinkpad_0 = gst_element_get_static_pad (join_handle, "sink_0");
+  ASSERT_NE (sinkpad_0, nullptr);
+  srcpad_0 = gst_pad_get_peer (sinkpad_0);
+  ASSERT_NE (srcpad_0, nullptr);
+  EXPECT_TRUE (gst_pad_unlink (srcpad_0, sinkpad_0));
+  gst_object_unref (srcpad_0);
+  gst_object_unref (sinkpad_0);
+
+  EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
+
+  idx = 1;
+  ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_1),
+                 gst_buffer_new_wrapped (_g_memdup (test_frames[1], 192), 192)),
+      GST_FLOW_OK);
+  g_usleep (100000);
+  EXPECT_EQ (2, data_received);
+
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
+  EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (join_handle);
+  gst_object_unref (appsrc_1);
+  gst_object_unref (appsrc_0);
+  gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Test that unlinking one of three sink pads does not end the output.
+ * @detail Three branches into one join is the shape the datarepo and
+ *         custom-easy filter fixtures use, where an output cut short would
+ *         silently truncate a recording. Retiring one branch has to leave the
+ *         join waiting for the one that is still linked and still running.
+ */
+TEST (join, noEosOnUnlinkWhileOthersRun)
+{
+  const gchar *desc
+      = "appsrc name=appsrc_0 ! other/tensor,dimension=(string)3:4:2:2,type=(string)int32,framerate=(fraction)0/1 ! join.sink_0 "
+        "appsrc name=appsrc_1 ! other/tensor,dimension=(string)3:4:2:2,type=(string)int32,framerate=(fraction)0/1 ! join.sink_1 "
+        "appsrc name=appsrc_2 ! other/tensor,dimension=(string)3:4:2:2,type=(string)int32,framerate=(fraction)0/1 ! join.sink_2 "
+        "join name=join ! other/tensor,dimension=(string)3:4:2:2, type=(string)int32, framerate=(fraction)0/1 ! "
+        "tensor_sink name=sinkx async=false";
+  GstElement *appsrc[3], *join_handle, *sink_handle;
+  GstPad *sinkpad_0, *srcpad_0;
+  guint received = 0;
+  guint i;
+
+  GstElement *pipeline = gst_parse_launch (desc, NULL);
+  ASSERT_NE (pipeline, nullptr);
+
+  for (i = 0; i < 3; i++) {
+    gchar *name = g_strdup_printf ("appsrc_%u", i);
+    appsrc[i] = gst_bin_get_by_name (GST_BIN (pipeline), name);
+    g_free (name);
+    ASSERT_NE (appsrc[i], nullptr);
+  }
+  join_handle = gst_bin_get_by_name (GST_BIN (pipeline), "join");
+  ASSERT_NE (join_handle, nullptr);
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
+
+  ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  for (i = 0; i < 3; i++) {
+    ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc[i]),
+                   gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192)),
+        GST_FLOW_OK);
+    g_usleep (100000);
+  }
+
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc[1])), GST_FLOW_OK);
+  EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
+
+  sinkpad_0 = gst_element_get_static_pad (join_handle, "sink_0");
+  ASSERT_NE (sinkpad_0, nullptr);
+  srcpad_0 = gst_pad_get_peer (sinkpad_0);
+  ASSERT_NE (srcpad_0, nullptr);
+  EXPECT_TRUE (gst_pad_unlink (srcpad_0, sinkpad_0));
+  gst_object_unref (srcpad_0);
+  gst_object_unref (sinkpad_0);
+
+  /* sink_2 is still linked and has not ended, so nothing may be forwarded. */
+  EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
+
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc[2])), GST_FLOW_OK);
+  EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
+  EXPECT_EQ (3U, received);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (join_handle);
+  for (i = 0; i < 3; i++)
+    gst_object_unref (appsrc[i]);
+  gst_object_unref (pipeline);
+}
+
+/**
  * @brief Main GTest
  */
 int

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -696,12 +696,15 @@ typedef struct {
  * @note Every expected frame is in place before the pipeline plays, so the
  *       streaming thread never reads a field the test thread writes. That is
  *       what the index shared with new_data_cb did, and it is also why this
- *       needs no ordering between the count and the frame it selects.
+ *       needs no ordering between the count and the frame it selects. A buffer
+ *       arriving past the frames a test named fails on the bound or on the
+ *       empty slot, rather than being compared against whatever is there.
  */
 static void
 count_checked_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
 {
   JoinCounter *counter = (JoinCounter *) user_data;
+  const gint *expected;
   GstMemory *mem_res;
   GstMapInfo info_res;
   gboolean mapped;
@@ -709,6 +712,8 @@ count_checked_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_dat
   (void) element;
 
   ASSERT_LT (counter->received, G_N_ELEMENTS (counter->expected));
+  expected = counter->expected[counter->received];
+  ASSERT_NE (expected, nullptr);
 
   mem_res = gst_buffer_get_memory (buffer, 0);
   mapped = gst_memory_map (mem_res, &info_res, GST_MAP_READ);
@@ -716,7 +721,7 @@ count_checked_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_dat
   output = (gint *) info_res.data;
 
   for (i = 0; i < 48; i++) {
-    EXPECT_EQ (counter->expected[counter->received][i], output[i]);
+    EXPECT_EQ (expected[i], output[i]);
   }
   gst_memory_unmap (mem_res, &info_res);
   gst_memory_unref (mem_res);

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -695,7 +695,7 @@ TEST (join, eosAfterUnlinkLast)
 {
   GstElement *appsrc_0, *appsrc_1, *join_handle, *sink_handle;
   GstPad *sinkpad_0, *srcpad_0;
-  gint idx = 0;
+  guint received = 0;
 
   GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
   ASSERT_NE (pipeline, nullptr);
@@ -708,16 +708,14 @@ TEST (join, eosAfterUnlinkLast)
   ASSERT_NE (join_handle, nullptr);
   sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
   ASSERT_NE (sink_handle, nullptr);
-  g_signal_connect (sink_handle, "new-data", (GCallback) new_data_cb, (gpointer) &idx);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
 
-  data_received = 0;
   ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
-  idx = 0;
   ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_0),
                  gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192)),
       GST_FLOW_OK);
-  g_usleep (100000);
+  ASSERT_TRUE (wait_pipeline_process_buffers (&received, 1, TEST_TIMEOUT_LIMIT_MS));
 
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
   EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
@@ -731,7 +729,7 @@ TEST (join, eosAfterUnlinkLast)
   gst_object_unref (sinkpad_0);
 
   EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
-  EXPECT_EQ (1, data_received);
+  EXPECT_EQ (1U, received);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
@@ -752,7 +750,7 @@ TEST (join, noEosOnUnlinkWhileRunning)
 {
   GstElement *appsrc_0, *appsrc_1, *join_handle, *sink_handle;
   GstPad *sinkpad_0, *srcpad_0;
-  gint idx = 0;
+  guint received = 0;
 
   GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
   ASSERT_NE (pipeline, nullptr);
@@ -765,16 +763,14 @@ TEST (join, noEosOnUnlinkWhileRunning)
   ASSERT_NE (join_handle, nullptr);
   sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
   ASSERT_NE (sink_handle, nullptr);
-  g_signal_connect (sink_handle, "new-data", (GCallback) new_data_cb, (gpointer) &idx);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
 
-  data_received = 0;
   ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
-  idx = 0;
   ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_0),
                  gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192)),
       GST_FLOW_OK);
-  g_usleep (100000);
+  ASSERT_TRUE (wait_pipeline_process_buffers (&received, 1, TEST_TIMEOUT_LIMIT_MS));
 
   sinkpad_0 = gst_element_get_static_pad (join_handle, "sink_0");
   ASSERT_NE (sinkpad_0, nullptr);
@@ -786,12 +782,10 @@ TEST (join, noEosOnUnlinkWhileRunning)
 
   EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
 
-  idx = 1;
   ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_1),
                  gst_buffer_new_wrapped (_g_memdup (test_frames[1], 192), 192)),
       GST_FLOW_OK);
-  g_usleep (100000);
-  EXPECT_EQ (2, data_received);
+  ASSERT_TRUE (wait_pipeline_process_buffers (&received, 2, TEST_TIMEOUT_LIMIT_MS));
 
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
   EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
@@ -846,8 +840,8 @@ TEST (join, noEosOnUnlinkWhileOthersRun)
     ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc[i]),
                    gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192)),
         GST_FLOW_OK);
-    g_usleep (100000);
   }
+  ASSERT_TRUE (wait_pipeline_process_buffers (&received, 3, TEST_TIMEOUT_LIMIT_MS));
 
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc[1])), GST_FLOW_OK);
   EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -684,19 +684,19 @@ TEST (join, eosAfterUnlink)
 }
 
 /**
- * @brief Buffer count, and the frame the buffers counted next must carry.
+ * @brief Buffer count, and the frame each buffer must carry in arrival order.
  */
 typedef struct {
-  const gint *expected;
+  const gint *expected[3];
   guint received;
 } JoinCounter;
 
 /**
  * @brief Count a buffer once its payload matches the frame that was pushed.
- * @note The count is raised last. A test that waits on it before setting the
- *       next expected frame therefore cannot overwrite the frame while this
- *       callback is still reading it, which is what made the plain index
- *       shared with new_data_cb racy.
+ * @note Every expected frame is in place before the pipeline plays, so the
+ *       streaming thread never reads a field the test thread writes. That is
+ *       what the index shared with new_data_cb did, and it is also why this
+ *       needs no ordering between the count and the frame it selects.
  */
 static void
 count_checked_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
@@ -708,13 +708,15 @@ count_checked_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_dat
   gint *output, i;
   (void) element;
 
+  ASSERT_LT (counter->received, G_N_ELEMENTS (counter->expected));
+
   mem_res = gst_buffer_get_memory (buffer, 0);
   mapped = gst_memory_map (mem_res, &info_res, GST_MAP_READ);
   ASSERT_TRUE (mapped);
   output = (gint *) info_res.data;
 
   for (i = 0; i < 48; i++) {
-    EXPECT_EQ (counter->expected[i], output[i]);
+    EXPECT_EQ (counter->expected[counter->received][i], output[i]);
   }
   gst_memory_unmap (mem_res, &info_res);
   gst_memory_unref (mem_res);
@@ -734,7 +736,7 @@ TEST (join, eosAfterUnlinkLast)
 {
   GstElement *appsrc_0, *appsrc_1, *join_handle, *sink_handle;
   GstPad *sinkpad_0, *srcpad_0;
-  JoinCounter counter = { test_frames[0], 0 };
+  JoinCounter counter = { { test_frames[0], NULL, NULL }, 0 };
 
   GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
   ASSERT_NE (pipeline, nullptr);
@@ -790,7 +792,8 @@ TEST (join, noEosOnUnlinkWhileRunning)
 {
   GstElement *appsrc_0, *appsrc_1, *join_handle, *sink_handle;
   GstPad *sinkpad_0, *srcpad_0;
-  JoinCounter counter = { test_frames[0], 0 };
+  /* Frame 1 is branch 1's, so the buffer after the unlink must be its own. */
+  JoinCounter counter = { { test_frames[0], test_frames[1], NULL }, 0 };
 
   GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
   ASSERT_NE (pipeline, nullptr);
@@ -823,8 +826,6 @@ TEST (join, noEosOnUnlinkWhileRunning)
 
   EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
 
-  /* The branch that survives the unlink, so this buffer must be its own. */
-  counter.expected = test_frames[1];
   ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_1),
                  gst_buffer_new_wrapped (_g_memdup (test_frames[1], 192), 192)),
       GST_FLOW_OK);
@@ -859,7 +860,7 @@ TEST (join, noEosOnUnlinkWhileOthersRun)
         "tensor_sink name=sinkx async=false";
   GstElement *appsrc[3], *join_handle, *sink_handle;
   GstPad *sinkpad_0, *srcpad_0;
-  JoinCounter counter = { test_frames[0], 0 };
+  JoinCounter counter = { { test_frames[0], test_frames[0], test_frames[0] }, 0 };
   guint i;
 
   GstElement *pipeline = gst_parse_launch (desc, NULL);

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -684,6 +684,45 @@ TEST (join, eosAfterUnlink)
 }
 
 /**
+ * @brief Buffer count, and the frame the buffers counted next must carry.
+ */
+typedef struct {
+  const gint *expected;
+  guint received;
+} JoinCounter;
+
+/**
+ * @brief Count a buffer once its payload matches the frame that was pushed.
+ * @note The count is raised last. A test that waits on it before setting the
+ *       next expected frame therefore cannot overwrite the frame while this
+ *       callback is still reading it, which is what made the plain index
+ *       shared with new_data_cb racy.
+ */
+static void
+count_checked_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  JoinCounter *counter = (JoinCounter *) user_data;
+  GstMemory *mem_res;
+  GstMapInfo info_res;
+  gboolean mapped;
+  gint *output, i;
+  (void) element;
+
+  mem_res = gst_buffer_get_memory (buffer, 0);
+  mapped = gst_memory_map (mem_res, &info_res, GST_MAP_READ);
+  ASSERT_TRUE (mapped);
+  output = (gint *) info_res.data;
+
+  for (i = 0; i < 48; i++) {
+    EXPECT_EQ (counter->expected[i], output[i]);
+  }
+  gst_memory_unmap (mem_res, &info_res);
+  gst_memory_unref (mem_res);
+
+  counter->received++;
+}
+
+/**
  * @brief Test that unlinking the sink pad the join is waiting for ends the
  *        output stream.
  * @detail The reverse order of join.eosAfterUnlink. sink_0 is still linked and
@@ -695,7 +734,7 @@ TEST (join, eosAfterUnlinkLast)
 {
   GstElement *appsrc_0, *appsrc_1, *join_handle, *sink_handle;
   GstPad *sinkpad_0, *srcpad_0;
-  guint received = 0;
+  JoinCounter counter = { test_frames[0], 0 };
 
   GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
   ASSERT_NE (pipeline, nullptr);
@@ -708,14 +747,15 @@ TEST (join, eosAfterUnlinkLast)
   ASSERT_NE (join_handle, nullptr);
   sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
   ASSERT_NE (sink_handle, nullptr);
-  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_checked_data_cb,
+      (gpointer) &counter);
 
   ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
   ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_0),
                  gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192)),
       GST_FLOW_OK);
-  ASSERT_TRUE (wait_pipeline_process_buffers (&received, 1, TEST_TIMEOUT_LIMIT_MS));
+  ASSERT_TRUE (wait_pipeline_process_buffers (&counter.received, 1, TEST_TIMEOUT_LIMIT_MS));
 
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
   EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
@@ -729,7 +769,7 @@ TEST (join, eosAfterUnlinkLast)
   gst_object_unref (sinkpad_0);
 
   EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
-  EXPECT_EQ (1U, received);
+  EXPECT_EQ (1U, counter.received);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
@@ -750,7 +790,7 @@ TEST (join, noEosOnUnlinkWhileRunning)
 {
   GstElement *appsrc_0, *appsrc_1, *join_handle, *sink_handle;
   GstPad *sinkpad_0, *srcpad_0;
-  guint received = 0;
+  JoinCounter counter = { test_frames[0], 0 };
 
   GstElement *pipeline = gst_parse_launch (join_pipeline_desc, NULL);
   ASSERT_NE (pipeline, nullptr);
@@ -763,14 +803,15 @@ TEST (join, noEosOnUnlinkWhileRunning)
   ASSERT_NE (join_handle, nullptr);
   sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
   ASSERT_NE (sink_handle, nullptr);
-  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_checked_data_cb,
+      (gpointer) &counter);
 
   ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
   ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_0),
                  gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192)),
       GST_FLOW_OK);
-  ASSERT_TRUE (wait_pipeline_process_buffers (&received, 1, TEST_TIMEOUT_LIMIT_MS));
+  ASSERT_TRUE (wait_pipeline_process_buffers (&counter.received, 1, TEST_TIMEOUT_LIMIT_MS));
 
   sinkpad_0 = gst_element_get_static_pad (join_handle, "sink_0");
   ASSERT_NE (sinkpad_0, nullptr);
@@ -782,10 +823,12 @@ TEST (join, noEosOnUnlinkWhileRunning)
 
   EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
 
+  /* The branch that survives the unlink, so this buffer must be its own. */
+  counter.expected = test_frames[1];
   ASSERT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_1),
                  gst_buffer_new_wrapped (_g_memdup (test_frames[1], 192), 192)),
       GST_FLOW_OK);
-  ASSERT_TRUE (wait_pipeline_process_buffers (&received, 2, TEST_TIMEOUT_LIMIT_MS));
+  ASSERT_TRUE (wait_pipeline_process_buffers (&counter.received, 2, TEST_TIMEOUT_LIMIT_MS));
 
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc_1)), GST_FLOW_OK);
   EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
@@ -816,7 +859,7 @@ TEST (join, noEosOnUnlinkWhileOthersRun)
         "tensor_sink name=sinkx async=false";
   GstElement *appsrc[3], *join_handle, *sink_handle;
   GstPad *sinkpad_0, *srcpad_0;
-  guint received = 0;
+  JoinCounter counter = { test_frames[0], 0 };
   guint i;
 
   GstElement *pipeline = gst_parse_launch (desc, NULL);
@@ -832,7 +875,8 @@ TEST (join, noEosOnUnlinkWhileOthersRun)
   ASSERT_NE (join_handle, nullptr);
   sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
   ASSERT_NE (sink_handle, nullptr);
-  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_checked_data_cb,
+      (gpointer) &counter);
 
   ASSERT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
 
@@ -841,7 +885,7 @@ TEST (join, noEosOnUnlinkWhileOthersRun)
                    gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192)),
         GST_FLOW_OK);
   }
-  ASSERT_TRUE (wait_pipeline_process_buffers (&received, 3, TEST_TIMEOUT_LIMIT_MS));
+  ASSERT_TRUE (wait_pipeline_process_buffers (&counter.received, 3, TEST_TIMEOUT_LIMIT_MS));
 
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc[1])), GST_FLOW_OK);
   EXPECT_EQ (pop_eos_or_error (pipeline, 300), GST_MESSAGE_UNKNOWN);
@@ -859,7 +903,7 @@ TEST (join, noEosOnUnlinkWhileOthersRun)
 
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc[2])), GST_FLOW_OK);
   EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
-  EXPECT_EQ (3U, received);
+  EXPECT_EQ (3U, counter.received);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
 


### PR DESCRIPTION
Fixes #4886.

## The defect

`gst_join_all_sinkpads_eos()` skips sink pads that are not linked, but it only ran on `GST_EVENT_EOS` and on pad release. Unlinking a sink pad changes its answer without running it, so the outcome depended on the order of operations:

| order | result |
|---|---|
| unlink `sink_0`, then `sink_1` gets EOS | EOS forwarded — covered by `join.eosAfterUnlink` |
| `sink_1` gets EOS, then unlink `sink_0` | **no EOS, ever** — a silent hang with no indication why |

## Why `gst_pad_set_unlink_function()` does not work

The issue records that the obvious fix deadlocks, and that avoiding the deadlock still leaves the test failing for reasons that were not diagnosed. Both fall out of `gst_pad_unlink()`:

```c
GST_OBJECT_LOCK (srcpad);
GST_OBJECT_LOCK (sinkpad);
...
GST_PAD_UNLINKFUNC (sinkpad) (sinkpad, tmpparent);   /* <- unlink function */
...
/* first clear peers */
GST_PAD_PEER (srcpad) = NULL;
GST_PAD_PEER (sinkpad) = NULL;
```

- The unlink function runs holding **both** pad object locks, so `gst_pad_is_linked()` on the pad being unlinked self-deadlocks.
- It also runs **before either peer is cleared** — so with the bare `GST_PAD_IS_LINKED` macro instead there is no deadlock, but the scan still reads that pad as linked and forwards nothing. That is the undiagnosed finding 2 in the issue, and it means reverting the `gst_pad_is_linked()` line, listed there as one way out, cannot help.
- Taking the JOIN_LOCK from that context would additionally invert the JOIN_LOCK → pad object lock order that `gst_join_pad_event()` establishes.

## The fix

Three lines further on, `gst_pad_unlink()` does:

```c
GST_OBJECT_UNLOCK (sinkpad);
GST_OBJECT_UNLOCK (srcpad);
g_signal_emit (sinkpad, gst_pad_signals[PAD_UNLINKED], 0, srcpad);
```

The `"unlinked"` signal is emitted after both peers are cleared and both object locks are dropped — exactly the context `gst_join_all_sinkpads_eos()` documents that it needs. Connecting there gives the re-examination hook with **no change to the scan** and none of the three hazards above.

`gst_element_remove_pad()` unlinks before it drops the pad from the element, so `gst_join_release_pad()` now reaches the same handler whenever the released pad was linked; `eos_sent` under the JOIN_LOCK keeps that from forwarding twice, and the release path keeps its own check for a pad released without a peer.

The `SECTION:element-join` contract is updated: unlinking and releasing are now equivalent ways to retire a branch, in any order relative to the other streams ending.

## Tests

`tests/gstreamer_join/unittest_join.cc`, all verified locally against gstreamer 1.20.3:

| case | what it pins | mutant that kills it |
|---|---|---|
| `eosAfterUnlinkLast` | the issue's repro, the reverse order of `eosAfterUnlink` | **fails without the fix** — 10 s bus timeout |
| `noEosOnUnlinkWhileRunning` | unlinking retires a branch, it does not end the output | fails against a handler forwarding EOS on any unlink |
| `noEosOnUnlinkWhileOthersRun` | three branches; one retired, another still linked and running | fails against the same mutant |

`noEosOnUnlinkWhileOthersRun` uses the three-into-one shape the `datarepo` and `custom-easy` filter fixtures use, where an output cut short would silently truncate a recording — that is the cross-module regression this change could plausibly cause, so it is guarded directly.

## Verification

- `unittest_join`: 13/13 pass; `eosAfterUnlinkLast` reproduced failing on the pre-fix tree and passing after.
- Consumers of the `join` element — `unittest_datareposink`, `unittest_datareposrc`, `unittest_filter_custom` — all pass.
- Full `meson test -C build`: **21/21 suites OK**.
- No new compiler warnings; `gst-indent` and `clang-format` produce no diff.
