### PR TITLE
[Test] Close the last two vacuous single-buffer golden checks

### DIFF
--- a/tests/nnstreamer_filter_lua/unittest_filter_lua.cc
+++ b/tests/nnstreamer_filter_lua/unittest_filter_lua.cc
@@ -89,6 +89,22 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 }
 
 /**
+ * @brief Signal to count invocations of tensor_sink
+ * @note Connect this after check_output. GObject runs same-stage handlers in
+ *       connection order, so a satisfied count implies the golden comparison
+ *       for that buffer has already run; connecting it first would let the
+ *       waiter tear the pipeline down before check_output had a say.
+ */
+static void
+count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  guint *count = (guint *) user_data;
+  UNUSED (element);
+  UNUSED (buffer);
+  g_atomic_int_inc (count);
+}
+
+/**
  * @brief Negative test case with invalid model file path
  */
 TEST (nnstreamerFilterLua, openClose00_n)
@@ -1044,12 +1060,17 @@ TEST (nnstreamerFilterLua, launch01)
 
   GstElement *sink_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sinkx");
   EXPECT_NE (sink_handle, nullptr);
+  guint count = 0U;
   g_signal_connect (sink_handle, "new-data", (GCallback) check_output, NULL);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_output, &count);
 
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT * 10),
       0);
+  EXPECT_TRUE (wait_pipeline_process_buffers (&count, 1U, TEST_TIMEOUT_LIMIT_MS));
   EXPECT_EQ (
       setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT * 10), 0);
+
+  EXPECT_GE (count, 1U);
 
   gst_object_unref (sink_handle);
   gst_object_unref (gstpipe);

--- a/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
+++ b/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
@@ -159,6 +159,21 @@ class NNStreamerFilterTVMTest : public ::testing::Test
 
     gst_memory_unmap (mem_res, &info_res);
   }
+
+  /**
+   * @brief Signal handler to count invocations of tensor_sink
+   * @note Connect this after CheckOutput. GObject runs same-stage handlers in
+   *       connection order, so a satisfied count implies the golden comparison
+   *       for that buffer has already run; connecting it first would let the
+   *       waiter tear the pipeline down before CheckOutput had a say.
+   */
+  static void CountOutput (GstElement *element, GstBuffer *buffer, gpointer user_data)
+  {
+    guint *count = (guint *) user_data;
+    UNUSED (element);
+    UNUSED (buffer);
+    g_atomic_int_inc (count);
+  }
 };
 
 /**
@@ -436,12 +451,18 @@ TEST_F (NNStreamerFilterTVMTest, launch00)
 
   sink_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "sink");
   EXPECT_NE (sink_handle, nullptr);
+  guint count = 0U;
   g_signal_connect (sink_handle, "new-data",
       (GCallback) NNStreamerFilterTVMTest::CheckOutput, NULL);
+  g_signal_connect (sink_handle, "new-data",
+      (GCallback) NNStreamerFilterTVMTest::CountOutput, &count);
 
   /* Test */
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_TRUE (wait_pipeline_process_buffers (&count, 1U, TEST_TIMEOUT_LIMIT_MS));
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  EXPECT_GE (count, 1U);
 }
 
 /**


### PR DESCRIPTION
Follow-up to #4889 (which fixed #4870). That PR closed this hole in the onnxruntime, tensorflow2-lite and litert filter tests; this finishes the job.

## What is left

Scanning the test tree for "connect a `new-data` handler, go `PLAYING`, go straight to `NULL`" leaves exactly two genuine cases:

| Test | Golden that can silently not run | Duration on GBS x86_64 |
| --- | --- | --- |
| `nnstreamerFilterLua.launch01` | `output[i - 1] == i * 11` | 9 ms |
| `NNStreamerFilterTVMTest.launch00` | `output[i] == 1`, `i < 10` | 58 ms |

`setPipelineStateSync (PLAYING)` returns on state-change completion, not when data has flowed, so when the teardown wins the race the handler never fires and the test passes without having compared anything. Neither test asserts that a buffer arrived, so nothing reports it.

Both tests do run in CI (Tizen GBS `unit_test 1`), so this is live behaviour rather than a theoretical hole, and the fix has a real signal.

## Fix

The same shape as #4889: count buffers through a *second* `new-data` handler, wait with the existing `wait_pipeline_process_buffers()`, then assert the count. `check_output` / `CheckOutput` stay single-purpose.

The connection-order dependency established during #4889's review is carried over into the doxygen of both new counters — `count_output` must be connected *after* the checking handler, since GObject runs same-stage handlers in connection order, so a satisfied count implies the golden comparison already ran.

## Scope decisions, stated so they can be challenged

**No meson timeout bump, unlike #4889.** That bump was needed because `unittest_filter_tensorflow2_lite` already spent 10 of its 30 allowed seconds in fixed `g_usleep()` calls *and* gained two bounded waits. Neither file here contains a `g_usleep()` at all, and each gains exactly one wait, so the worst case stays far below the 30 s default.

**Three candidates deliberately not changed**, having checked each:

- `NNStreamerFilterTVMTest.launch00_n` and `launch01_n` — end in `fakesink` with no handler connected, and assert that `PLAYING` *fails*. Correct as written.
- `join.forwardAllBuffers` — already waits, via `pop_eos_or_error (...) == GST_MESSAGE_EOS`, before asserting `received == 30`. My scanner did not recognise that as a wait; the test does. It is also in `gst/join`, which is being changed by #4875.

## Verification

- Both files compile warning-free under `-Wall -Wextra`.
- `clang-format --style=file`: clean.
- `.github/workflows/static.check.scripts/doxygen-tag.sh` run in the same advanced mode CI uses: clean — and verified with a negative control that the harness actually errors on a bad comment, since that script exits 0 on wrong arguments and a no-op run is indistinguishable from a pass. (#4889 broke that check, so it is now part of my pre-push loop.)
- The lua and tvm subplugins are not installable in this environment, so these two binaries were compile-verified but not executed locally; CI provides the runtime signal.

The mechanism itself was measured in #4889: a standalone reproducer of the pipeline shape lost the buffer in 46 of 60 iterations on a saturated machine without the wait, and 0 of 60 with it.

Test-only. No production code, no API change, so no documentation update applies.
