### PR TITLE
[Test] Let the remaining SSAT suites find sub-plugins when installed

### DIFF
--- a/tests/nnstreamer_converter_python3/runTest.sh
+++ b/tests/nnstreamer_converter_python3/runTest.sh
@@ -40,37 +40,45 @@ convertBMP2PNG
 
 PATH_TO_PLUGIN="../../build"
 # Check python libraries are built
-if [[ -d $PATH_TO_PLUGIN ]]; then
+if [[ -d ${PATH_TO_PLUGIN} ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_converter"
-    if [[ -d ${ini_path} ]]; then
-        check=$(ls ${ini_path} | grep python3.so)
-        if [[ ! $check ]]; then
-            echo "Cannot find python shared lib"
-            report
-            exit
-        fi
-    else
-        echo "Cannot find ${ini_path}"
-        report exit
-    fi
 else
-    echo "No build directory"
+    ini_file="/etc/nnstreamer.ini"
+    if [[ ! -f ${ini_file} ]]; then
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
+    fi
+
+    sub_plugin_line=$(grep "^converters" ${ini_file})
+    if [[ ${sub_plugin_line%%=*} != "converters" ]]; then
+        echo "Cannot identify the sub-plugin path from ${ini_file}"
+        report
+        exit
+    fi
+    ini_path=${sub_plugin_line##*=}
+fi
+
+if [[ ! -d ${ini_path} ]] || [[ -z $(ls ${ini_path} | grep python3.so) ]]; then
+    echo "Cannot find python shared lib"
     report
     exit
 fi
 
 FRAMEWORK="python3"
-# This symlink is necessary only for testcases; when installed, symlinks will be made
-pushd ../../build/ext/nnstreamer/tensor_converter
-TEST_PYTHONPATH=$(pwd)/${FRAMEWORK}_pymodule
-mkdir -p ${TEST_PYTHONPATH}
-pushd ${TEST_PYTHONPATH}
-export PYTHONPATH=$(pwd):${PYTHONPATH}
-if [[ ! -f ./nnstreamer_python.so ]]; then
-  ln -s ../../extra/nnstreamer_${FRAMEWORK}.so nnstreamer_python.so
+if [[ -d ${PATH_TO_PLUGIN} ]]; then
+    # This symlink is necessary only for testcases; when installed, symlinks will be made
+    pushd ${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_converter
+    TEST_PYTHONPATH=$(pwd)/${FRAMEWORK}_pymodule
+    mkdir -p ${TEST_PYTHONPATH}
+    pushd ${TEST_PYTHONPATH}
+    export PYTHONPATH=$(pwd):${PYTHONPATH}
+    if [[ ! -f ./nnstreamer_python.so ]]; then
+      ln -s ../../extra/nnstreamer_${FRAMEWORK}.so nnstreamer_python.so
+    fi
+    popd
+    popd
 fi
-popd
-popd
 
 PATH_TO_SCRIPT="../test_models/models/custom_converter.py"
 ##
@@ -139,6 +147,9 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesp
 callCompareTest test.audio8k.s16le.origin.log test.consecutive.log 4-1 "Consecutive converting test" 0 0
 
 rm *.golden *.log *.bmp *.png *.dat
-rm -r ${TEST_PYTHONPATH}
+# TEST_PYTHONPATH is only set when the symlink was made in a build tree.
+if [[ -n ${TEST_PYTHONPATH} ]]; then
+    rm -r ${TEST_PYTHONPATH}
+fi
 
 report

--- a/tests/nnstreamer_decoder_python3/runTest.sh
+++ b/tests/nnstreamer_decoder_python3/runTest.sh
@@ -40,38 +40,45 @@ convertBMP2PNG
 
 PATH_TO_PLUGIN="../../build"
 # Check python libraries are built
-if [[ -d $PATH_TO_PLUGIN ]]; then
+if [[ -d ${PATH_TO_PLUGIN} ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_decoder"
-    if [[ -d ${ini_path} ]]; then
-        check=$(ls ${ini_path} | grep python3.so)
-        if [[ ! $check ]]; then
-            echo "Cannot find python shared lib"
-            report
-            exit
-        fi
-    else
-        echo "Cannot find ${ini_path}"
+else
+    ini_file="/etc/nnstreamer.ini"
+    if [[ ! -f ${ini_file} ]]; then
+        echo "Cannot identify nnstreamer.ini"
         report
         exit
     fi
-else
-    echo "No build directory"
+
+    sub_plugin_line=$(grep "^decoders" ${ini_file})
+    if [[ ${sub_plugin_line%%=*} != "decoders" ]]; then
+        echo "Cannot identify the sub-plugin path from ${ini_file}"
+        report
+        exit
+    fi
+    ini_path=${sub_plugin_line##*=}
+fi
+
+if [[ ! -d ${ini_path} ]] || [[ -z $(ls ${ini_path} | grep python3.so) ]]; then
+    echo "Cannot find python shared lib"
     report
     exit
 fi
 
 FRAMEWORK="python3"
-# This symlink is necessary only for testcases; when installed, symlinks will be made
-pushd ../../build/ext/nnstreamer/tensor_decoder
-TEST_PYTHONPATH=$(pwd)/${FRAMEWORK}_pymodule
-mkdir -p ${TEST_PYTHONPATH}
-pushd ${TEST_PYTHONPATH}
-export PYTHONPATH=$(pwd):${PYTHONPATH}
-if [[ ! -f ./nnstreamer_python.so ]]; then
-  ln -s ../../extra/nnstreamer_${FRAMEWORK}.so nnstreamer_python.so
+if [[ -d ${PATH_TO_PLUGIN} ]]; then
+    # This symlink is necessary only for testcases; when installed, symlinks will be made
+    pushd ${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_decoder
+    TEST_PYTHONPATH=$(pwd)/${FRAMEWORK}_pymodule
+    mkdir -p ${TEST_PYTHONPATH}
+    pushd ${TEST_PYTHONPATH}
+    export PYTHONPATH=$(pwd):${PYTHONPATH}
+    if [[ ! -f ./nnstreamer_python.so ]]; then
+      ln -s ../../extra/nnstreamer_${FRAMEWORK}.so nnstreamer_python.so
+    fi
+    popd
+    popd
 fi
-popd
-popd
 
 PATH_TO_SCRIPT="../test_models/models/custom_decoder.py"
 #
@@ -130,6 +137,9 @@ callCompareTest testsynch19_3.golden testsynch19_3.log 3-4 "Tensor mux Compare 3
 callCompareTest testsynch19_4.golden testsynch19_4.log 3-5 "Tensor mux Compare 3-5" 1 0
 
 rm *.golden *.log *.bmp *.png *.dat
-rm -r ${TEST_PYTHONPATH}
+# TEST_PYTHONPATH is only set when the symlink was made in a build tree.
+if [[ -n ${TEST_PYTHONPATH} ]]; then
+    rm -r ${TEST_PYTHONPATH}
+fi
 
 report

--- a/tests/nnstreamer_filter_lua/runTest.sh
+++ b/tests/nnstreamer_filter_lua/runTest.sh
@@ -21,21 +21,27 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 # Check lua libraries are built
-if [[ -d $PATH_TO_PLUGIN ]]; then
+if [[ -d ${PATH_TO_PLUGIN} ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
-    if [[ -d ${ini_path} ]]; then
-        check=$(ls ${ini_path} | grep lua.so)
-        if [[ ! $check ]]; then
-            echo "Cannot find lua shared lib"
-            report
-            exit
-        fi
-    else
-        echo "Cannot find ${ini_path}"
-        report exit
-    fi
 else
-    echo "No build directory"
+    ini_file="/etc/nnstreamer.ini"
+    if [[ ! -f ${ini_file} ]]; then
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
+    fi
+
+    sub_plugin_line=$(grep "^filters" ${ini_file})
+    if [[ ${sub_plugin_line%%=*} != "filters" ]]; then
+        echo "Cannot identify the sub-plugin path from ${ini_file}"
+        report
+        exit
+    fi
+    ini_path=${sub_plugin_line##*=}
+fi
+
+if [[ ! -d ${ini_path} ]] || [[ -z $(ls ${ini_path} | grep lua.so) ]]; then
+    echo "Cannot find lua shared lib"
     report
     exit
 fi

--- a/tests/nnstreamer_filter_python3/runTest.sh
+++ b/tests/nnstreamer_filter_python3/runTest.sh
@@ -32,7 +32,8 @@ if [[ -d $PATH_TO_PLUGIN ]]; then
         fi
     else
         echo "Cannot find ${ini_path}"
-        report exit
+        report
+        exit
     fi
 else
     echo "No build directory"

--- a/tests/nnstreamer_flatbuf/runTest.sh
+++ b/tests/nnstreamer_flatbuf/runTest.sh
@@ -32,20 +32,27 @@ convertBMP2PNG
 
 PATH_TO_PLUGIN="../../build"
 
-if [[ -d $PATH_TO_PLUGIN ]]; then
+if [[ -d ${PATH_TO_PLUGIN} ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_converter"
-    if [[ -d ${ini_path} ]]; then
-        check=$(ls ${ini_path} | grep flatbuf.so)
-        if [[ ! $check ]]; then
-            echo "Cannot find flatbuf shared lib"
-            report
-            exit
-        fi
-    else
-        echo "Cannot find ${ini_path}"
-    fi
 else
-    echo "No build directory"
+    ini_file="/etc/nnstreamer.ini"
+    if [[ ! -f ${ini_file} ]]; then
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
+    fi
+
+    sub_plugin_line=$(grep "^converters" ${ini_file})
+    if [[ ${sub_plugin_line%%=*} != "converters" ]]; then
+        echo "Cannot identify the sub-plugin path from ${ini_file}"
+        report
+        exit
+    fi
+    ini_path=${sub_plugin_line##*=}
+fi
+
+if [[ ! -d ${ini_path} ]] || [[ -z $(ls ${ini_path} | grep flatbuf.so) ]]; then
+    echo "Cannot find flatbuf shared lib"
     report
     exit
 fi

--- a/tests/nnstreamer_flexbuf/runTest.sh
+++ b/tests/nnstreamer_flexbuf/runTest.sh
@@ -32,20 +32,27 @@ convertBMP2PNG
 
 PATH_TO_PLUGIN="../../build"
 
-if [[ -d $PATH_TO_PLUGIN ]]; then
+if [[ -d ${PATH_TO_PLUGIN} ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_converter"
-    if [[ -d ${ini_path} ]]; then
-        check=$(ls ${ini_path} | grep flexbuf.so)
-        if [[ ! $check ]]; then
-            echo "Cannot find flexbuf shared lib"
-            report
-            exit
-        fi
-    else
-        echo "Cannot find ${ini_path}"
-    fi
 else
-    echo "No build directory"
+    ini_file="/etc/nnstreamer.ini"
+    if [[ ! -f ${ini_file} ]]; then
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
+    fi
+
+    sub_plugin_line=$(grep "^converters" ${ini_file})
+    if [[ ${sub_plugin_line%%=*} != "converters" ]]; then
+        echo "Cannot identify the sub-plugin path from ${ini_file}"
+        report
+        exit
+    fi
+    ini_path=${sub_plugin_line##*=}
+fi
+
+if [[ ! -d ${ini_path} ]] || [[ -z $(ls ${ini_path} | grep flexbuf.so) ]]; then
+    echo "Cannot find flexbuf shared lib"
     report
     exit
 fi

--- a/tests/nnstreamer_protobuf/runTest.sh
+++ b/tests/nnstreamer_protobuf/runTest.sh
@@ -32,20 +32,27 @@ convertBMP2PNG
 
 PATH_TO_PLUGIN="../../build"
 
-if [[ -d $PATH_TO_PLUGIN ]]; then
+if [[ -d ${PATH_TO_PLUGIN} ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/extra"
-    if [[ -d ${ini_path} ]]; then
-        check=$(ls ${ini_path} | grep protobuf.so)
-        if [[ ! $check ]]; then
-            echo "Cannot find protobuf shared lib"
-            report
-            exit
-        fi
-    else
-        echo "Cannot find ${ini_path}"
-    fi
 else
-    echo "No build directory"
+    ini_file="/etc/nnstreamer.ini"
+    if [[ ! -f ${ini_file} ]]; then
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
+    fi
+
+    sub_plugin_line=$(grep "^converters" ${ini_file})
+    if [[ ${sub_plugin_line%%=*} != "converters" ]]; then
+        echo "Cannot identify the sub-plugin path from ${ini_file}"
+        report
+        exit
+    fi
+    ini_path=${sub_plugin_line##*=}
+fi
+
+if [[ ! -d ${ini_path} ]] || [[ -z $(ls ${ini_path} | grep protobuf.so) ]]; then
+    echo "Cannot find protobuf shared lib"
     report
     exit
 fi

--- a/tests/nnstreamer_sparse/runTest.sh
+++ b/tests/nnstreamer_sparse/runTest.sh
@@ -21,21 +21,27 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 # Check lua libraries are built. This test utilizes it for making "sparse" dense tensors.
-if [[ -d $PATH_TO_PLUGIN ]]; then
+if [[ -d ${PATH_TO_PLUGIN} ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
-    if [[ -d ${ini_path} ]]; then
-        check=$(ls ${ini_path} | grep lua.so)
-        if [[ ! $check ]]; then
-            echo "Cannot find lua shared lib"
-            report
-            exit
-        fi
-    else
-        echo "Cannot find ${ini_path}"
-        report exit
-    fi
 else
-    echo "No build directory"
+    ini_file="/etc/nnstreamer.ini"
+    if [[ ! -f ${ini_file} ]]; then
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
+    fi
+
+    sub_plugin_line=$(grep "^filters" ${ini_file})
+    if [[ ${sub_plugin_line%%=*} != "filters" ]]; then
+        echo "Cannot identify the sub-plugin path from ${ini_file}"
+        report
+        exit
+    fi
+    ini_path=${sub_plugin_line##*=}
+fi
+
+if [[ ! -d ${ini_path} ]] || [[ -z $(ls ${ini_path} | grep lua.so) ]]; then
+    echo "Cannot find lua shared lib"
     report
     exit
 fi


### PR DESCRIPTION
Every `runTest.sh` probes `../../build` to decide whether the sub-plugin it needs was built, and most fall back to reading the installed path out of `/etc/nnstreamer.ini` when that directory is absent. Seven did not — they ended the probe with

```sh
else
    echo "No build directory"
    report
    exit
fi
```

so from the installed test package they report no cases at all. #4885 started shipping two of them (`filter_lua`, `sparse`) and the other five were already there, so `unittest-nnstreamer` has been carrying suites that could never run. This is the follow-up that #4885's description said was needed.

**Changes proposed in this PR:**
- Give the seven the same fallback the other suites use: `nnstreamer_converter_python3`, `nnstreamer_decoder_python3`, `nnstreamer_filter_lua`, `nnstreamer_flatbuf`, `nnstreamer_flexbuf`, `nnstreamer_protobuf`, `nnstreamer_sparse`. Each reads the ini key matching the kind of sub-plugin it actually needs — `filters`, `converters` or `decoders`.
- Restructure the probe instead of bolting an `else` onto it, so the sub-plugin lookup happens once against whichever path was resolved.
- Move the `nnstreamer_python.so` symlink setup in `converter_python3` / `decoder_python3` inside the build-tree branch, and guard the tail-end `rm -r ${TEST_PYTHONPATH}` on the variable that block sets.

**Which ini key each suite needs**

| suite | build-tree probe | ini key | looks for |
| --- | --- | --- | --- |
| `converter_python3` | `ext/nnstreamer/tensor_converter` | `converters` | `python3.so` |
| `decoder_python3` | `ext/nnstreamer/tensor_decoder` | `decoders` | `python3.so` |
| `filter_lua` | `ext/nnstreamer/tensor_filter` | `filters` | `lua.so` |
| `flatbuf` | `ext/nnstreamer/tensor_converter` | `converters` | `flatbuf.so` |
| `flexbuf` | `ext/nnstreamer/tensor_converter` | `converters` | `flexbuf.so` |
| `protobuf` | `ext/nnstreamer/extra` | `converters` | `protobuf.so` |
| `sparse` | `ext/nnstreamer/tensor_filter` | `filters` | `lua.so` |

`protobuf` is the odd one. Its build-tree probe looks at `ext/nnstreamer/extra`, which holds `libnnstreamer_protobuf.so` — a helper library installed to `%{_libdir}`, not a sub-plugin — so there is no ini key that points at it. The installed check looks for the converter sub-plugin instead, which the suite does exercise, and `debian/nnstreamer-protobuf.install` ships converter and decoder together.

**The symlink block**

`converter_python3` and `decoder_python3` each did this unconditionally after the probe:

```sh
# This symlink is necessary only for testcases; when installed, symlinks will be made
pushd ../../build/ext/nnstreamer/tensor_converter
```

That would have failed the moment the new fallback let them past the probe — the guard would pass and the script would then die on a missing build tree, which is worse than skipping. The comment already states the symlink is only for testcases, and `filter_python3` has always wrapped the same block in `if [[ -d ../../build ]]`, so both now do the same. `debian/nnstreamer-python3.links` puts `nnstreamer_python.so` on the default `PYTHONPATH`, so the installed tree genuinely provides what the build-tree block was faking.

`filter_python3` itself is otherwise untouched: it already handles the installed case by checking for the `nnstreamer_python` module, so it was never in the inert set. It carried a `report exit` typo, which is fixed there as a one-liner.

**The build-tree arm changes too**

Restructuring the probe also fixes a second, separate defect, and it is worth being explicit that this is not confined to the new branch. In the arm taken when `../../build` exists but the sub-plugin directory does not, six of the seven previously fell through and ran the tests anyway:

- `converter_python3`, `filter_lua`, `sparse` had `report exit` — `report` called with a stray argument, no `exit` executed
- `flatbuf`, `flexbuf`, `protobuf` printed a message and did nothing else
- `decoder_python3` was the only one that correctly did `report` then `exit`

All seven now skip cleanly. This does not change any CI result, because those directories always exist in a CI build — but the reason is that the arm is unreachable there, not that the diff is confined to the installed path.

One consequence to be deliberate about: a build that disables the converter sub-plugins will now silently skip `flatbuf` / `flexbuf` / `protobuf` instead of running them and failing. Every other suite in the tree already behaves that way, so it is the consistent choice, but it does turn a loud failure into a quiet skip in that configuration.

**Verification**

CI cannot cover the installed path: no job runs SSAT from an installed tree, and none can without new plumbing — RPM runs `%check` before `%install` and debhelper runs `dh_auto_test` before `dh_auto_install`, so neither packaging flow has a point at which an installed tree exists. So I drove each script's probe directly with a stub SSAT API, against a fake ini pointing at fake sub-plugin directories and separately against a fake build tree:

- sub-plugin present, no build dir → guard passes and the script reaches its first `gstTest`, with no build-tree errors
- sub-plugin absent, no build dir → `Cannot find <name> shared lib`, `report`, clean exit
- no ini at all → `Cannot identify nnstreamer.ini`, `report`, clean exit
- build dir present, sub-plugin present → reaches the tests, unchanged
- build dir present, sub-plugin directory absent → clean skip (previously a fall-through for six of seven, as above)

The cleanup was checked both ways too: silent when `TEST_PYTHONPATH` is unset, still removing the directory when it is set.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped (no build input changed)
2. Run test: [*]Passed [ ]Failed [ ]Skipped (probe driven directly, as above; CI covers the build-tree path)

**How to evaluate:**
1. In a build tree, run `ssat` in each of the seven directories and confirm the results are unchanged.
2. Install with `-Dinstall-test=true`, then from `<prefix>/lib/nnstreamer/bin/unittest-nnstreamer/tests/<suite>` run `ssat` and confirm the suite now executes instead of printing `No build directory`.
3. Rename `/etc/nnstreamer.ini` and confirm each suite skips cleanly rather than failing.
