### PR TITLE
[Build] Keep the meson floor at a version Ubuntu 22.04 ships

### DIFF
--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -83,7 +83,7 @@ jobs:
         sudo apt-get install -y pbuilder debootstrap curl ubuntu-dev-tools qemu-user-static debian-archive-keyring ubuntu-keyring debhelper
         echo "::endgroup::"
         echo "DISTRIBUTION=${{ matrix.distroname }}" > ~/.pbuilderrc
-        echo "OTHERMIRROR=\"deb [trusted=yes] http://archive.ubuntu.com/ubuntu ${{ matrix.distroname }}-backports universe |deb [trusted=yes] http://ppa.launchpad.net/nnstreamer/ppa/ubuntu ${{ matrix.distroname }} main |deb [trusted=yes] http://ppa.launchpad.net/kubuntu-ppa/backports-extra/ubuntu ${{ matrix.distroname }} main\"" >> ~/.pbuilderrc
+        echo "OTHERMIRROR=\"deb [trusted=yes] http://archive.ubuntu.com/ubuntu ${{ matrix.distroname }}-backports universe |deb [trusted=yes] http://ppa.launchpad.net/nnstreamer/ppa/ubuntu ${{ matrix.distroname }} main\"" >> ~/.pbuilderrc
         cat ~/.pbuilderrc
         sudo mkdir -p /root/
         sudo ln -sf ~/.pbuilderrc /root/

--- a/.github/workflows/risc-v.yml
+++ b/.github/workflows/risc-v.yml
@@ -26,8 +26,7 @@ jobs:
           githubToken: ${{ github.token }}
           run: |
             apt-get -qy update
-            apt-get -qy install ninja-build libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libglib2.0-dev libjson-glib-dev gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good libgtest-dev libpng-dev libopencv-dev python3 python3-dev python3-numpy python3-pip pkg-config gcc g++ liblua5.1-dev bash wget libpng-dev
-            pip3 install meson
+            apt-get -qy install meson ninja-build libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libglib2.0-dev libjson-glib-dev gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good libgtest-dev libpng-dev libopencv-dev python3 python3-dev python3-numpy pkg-config gcc g++ liblua5.1-dev bash wget libpng-dev
             bash .github/workflows/get_ssat.sh
             meson setup build -Denable-tizen=false -Denable-test=true
             ninja -C build

--- a/.github/workflows/static.check.scripts/meson-version.sh
+++ b/.github/workflows/static.check.scripts/meson-version.sh
@@ -18,7 +18,10 @@
 #
 # Every tracked document and packaging file is scanned rather than a list of
 # the sites that happen to declare it today, so a ninth one cannot appear
-# unnoticed - which is the whole point of the check.
+# unnoticed - which is the whole point of the check. Tracked, via git, so a
+# build directory or a vendored copy left in the tree cannot fail the check on
+# a file nobody owns; find is the fallback for a directory that is not a
+# repository, which is how the self-test drives this.
 #
 # Argument ($1): repository root to check. Defaults to the repository this
 #                script lives in.
@@ -109,8 +112,12 @@ while IFS= read -r rel; do
 done < <(
   cd "$ROOT" || exit 1
   {
-    find . -name .git -prune -o -type f \( -name '*.md' -o -name '*.spec' \) -print
-    ls -1 debian/control* 2>/dev/null
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      git ls-files -- '*.md' '*.spec' 'debian/control*'
+    else
+      find . -name .git -prune -o -type f \( -name '*.md' -o -name '*.spec' \) -print
+      ls -1 debian/control* 2>/dev/null
+    fi
   } | sed "s|^\./||" | sort -u
 )
 

--- a/.github/workflows/static.check.scripts/meson-version.sh
+++ b/.github/workflows/static.check.scripts/meson-version.sh
@@ -26,13 +26,17 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 ROOT=${1:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}
 failed=0
 
-# A declared requirement: meson, then >= with nothing but an optional bracket
-# between them, then a version. Every form in the tree fits - "meson (>=X)",
-# "meson >= X", "Meson >= X + Ninja". Keeping the gap this tight is what stops
-# prose such as "meson.build wants glib >= 2.60" from reading as a meson
-# requirement. Because the gap cannot contain a digit, the only digits in a
-# match belong to the version itself.
-DECL_RE='[Mm]eson[[:space:]]*\(?[[:space:]]*>=[[:space:]]*[0-9]+(\.[0-9]+)+'
+# A declared requirement: meson, then >=, then a version. The gap between them
+# may hold punctuation but no letter or digit, which is what separates a
+# declaration from prose: "meson (>=X)", "**meson** >= X" and "`meson` >= X"
+# all match, while "meson.build wants glib >= 2.60" does not, because another
+# package name stands in the way. Excluding digits from the gap also means the
+# only digits in a match belong to the version itself.
+#
+# Known limit: a markdown link, "[meson](https://example.com) >= X", puts
+# letters in the gap and is not recognised. Write the requirement outside the
+# link text.
+DECL_RE='meson(_version)?[^[:alnum:]]{0,12}>=[[:space:]]*[0-9]+(\.[0-9]+)+'
 
 ##
 # @brief Print a version padded to four components so 0.56 and 0.56.0 compare equal.
@@ -87,8 +91,8 @@ check_file() {
         echo "::error::${rel}:${lineno} requires meson ${found_raw}, but meson.build requires ${expected_raw}. Keep every declaration in step."
         failed=1
       fi
-    done < <(echo "$text" | grep -oE "$DECL_RE")
-  done < <(grep -nE "$DECL_RE" "$file")
+    done < <(echo "$text" | grep -oiE "$DECL_RE")
+  done < <(grep -niE "$DECL_RE" "$file")
 }
 
 while IFS= read -r rel; do

--- a/.github/workflows/static.check.scripts/meson-version.sh
+++ b/.github/workflows/static.check.scripts/meson-version.sh
@@ -26,17 +26,21 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 ROOT=${1:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}
 failed=0
 
-# A declared requirement: meson, then >=, then a version. The gap between them
-# may hold punctuation but no letter or digit, which is what separates a
-# declaration from prose: "meson (>=X)", "**meson** >= X" and "`meson` >= X"
-# all match, while "meson.build wants glib >= 2.60" does not, because another
-# package name stands in the way. Excluding digits from the gap also means the
-# only digits in a match belong to the version itself.
+# A declared requirement: meson, then >=, then a version, with a gap between
+# them that may hold decoration but nothing that means the sentence moved on.
+# Letters and digits are excluded, so a named neighbour breaks the match -
+# "meson.build wants glib >= 2.60" is prose about glib, not a meson
+# requirement - and so the only digits in a match belong to the version.
+# Comma, period and semicolon are excluded too, so an unnamed version further
+# along a sentence, as in "see meson, (>=5.0) elsewhere", is not attributed to
+# meson either. What is left through is decoration: "meson (>=X)",
+# "**meson** >= X", "`meson` >= X", "meson_version: >=X".
 #
