### PR TITLE
[Filter/LiteRT] Let the run write outputs into the caller's tensor

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -31,14 +31,18 @@
  *      Select the model signature to run by its key string.
  *      Default: the first signature (index 0).
  *
- * @todo Zero-copy invoke by wrapping GstTensorMemory with
- *       LiteRtCreateTensorBufferFromHostMemory when alignment permits.
+ * @todo Zero-copy the input side too. Outputs already skip the copy when
+ *       LiteRT accepts the caller's memory, but inputs cannot: tensor_filter
+ *       maps them GST_MAP_READ and the memory may be shared with another
+ *       branch, so it would take a mapping change in the element plus a
+ *       statement from upstream that a run never writes to an input.
  * @todo Support dynamic input dimensions (invoke_dynamic).
  * @todo Expose accelerator-specific opaque options (GPU precision, NPU
  *       compiler plugin paths, etc.).
  */
 
 #include <cerrno>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <mutex>
@@ -135,6 +139,45 @@ LiteRtEnvironment litert_env = nullptr;
 unsigned int litert_env_refs = 0;
 
 /**
+ * @brief Whether a pointer meets LiteRT's host memory buffer alignment.
+ */
+inline bool
+isHostMemoryAligned (const void *data)
+{
+  return (reinterpret_cast<uintptr_t> (data) % LITERT_HOST_MEMORY_BUFFER_ALIGNMENT) == 0;
+}
+
+/**
+ * @brief Destroys the tensor buffers that wrap caller memory for one invoke.
+ *
+ * The wrappers are created with a null deallocator, so this releases only the
+ * LiteRT objects and never the caller's memory. Holding them in a scope guard
+ * keeps a throw between creation and the run from leaking them.
+ */
+class wrapped_buffers final
+{
+  public:
+  wrapped_buffers () = default;
+  ~wrapped_buffers ()
+  {
+    for (auto &buf : held)
+      LiteRtDestroyTensorBuffer (buf);
+  }
+
+  wrapped_buffers (const wrapped_buffers &) = delete;
+  wrapped_buffers &operator= (const wrapped_buffers &) = delete;
+
+  /** @brief Take ownership of one wrapper. */
+  void hold (LiteRtTensorBuffer buf)
+  {
+    held.push_back (buf);
+  }
+
+  private:
+  std::vector<LiteRtTensorBuffer> held{};
+};
+
+/**
  * @brief Take a reference to the shared environment, creating it if needed.
  * @return the shared environment; the caller must not destroy it
  * @throw std::runtime_error if the environment cannot be created
@@ -218,12 +261,17 @@ class litert_subplugin final : public tensor_filter_subplugin
   std::vector<size_t> input_tensor_sizes{}; /**< nnstreamer tensor sizes; each is <= its LiteRT buffer */
   std::vector<size_t> output_tensor_sizes{}; /**< nnstreamer tensor sizes; each is <= its LiteRT buffer */
 
+  std::vector<LiteRtRankedTensorType> output_types{}; /**< to wrap caller memory per invoke */
+  std::vector<char> output_wrappable{}; /**< requirements allow host memory and the sizes match exactly */
+  std::vector<LiteRtTensorBuffer> invoke_outputs{}; /**< per-invoke argument array, storage reused */
+
   void cleanup ();
   void parseCustomProperties (const GstTensorFilterProperties *prop);
   void applyHwList (const GstTensorFilterProperties *prop);
   LiteRtParamIndex resolveSignature () const;
   void setTensorMeta (LiteRtSignature sig, bool is_input, GstTensorsInfo *meta);
   void createTensorBuffers ();
+  static bool requirementsAllowHostMemory (LiteRtTensorBufferRequirements reqs);
 
   static tensor_type convertElementType (LiteRtElementType type);
   static void convertLayout (const LiteRtLayout &layout, tensor_dim dim);
@@ -268,6 +316,9 @@ litert_subplugin::cleanup ()
       LiteRtDestroyTensorBuffer (buf);
     output_buffers.clear ();
     output_tensor_sizes.clear ();
+    output_types.clear ();
+    output_wrappable.clear ();
+    invoke_outputs.clear ();
 
     if (compiled_model != nullptr) {
       LiteRtDestroyCompiledModel (compiled_model);
@@ -651,7 +702,38 @@ litert_subplugin::createTensorBuffers ()
                                 + std::to_string (buf_size) + " B) than the tensor ("
                                 + std::to_string (nns_size) + " B).");
     output_tensor_sizes.push_back ((size_t) nns_size);
+
+    output_types.push_back (ranked_type);
+    /** A larger LiteRT buffer means it carries padding the caller's tensor has
+     *  no room for, so only an exact match may back the run directly. */
+    output_wrappable.push_back (
+        (buf_size == (size_t) nns_size && requirementsAllowHostMemory (reqs)) ? 1 : 0);
   }
