### PR TITLE
[Test] Hoist the duplicated tensor_sink buffer counter into unittest_util

### DIFF
--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -2748,6 +2748,117 @@ TEST (commonUtil, waitPipelineProcessBuffers_n)
 }
 
 /**
+ * @brief Test that count_output bumps the counter it is handed, once per call.
+ */
+TEST (commonUtil, countOutput)
+{
+  guint count = 0U;
+
+  count_output (NULL, NULL, &count);
+  EXPECT_EQ (count, 1U);
+
+  count_output (NULL, NULL, &count);
+  count_output (NULL, NULL, &count);
+  EXPECT_EQ (count, 3U);
+}
+
+/**
+ * @brief Shared state for the count_output pipeline tests.
+ */
+typedef struct {
+  guint count;
+  guint checked;
+  guint out_of_order;
+} count_output_test_data;
+
+/**
+ * @brief Checking handler connected before count_output.
+ * @details Records whether count_output had already run for this buffer,
+ *          which is exactly what its connection-order note rules out.
+ */
+static void
+check_before_count (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  count_output_test_data *data = (count_output_test_data *) user_data;
+  (void) element;
+  (void) buffer;
+
+  if ((guint) g_atomic_int_get (&data->count) != data->checked)
+    data->out_of_order++;
+  data->checked++;
+}
+
+/**
+ * @brief Build a pipeline that delivers num_buffers tensors to a tensor_sink named sink.
+ */
+static GstElement *
+build_count_output_pipeline (guint num_buffers)
+{
+  gchar *desc = g_strdup_printf ("videotestsrc num-buffers=%u ! video/x-raw,width=16,height=16,format=RGB,framerate=30/1 ! tensor_converter ! tensor_sink name=sink",
+      num_buffers);
+  GstElement *pipeline = gst_parse_launch (desc, NULL);
+
+  g_free (desc);
+  return pipeline;
+}
+
+/**
+ * @brief Test count_output as a tensor_sink handler feeding wait_pipeline_process_buffers.
+ * @details Also pins the connection-order guarantee the helper's note relies on:
+ *          the handler connected first sees the count before it is bumped.
+ */
+TEST (commonUtil, countOutputPipeline)
+{
+  const guint num_buffers = 3U;
+  count_output_test_data data = { 0U, 0U, 0U };
+  GstElement *pipeline = build_count_output_pipeline (num_buffers);
+  GstElement *sink;
+
+  ASSERT_TRUE (pipeline != nullptr);
+  sink = gst_bin_get_by_name (GST_BIN (pipeline), "sink");
+  ASSERT_TRUE (sink != nullptr);
+
+  g_signal_connect (sink, "new-data", (GCallback) check_before_count, &data);
+  g_signal_connect (sink, "new-data", (GCallback) count_output, &data.count);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_TRUE (wait_pipeline_process_buffers (&data.count, num_buffers, TEST_TIMEOUT_LIMIT_MS));
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  EXPECT_EQ (data.count, num_buffers);
+  EXPECT_EQ (data.checked, num_buffers);
+  EXPECT_EQ (data.out_of_order, 0U);
+
+  gst_object_unref (sink);
+  gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Test that a pipeline delivering no buffer leaves the count at zero and times out the waiter.
+ */
+TEST (commonUtil, countOutputPipelineNoBuffer_n)
+{
+  guint count = 0U;
+  GstElement *pipeline = build_count_output_pipeline (0U);
+  GstElement *sink;
+
+  ASSERT_TRUE (pipeline != nullptr);
+  sink = gst_bin_get_by_name (GST_BIN (pipeline), "sink");
+  ASSERT_TRUE (sink != nullptr);
+
+  g_signal_connect (sink, "new-data", (GCallback) count_output, &count);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  EXPECT_FALSE (wait_pipeline_process_buffers (&count, 1U, 200U));
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  EXPECT_EQ (count, 0U);
+
+  gst_object_unref (sink);
+  gst_object_unref (pipeline);
+}
+
+/**
  * @brief Main function for unit test.
  */
 int

--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -328,19 +328,6 @@ TEST (join, eosAfterRestart)
 }
 
 /**
- * @brief Callback counting the buffers that reached the sink.
- */
-static void
-count_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
-{
-  guint *received = (guint *) user_data;
-  (void) element;
-  (void) buffer;
-
-  (*received)++;
-}
-
-/**
  * @brief Test that a join of N finite sources delivers every buffer downstream.
  * @detail This is the pipeline shape used by the datarepo fixtures. The
  *         branches run in their own streaming threads, so which sink pad is
@@ -373,7 +360,7 @@ TEST (join, forwardAllBuffers)
 
   sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
   ASSERT_NE (sink_handle, nullptr);
-  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_output, (gpointer) &received);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
   EXPECT_EQ (pop_eos_or_error (pipeline, UNITTEST_STATECHANGE_TIMEOUT), GST_MESSAGE_EOS);
@@ -533,7 +520,7 @@ run_pad_release_while_streaming (void)
     gst_object_unref (pipeline);
     return FALSE;
   }
-  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, (gpointer) &received);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_output, (gpointer) &received);
 
   if (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT) != 0)
     started = FALSE;
@@ -726,7 +713,7 @@ count_checked_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_dat
   gst_memory_unmap (mem_res, &info_res);
   gst_memory_unref (mem_res);
 
-  counter->received++;
+  g_atomic_int_inc (&counter->received);
 }
 
 /**

--- a/tests/nnstreamer_converter/unittest_converter.cc
+++ b/tests/nnstreamer_converter/unittest_converter.cc
@@ -359,15 +359,6 @@ const gint _test_frames2[48] = { 1101, 1102, 1103, 1104, 1105, 1106, 1107, 1108,
   1212, 1213, 1214, 1215, 1216, 1217, 1218, 1219, 1220, 1221, 1222, 1223, 1224 };
 
 /**
- * @brief Callback for tensor sink signal.
- */
-static void
-new_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
-{
-  (*(guint *) user_data)++;
-}
-
-/**
  * @brief Test for dynamic dimension of the custom converter
  */
 TEST (tensorConverterPython, dynamicDimension)