-# Known limit: a markdown link, "[meson](https://example.com) >= X", puts
-# letters in the gap and is not recognised. Write the requirement outside the
-# link text.
-DECL_RE='meson(_version)?[^[:alnum:]]{0,12}>=[[:space:]]*[0-9]+(\.[0-9]+)+'
+# This is a heuristic over prose and is deliberately not grown any further. A
+# markdown link, "[meson](https://example.com) >= X", puts letters in the gap
+# and is not recognised. If some other phrasing escapes it, write the
+# requirement in one of the plain forms above rather than widening this.
+DECL_RE='meson(_version)?[^[:alnum:],.;]{0,12}>=[[:space:]]*[0-9]+(\.[0-9]+)+'
 
 ##
 # @brief Print a version padded to four components so 0.56 and 0.56.0 compare equal.

--- a/.github/workflows/static.check.scripts/meson-version.sh
+++ b/.github/workflows/static.check.scripts/meson-version.sh
@@ -16,6 +16,10 @@
 # the source build resolves against. meson.build is the authority here,
 # because it is the file meson itself enforces.
 #
+# Every tracked document and packaging file is scanned rather than a list of
+# the sites that happen to declare it today, so a ninth one cannot appear
+# unnoticed - which is the whole point of the check.
+#
 # Argument ($1): repository root to check. Defaults to the repository this
 #                script lives in.
 #
@@ -58,7 +62,7 @@ if [ ! -f "${ROOT}/meson.build" ]; then
   exit 1
 fi
 
-expected_raw=$(grep -oE "meson_version:[[:space:]]*'>=[0-9]+(\.[0-9]+)+'" "${ROOT}/meson.build" \
+expected_raw=$(grep -oE "meson_version:[[:space:]]*'>=[[:space:]]*[0-9]+(\.[0-9]+)+'" "${ROOT}/meson.build" \
   | head -1 | grep -oE '[0-9]+(\.[0-9]+)+')
 if [ -z "$expected_raw" ]; then
   echo "::error::meson.build does not declare meson_version."
@@ -104,8 +108,10 @@ while IFS= read -r rel; do
   check_file "$rel"
 done < <(
   cd "$ROOT" || exit 1
-  ls -1 AGENTS.md packaging/nnstreamer.spec debian/control* 2>/dev/null
-  find Documentation -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort
+  {
+    find . -name .git -prune -o -type f \( -name '*.md' -o -name '*.spec' \) -print
+    ls -1 debian/control* 2>/dev/null
+  } | sed "s|^\./||" | sort -u
 )
 
 if [ "$failed" -ne 0 ]; then

--- a/.github/workflows/static.check.scripts/meson-version.sh
+++ b/.github/workflows/static.check.scripts/meson-version.sh
@@ -43,11 +43,16 @@ failed=0
 # meson either. What is left through is decoration: "meson (>=X)",
 # "**meson** >= X", "`meson` >= X", "meson_version: >=X".
 #
-# This is a heuristic over prose and is deliberately not grown any further. A
-# markdown link, "[meson](https://example.com) >= X", puts letters in the gap
-# and is not recognised. If some other phrasing escapes it, write the
-# requirement in one of the plain forms above rather than widening this.
-DECL_RE='meson(_version)?[^[:alnum:],.;]{0,12}>=[[:space:]]*[0-9]+(\.[0-9]+)+'
+# The gap is three characters because that is what the forms above need: one
+# for a space, two for a backtick or a bracket, three for "**meson** >=".
+# Anything longer is a sentence that has wandered, as in "see meson -- (>=9.0)
+# elsewhere", where the version belongs to something else entirely.
+#
+# This is a heuristic over prose and is deliberately not grown. A markdown
+# link, "[meson](https://example.com) >= X", puts letters in the gap and is
+# not recognised. If some other phrasing escapes it, write the requirement in
+# one of the plain forms above rather than widening this.
+DECL_RE='meson(_version)?[^[:alnum:],.;]{0,3}>=[[:space:]]*[0-9]+(\.[0-9]+)+'
 
 ##
 # @brief Print a version padded to four components so 0.56 and 0.56.0 compare equal.

--- a/.github/workflows/static.check.scripts/meson-version.sh
+++ b/.github/workflows/static.check.scripts/meson-version.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# @file     meson-version.sh
+# @brief    Check that the minimum meson version is declared consistently.
+# @see      https://github.com/nnstreamer/nnstreamer
+# @author   MyungJoo Ham <myungjoo.ham@samsung.com>
+#
+# The minimum meson is written down in eight places: meson.build, the three
+# debian/control* files, packaging/nnstreamer.spec, AGENTS.md and two
+# Documentation pages. Nothing tied them together, so raising the floor in
+# 647b30e5 left debian/control.ubuntu.ppa and debian/control.debian behind at
+# 0.49 and the value that reaches the published .dsc disagreed with the value
+# the source build resolves against. meson.build is the authority here,
+# because it is the file meson itself enforces.
+#
+# Argument ($1): repository root to check. Defaults to the repository this
+#                script lives in.
+#
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT=${1:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}
+failed=0
+
+# A declared requirement: the word meson, then >=, then a version. Plain
+# mentions of a version some distro happens to ship carry no >= and are left
+# alone.
+DECL_RE='[Mm]eson[^0-9]{0,24}>=[[:space:]]*[0-9]+(\.[0-9]+)+'
+
+##
+# @brief Print a version as major.minor.patch so 0.56 and 0.56.0 compare equal.
+# @param $1 version string
+normalize() {
+  echo "$1" | awk -F. '{ printf "%d.%d.%d\n", $1, ($2 == "" ? 0 : $2), ($3 == "" ? 0 : $3) }'
+}
+
+if [ ! -f "${ROOT}/meson.build" ]; then
+  echo "::error::${ROOT}/meson.build not found."
+  exit 1
+fi
+
+expected_raw=$(grep -oE "meson_version:[[:space:]]*'>=[0-9]+(\.[0-9]+)+'" "${ROOT}/meson.build" \
+  | head -1 | grep -oE '[0-9]+(\.[0-9]+)+')
+if [ -z "$expected_raw" ]; then
+  echo "::error::meson.build does not declare meson_version."
+  exit 1
+fi
+expected=$(normalize "$expected_raw")
+echo "meson.build declares meson_version >= ${expected_raw}"
+
+targets=$(cd "$ROOT" && ls -1 AGENTS.md packaging/nnstreamer.spec debian/control* 2>/dev/null; \
+          cd "$ROOT" && find Documentation -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort)
+
+for rel in $targets; do
+  file="${ROOT}/${rel}"
+  [ -f "$file" ] || continue
+  while IFS= read -r hit; do
+    [ -z "$hit" ] && continue
+    lineno=${hit%%:*}
+    found_raw=$(echo "${hit#*:}" | grep -oE '[0-9]+(\.[0-9]+)+' | tail -1)
+    found=$(normalize "$found_raw")
+    if [ "$found" = "$expected" ]; then
+      echo "  ok   ${rel}:${lineno} (${found_raw})"
+    else
+      echo "::error::${rel}:${lineno} requires meson ${found_raw}, but meson.build requires ${expected_raw}. Keep every declaration in step."
+      failed=1
+    fi
+  done < <(grep -nE "$DECL_RE" "$file" | grep -oE "^[0-9]+:.*")
+done
+
+if [ "$failed" -ne 0 ]; then
+  echo "::error::The meson version declarations disagree."
+  exit 1
+fi
+
+echo "The meson version declarations agree."

--- a/.github/workflows/static.check.scripts/meson-version.sh
+++ b/.github/workflows/static.check.scripts/meson-version.sh
@@ -12,7 +12,7 @@
 # debian/control* files, packaging/nnstreamer.spec, AGENTS.md and two
 # Documentation pages. Nothing tied them together, so raising the floor in
 # 647b30e5 left debian/control.ubuntu.ppa and debian/control.debian behind at
-# 0.49 and the value that reaches the published .dsc disagreed with the value
+# 0.49, and the value that reaches the published .dsc disagreed with the value
 # the source build resolves against. meson.build is the authority here,
 # because it is the file meson itself enforces.
 #
@@ -26,16 +26,23 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 ROOT=${1:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}
 failed=0
 
-# A declared requirement: the word meson, then >=, then a version. Plain
-# mentions of a version some distro happens to ship carry no >= and are left
-# alone.
-DECL_RE='[Mm]eson[^0-9]{0,24}>=[[:space:]]*[0-9]+(\.[0-9]+)+'
+# A declared requirement: meson, then >= with nothing but an optional bracket
+# between them, then a version. Every form in the tree fits - "meson (>=X)",
+# "meson >= X", "Meson >= X + Ninja". Keeping the gap this tight is what stops
+# prose such as "meson.build wants glib >= 2.60" from reading as a meson
+# requirement. Because the gap cannot contain a digit, the only digits in a
+# match belong to the version itself.
+DECL_RE='[Mm]eson[[:space:]]*\(?[[:space:]]*>=[[:space:]]*[0-9]+(\.[0-9]+)+'
 
 ##
-# @brief Print a version as major.minor.patch so 0.56 and 0.56.0 compare equal.
+# @brief Print a version padded to four components so 0.56 and 0.56.0 compare equal.
 # @param $1 version string
 normalize() {
-  echo "$1" | awk -F. '{ printf "%d.%d.%d\n", $1, ($2 == "" ? 0 : $2), ($3 == "" ? 0 : $3) }'
+  echo "$1" | awk -F. '{
+    for (i = 1; i <= 4; i++) {
+      printf "%d%s", ($i == "" ? 0 : $i), (i < 4 ? "." : "\n")
+    }
+  }'
 }
 
 if [ ! -f "${ROOT}/meson.build" ]; then