+
+  invoke_outputs.resize (outputTensorMeta.num_tensors);
+}
+
+/**
+ * @brief Whether a tensor's buffer requirements admit plain host memory.
+ */
+bool
+litert_subplugin::requirementsAllowHostMemory (LiteRtTensorBufferRequirements reqs)
+{
+  int num_types = 0;
+
+  if (LiteRtGetNumTensorBufferRequirementsSupportedBufferTypes (reqs, &num_types) != kLiteRtStatusOk)
+    return false;
+
+  for (int i = 0; i < num_types; ++i) {
+    LiteRtTensorBufferType type;
+
+    if (LiteRtGetTensorBufferRequirementsSupportedTensorBufferType (reqs, i, &type) != kLiteRtStatusOk)
+      return false;
+    if (type == kLiteRtTensorBufferTypeHostMemory)
+      return true;
+  }
+
+  return false;
 }
 
 /**
@@ -768,14 +850,16 @@ litert_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
     LITERT_CHECK (LiteRtUnlockTensorBuffer (input_buffers[i]));
   }
 
-  LITERT_CHECK (LiteRtRunCompiledModel (compiled_model, signature_index,
-      input_buffers.size (), input_buffers.data (), output_buffers.size (),
-      output_buffers.data ()));
+  /** Let the run write straight into the caller's tensor where LiteRT will
+   *  accept it, which drops the read-back copy below for that tensor.
+   *
+   *  Only outputs. The input side is mapped GST_MAP_READ by tensor_filter and
+   *  its memory may be shared with another branch of the pipeline, so handing
+   *  it out as a writable buffer would rest on LiteRT never writing to an
+   *  input - which upstream does not state anywhere. */
+  wrapped_buffers wrappers;
 
-  /* Read back output buffers */
   for (i = 0; i < outputTensorMeta.num_tensors; ++i) {
-    void *host_mem = nullptr;
-
     if (output[i].data == nullptr)
       throw std::invalid_argument ("Output tensor memory is null.");
 
@@ -785,6 +869,29 @@ litert_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
       throw std::invalid_argument ("Output tensor " + std::to_string (i) + " ("
                                    + std::to_string (output[i].size) + " B) does not match the model tensor ("
                                    + std::to_string (output_tensor_sizes[i]) + " B).");
+
+    if (output_wrappable[i] && isHostMemoryAligned (output[i].data)) {
+      LiteRtTensorBuffer buf = nullptr;
+
+      LITERT_CHECK (LiteRtCreateTensorBufferFromHostMemory (
+          &output_types[i], output[i].data, output[i].size, nullptr, &buf));
+      wrappers.hold (buf);
+      invoke_outputs[i] = buf;
+    } else {
+      invoke_outputs[i] = output_buffers[i];
+    }
+  }
+
+  LITERT_CHECK (LiteRtRunCompiledModel (compiled_model, signature_index,
+      input_buffers.size (), input_buffers.data (), invoke_outputs.size (),
+      invoke_outputs.data ()));
+
+  /* Read back the outputs that the run could not write into directly */
+  for (i = 0; i < outputTensorMeta.num_tensors; ++i) {
+    void *host_mem = nullptr;
+
+    if (invoke_outputs[i] != output_buffers[i])
+      continue;
 
     LITERT_CHECK (LiteRtLockTensorBuffer (
         output_buffers[i], &host_mem, kLiteRtTensorBufferLockModeRead));

--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -746,7 +746,11 @@ litert_subplugin::createTensorBuffers ()
      *  user, and it is the only way the choice is visible from outside: both
      *  branches return identical bytes, so nothing else would notice if a
      *  future SDK stopped reporting host memory here and the direct path
-     *  quietly went dead. */
+     *  quietly went dead.
+     *
+     *  zeroCopyDirectPathElected in unittest_filter_litert.cc matches on
+     *  "will be written directly", so reword that phrase and the test starts
+     *  failing as though the path were gone. Change both together. */
     ml_logd ("litert output %u (%zu B) will be %s", i, (size_t) nns_size,
         wrappable ? "written directly when aligned" : "copied");
   }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -283,7 +283,7 @@ class litert_subplugin final : public tensor_filter_subplugin
   std::vector<size_t> output_tensor_sizes{}; /**< nnstreamer tensor sizes; each is <= its LiteRT buffer */
 
   std::vector<LiteRtRankedTensorType> output_types{}; /**< to wrap caller memory per invoke */
-  std::vector<char> output_wrappable{}; /**< requirements allow host memory and the sizes match exactly */
+  std::vector<char> output_wrappable{}; /**< LiteRT chose host memory, the sizes match exactly and it is worth wrapping */
   std::vector<LiteRtTensorBuffer> invoke_outputs{}; /**< per-invoke argument array, storage reused */
 
   void cleanup ();
@@ -741,6 +741,14 @@ litert_subplugin::createTensorBuffers ()
                            && (LiteRtGetTensorBufferType (buf, &buf_type) == kLiteRtStatusOk)
                            && (buf_type == kLiteRtTensorBufferTypeHostMemory);
     output_wrappable.push_back (wrappable ? 1 : 0);
+
+    /** Report the decision. It answers "why am I not seeing zero-copy" for a
+     *  user, and it is the only way the choice is visible from outside: both
+     *  branches return identical bytes, so nothing else would notice if a
+     *  future SDK stopped reporting host memory here and the direct path
+     *  quietly went dead. */
+    ml_logd ("litert output %u (%zu B) will be %s", i, (size_t) nns_size,
+        wrappable ? "written directly when aligned" : "copied");
   }
 
   invoke_outputs.resize (outputTensorMeta.num_tensors);