@@ -405,7 +396,7 @@ TEST (tensorConverterPython, dynamicDimension)
   EXPECT_NE (sink_handle, nullptr);
 
   data_received = (guint *) g_malloc0 (sizeof (guint));
-  g_signal_connect (sink_handle, "new-data", (GCallback) new_data_cb, data_received);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_output, data_received);
 
   buf_0 = gst_buffer_new_wrapped (_g_memdup (_test_frames1, 96), 96);
   buf_1 = gst_buffer_new_wrapped (_g_memdup (_test_frames2, 192), 192);
@@ -486,7 +477,7 @@ new_data_cb_json (GstElement *element, GstBuffer *buffer, gpointer user_data)
   gboolean mapped;
   GstMemory *mem_res;
   gchar *output;
-  (*(guint *) user_data)++;
+  g_atomic_int_inc ((guint *) user_data);
 
   num_tensors = gst_buffer_n_memory (buffer);
   EXPECT_EQ (2U, num_tensors);

--- a/tests/nnstreamer_filter_custom/unittest_filter_custom.cc
+++ b/tests/nnstreamer_filter_custom/unittest_filter_custom.cc
@@ -87,7 +87,7 @@ new_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
   /** Protect cbdata->* */
   g_mutex_lock (&cbdata->lock);
 
-  cbdata->sink_received = cbdata->sink_received + 1;
+  g_atomic_int_inc (&cbdata->sink_received);
   expected_size = sizeof (guint) * cbdata->sink_received;
 
   EXPECT_EQ (1U, gst_buffer_n_memory (buffer));

--- a/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
+++ b/tests/nnstreamer_filter_litert/unittest_filter_litert.cc
@@ -146,22 +146,6 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 }
 
 /**
- * @brief Signal to count invocations of tensor_sink
- * @note Connect this after check_output. GObject runs same-stage handlers in
- *       connection order, so a satisfied count implies the golden comparison
- *       for that buffer has already run; connecting it first would let the
- *       waiter tear the pipeline down before check_output had a say.
- */
-static void
-count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
-{
-  guint *count = (guint *) user_data;
-  UNUSED (element);
-  UNUSED (buffer);
-  g_atomic_int_inc (count);
-}
-
-/**
  * @brief Check the litert subplugin is registered.
  */
 TEST (nnstreamerFilterLiteRT, checkExistence)

--- a/tests/nnstreamer_filter_lua/unittest_filter_lua.cc
+++ b/tests/nnstreamer_filter_lua/unittest_filter_lua.cc
@@ -89,22 +89,6 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 }
 
 /**
- * @brief Signal to count invocations of tensor_sink
- * @note Connect this after check_output. GObject runs same-stage handlers in
- *       connection order, so a satisfied count implies the golden comparison
- *       for that buffer has already run; connecting it first would let the
- *       waiter tear the pipeline down before check_output had a say.
- */
-static void
-count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
-{
-  guint *count = (guint *) user_data;
-  UNUSED (element);
-  UNUSED (buffer);
-  g_atomic_int_inc (count);
-}
-
-/**
  * @brief Negative test case with invalid model file path
  */
 TEST (nnstreamerFilterLua, openClose00_n)