@@ -52,25 +59,46 @@ fi
 expected=$(normalize "$expected_raw")
 echo "meson.build declares meson_version >= ${expected_raw}"
 
-targets=$(cd "$ROOT" && ls -1 AGENTS.md packaging/nnstreamer.spec debian/control* 2>/dev/null; \
-          cd "$ROOT" && find Documentation -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort)
+##
+# @brief Compare every declaration in one file against meson.build.
+# @param $1 path of the file relative to the repository root
+check_file() {
+  local rel=$1
+  local file="${ROOT}/${rel}"
+  local hit lineno text decl found_raw found
 
-for rel in $targets; do
-  file="${ROOT}/${rel}"
-  [ -f "$file" ] || continue
+  [ -f "$file" ] || return 0
+
   while IFS= read -r hit; do
     [ -z "$hit" ] && continue
     lineno=${hit%%:*}
-    found_raw=$(echo "${hit#*:}" | grep -oE '[0-9]+(\.[0-9]+)+' | tail -1)
-    found=$(normalize "$found_raw")
-    if [ "$found" = "$expected" ]; then
-      echo "  ok   ${rel}:${lineno} (${found_raw})"
-    else
-      echo "::error::${rel}:${lineno} requires meson ${found_raw}, but meson.build requires ${expected_raw}. Keep every declaration in step."
-      failed=1
-    fi
-  done < <(grep -nE "$DECL_RE" "$file" | grep -oE "^[0-9]+:.*")
-done
+    text=${hit#*:}
+    # One line may carry more than one declaration, and the version has to be
+    # read out of the matched text rather than the whole line: a neighbouring
+    # constraint such as "debhelper (>=9.20)" would otherwise be picked up as
+    # the meson requirement.
+    while IFS= read -r decl; do
+      [ -z "$decl" ] && continue
+      found_raw=$(echo "$decl" | grep -oE '[0-9]+(\.[0-9]+)+' | tail -1)
+      found=$(normalize "$found_raw")
+      if [ "$found" = "$expected" ]; then
+        echo "  ok   ${rel}:${lineno} (${found_raw})"
+      else
+        echo "::error::${rel}:${lineno} requires meson ${found_raw}, but meson.build requires ${expected_raw}. Keep every declaration in step."
+        failed=1
+      fi
+    done < <(echo "$text" | grep -oE "$DECL_RE")
+  done < <(grep -nE "$DECL_RE" "$file")
+}
+
+while IFS= read -r rel; do
+  [ -z "$rel" ] && continue
+  check_file "$rel"
+done < <(
+  cd "$ROOT" || exit 1
+  ls -1 AGENTS.md packaging/nnstreamer.spec debian/control* 2>/dev/null
+  find Documentation -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort
+)
 
 if [ "$failed" -ne 0 ]; then
   echo "::error::The meson version declarations disagree."

--- a/.github/workflows/static.check.scripts/meson-version.sh
+++ b/.github/workflows/static.check.scripts/meson-version.sh
@@ -43,16 +43,24 @@ failed=0
 # meson either. What is left through is decoration: "meson (>=X)",
 # "**meson** >= X", "`meson` >= X", "meson_version: >=X".
 #
-# The gap is three characters because that is what the forms above need: one
-# for a space, two for a backtick or a bracket, three for "**meson** >=".
-# Anything longer is a sentence that has wandered, as in "see meson -- (>=9.0)
-# elsewhere", where the version belongs to something else entirely.
+# These are the accepted forms, and the gap of four characters is what the
+# longest of them needs:
+#
+#   meson >= X            meson (>= X)          **meson** >= X
+#   `meson` >= X          `meson` (>= X)        **meson** (>= X)
+#   meson_version: >= X   meson_version : >= X
+#
+# Comma, period, semicolon, question mark and exclamation mark are barred from
+# the gap because they end a clause: in "see meson -- (>=9.0) elsewhere" or
+# "really, meson?! (>=5.0)" the version belongs to something else. Letters and
+# digits are barred too, so a named neighbour such as "glib >= 2.60" breaks the
+# match, and the only digits left inside one belong to the version.
 #
 # This is a heuristic over prose and is deliberately not grown. A markdown
 # link, "[meson](https://example.com) >= X", puts letters in the gap and is
 # not recognised. If some other phrasing escapes it, write the requirement in
-# one of the plain forms above rather than widening this.
-DECL_RE='meson(_version)?[^[:alnum:],.;]{0,3}>=[[:space:]]*[0-9]+(\.[0-9]+)+'
+# one of the forms listed above rather than widening this.
+DECL_RE='meson(_version[[:space:]]*:)?[^[:alnum:],.;?!]{0,4}>=[[:space:]]*[0-9]+(\.[0-9]+)+'
 
 ##
 # @brief Print a version padded to four components so 0.56 and 0.56.0 compare equal.
@@ -70,7 +78,7 @@ if [ ! -f "${ROOT}/meson.build" ]; then
   exit 1
 fi
 
-expected_raw=$(grep -oE "meson_version:[[:space:]]*'>=[[:space:]]*[0-9]+(\.[0-9]+)+'" "${ROOT}/meson.build" \
+expected_raw=$(grep -oE "meson_version[[:space:]]*:[[:space:]]*'>=[[:space:]]*[0-9]+(\.[0-9]+)+'" "${ROOT}/meson.build" \
   | head -1 | grep -oE '[0-9]+(\.[0-9]+)+')
 if [ -z "$expected_raw" ]; then
   echo "::error::meson.build does not declare meson_version."

--- a/.github/workflows/static.check.scripts/test_meson_version.sh
+++ b/.github/workflows/static.check.scripts/test_meson_version.sh
@@ -121,6 +121,14 @@ expect_checker 1 "meson.build syntax quoted in a page is checked too" \
 "${MESON_BUILD}
 $(printf 'Documentation/getting-started-meson-build.md\tThe project declares meson_version: >=0.62.0 today.')"
 
+expect_checker 0 "a version further along a sentence is not attributed to meson" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\tSee meson, (>=5.0) is the tool version we mean elsewhere.')"
+
+expect_checker 0 "an ellipsis breaks the association as well" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\tAfter installing meson... (>=2024.1) support was added.')"
+
 expect_checker 1 "two declarations on one line are both checked" \
 "${MESON_BUILD}
 $(printf 'Documentation/how-to-run-examples.md\tUse meson >= 0.56.0 on Ubuntu and Meson >= 0.62.0 on Tizen.')"

--- a/.github/workflows/static.check.scripts/test_meson_version.sh
+++ b/.github/workflows/static.check.scripts/test_meson_version.sh
@@ -141,6 +141,18 @@ expect_checker 0 "punctuation between the two does not carry a version either" \
 "${MESON_BUILD}
 $(printf 'Documentation/getting-started-meson-build.md\tReally, meson?! (>=5.0) is unrelated.')"
 
+expect_checker 1 "a bracketed bold form is recognised" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\tBuild with **meson** (>= 0.62.0).')"
+
+expect_checker 0 "a space before the colon still yields the authority" \
+"$(printf 'meson.build\tproject(%s, %s, meson_version : %s)' "'nnstreamer'" "'c'" "'>=0.57.0'")
+$(printf 'AGENTS.md\tBuild system: **Meson >= 0.57.0 + Ninja**.')"
+
+expect_checker 1 "meson_version with a spaced colon is checked in a page" \
+"${MESON_BUILD}
+$(printf 'Documentation/how-to-run-examples.md\tIt declares meson_version : >=0.62.0 today.')"
+
 expect_checker 1 "two declarations on one line are both checked" \
 "${MESON_BUILD}
 $(printf 'Documentation/how-to-run-examples.md\tUse meson >= 0.56.0 on Ubuntu and Meson >= 0.62.0 on Tizen.')"

--- a/.github/workflows/static.check.scripts/test_meson_version.sh
+++ b/.github/workflows/static.check.scripts/test_meson_version.sh
@@ -103,6 +103,22 @@ expect_checker 0 "another package's requirement near the word meson is ignored" 
 "${MESON_BUILD}
 $(printf 'Documentation/getting-started-meson-build.md\tmeson.build additionally wants glib >= 2.60 at configure time.')"
 
+expect_checker 1 "markdown emphasis does not hide a declaration" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\tBuild system: **meson** >= 0.62.0 and ninja.')"
+
+expect_checker 1 "a code span does not hide a declaration" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\tYou need `meson` >= 0.62.0 to configure.')"
+
+expect_checker 1 "an upper case spelling does not hide a declaration" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\tMESON >= 0.62.0 is required.')"
+
+expect_checker 1 "meson.build syntax quoted in a page is checked too" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\tThe project declares meson_version: >=0.62.0 today.')"
+
 expect_checker 1 "two declarations on one line are both checked" \
 "${MESON_BUILD}
 $(printf 'Documentation/how-to-run-examples.md\tUse meson >= 0.56.0 on Ubuntu and Meson >= 0.62.0 on Tizen.')"

--- a/.github/workflows/static.check.scripts/test_meson_version.sh
+++ b/.github/workflows/static.check.scripts/test_meson_version.sh
@@ -133,6 +133,18 @@ expect_checker 1 "two declarations on one line are both checked" \
 "${MESON_BUILD}
 $(printf 'Documentation/how-to-run-examples.md\tUse meson >= 0.56.0 on Ubuntu and Meson >= 0.62.0 on Tizen.')"
 
+expect_checker 0 "a spaced >= in meson.build is still read as the authority" \
+"$(printf 'meson.build\tproject(%s, %s, meson_version: %s)' "'nnstreamer'" "'c'" "'>= 0.56.0'")
+$(printf 'AGENTS.md\tBuild system: **Meson >= 0.56.0 + Ninja**.')"
+
+expect_checker 1 "a declaration in a file outside the old list is caught" \
+"${MESON_BUILD}
+$(printf 'README.md\tnnstreamer builds with meson >= 0.62.0.')"
+
+expect_checker 1 "a declaration in a Documentation subdirectory is caught" \
+"${MESON_BUILD}
+$(printf 'Documentation/tutorials/tutorial1.md\tInstall meson >= 0.62.0 first.')"
+
 # A path with a space must not be skipped by word splitting.
 spaced_root="${workdir}/spaced"
 mkdir -p "${spaced_root}/Documentation"

--- a/.github/workflows/static.check.scripts/test_meson_version.sh
+++ b/.github/workflows/static.check.scripts/test_meson_version.sh
@@ -129,6 +129,18 @@ expect_checker 0 "an ellipsis breaks the association as well" \
 "${MESON_BUILD}
 $(printf 'Documentation/getting-started-meson-build.md\tAfter installing meson... (>=2024.1) support was added.')"
 
+expect_checker 0 "a bracketed aside does not carry a version to meson" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\tSee meson [*] (>=5.0) for the other tool.')"
+
+expect_checker 0 "a dashed aside does not carry a version to meson" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\tSee meson -- (>=9.0) for the other tool.')"
+
+expect_checker 0 "punctuation between the two does not carry a version either" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\tReally, meson?! (>=5.0) is unrelated.')"
+
 expect_checker 1 "two declarations on one line are both checked" \
 "${MESON_BUILD}
 $(printf 'Documentation/how-to-run-examples.md\tUse meson >= 0.56.0 on Ubuntu and Meson >= 0.62.0 on Tizen.')"

--- a/.github/workflows/static.check.scripts/test_meson_version.sh
+++ b/.github/workflows/static.check.scripts/test_meson_version.sh
@@ -14,7 +14,10 @@
 # a requirement. Without the first the checker could accept any drift; without
 # the last it would fail on prose that is simply describing a release. The
 # repository's own tree is checked at the end so the shipped files stay
-# covered when no fixture changes.
+# covered when no fixture changes. Later fixtures pin the parts that were
+# got wrong once: the version must come out of the matched text and not the
+# rest of the line, and a path carrying a space must not fall out of the
+# file list.
 #
 # The checker is invoked with stdin closed, matching how GitHub runs it, so
 # that a future reader-of-stdin bug fails here instead of hanging.
@@ -87,6 +90,34 @@ $(printf 'AGENTS.md\tBuild system: **Meson >= 0.56 + Ninja**.')"
 expect_checker 0 "a version a distro ships is not read as a requirement" \
 "${MESON_BUILD}
 $(printf 'Documentation/getting-started-meson-build.md\tUbuntu 20.04 ships meson 0.53.2, which is too old.')"
+
+expect_checker 0 "a neighbouring constraint on the same line is not read as meson's" \
+"${MESON_BUILD}
+$(printf 'debian/control\tBuild-Depends: meson (>=0.56.0), debhelper (>=9.20), libfoo (>= 1.2.3)')"
+
+expect_checker 1 "a neighbouring constraint does not mask a stale meson" \
+"${MESON_BUILD}
+$(printf 'debian/control\tBuild-Depends: meson (>=0.49.0), debhelper (>=0.56.0)')"
+
+expect_checker 0 "another package's requirement near the word meson is ignored" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\tmeson.build additionally wants glib >= 2.60 at configure time.')"
+
+expect_checker 1 "two declarations on one line are both checked" \
+"${MESON_BUILD}
+$(printf 'Documentation/how-to-run-examples.md\tUse meson >= 0.56.0 on Ubuntu and Meson >= 0.62.0 on Tizen.')"
+
+# A path with a space must not be skipped by word splitting.
+spaced_root="${workdir}/spaced"
+mkdir -p "${spaced_root}/Documentation"
+echo "project('nnstreamer', 'c', meson_version: '>=0.56.0')" > "${spaced_root}/meson.build"
+echo '* meson >= 0.62.0' > "${spaced_root}/Documentation/getting started.md"
+if bash "$CHECKER" "$spaced_root" > /dev/null 2>&1 < /dev/null; then
+  echo "FAIL: a path containing a space is silently skipped"
+  failed=1
+else
+  echo "PASS: a path containing a space is still checked (exit 1)"
+fi
 
 echo "Checking the tree shipped in this repository"
 if bash "$CHECKER" "$REPO_ROOT" < /dev/null; then

--- a/.github/workflows/static.check.scripts/test_meson_version.sh
+++ b/.github/workflows/static.check.scripts/test_meson_version.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# @file     test_meson_version.sh
+# @brief    Self-test for meson-version.sh.
+# @see      https://github.com/nnstreamer/nnstreamer
+# @author   MyungJoo Ham <myungjoo.ham@samsung.com>
+#
+# Builds throwaway trees and pins what the checker must say about each: a
+# declaration left behind must fail, matching declarations must pass, and a
+# version a distro merely ships, written without >=, must not be mistaken for
+# a requirement. Without the first the checker could accept any drift; without
+# the last it would fail on prose that is simply describing a release. The
+# repository's own tree is checked at the end so the shipped files stay
+# covered when no fixture changes.
+#
+# The checker is invoked with stdin closed, matching how GitHub runs it, so
+# that a future reader-of-stdin bug fails here instead of hanging.
+#
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../../.." && pwd)
+CHECKER="${SCRIPT_DIR}/meson-version.sh"
+workdir=$(mktemp -d)
+failed=0
+
+trap 'rm -rf "$workdir"' EXIT
+
+##
+# @brief Build a tree from "path<TAB>content" lines and run the checker on it.
+# @param $1 expected exit status, 0 or 1
+# @param $2 description used for the tree name and the report line
+# @param $3 newline separated "relative path<TAB>file content" entries
+expect_checker() {
+  local expected=$1 desc=$2 spec=$3
+  local root actual rel body
+
+  root="${workdir}/$(echo "$desc" | tr -c 'a-zA-Z0-9' '_')"
+  mkdir -p "$root"
+  while IFS=$'\t' read -r rel body; do
+    [ -z "$rel" ] && continue
+    mkdir -p "$(dirname "${root}/${rel}")"
+    printf '%s\n' "$body" > "${root}/${rel}"
+  done <<< "$spec"
+
+  bash "$CHECKER" "$root" > /dev/null 2>&1 < /dev/null
+  actual=$?
+  if [ $actual -ne 0 ]; then
+    actual=1
+  fi
+
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: ${desc} (exit ${actual})"
+  else
+    echo "FAIL: ${desc} expected exit ${expected}, got ${actual}"
+    failed=1
+  fi
+}
+
+MESON_BUILD=$'meson.build\tproject(\'nnstreamer\', \'c\', meson_version: \'>=0.56.0\')'
+
+expect_checker 0 "declarations that all agree pass" \
+"${MESON_BUILD}
+$(printf 'debian/control\tBuild-Depends: ninja-build, meson (>=0.56.0), debhelper (>=9)')
+$(printf 'AGENTS.md\tBuild system: **Meson >= 0.56.0 + Ninja**.')"
+
+expect_checker 1 "a control file left behind is rejected" \
+"${MESON_BUILD}
+$(printf 'debian/control\tBuild-Depends: ninja-build, meson (>=0.49), debhelper (>=9)')"
+
+expect_checker 1 "a document left behind is rejected" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\t* meson >= 0.62.0')"
+
+expect_checker 1 "a spec file left behind is rejected" \
+"${MESON_BUILD}
+$(printf 'packaging/nnstreamer.spec\tBuildRequires:\tmeson >= 0.62.0')"
+
+expect_checker 0 "an omitted patch component still matches" \
+"${MESON_BUILD}
+$(printf 'AGENTS.md\tBuild system: **Meson >= 0.56 + Ninja**.')"
+
+expect_checker 0 "a version a distro ships is not read as a requirement" \
+"${MESON_BUILD}
+$(printf 'Documentation/getting-started-meson-build.md\tUbuntu 20.04 ships meson 0.53.2, which is too old.')"
+
+echo "Checking the tree shipped in this repository"
+if bash "$CHECKER" "$REPO_ROOT" < /dev/null; then
+  echo "PASS: the repository declares meson consistently"
+else
+  echo "FAIL: the repository meson declarations disagree"
+  failed=1
+fi
+
+if [ "$failed" -ne 0 ]; then
+  echo "::error::test_meson_version.sh has failed."
+  exit 1
+fi
+
+echo "test_meson_version.sh has passed."

--- a/.github/workflows/static.check.scripts/test_meson_version.sh
+++ b/.github/workflows/static.check.scripts/test_meson_version.sh
@@ -157,6 +157,37 @@ else
   echo "PASS: a path containing a space is still checked (exit 1)"
 fi
 
+# In a repository, only tracked files count: a document left in a build
+# directory belongs to nobody and must not fail the check. The fixture trees
+# above are not repositories, so they cover the find fallback instead.
+if command -v git > /dev/null 2>&1; then
+  git_root="${workdir}/tracked"
+  mkdir -p "${git_root}/build/vendor"
+  echo "project('nnstreamer', 'c', meson_version: '>=0.57.0')" > "${git_root}/meson.build"
+  echo 'Build system: **Meson >= 0.57.0 + Ninja**.' > "${git_root}/AGENTS.md"
+  echo '* meson >= 0.62.0' > "${git_root}/build/vendor/README.md"
+  (
+    cd "$git_root" || exit 1
+    git init -q .
+    git add meson.build AGENTS.md
+  ) > /dev/null 2>&1
+  if bash "$CHECKER" "$git_root" > /dev/null 2>&1 < /dev/null; then
+    echo "PASS: an untracked document is not checked (exit 0)"
+  else
+    echo "FAIL: an untracked document was checked"
+    failed=1
+  fi
+  (cd "$git_root" && git add build/vendor/README.md) > /dev/null 2>&1
+  if bash "$CHECKER" "$git_root" > /dev/null 2>&1 < /dev/null; then
+    echo "FAIL: tracking that document did not bring it under the check"
+    failed=1
+  else
+    echo "PASS: the same document is checked once tracked (exit 1)"
+  fi
+else
+  echo "SKIP: git is unavailable, tracked-file selection not covered"
+fi
+
 echo "Checking the tree shipped in this repository"
 if bash "$CHECKER" "$REPO_ROOT" < /dev/null; then
   echo "PASS: the repository declares meson consistently"

--- a/.github/workflows/static.check.scripts/test_meson_version.sh
+++ b/.github/workflows/static.check.scripts/test_meson_version.sh
@@ -107,6 +107,8 @@ expect_checker 1 "markdown emphasis does not hide a declaration" \
 "${MESON_BUILD}
 $(printf 'Documentation/getting-started-meson-build.md\tBuild system: **meson** >= 0.62.0 and ninja.')"
 
+# The backticks below are the markdown being tested, not a substitution.
+# shellcheck disable=SC2016
 expect_checker 1 "a code span does not hide a declaration" \
 "${MESON_BUILD}
 $(printf 'Documentation/getting-started-meson-build.md\tYou need `meson` >= 0.62.0 to configure.')"

--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -215,6 +215,32 @@ jobs:
           else
             echo "Skipped: $selftest is not in this branch's tree and this PR does not remove it."
           fi
+      - name: /Checker/ meson version declarations agree
+        # Checks a fixed set of files rather than $changed_file_list, so it
+        # needs the same merge-ref guard as the steps above.
+        run: |
+          checker=.github/workflows/static.check.scripts/meson-version.sh
+          if [ -f "$checker" ]; then
+            bash "$checker"
+          elif git show --pretty="format:" --name-only --no-renames --diff-filter=D ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | grep -qxF "$checker"; then
+            echo "::error::This PR removes $checker; remove its workflow step too, or restore the script (also update this step if the script moved)."
+            exit 1
+          else
+            echo "Skipped: $checker is not in this branch's tree and this PR does not remove it."
+          fi
+      - name: /Checker/ meson-version self-test
+        # Runs a repository script unrelated to $changed_file_list, so it
+        # needs the same merge-ref guard as the step above.
+        run: |
+          selftest=.github/workflows/static.check.scripts/test_meson_version.sh
+          if [ -f "$selftest" ]; then
+            bash "$selftest"
+          elif git show --pretty="format:" --name-only --no-renames --diff-filter=D ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | grep -qxF "$selftest"; then
+            echo "::error::This PR removes $selftest; remove its workflow step too, or restore the script (also update this step if the script moved)."
+            exit 1
+          else
+            echo "Skipped: $selftest is not in this branch's tree and this PR does not remove it."
+          fi
       - name: /Checker/ shellcheck for shell scripts
         # Originally from "pr-prebuild-shellcheck"
         run: |

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -125,6 +125,11 @@ jobs:
         # have. Meson does say so, and only in a warning: the PPA build for a
         # distro carrying an older meson is where it turns into a failure, far
         # from here. Catch it on a required check instead.
+        #
+        # This sees only what this job configures. A block behind an SDK that
+        # is not installed here - SNPE, TensorRT, tensorflow, pytorch, ncnn,
+        # mvncsdk2 - is never visited, so it can still carry a construct newer
+        # than the floor.
         if grep -q 'uses feature introduced' build/meson-logs/meson-log.txt; then
           grep 'uses feature introduced' build/meson-logs/meson-log.txt
           echo "::error::This tree uses a meson feature newer than the meson_version floor in meson.build. Use an older construct, or raise the floor only if every distro that has to build this ships that meson."

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -119,6 +119,18 @@ jobs:
       if: env.rebuild == '1'
       run: |
         meson setup build/ -Darmnn-support=enabled
+
+        # This job installs the newest meson from PyPI, so it configures
+        # happily with a construct that the meson on a target distro does not
+        # have. Meson does say so, and only in a warning: the PPA build for a
+        # distro carrying an older meson is where it turns into a failure, far
+        # from here. Catch it on a required check instead.
+        if grep -q 'uses feature introduced' build/meson-logs/meson-log.txt; then
+          grep 'uses feature introduced' build/meson-logs/meson-log.txt
+          echo "::error::This tree uses a meson feature newer than the meson_version floor in meson.build. Use an older construct, or raise the floor only if every distro that has to build this ships that meson."
+          exit 1
+        fi
+
         meson compile -C build/
 
         if [ '${{ matrix.os }}' == 'ubuntu-22.04' ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ### Project Overview
 
-NNStreamer is a set of GStreamer plugins (C/C++) that integrate neural network inference into media streaming pipelines. Build system: **Meson >= 0.56.0 + Ninja**. See `Documentation/getting-started-meson-build.md` for full build instructions.
+NNStreamer is a set of GStreamer plugins (C/C++) that integrate neural network inference into media streaming pipelines. Build system: **Meson >= 0.57.0 + Ninja**. See `Documentation/getting-started-meson-build.md` for full build instructions.
 
 ### Build & Run
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ### Project Overview
 
-NNStreamer is a set of GStreamer plugins (C/C++) that integrate neural network inference into media streaming pipelines. Build system: **Meson >= 0.62.0 + Ninja**. See `Documentation/getting-started-meson-build.md` for full build instructions.
+NNStreamer is a set of GStreamer plugins (C/C++) that integrate neural network inference into media streaming pipelines. Build system: **Meson >= 0.56.0 + Ninja**. See `Documentation/getting-started-meson-build.md` for full build instructions.
 
 ### Build & Run
 

--- a/Documentation/getting-started-meson-build.md
+++ b/Documentation/getting-started-meson-build.md
@@ -20,7 +20,7 @@ The following dependencies are needed to compile/build/run.
 * gcc/g++ (C++17 for C++-class filters)
 * gstreamer 1.0 and its relatives
 * glib 2.0
-* meson >= 0.56.0
+* meson >= 0.57.0
 * ninja-build
 * Neural network frameworks or libraries for plugins (e.g., tensorflow) you want to use, including their pkgconfig files or mechanisms to allow meson to discover its headers and libraries. If you use development packages packaged by us for tensorflow/pytorch/openvino/..., you do not need to worry.
     * Possible frameworks for "extra" plugins: tensorflow, tensorflow-lite, pytorch, protobuf, flatbuf, openvino, ncsdk2, Verisilicon-Vivante, SNPE, TensorRT, mqtt, ...

--- a/Documentation/getting-started-meson-build.md
+++ b/Documentation/getting-started-meson-build.md
@@ -20,7 +20,7 @@ The following dependencies are needed to compile/build/run.
 * gcc/g++ (C++17 for C++-class filters)
 * gstreamer 1.0 and its relatives
 * glib 2.0
-* meson >= 0.62.0
+* meson >= 0.56.0
 * ninja-build
 * Neural network frameworks or libraries for plugins (e.g., tensorflow) you want to use, including their pkgconfig files or mechanisms to allow meson to discover its headers and libraries. If you use development packages packaged by us for tensorflow/pytorch/openvino/..., you do not need to worry.
     * Possible frameworks for "extra" plugins: tensorflow, tensorflow-lite, pytorch, protobuf, flatbuf, openvino, ncsdk2, Verisilicon-Vivante, SNPE, TensorRT, mqtt, ...

--- a/Documentation/how-to-run-examples.md
+++ b/Documentation/how-to-run-examples.md
@@ -43,7 +43,7 @@ Ubuntu 22.04 (LTS) is currently supported.
 * [getting-started](getting-started.md)
 
 - Install related packages before building nnstreamer and examples.
-1. ninja-build, meson (>=0.62.0)
+1. ninja-build, meson (>=0.56.0)
 2. liborc (>=0.4.17, optional)
 3. tensorflow, protobuf (>=3.6.1)
 4. tensorflow-lite

--- a/Documentation/how-to-run-examples.md
+++ b/Documentation/how-to-run-examples.md
@@ -43,7 +43,7 @@ Ubuntu 22.04 (LTS) is currently supported.
 * [getting-started](getting-started.md)
 
 - Install related packages before building nnstreamer and examples.
-1. ninja-build, meson (>=0.56.0)
+1. ninja-build, meson (>=0.57.0)
 2. liborc (>=0.4.17, optional)
 3. tensorflow, protobuf (>=3.6.1)
 4. tensorflow-lite

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
 Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4) | gcc,
- ninja-build, meson (>=0.62.0), debhelper (>=9), nnstreamer-edge-dev,
+ ninja-build, meson (>=0.56.0), debhelper (>=9), nnstreamer-edge-dev,
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev, libjson-glib-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev, flex, bison,

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
 Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4) | gcc,
- ninja-build, meson (>=0.56.0), debhelper (>=9), nnstreamer-edge-dev,
+ ninja-build, meson (>=0.57.0), debhelper (>=9), nnstreamer-edge-dev,
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev, libjson-glib-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev, flex, bison,

--- a/debian/control.debian
+++ b/debian/control.debian
@@ -3,7 +3,7 @@ Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
 Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4) | gcc,