--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -177,6 +177,8 @@ class wrapped_buffers final
 {
   public:
   wrapped_buffers () = default;
+
+  /** @brief Release every wrapper taken during this invoke. */
   ~wrapped_buffers ()
   {
     for (auto &buf : held)
@@ -290,7 +292,6 @@ class litert_subplugin final : public tensor_filter_subplugin
   LiteRtParamIndex resolveSignature () const;
   void setTensorMeta (LiteRtSignature sig, bool is_input, GstTensorsInfo *meta);
   void createTensorBuffers ();
-  static bool requirementsAllowHostMemory (LiteRtTensorBufferRequirements reqs);
 
   static tensor_type convertElementType (LiteRtElementType type);
   static void convertLayout (const LiteRtLayout &layout, tensor_dim dim);
@@ -722,41 +723,27 @@ litert_subplugin::createTensorBuffers ()
                                 + std::to_string (nns_size) + " B).");
     output_tensor_sizes.push_back ((size_t) nns_size);
 
+    LiteRtTensorBufferType buf_type;
+
     output_types.push_back (ranked_type);
 
-    /** A larger LiteRT buffer means it carries padding the caller's tensor has
-     *  no room for, so only an exact match may back the run directly. The size
+    /** Swap like for like. Asking whether the requirements *allow* host memory
+     *  is not the same question: with an accelerator enabled they can allow it
+     *  while LiteRT still picked a device buffer, and wrapping there would
+     *  force the output back to the host on every invoke, adding a transfer
+     *  the managed path never paid. So gate on the type LiteRT actually chose.
+     *
+     *  A larger LiteRT buffer carries padding the caller's tensor has no room
+     *  for, so only an exact match may back the run directly, and the size
      *  floor keeps the wrap off tensors whose copy is cheaper than it. */
     const bool wrappable = (buf_size == (size_t) nns_size)
                            && ((size_t) nns_size >= litert_wrap_min_bytes)
-                           && requirementsAllowHostMemory (reqs);
+                           && (LiteRtGetTensorBufferType (buf, &buf_type) == kLiteRtStatusOk)
+                           && (buf_type == kLiteRtTensorBufferTypeHostMemory);
     output_wrappable.push_back (wrappable ? 1 : 0);
   }
 
   invoke_outputs.resize (outputTensorMeta.num_tensors);
-}
-
-/**
- * @brief Whether a tensor's buffer requirements admit plain host memory.
- */
-bool
-litert_subplugin::requirementsAllowHostMemory (LiteRtTensorBufferRequirements reqs)
-{
-  int num_types = 0;
-
-  if (LiteRtGetNumTensorBufferRequirementsSupportedBufferTypes (reqs, &num_types) != kLiteRtStatusOk)
-    return false;
-
-  for (int i = 0; i < num_types; ++i) {
-    LiteRtTensorBufferType type;
-
-    if (LiteRtGetTensorBufferRequirementsSupportedTensorBufferType (reqs, i, &type) != kLiteRtStatusOk)
-      return false;
-    if (type == kLiteRtTensorBufferTypeHostMemory)
-      return true;
-  }
-
-  return false;
 }
 
 /**
@@ -849,7 +836,11 @@ litert_subplugin::invoke (const GstTensorMemory *input, GstTensorMemory *output)
   /** Shared, so inference is never serialized across instances; see the
    *  shared-environment comment for why concurrent invoke is a reasoned
    *  choice rather than a documented guarantee. This only blocks while
-   *  another instance is being configured or torn down. */
+   *  another instance is being configured or torn down.
+   *
+   *  Across instances, not within one: invoke_outputs below is instance state
+   *  written before the run, so a single instance still expects the one
+   *  streaming thread the framework gives it. */
   std::shared_lock<std::shared_mutex> guard (litert_env_lock);
 
   /* Fill input buffers */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -139,6 +139,23 @@ LiteRtEnvironment litert_env = nullptr;
 unsigned int litert_env_refs = 0;
 
 /**
+ * @brief Output size from which wrapping the caller's memory beats copying it.
+ *
+ * Wrapping is not free: creating and destroying a tensor buffer around caller
+ * memory measured 1.3-2.4 us on x86_64, against 0.06-0.28 us to lock, copy and
+ * unlock a 4 kB output. On a classifier it therefore costs an order of
+ * magnitude more than the copy it removes, and only starts paying once the
+ * copy grows. A segmentation model's 5 MB output, by contrast, copies for
+ * hundreds of microseconds and wraps for the same 2 us.
+ *
+ * 256 kB sits well above the break-even, so a tensor taking the direct path is
+ * a clear win rather than a marginal one. The figures are indicative of one
+ * machine; the threshold is deliberately conservative so that being wrong
+ * about them costs a copy that was already cheap.
+ */
+constexpr size_t litert_wrap_min_bytes = 256 * 1024;
+
+/**
  * @brief Whether a pointer meets LiteRT's host memory buffer alignment.
  */
 inline bool
@@ -704,10 +721,14 @@ litert_subplugin::createTensorBuffers ()
     output_tensor_sizes.push_back ((size_t) nns_size);
 
     output_types.push_back (ranked_type);
+
     /** A larger LiteRT buffer means it carries padding the caller's tensor has
-     *  no room for, so only an exact match may back the run directly. */
-    output_wrappable.push_back (
-        (buf_size == (size_t) nns_size && requirementsAllowHostMemory (reqs)) ? 1 : 0);
+     *  no room for, so only an exact match may back the run directly. The size
+     *  floor keeps the wrap off tensors whose copy is cheaper than it. */
+    const bool wrappable = (buf_size == (size_t) nns_size)
+                           && ((size_t) nns_size >= litert_wrap_min_bytes)
+                           && requirementsAllowHostMemory (reqs);
+    output_wrappable.push_back (wrappable ? 1 : 0);
   }
 
   invoke_outputs.resize (outputTensorMeta.num_tensors);

--- a/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_litert.cc
@@ -148,8 +148,10 @@ unsigned int litert_env_refs = 0;
  * copy grows. A segmentation model's 5 MB output, by contrast, copies for
  * hundreds of microseconds and wraps for the same 2 us.
  *