--- a/tests/nnstreamer_filter_onnxruntime/unittest_filter_onnxruntime.cc
+++ b/tests/nnstreamer_filter_onnxruntime/unittest_filter_onnxruntime.cc
@@ -126,22 +126,6 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 }
 
 /**
- * @brief Signal to count invocations of tensor_sink
- * @note Connect this after check_output. GObject runs same-stage handlers in
- *       connection order, so a satisfied count implies the golden comparison
- *       for that buffer has already run; connecting it first would let the
- *       waiter tear the pipeline down before check_output had a say.
- */
-static void
-count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
-{
-  guint *count = (guint *) user_data;
-  UNUSED (element);
-  UNUSED (buffer);
-  g_atomic_int_inc (count);
-}
-
-/**
  * @brief Negative test case with invalid model file path
  */
 TEST (nnstreamerFilterOnnxRuntime, openClose00)

--- a/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
+++ b/tests/nnstreamer_filter_tensorflow2_lite/unittest_filter_tensorflow2_lite.cc
@@ -111,22 +111,6 @@ check_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
 }
 
 /**
- * @brief Signal to count invocations of tensor_sink
- * @note Connect this after check_output. GObject runs same-stage handlers in
- *       connection order, so a satisfied count implies the golden comparison
- *       for that buffer has already run; connecting it first would let the
- *       waiter tear the pipeline down before check_output had a say.
- */
-static void
-count_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
-{
-  guint *count = (guint *) user_data;
-  UNUSED (element);
-  UNUSED (buffer);
-  g_atomic_int_inc (count);
-}
-
-/**
  * @brief Negative case to launch gst pipeline: wrong dimension
  */
 TEST (nnstreamerFilterTensorFlow2Lite, launch0_n)

--- a/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
+++ b/tests/nnstreamer_filter_tvm/unittest_filter_tvm.cc
@@ -159,21 +159,6 @@ class NNStreamerFilterTVMTest : public ::testing::Test
 
     gst_memory_unmap (mem_res, &info_res);
   }
-
-  /**
-   * @brief Signal handler to count invocations of tensor_sink
-   * @note Connect this after CheckOutput. GObject runs same-stage handlers in
-   *       connection order, so a satisfied count implies the golden comparison
-   *       for that buffer has already run; connecting it first would let the
-   *       waiter tear the pipeline down before CheckOutput had a say.
-   */
-  static void CountOutput (GstElement *element, GstBuffer *buffer, gpointer user_data)
-  {
-    guint *count = (guint *) user_data;
-    UNUSED (element);
-    UNUSED (buffer);
-    g_atomic_int_inc (count);
-  }
 };
 
 /**
@@ -454,8 +439,7 @@ TEST_F (NNStreamerFilterTVMTest, launch00)
   guint count = 0U;
   g_signal_connect (sink_handle, "new-data",
       (GCallback) NNStreamerFilterTVMTest::CheckOutput, NULL);
-  g_signal_connect (sink_handle, "new-data",
-      (GCallback) NNStreamerFilterTVMTest::CountOutput, &count);
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_output, &count);
 
   /* Test */
   EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);

--- a/tests/tizen_sensor/unittest_tizen_sensor.cc
+++ b/tests/tizen_sensor/unittest_tizen_sensor.cc
@@ -159,7 +159,7 @@ callback_nns (GstElement *element, GstBuffer *buffer, gpointer user_data)
     if (dataptr[0] == vdata->golden[vdata->cursor + 1][0])
       vdata->cursor += 1;
 
-    vdata->checked += 1;
+    g_atomic_int_inc (&vdata->checked);
     gst_memory_unmap (mem, &map_info);
   }
 }

