### PR TITLE
[CI] Put apt-get update on its own line so its failure fails the step

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,9 +73,12 @@ jobs:
     - if: matrix.build-mode == 'manual'
       shell: bash
       run: |
-        sudo apt update && sudo apt install -y libglib2.0-dev libjson-glib-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev googletest
+        sudo apt update
+        sudo apt install -y libglib2.0-dev libjson-glib-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev googletest
         sudo apt-get install -y liborc-0.4-dev flex bison libopencv-dev pkg-config python3-dev python3-numpy python3 python3-pip
-        sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update && sudo apt-get install -y ssat libpaho-mqtt-dev
+        sudo add-apt-repository -y ppa:nnstreamer/ppa
+        sudo apt-get update
+        sudo apt-get install -y ssat libpaho-mqtt-dev
         sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-good gstreamer1.0-plugins-base libgtest-dev libpng-dev
         sudo apt install nnstreamer-edge-dev flatbuffers-compiler libflatbuffers-dev protobuf-compiler libprotobuf-dev tensorflow2-lite-dev onnxruntime-dev liblua5.1-0-dev
         pip install meson ninja

--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -43,7 +43,8 @@ jobs:
     - name: prepare GBS
       run: |
         echo "deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_22.04/ /" | sudo tee /etc/apt/sources.list.d/tizen.list
-        sudo apt-get update && sudo apt-get install -y gbs
+        sudo apt-get update
+        sudo apt-get install -y gbs
         cp .github/workflows/tizen.gbs.conf ~/.gbs.conf
 
     - name: get date

--- a/.github/workflows/gbs_build.yml
+++ b/.github/workflows/gbs_build.yml
@@ -39,7 +39,8 @@ jobs:
       if: env.rebuild == '1'
       run: |
         echo "deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_22.04/ /" | sudo tee /etc/apt/sources.list.d/tizen.list
-        sudo apt-get update && sudo apt-get install -y gbs
+        sudo apt-get update
+        sudo apt-get install -y gbs
         cp .github/workflows/tizen.gbs.conf ~/.gbs.conf
 
     - name: get date

--- a/.github/workflows/nns_testhub.yml
+++ b/.github/workflows/nns_testhub.yml
@@ -21,7 +21,8 @@ jobs:
       run: |
         ubuntu_version=`lsb_release -rs`
         echo "deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_$ubuntu_version/ /" | sudo tee /etc/apt/sources.list.d/tizen.list
-        sudo apt-get update && sudo apt-get install -y gbs rpm2cpio cpio
+        sudo apt-get update
+        sudo apt-get install -y gbs rpm2cpio cpio
         cp .github/workflows/tizen.gbs.conf ~/.gbs.conf
 
     - name: Run nnstreamer gbs build

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -17,7 +17,8 @@ jobs:
         python-version: '3.11'
     - name: Install packages for hotdoc
       run: |
-        sudo apt-get update && sudo apt-get install -y python3-dev libxml2-dev libxslt1-dev cmake libyaml-dev libclang-dev llvm-dev libglib2.0-dev libjson-glib-dev flex
+        sudo apt-get update
+        sudo apt-get install -y python3-dev libxml2-dev libxslt1-dev cmake libyaml-dev libclang-dev llvm-dev libglib2.0-dev libjson-glib-dev flex
         python -m pip install --upgrade pip
         pip install hotdoc cmake==3.22
 

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -28,9 +28,12 @@ jobs:
     - name: install requirements
       if: env.rebuild == '1'
       run: |
-        sudo apt-get update && sudo apt-get install -y libglib2.0-dev libjson-glib-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev googletest gdb
+        sudo apt-get update
+        sudo apt-get install -y libglib2.0-dev libjson-glib-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev googletest gdb
         sudo apt-get install -y liborc-0.4-dev flex bison libopencv-dev pkg-config python3-dev python3-numpy python3
-        sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update && sudo apt-get install -y ssat libpaho-mqtt-dev
+        sudo add-apt-repository -y ppa:nnstreamer/ppa
+        sudo apt-get update
+        sudo apt-get install -y ssat libpaho-mqtt-dev
         sudo apt-get install -y valgrind gstreamer1.0-tools gstreamer1.0-plugins-good gstreamer1.0-plugins-base libgtest-dev libpng-dev libc6-dbg binutils-x86-64-linux-gnu-dbg valgrind-dbg
         sudo apt-get install -y libarmnn-dev libarmnntfliteparser-dev libarmnn-cpuref-backend22
         # The armnn subplugin auto-selects the NEON-accelerated CpuAcc backend on arm.

--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -78,8 +78,7 @@ jobs:
             echo "Enough free disk space (${avail_gb}G); skipping cleanup."
             exit 0
           fi
-          sudo apt-get update --fix-missing \
-            && sudo apt-get remove -y '^dotnet-.*' '^llvm-.*' '^mysql-server-core-.*' '^postgresql-.*' '^temurin-.*' \
+          sudo apt-get remove -y '^dotnet-.*' '^llvm-.*' '^mysql-server-core-.*' '^postgresql-.*' '^temurin-.*' \
             azure-cli google-chrome-stable google-cloud-cli firefox powershell microsoft-edge-stable mono-devel \
             && sudo apt-get purge docker-ce docker-ce-cli \
             && sudo apt-get autoremove -y \


### PR DESCRIPTION
Fixes #4887.

Under `bash -e`, a command that is not the last of an `&&` list does not abort the shell when it fails, so `sudo apt-get update && sudo apt-get install ...` followed by another command reports success on a broken mirror and the job dies later on a missing tool. #4877 fixed two workflows; this PR fixes the rest by putting `apt-get update` on a line of its own.

## Sites

The seven listed in the issue, plus two more of the same shape that already existed at the issue's base commit:

- `docker_build_test.yml:46`, identical to `gbs_build.yml:42`.
- The `yocto.yml` disk-space cleanup, where a failed `apt-get update --fix-missing` silently skipped the whole `remove && purge && autoremove && rm -rf` chain. That update is removed rather than split: `apt-get remove`/`purge`/`autoremove` resolve against installed package state, the step deletes `/var/lib/apt/lists` at the end anyway, and keeping it on its own line would add a new way for a mirror hiccup to fail the yocto job before the build starts.

Left alone, as the issue asks: the single-line steps in `publish_docs.yml:49`, `static.check.yml:24`, `update_gbs_cache.yml:40`, and the `&& \` step in `ubuntu_clean_llvm_build.yml`, where the chain's status is the step's status.

## Tests

No GTest or SSAT case: the change is CI-workflow-only and touches no code. The CI run of this PR exercises every changed step. Earlier heads of this PR carried a composite action with retries and a static checker with self-tests; they were dropped as out of proportion to a one-line-per-site fix.

## Things to know

As the issue anticipated, `codeql`, `ubuntu_clean_meson_build` and `publish_docs` used to survive a transient mirror failure because the packages they install are largely preinstalled. They now fail on the first failed update. Unlike `pdebuild`, which #4877 gave a three-attempt retry, there is no retry here; a red run from a mirror hiccup is re-run by hand. That is a deliberate choice of the smallest fix over a softer failure mode, and it can be revisited if such reds turn out to be frequent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