- ninja-build, meson (>=0.49), debhelper (>=9), nnstreamer-edge-dev,
+ ninja-build, meson (>=0.56.0), debhelper (>=9), nnstreamer-edge-dev,
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  libgtest-dev, libpng-dev, libopencv-dev, liborc-0.4-dev, flex, bison,

--- a/debian/control.debian
+++ b/debian/control.debian
@@ -3,7 +3,7 @@ Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
 Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4) | gcc,
- ninja-build, meson (>=0.56.0), debhelper (>=9), nnstreamer-edge-dev,
+ ninja-build, meson (>=0.57.0), debhelper (>=9), nnstreamer-edge-dev,
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  libgtest-dev, libpng-dev, libopencv-dev, liborc-0.4-dev, flex, bison,

--- a/debian/control.ubuntu.ppa
+++ b/debian/control.ubuntu.ppa
@@ -3,7 +3,7 @@ Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
 Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4) | gcc,
- ninja-build, meson (>=0.49), debhelper (>=9), nnstreamer-edge-dev,
+ ninja-build, meson (>=0.56.0), debhelper (>=9), nnstreamer-edge-dev,
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev, libjson-glib-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev, flex, bison,

--- a/debian/control.ubuntu.ppa
+++ b/debian/control.ubuntu.ppa
@@ -3,7 +3,7 @@ Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
 Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4) | gcc,