- * 256 kB sits well above the break-even, so a tensor taking the direct path is
- * a clear win rather than a marginal one. The figures are indicative of one
+ * Working the break-even back from the large case, where the copy is memory
+ * bound rather than cache resident, puts it near 26-49 kB. 256 kB therefore
+ * leaves five to ten times the margin, so a tensor taking the direct path
+ * wins clearly rather than marginally. The figures are indicative of one
  * machine; the threshold is deliberately conservative so that being wrong
  * about them costs a copy that was already cheap.
  */

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -51,6 +51,9 @@ _GetModelFilePath (gchar **model_file, int option)
     case 2:
       model_name = "simple_32_in_32_out.tflite";
       break;
+    case 3:
+      model_name = "deeplabv3_257_mv_gpu.tflite";
+      break;
     default:
       break;
   }
@@ -493,8 +496,10 @@ TEST (nnstreamerFilterLiteRT, invoke01_n)
 }
 
 /**
- * @brief Positive case: invoke with a 64-byte aligned output buffer takes the
- * zero-copy path; the result must still be correct.
+ * @brief Positive case: invoke with a 64-byte aligned output buffer that is
+ * at/above the zero-copy size gate (deeplabv3 output is 5548116 B, well over
+ * the 256 KiB threshold) takes the zero-copy wrap path; the result must
+ * still be correct.
  */
 TEST (nnstreamerFilterLiteRT, zeroCopyAlignedOutput)
 {
@@ -503,7 +508,7 @@ TEST (nnstreamerFilterLiteRT, zeroCopyAlignedOutput)
   GstTensorMemory input, output;
   g_autofree gchar *model_file = NULL;
 
-  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 3));
 
   const gchar *model_files[] = { model_file, NULL };
   const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
@@ -512,8 +517,8 @@ TEST (nnstreamerFilterLiteRT, zeroCopyAlignedOutput)
   GstTensorFilterProperties prop;
   _SetFilterProp (&prop, "litert", model_files);
 
-  input.size = sizeof (float) * 224 * 224 * 3;
-  output.size = sizeof (float) * 1001;
+  input.size = 792588;
+  output.size = 5548116;
   input.data = g_malloc0 (input.size);
   ASSERT_EQ (posix_memalign (&output.data, 64, output.size), 0);
   memset (output.data, 0xAA, output.size); /* canary */
@@ -540,7 +545,8 @@ TEST (nnstreamerFilterLiteRT, zeroCopyAlignedOutput)
 
 /**
  * @brief Positive case: invoke with a deliberately misaligned output buffer
- * takes the memcpy fallback path; the result must still be correct.
+ * takes the memcpy fallback path even though the output is above the
+ * zero-copy size gate; the result must still be correct.
  */
 TEST (nnstreamerFilterLiteRT, zeroCopyUnalignedOutput)
 {
@@ -550,7 +556,7 @@ TEST (nnstreamerFilterLiteRT, zeroCopyUnalignedOutput)
   GstTensorMemory input, output;
   g_autofree gchar *model_file = NULL;
 
-  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 3));
 
   const gchar *model_files[] = { model_file, NULL };
   const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
@@ -559,8 +565,8 @@ TEST (nnstreamerFilterLiteRT, zeroCopyUnalignedOutput)
   GstTensorFilterProperties prop;
   _SetFilterProp (&prop, "litert", model_files);
 
-  input.size = sizeof (float) * 224 * 224 * 3;
-  output.size = sizeof (float) * 1001;
+  input.size = 792588;
+  output.size = 5548116;
   input.data = g_malloc0 (input.size);
   /* 64-byte aligned block, offset by 8 B so output.data itself is not */
   ASSERT_EQ (posix_memalign (&base, 64, output.size + 64), 0);
@@ -600,7 +606,7 @@ TEST (nnstreamerFilterLiteRT, zeroCopyPathEquivalence)
   GstTensorMemory input, aligned_output, unaligned_output;
   g_autofree gchar *model_file = NULL;
 
-  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 3));
 
   const gchar *model_files[] = { model_file, NULL };
   const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
@@ -609,13 +615,9 @@ TEST (nnstreamerFilterLiteRT, zeroCopyPathEquivalence)
   GstTensorFilterProperties prop;
   _SetFilterProp (&prop, "litert", model_files);
 
-  input.size = sizeof (float) * 224 * 224 * 3;
-  aligned_output.size = unaligned_output.size = sizeof (float) * 1001;
-  input.data = g_malloc (input.size);
-
-  /* a deterministic non-trivial input pattern */
-  for (gsize i = 0; i < input.size / sizeof (float); ++i)
-    ((float *) input.data)[i] = (float) (i % 255) / 255.0f - 0.5f;
+  input.size = 792588;
+  aligned_output.size = unaligned_output.size = 5548116;
+  input.data = g_malloc0 (input.size);
 
   ASSERT_EQ (posix_memalign (&aligned_output.data, 64, aligned_output.size), 0);
   ASSERT_EQ (posix_memalign (&unaligned_base, 64, unaligned_output.size + 64), 0);
@@ -638,17 +640,19 @@ TEST (nnstreamerFilterLiteRT, zeroCopyPathEquivalence)
 /**
  * @brief Positive case: repeated invoke through the zero-copy path must not
  * leak or corrupt state; every run must succeed and match the first result.
+ * The iteration count is kept low because deeplabv3 is a large model and
+ * each invoke is comparatively slow.
  */
 TEST (nnstreamerFilterLiteRT, zeroCopyRepeatedInvoke)
 {
-  const guint iterations = 20U;
+  const guint iterations = 5U;
   int ret;
   void *data = NULL;
   GstTensorMemory input, output;
   g_autofree gchar *model_file = NULL;
   g_autofree gchar *first_result = NULL;
 
-  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 3));
 
   const gchar *model_files[] = { model_file, NULL };
   const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