--- a/tests/unittest_util.c
+++ b/tests/unittest_util.c
@@ -196,7 +196,7 @@ wait_pipeline_process_buffers (const guint * data_received,
   guint tick = TEST_DEFAULT_SLEEP_TIME / 1000U;
 
   /* Waiting for expected buffers to arrive */
-  while (*data_received < expected_num_buffers) {
+  while ((guint) g_atomic_int_get (data_received) < expected_num_buffers) {
     g_usleep (TEST_DEFAULT_SLEEP_TIME);
     timer += tick;
     if (timer > timeout_ms)

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -80,6 +80,25 @@ extern void leavePrivateWorkDir (gchar **work_dir);
 extern gboolean wait_pipeline_process_buffers (const guint * data_received, guint expected_num_buffers, guint timeout_ms);
 
 /**
+ * @brief tensor_sink new-data handler that counts the buffers it receives.
+ * @details Pass the address of a guint as user_data and hand the same address
+ *          to wait_pipeline_process_buffers(). The increment is atomic; the
+ *          handler runs on the streaming thread while the waiter polls from
+ *          the test thread.
+ * @note Connect this after the handler that checks the buffer. GObject runs
+ *       same-stage handlers in connection order, so a satisfied count implies
+ *       the check for that buffer has already run; connecting it first would
+ *       let the waiter tear the pipeline down before the check had a say.
+ */
+static inline void
+count_output (GstElement * element, GstBuffer * buffer, gpointer user_data)
+{
+  (void) element;
+  (void) buffer;
+  g_atomic_int_inc ((guint *) user_data);
+}
+
+/**
  * @brief Replaces string.
  * This function deallocates the input source string.
  * @param[in] source The input string. This will be freed when returning the replaced string.

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -75,6 +75,7 @@ extern void leavePrivateWorkDir (gchar **work_dir);
 
 /**
  * @brief Wait until the pipeline processing the buffers
+ * @param data_received counter bumped by the streaming thread; read atomically
  * @return TRUE on success, FALSE when a time-out occurs
  */
 extern gboolean wait_pipeline_process_buffers (const guint * data_received, guint expected_num_buffers, guint timeout_ms);


### PR DESCRIPTION
Fixes #4910. Follow-up to #4889 and #4909.

## What

Three test-only commits, no production code.

1. **Hoist the `tensor_sink` buffer counter into `unittest_util.h`.** The five identical `count_output` handlers in the onnxruntime, tensorflow2-lite, litert, lua and tvm filter tests are replaced by one `static inline` next to `wait_pipeline_process_buffers()`, following the `argmax_float` precedent. The TVM copy was a `static` member of the fixture; its call site now names the shared function. The connection-order note from #4889 lives in one place.
2. **Read the counter atomically in `wait_pipeline_process_buffers()`.** #4889 made the filter-test writers atomic and left the read alone because it was shared with every caller. Now that writer and waiter live in the same header, settle it: the load goes through `g_atomic_int_get()`. No caller changes.
3. **Bump every counter the waiter polls atomically** (from review). The join and converter tests carried a sixth and seventh copy of the handler; they now use the shared one. The in-place increments in the join checking callback, the custom-filter test and the tizen_sensor test become `g_atomic_int_inc()`, so every waiter-polled counter is written and read through the same atomic pair.

## Tests

Added to `unittest_common`, which is always built:

- `commonUtil.countOutput`: direct calls bump the counter once each.
- `commonUtil.countOutputPipeline`: `videotestsrc num-buffers=3 ! tensor_converter ! tensor_sink` drives the handler through a real `new-data` emission into the waiter; asserts the count is exactly 3. A checking handler connected first records whether it saw the count before every increment, so the connection-order guarantee the helper's note relies on is pinned rather than assumed.
- `commonUtil.countOutputPipelineNoBuffer_n`: `num-buffers=0` leaves the count at 0 and the waiter times out.

## Local verification (WSL, Ubuntu 22.04, x86_64)

- `unittest_common` 145/145, `unittest_join` 13/13, `unittest_filter_litert` (built with `-Dlitert-support=enabled`) 33/33.
- `unittest_filter_custom` 5/6; the one failure is the pre-existing `notRegisterFlexibleInvoke_n` path assertion on an out-of-tree build directory, unrelated to this diff.
- Negative control: swapping the two `g_signal_connect` lines in `countOutputPipeline` fails it with `out_of_order` = 3; restoring them passes.
- clang-format on the changed `.cc` files, `doxygen-tag.sh` on the changed list, and a recompile of the changed C++ objects with `-Werror=sign-compare` active all pass.
- Not buildable here: lua, tvm, onnxruntime, tensorflow2-lite, the python converter test and tizen_sensor. Those edits are deletions of a local copy or one-line increments; CI builds and runs them.

## Note on the issue text

The issue says all five tests run in the GBS `unit_test 1` job. That holds for onnxruntime, tensorflow2-lite, lua and tvm, but `packaging/nnstreamer.spec` has no `litert_support` define, so the litert test is only covered by the Ubuntu meson job (`meson test`, x86_64 leg). Both jobs run per PR, so the move is still fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