- ninja-build, meson (>=0.56.0), debhelper (>=9), nnstreamer-edge-dev,
+ ninja-build, meson (>=0.57.0), debhelper (>=9), nnstreamer-edge-dev,
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev, libjson-glib-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev, flex, bison,

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 project('nnstreamer', 'c', 'cpp',
   version: '2.7.0',
   license: ['LGPL-2.1'],
-  meson_version: '>=0.62.0',
+  meson_version: '>=0.56.0',
   default_options: [
     'werror=true',
     'warning_level=2',
@@ -170,7 +170,8 @@ flatbuf_dep = disabler()
 flatbuf_version_check_dep = disabler()
 flatc_dep = disabler()
 if flatc.found()
-  flatc_ver = flatc.version()
+  # flatc.version() needs meson 0.62.0, which Ubuntu 22.04 does not ship.
+  flatc_ver = run_command(flatc, '--version', check : true).stdout().split()[2]
   flatbuf_dep = dependency('flatbuffers', version: flatc_ver,
       required : get_option('flatbuf-support'),
       not_found_message : 'flatbuffers version '+flatc_ver+' is required because flatc (flatbuf-compiler) '+flatc_ver+' is installed'

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 project('nnstreamer', 'c', 'cpp',
   version: '2.7.0',
   license: ['LGPL-2.1'],
-  meson_version: '>=0.56.0',
+  meson_version: '>=0.57.0',
   default_options: [
     'werror=true',
     'warning_level=2',

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -223,7 +223,7 @@ BuildRequires:	gstreamer-devel
 BuildRequires:	gst-plugins-base-devel
 BuildRequires:	gst-plugins-bad-devel
 BuildRequires:	glib2-devel
-BuildRequires:	meson >= 0.56.0
+BuildRequires:	meson >= 0.57.0
 
 %{?_toolchain:
 %if %{toolchain_is clang}

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -223,7 +223,7 @@ BuildRequires:	gstreamer-devel
 BuildRequires:	gst-plugins-base-devel
 BuildRequires:	gst-plugins-bad-devel
 BuildRequires:	glib2-devel
-BuildRequires:	meson >= 0.62.0
+BuildRequires:	meson >= 0.56.0
 
 %{?_toolchain:
 %if %{toolchain_is clang}


### PR DESCRIPTION
## Problem

The PPA has published nothing for jammy since 2025-12-04. The Launchpad recipe
build has been parked since 2025-12-19:

```
Build status: Dependency wait
Missing build dependencies: meson (>= 0.62.0)
Series: Jammy
```

647b30e5 raised the minimum meson to 0.62.0. Ubuntu 22.04 ships 0.61.2:

| series | archive meson | in the nnstreamer PPA |
|---|---|---|
| focal 20.04 | 0.53.2 | **1.6.1** — this is why focal still builds |
| jammy 22.04 | 0.61.2 | none |
| noble 24.04 | 1.3.2 | — |
| plucky 25.04 | 1.7.0 | — |
| resolute 26.04 | 1.10.1 | — |

CI did not catch it because the same commit added
`ppa:kubuntu-ppa/backports-extra` (meson 0.63.2) to the pdebuild chroot. The
Launchpad recipe has no such archive, so CI went green while the PPA silently
stopped.

## What actually needs 0.62.0

One construct: `ExternalProgram.version()`, used once for the flatc version.
Probed on jammy's meson directly:

```
meson.build:4:2: ERROR: Unknown method "version" in object
<[ExternalProgramHolder] holds [ExternalProgram]: <ExternalProgram 'flatc' -> ['/usr/bin/flatc']>>
```

Everything else 647b30e5 introduced needs at most 0.56.0 — the `fs` module
(0.53), `ExternalProgram.full_path()` (0.55), `meson.project_source_root()` and
`meson.project_build_root()` (0.56). The floor lands a step above that at
0.57.0, because of something 647b30e5 never touched; see the verification
section.

## Change

Read the flatc version through `run_command` again, as this file did before
647b30e5, and declare 0.57.0. **The version check itself is unchanged**:
libflatbuffers must still match the installed flatc exactly, and must still be
at least 2.0.0. Only the call used to obtain the string differs. Confirmed
live on jammy:

```
meson 0.61.2  /  flatc version 1.12.0
Message: flatbuffers version 1.12.0 is required because flatc (flatbuf-compiler) 1.12.0 is installed
Run-time dependency flatbuffers found: NO
```

That is the check correctly rejecting jammy's libflatbuffers 2.0.0 against
flatc 1.12.0, so it is demonstrably still doing its job. None of the other
modernisation from 647b30e5 is touched.

## Verification, and how the floor was corrected

The floor first proposed here was 0.56.0, derived from
`meson.project_source_root()`, and sampling meson 0.56.0, 0.58.2, 0.60.3 and
0.61.2 configured cleanly under each. That sampling was wrong, and the check
below caught it on its first CI run:

```
meson.build:342: WARNING: Project targets '>= 0.56.0' but uses feature
introduced in '0.57.0': compiler method "dependencies" kwarg with internal dep.
```

That is the LiteRT sanity link, `cxx.links(..., dependencies: litert_dep)`, and
it sits behind `if litert_dep.found()`. A configure without the LiteRT SDK never
visits it, so every one of those samples missed it; the required Valgrind job
installs LiteRT and does visit it. The floor is 0.57.0, declared across all
eight sites. jammy carries 0.61.2, so the point of coming down from 0.62.0
stands.

The lesson is in the method: asking meson to enumerate what exceeds the floor
beats sampling versions that happen to configure, because the option set decides
which code paths a configure visits at all. meson 0.57.0 configures the tree
with zero feature warnings.

Full build with tests on jammy stock meson, no backports archive:

```
Ubuntu 22.04.4 LTS / gcc 11.4.0 / meson 0.61.2 / flatc 1.12.0
[256/256] Linking target tests/unittest_sink
=== NINJA OK ===
```

## Consistency

`debian/control.ubuntu.ppa` and `debian/control.debian` were still at
`meson (>=0.49)` while `meson.build` required 0.62.0. That understatement
reaches users: `debian/rules` copies `control.ubuntu.ppa` over `debian/control`
during `dh_clean`, before the source package is generated, so it is the
`ubuntu.ppa` value that ends up in the published `.dsc` and gates the binary
build. From the current noble publication:

```
$ curl -s .../nnstreamer_2.7.0.0-0~202512190802~ubuntu24.04.1.dsc
Build-Depends: ... ninja-build, meson (>= 0.49), ...
```

So the source build and the binary build were resolving against different
requirements. All eight sites now say 0.57.0: `meson.build`, the three control
files, `packaging/nnstreamer.spec`, `AGENTS.md`, and two Documentation pages.

## Regression test

Two guards, and one of them is weaker than it looks.

**The floor itself.** The two CI workarounds are removed, so the jobs that
build against a real jammy toolchain do what the Launchpad recipe does:
`pdebuild.yml` drops the `kubuntu-ppa/backports-extra` mirror, and `risc-v.yml`
installs the distro `meson` package again instead of `pip3 install meson`.
Reintroducing a construct newer than 0.61.2 makes both fail.

Neither of those is a required status check, though. Required on `main` are
DCO, the three Tizen GBS jobs, MacOS, Android NDK, LLVM/Clang, Valgrind on
ubuntu-22.04, and Static checks; of those, the ubuntu-22.04 jobs run `pip
install meson ninja`, which fetches PyPI's newest regardless of the runner's
release, and MacOS uses `brew install meson`. A red pdebuild alone would not
block a merge.

So the required Valgrind job now carries the check directly. The newest meson
is precisely the one that knows every feature's introduction version, and it
reports the problem — as a warning, which is why nobody saw it:

```
meson.build:174: WARNING: Project targets '>= 0.57.0' but uses feature
introduced in '0.62.0': Program.version.
```

The job reads that out of `build/meson-logs/meson-log.txt` after the configure
it already runs, so no existing step changes. Measured with the newest meson:
no match and a pass on this tree, one match and a failure with
`ExternalProgram.version()` put back. `--fatal-meson-warnings` would be tidier
but is unusable — the tree already emits two unrelated warnings about a
`>= 0.52.0` conditional in `tools/development/parser/meson.build` that the
floor has made constant.

Making pdebuild and risc-v required is still a branch-protection setting and
still worth doing, but the floor no longer depends on it.

**The declarations.** `meson-version.sh` takes `meson.build` as the authority
and requires the other seven sites to match. It rejects the tree as it stood
before the second commit here and accepts it after, and it runs under Static
checks, which *is* required. This is the guard for the failure that actually
happened twice: 647b30e5 left two control files at 0.49, and the first commit
of this PR left three documents at 0.62.0.

There is no unit or SSAT test, because nothing in the built artifacts changes.
The constraint is a build-time dependency version, so a checker over the
declarations and CI running the real toolchain are what can detect it.

## Scope

This unblocks jammy only. It does not affect focal, noble, or the newer series,
which all have meson well above the floor. #4902 tracks the remaining release
work.