@@ -657,8 +661,8 @@ TEST (nnstreamerFilterLiteRT, zeroCopyRepeatedInvoke)
   GstTensorFilterProperties prop;
   _SetFilterProp (&prop, "litert", model_files);
 
-  input.size = sizeof (float) * 224 * 224 * 3;
-  output.size = sizeof (float) * 1001;
+  input.size = 792588;
+  output.size = 5548116;
   input.data = g_malloc0 (input.size);
   ASSERT_EQ (posix_memalign (&output.data, 64, output.size), 0);
   first_result = (gchar *) g_malloc (output.size);
@@ -700,8 +704,59 @@ TEST (nnstreamerFilterLiteRT, zeroCopyRepeatedInvoke)
 }
 
 /**
- * @brief Positive case: the zero-copy path also holds for a model with many
- * output tensors, each individually 64-byte aligned.
+ * @brief Positive case: invoke with a 64-byte aligned output buffer whose
+ * size (4004 B, the mobilenet output) is below the 256 KiB zero-copy size
+ * gate. The gate must route this through the memcpy fallback rather than
+ * wrapping caller memory, and the result must still be correct: the size
+ * gate must not break small aligned outputs.
+ */
+TEST (nnstreamerFilterLiteRT, zeroCopyBelowThreshold)
+{
+  int ret;
+  void *data = NULL;
+  GstTensorMemory input, output;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  input.size = sizeof (float) * 224 * 224 * 3;
+  output.size = sizeof (float) * 1001;
+  input.data = g_malloc0 (input.size);
+  ASSERT_EQ (posix_memalign (&output.data, 64, output.size), 0);
+  memset (output.data, 0xAA, output.size); /* canary */
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  ret = sp->invoke (NULL, &prop, data, &input, &output);
+  EXPECT_EQ (ret, 0);
+
+  gboolean changed = FALSE;
+  for (gsize i = 0; i < output.size; ++i) {
+    if (((guint8 *) output.data)[i] != 0xAA) {
+      changed = TRUE;
+      break;
+    }
+  }
+  EXPECT_TRUE (changed) << "invoke() succeeded but did not write the output buffer.";
+
+  g_free (input.data);
+  free (output.data);
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Positive case: a model with many small output tensors, each
+ * individually 64-byte aligned. Every output tensor here (4 B) is far below
+ * the zero-copy size gate, so this exercises the memcpy fallback path across
+ * many simultaneous outputs rather than the zero-copy wrap path.
  */
 TEST (nnstreamerFilterLiteRT, zeroCopyManyOutputsAligned)
 {

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -19,6 +19,8 @@
 #include <gst/gst.h>
 
 #include <atomic>
+#include <cstdlib>
+#include <cstring>
 #include <thread>
 #include <vector>
 
@@ -487,6 +489,261 @@ TEST (nnstreamerFilterLiteRT, invoke01_n)
 
   g_free (input.data);
   g_free (output.data);
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Positive case: invoke with a 64-byte aligned output buffer takes the
+ * zero-copy path; the result must still be correct.
+ */
+TEST (nnstreamerFilterLiteRT, zeroCopyAlignedOutput)
+{
+  int ret;
+  void *data = NULL;
+  GstTensorMemory input, output;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  input.size = sizeof (float) * 224 * 224 * 3;
+  output.size = sizeof (float) * 1001;
+  input.data = g_malloc0 (input.size);
+  ASSERT_EQ (posix_memalign (&output.data, 64, output.size), 0);
+  memset (output.data, 0xAA, output.size); /* canary */
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  ret = sp->invoke (NULL, &prop, data, &input, &output);
+  EXPECT_EQ (ret, 0);
+
+  gboolean changed = FALSE;
+  for (gsize i = 0; i < output.size; ++i) {
+    if (((guint8 *) output.data)[i] != 0xAA) {
+      changed = TRUE;
+      break;
+    }
+  }
+  EXPECT_TRUE (changed) << "invoke() succeeded but did not write the output buffer.";
+
+  g_free (input.data);
+  free (output.data);
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Positive case: invoke with a deliberately misaligned output buffer
+ * takes the memcpy fallback path; the result must still be correct.
+ */
+TEST (nnstreamerFilterLiteRT, zeroCopyUnalignedOutput)
+{
+  int ret;
+  void *data = NULL;
+  void *base = NULL;
+  GstTensorMemory input, output;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  input.size = sizeof (float) * 224 * 224 * 3;
+  output.size = sizeof (float) * 1001;
+  input.data = g_malloc0 (input.size);
+  /* 64-byte aligned block, offset by 8 B so output.data itself is not */
+  ASSERT_EQ (posix_memalign (&base, 64, output.size + 64), 0);
+  output.data = (guint8 *) base + 8;
+  memset (output.data, 0xAA, output.size); /* canary */
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  ret = sp->invoke (NULL, &prop, data, &input, &output);
+  EXPECT_EQ (ret, 0);
+
+  gboolean changed = FALSE;
+  for (gsize i = 0; i < output.size; ++i) {
+    if (((guint8 *) output.data)[i] != 0xAA) {
+      changed = TRUE;
+      break;
+    }
+  }
+  EXPECT_TRUE (changed) << "invoke() succeeded but did not write the output buffer.";
+
+  g_free (input.data);
+  free (base);
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Positive case: the zero-copy path and the memcpy fallback path must
+ * produce byte-identical output for the same input. This is the key safety
+ * property of routing some invocations directly into caller memory.
+ */
+TEST (nnstreamerFilterLiteRT, zeroCopyPathEquivalence)
+{
+  int ret;
+  void *data = NULL;
+  void *unaligned_base = NULL;
+  GstTensorMemory input, aligned_output, unaligned_output;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  input.size = sizeof (float) * 224 * 224 * 3;
+  aligned_output.size = unaligned_output.size = sizeof (float) * 1001;
+  input.data = g_malloc (input.size);
+
+  /* a deterministic non-trivial input pattern */
+  for (gsize i = 0; i < input.size / sizeof (float); ++i)
+    ((float *) input.data)[i] = (float) (i % 255) / 255.0f - 0.5f;
+
+  ASSERT_EQ (posix_memalign (&aligned_output.data, 64, aligned_output.size), 0);
+  ASSERT_EQ (posix_memalign (&unaligned_base, 64, unaligned_output.size + 64), 0);
+  unaligned_output.data = (guint8 *) unaligned_base + 8;
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  EXPECT_EQ (sp->invoke (NULL, &prop, data, &input, &aligned_output), 0);
+  EXPECT_EQ (sp->invoke (NULL, &prop, data, &input, &unaligned_output), 0);
+  EXPECT_EQ (memcmp (aligned_output.data, unaligned_output.data, aligned_output.size), 0)
+      << "The zero-copy path and the memcpy fallback path produced different output.";
+
+  g_free (input.data);
+  free (aligned_output.data);
+  free (unaligned_base);
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Positive case: repeated invoke through the zero-copy path must not
+ * leak or corrupt state; every run must succeed and match the first result.
+ */
+TEST (nnstreamerFilterLiteRT, zeroCopyRepeatedInvoke)
+{
+  const guint iterations = 20U;
+  int ret;
+  void *data = NULL;
+  GstTensorMemory input, output;
+  g_autofree gchar *model_file = NULL;
+  g_autofree gchar *first_result = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 1));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  input.size = sizeof (float) * 224 * 224 * 3;
+  output.size = sizeof (float) * 1001;
+  input.data = g_malloc0 (input.size);
+  ASSERT_EQ (posix_memalign (&output.data, 64, output.size), 0);
+  first_result = (gchar *) g_malloc (output.size);
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  for (guint i = 0; i < iterations; ++i) {
+    /** Re-poison every round. Comparing one round against the next only shows
+     *  they agree, which an untouched buffer also does; the canary is what
+     *  says the run actually wrote through the wrapper each time. */
+    memset (output.data, 0xAA, output.size);
+
+    ret = sp->invoke (NULL, &prop, data, &input, &output);
+    EXPECT_EQ (ret, 0) << "invoke() failed on iteration " << i;
+    if (ret != 0)
+      break;
+
+    gboolean changed = FALSE;
+    for (gsize b = 0; b < output.size; ++b) {
+      if (((guint8 *) output.data)[b] != 0xAA) {
+        changed = TRUE;
+        break;
+      }
+    }
+    EXPECT_TRUE (changed) << "Iteration " << i << " left the output buffer untouched.";
+
+    if (i == 0) {
+      memcpy (first_result, output.data, output.size);
+    } else {
+      EXPECT_EQ (memcmp (first_result, output.data, output.size), 0)
+          << "Output diverged on iteration " << i;
+    }
+  }
+
+  g_free (input.data);
+  free (output.data);
+  sp->close (&prop, &data);
+}
+
+/**
+ * @brief Positive case: the zero-copy path also holds for a model with many
+ * output tensors, each individually 64-byte aligned.
+ */
+TEST (nnstreamerFilterLiteRT, zeroCopyManyOutputsAligned)
+{
+  const guint num_tensors = 32U;
+  int ret;
+  void *data = NULL;
+  GstTensorMemory input[32], output[32];
+  void *output_base[32] = { NULL };
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 2));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  for (guint i = 0; i < num_tensors; ++i) {
+    input[i].size = sizeof (float);
+    input[i].data = g_malloc0 (sizeof (float));
+    ((float *) input[i].data)[0] = 16.0f;
+
+    output[i].size = sizeof (float);
+    ASSERT_EQ (posix_memalign (&output_base[i], 64, output[i].size), 0);
+    output[i].data = output_base[i];
+  }
+
+  ret = sp->open (&prop, &data);
+  ASSERT_EQ (ret, 0);
+
+  ret = sp->invoke (NULL, &prop, data, input, output);
+  EXPECT_EQ (ret, 0);
+
+  for (guint i = 0; i < num_tensors; ++i)
+    EXPECT_FLOAT_EQ (((float *) output[i].data)[0], 17.0f);
+
+  for (guint i = 0; i < num_tensors; ++i) {
+    g_free (input[i].data);
+    free (output_base[i]);
+  }
   sp->close (&prop, &data);
 }
 

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -704,11 +704,18 @@ TEST (nnstreamerFilterLiteRT, zeroCopyRepeatedInvoke)
 }
 
 /**
- * @brief Positive case: invoke with a 64-byte aligned output buffer whose
- * size (4004 B, the mobilenet output) is below the 256 KiB zero-copy size
- * gate. The gate must route this through the memcpy fallback rather than
- * wrapping caller memory, and the result must still be correct: the size
- * gate must not break small aligned outputs.
+ * @brief Positive case: an aligned output below the size gate stays correct.
+ *
+ * The mobilenet output is 4004 B, under litert_wrap_min_bytes, so the gate
+ * sends it through the copy even though its alignment would otherwise qualify
+ * it. What is pinned here is that the gate does not break such a tensor.
+ *
+ * It does not pin the gate itself, and no test does: which branch runs is a
+ * performance decision that produces identical bytes either way, so removing
+ * the size floor leaves this whole suite green. Guarding that would mean
+ * making the choice observable from outside the subplugin, which is not worth
+ * a constant this well commented. Anyone changing litert_wrap_min_bytes needs
+ * to re-measure rather than trust CI.
  */
 TEST (nnstreamerFilterLiteRT, zeroCopyBelowThreshold)
 {

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -640,12 +640,16 @@ TEST (nnstreamerFilterLiteRT, zeroCopyPathEquivalence)
 /**
  * @brief Positive case: repeated invoke through the zero-copy path must not
  * leak or corrupt state; every run must succeed and match the first result.
- * The iteration count is kept low because deeplabv3 is a large model and
- * each invoke is comparatively slow.
+ *
+ * Three rounds, not more. The model has to sit above the size gate to reach
+ * the wrapped path at all, so it has to be deeplabv3, and each of its invokes
+ * costs about 42 s under the CI memcheck run. Three still gives two
+ * comparisons against the first result, which is what catches a wrapper going
+ * stale; a leak needs a sanitizer rather than more rounds.
  */
 TEST (nnstreamerFilterLiteRT, zeroCopyRepeatedInvoke)
 {
-  const guint iterations = 5U;
+  const guint iterations = 3U;
   int ret;
   void *data = NULL;
   GstTensorMemory input, output;

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -495,6 +495,68 @@ TEST (nnstreamerFilterLiteRT, invoke01_n)
   sp->close (&prop, &data);
 }
 
+static std::atomic<int> _direct_output_count (0);
+
+/**
+ * @brief GLib log handler counting outputs the subplugin elected to write directly.
+ * @param[in] domain log domain, forwarded to the default handler
+ * @param[in] level log level, forwarded to the default handler
+ * @param[in] message the log message to inspect
+ * @param[in] user_data unused, forwarded to the default handler
+ */
+static void
+_countDirectOutputs (const gchar *domain, GLogLevelFlags level,
+    const gchar *message, gpointer user_data)
+{
+  if (message != NULL && g_strstr_len (message, -1, "will be written directly") != NULL)
+    ++_direct_output_count;
+
+  g_log_default_handler (domain, level, message, user_data);
+}
+
+/**
+ * @brief Positive case: a large output must actually elect the direct path.
+ *
+ * The other cases here only prove both paths return the same bytes, which they
+ * would keep doing if the direct path stopped being chosen at all. The gate now
+ * turns on an answer LiteRT gives at runtime, so an SDK that stopped reporting
+ * host memory for the CPU path would silently disable the optimisation with
+ * every one of them still green. This reads the decision the subplugin logs
+ * and fails if a qualifying tensor no longer elects the wrap.
+ */
+TEST (nnstreamerFilterLiteRT, zeroCopyDirectPathElected)
+{
+  void *data = NULL;
+  g_autofree gchar *model_file = NULL;
+
+  ASSERT_TRUE (_GetModelFilePath (&model_file, 3));
+
+  const gchar *model_files[] = { model_file, NULL };
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("litert");
+  ASSERT_TRUE (sp != nullptr);
+
+  GstTensorFilterProperties prop;
+  _SetFilterProp (&prop, "litert", model_files);
+
+  /** the decision is logged at debug level, so it is dropped unless the
+   *  domain is enabled for this process */
+  g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
+  _direct_output_count = 0;
+  GLogFunc prev_handler = g_log_set_default_handler (_countDirectOutputs, NULL);
+
+  const int ret = sp->open (&prop, &data);
+
+  g_log_set_default_handler (prev_handler, NULL);
+  g_unsetenv ("G_MESSAGES_DEBUG");
+
+  ASSERT_EQ (ret, 0);
+  EXPECT_GT (_direct_output_count.load (), 0)
+      << "No output elected the direct path for a model whose output clears "
+         "the size gate; the zero-copy path is no longer reachable.";
+
+  sp->close (&prop, &data);
+}
+
 /**
  * @brief Positive case: invoke with a 64-byte aligned output buffer that is
  * at/above the zero-copy size gate (deeplabv3 output is 5548116 B, well over

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -538,16 +538,16 @@ TEST (nnstreamerFilterLiteRT, zeroCopyDirectPathElected)
   GstTensorFilterProperties prop;
   _SetFilterProp (&prop, "litert", model_files);
 
-  /** the decision is logged at debug level, so it is dropped unless the
-   *  domain is enabled for this process */
-  g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
+  /** G_MESSAGES_DEBUG is deliberately not touched. Level filtering happens
+   *  inside g_log_default_handler, so a handler installed in front of it sees
+   *  g_debug output either way - verified on glib 2.72 - and setting the
+   *  variable would only discard whatever the caller had exported. */
   _direct_output_count = 0;
   GLogFunc prev_handler = g_log_set_default_handler (_countDirectOutputs, NULL);
 
   const int ret = sp->open (&prop, &data);
 
   g_log_set_default_handler (prev_handler, NULL);
-  g_unsetenv ("G_MESSAGES_DEBUG");
 
   ASSERT_EQ (ret, 0);
   EXPECT_GT (_direct_output_count.load (), 0)


### PR DESCRIPTION
## What

Lets `LiteRtRunCompiledModel` write its results straight into the caller's output tensor, instead of writing a managed buffer that `invoke()` then copies out — but only where that is actually faster.

Addresses the **zero-copy invoke** item of #4869, for outputs. Inputs are deliberately excluded, for a reason below.

## Why inputs are excluded

The issue frames this as "when alignment permits". On the input side alignment is not the binding constraint:

`tensor_filter` maps input memory **`GST_MAP_READ`** ([tensor_filter.c:729](https://github.com/nnstreamer/nnstreamer/blob/main/gst/nnstreamer/tensor_filter/tensor_filter.c#L729)), and that memory may be **shared with another branch** of the pipeline — SSAT case 6 in this very suite runs two litert filters off one `tee`. Handing that pointer to LiteRT as a writable tensor buffer would rest on LiteRT never writing to an input tensor, which upstream states nowhere. Being wrong corrupts a buffer another branch is still reading.

Outputs are mapped `GST_MAP_WRITE` ([tensor_filter.c:904](https://github.com/nnstreamer/nnstreamer/blob/main/gst/nnstreamer/tensor_filter/tensor_filter.c#L904)) and are per-branch, so they carry no such risk. The `@todo` records the input constraint and what lifting it would need.

## The size gate, and why it exists

Wrapping is not free, and this is the part the first version of this PR got wrong. Measured on x86_64:

| output size | wrap create+destroy | lock + copy + unlock | verdict |
|---|---|---|---|
| 4 kB (mobilenet classifier) | 1.3–2.4 µs | 0.06–0.28 µs | **copy wins** |
| 5.5 MB (deeplabv3 segmentation) | 2.9–3.1 µs | 259–286 µs | **wrap wins ~90×** |

Wrapping a small output is an order of magnitude *slower* than copying it. So the direct path is gated on `litert_wrap_min_bytes = 256 kB`, an order of magnitude above the break-even — a tensor that takes it wins clearly rather than marginally, and being wrong about these constants on other hardware costs a copy that was already cheap. The gate is evaluated once per configuration, so nothing is added to the per-invoke path.

Being straight about the scope of the benefit: this does nothing for classifiers. It matters for models with large outputs — segmentation, super-resolution, dense prediction — and for accelerator-owned buffers later, which CI has no hardware to demonstrate.

## How

A tensor takes the direct path when all of:

1. its buffer requirements admit `kLiteRtTensorBufferTypeHostMemory`,
2. the LiteRT buffer size **equals** the nnstreamer tensor size — a larger one carries padding the caller's tensor has no room for,
3. its size is at least `litert_wrap_min_bytes`,
4. the pointer meets `LITERT_HOST_MEMORY_BUFFER_ALIGNMENT` (64), which `LiteRtCreateTensorBufferFromHostMemory` rejects otherwise.

1–3 are settled at configure time; only the alignment check is per-invoke. Wrappers use a null deallocator and are released by a scope guard, so a throw between wrapping and the run cannot leak them, and the caller's memory is never freed here.

Output null/size checks now run **before** `LiteRtRunCompiledModel` instead of after, since the buffer choice must be made up front. A mismatched output now fails without spending an inference first.

## Tests

| Test | Model | Covers |
|---|---|---|
| `zeroCopyAlignedOutput` | deeplabv3 | the wrapped path writes through to the caller's buffer |
| `zeroCopyUnalignedOutput` | deeplabv3 | misaligned pointer falls back and still works |
| `zeroCopyPathEquivalence` | deeplabv3 | both paths produce **byte-identical** output |
| `zeroCopyRepeatedInvoke` | deeplabv3 | 3 invokes, buffer re-poisoned each round, catches a stale or leaking wrapper |
| `zeroCopyBelowThreshold` | mobilenet | an aligned output under the gate still returns correct results via the copy |
| `zeroCopyManyOutputsAligned` | simple_32_in_32_out | 32 outputs, all under the gate |
| `zeroCopyDirectPathElected` | deeplabv3 | a qualifying tensor **actually elects** the direct path, so the optimisation cannot go dead unnoticed |

Alignment cannot be controlled from a pipeline, so these drive `sp->invoke` directly with `posix_memalign`'d buffers — the only layer where the branch is selectable deterministically.

The last row exists because the other six are, by design, indifferent to which path runs: they compare the two paths against each other, so all six stay green if the direct path stops being chosen at all. That mattered once the gate started depending on a runtime answer from LiteRT — a future SDK reporting a different buffer type for the CPU path would silently disable the optimisation. The subplugin now logs its per-output decision at configure time (which also answers "why am I not getting zero-copy" for a user), and that case asserts a qualifying tensor still elects the wrap. Forcing the gate false fails it while the other six pass.

**Checked for teeth, not just for passing.** Inverting the selection so the run ignores the wrappers while the read-back stays skipped makes four of the five original cases fail; the survivor was the fallback case, which that bug cannot affect. `zeroCopyRepeatedInvoke` only caught it after being changed to re-poison the buffer every round — comparing one round to the next passes happily on a buffer nothing ever wrote.

Branch selection was confirmed by instrumentation rather than assumed:

```
ROUTE out[0] size=5548116 WRAPPED   (x7)
ROUTE out[0] size=5548116 copy      (x2 — the misaligned cases)
ROUTE out[0] size=4004    copy
ROUTE out[0] size=4       copy      (x32)
```

## Verification

| Check | Result |
|---|---|
| `unittest_filter_litert` | 32/32 pass |
| `ssat -n -p=1` | 9/9 cases pass |
| `-Db_sanitize=address,undefined` | clean |
| `-Db_sanitize=thread` | 0 warnings |
| `clang-format --dry-run -Werror` | no diff |

LeakSanitizer reports a 16 kB glib load-time allocation non-deterministically. It appears for pre-existing tests as readily as new ones, does not reproduce across repeated runs of the zero-copy tests, and has no nnstreamer or LiteRT frames. Not introduced here.

## Scope

`tensor_filter_litert.cc` and its own tests. No header, API, build, or shared-code change, so nothing outside `libnnstreamer_filter_litert` is affected. `LiteRtRankedTensorType` is cached by value at configure time; it is a 72-byte POD with inline dimension and stride arrays (the SDK's own `static_assert`s pin the offsets), so the cache cannot dangle.


