### PR TITLE
[CI] Restore the per-function Doxygen check and clear its backlog

### DIFF
--- a/.github/workflows/static.check.scripts/doxygen-tag.sh
+++ b/.github/workflows/static.check.scripts/doxygen-tag.sh
@@ -41,8 +41,9 @@ fi
 # @param $1 1-based line number where ctags placed the function
 # @return 0 when such a comment is found, 1 otherwise
 # Reads the global array file_lines (0-based). A declaration ends at the first
-# ';' outside braces, or at the '}' that closes an inline body; the comment may
-# follow on the next line.
+# ';' outside braces, or at the '}' that closes an inline body. The comment may
+# also open the next line; a "/**<" later on that line belongs to whatever is
+# declared there, not to this one.
 has_trailing_doc() {
   local -i i=$1-1
   local -i last=${#file_lines[@]}-1
@@ -55,7 +56,7 @@ has_trailing_doc() {
     closes=${l//[^\}]/}
     depth+=${#opens}-${#closes}
     if [[ $depth -le 0 && ( $l == *";"* || $l == *"}"* ) ]]; then
-      [[ $i -lt $last && ${file_lines[$i+1]} == *"/**<"* ]] && return 0
+      [[ $i -lt $last && ${file_lines[$i+1]} =~ ^[[:space:]]*/\*\*\< ]] && return 0
       return 1
     fi
     i+=1
@@ -147,8 +148,10 @@ for file in `cat $files`; do
                       # Find brief or copydoc tag in the comments between the codes.
                       if [[ $line =~  "@brief" || $line =~ "@copydoc" ]]; then
                           brief=1
-                      # Doxygen tags become zero in code section.
-                      elif [[ $line != *"*"*  && ( $line =~ ";" || $line =~ "}" || $line =~ "#") ]]; then
+                      # Doxygen tags become zero in code section. A comment line
+                      # ('*', '/*', '//') keeps the pending tag; a code line that
+                      # merely contains '*' (a pointer) does not.
+                      elif [[ ! $line =~ ^[[:space:]]*(\*|/\*|//) && ( $line =~ ";" || $line =~ "}" || $line =~ "#") ]]; then
                           brief=0
                       fi
 

--- a/.github/workflows/static.check.scripts/doxygen-tag.sh
+++ b/.github/workflows/static.check.scripts/doxygen-tag.sh
@@ -100,6 +100,7 @@ for file in `cat $files`; do
               if [[ $advanced == 1 ]]; then
                   declare -i idx=0
                   brief=0
+                  in_comment=0
                   function_positions="" # Line number of functions.
                   structure_positions="" # Line number of structure.
                   mapfile -t file_lines < "$file"
@@ -148,11 +149,19 @@ for file in `cat $files`; do
                       # Find brief or copydoc tag in the comments between the codes.
                       if [[ $line =~  "@brief" || $line =~ "@copydoc" ]]; then
                           brief=1
-                      # Doxygen tags become zero in code section. A comment line
-                      # ('*', '/*', '//') keeps the pending tag; a code line that
-                      # merely contains '*' (a pointer) does not.
-                      elif [[ ! $line =~ ^[[:space:]]*(\*|/\*|//) && ( $line =~ ";" || $line =~ "}" || $line =~ "#") ]]; then
+                      # Doxygen tags become zero in code section. Lines inside a
+                      # block comment, or opening one, keep the pending tag; a
+                      # code line that merely contains '*' (a pointer) does not.
+                      elif [[ $in_comment -eq 0 && ! $line =~ ^[[:space:]]*(/\*|//) && ( $line =~ ";" || $line =~ "}" || $line =~ "#") ]]; then
                           brief=0
+                      fi
+
+                      # Track block comments so that their continuation lines are
+                      # never mistaken for code, whatever character they start with.
+                      if [[ $in_comment -eq 1 ]]; then
+                          [[ $line == *"*/"* ]] && in_comment=0
+                      elif [[ $line == *"/*"* && ${line##*/\*} != *"*/"* ]]; then
+                          in_comment=1
                       fi
 
                       # Check a comment statement that begins with '/*'.

--- a/.github/workflows/static.check.scripts/doxygen-tag.sh
+++ b/.github/workflows/static.check.scripts/doxygen-tag.sh
@@ -28,11 +28,40 @@ fi
 
 files=$1
 failed=0
+report_path=${report_path:-/dev/null}
 
 if [ ! -f $files ]; then
   echo "::error The file $files does not exists."
   exit 1
 fi
+
+##
+# @brief Tell whether the declaration starting at a line carries a trailing
+#        "/**<" Doxygen comment, on the declaration itself or right after it.
+# @param $1 1-based line number where ctags placed the function
+# @return 0 when such a comment is found, 1 otherwise
+# Reads the global array file_lines (0-based). A declaration ends at the first
+# ';' outside braces, or at the '}' that closes an inline body; the comment may
+# follow on the next line.
+has_trailing_doc() {
+  local -i i=$1-1
+  local -i last=${#file_lines[@]}-1
+  local -i depth=0
+  local l opens closes
+  while [[ $i -le $last ]]; do
+    l=${file_lines[$i]}
+    [[ $l == *"/**<"* ]] && return 0
+    opens=${l//[^\{]/}
+    closes=${l//[^\}]/}
+    depth+=${#opens}-${#closes}
+    if [[ $depth -le 0 && ( $l == *";"* || $l == *"}"* ) ]]; then
+      [[ $i -lt $last && ${file_lines[$i+1]} == *"/**<"* ]] && return 0
+      return 1
+    fi
+    i+=1
+  done
+  return 1
+}
 
 echo "::group::Doxygen tag check started"
 
@@ -69,14 +98,19 @@ for file in `cat $files`; do
               # Checking tags for each function
               if [[ $advanced == 1 ]]; then
                   declare -i idx=0
+                  brief=0
                   function_positions="" # Line number of functions.
                   structure_positions="" # Line number of structure.
+                  mapfile -t file_lines < "$file"
 
-                  local function_check_flag="f+p" # check document for function and prototype of the function
-
-                  if [[ $pr_doxygen_check_skip_function_definition == 1 && $file != *.h ]]; then
-                      function_check_flag="p" # check document for only prototypes of the function for non-header file
-                  fi
+                  # Definitions are checked everywhere. Prototypes are checked
+                  # only in headers, where the declaration is the documented
+                  # form; a forward declaration in a .c/.cc is documented at
+                  # its definition.
+                  case $file in
+                      *.h|*.hh|*.hpp ) function_check_flag="f+p" ;;
+                      * ) function_check_flag="f" ;;
+                  esac
 
                   # Find line number of functions using ctags, and append them.
                   while IFS='' read -r line || [[ -n "$line" ]]; do
@@ -97,7 +131,7 @@ for file in `cat $files`; do
                       # Check if a function has @brief tag or not.
                       # To pass correct line number not sub number, keep space " $idx ".
                       # ex) want to pass 143 not 14, 43, 1, 3, 4
-                      if [[ $function_positions =~ " $idx " && $brief -eq 0 ]]; then
+                      if [[ $function_positions =~ " $idx " && $brief -eq 0 ]] && ! has_trailing_doc $idx; then
                           echo "[ERROR] File name: $file, $idx line, `echo $line | cut -d ' ' -f1` function needs @brief tag "
                           failed=1
                       fi

--- a/.github/workflows/static.check.scripts/test_doxygen_tag.sh
+++ b/.github/workflows/static.check.scripts/test_doxygen_tag.sh
@@ -168,11 +168,31 @@ class adder
 };'
 run_checker 1 "declaration without any doc between documented ones fails" trailing_missing.hh
 
+write_fixture trailing_belongs_to_next.hh '/** @brief adder */
+class adder
+{
+  public:
+  /** @brief the class */
+  adder ();
+  int add_one (int x);
+  int count; /**< documents count, not add_one */
+};'
+run_checker 1 "a /**< on the next declaration does not cover this one" trailing_belongs_to_next.hh
+
 write_fixture undocumented_struct.h 'struct point
 {
   int x;
 };'
 run_checker 1 "undocumented struct fails" undocumented_struct.h
+
+# The tag must not survive a code line just because that line has a '*' in
+# it: a pointer parameter is not a comment.
+write_fixture pointer_line.h '/**
+ * @brief add one in place
+ */
+void add_one (int *x);
+void add_two (int *x);'
+run_checker 1 "a brief does not carry over a pointer-typed declaration" pointer_line.h
 
 write_fixture ends_in_brief.c '/**
  * @brief add one

--- a/.github/workflows/static.check.scripts/test_doxygen_tag.sh
+++ b/.github/workflows/static.check.scripts/test_doxygen_tag.sh
@@ -194,6 +194,24 @@ void add_one (int *x);
 void add_two (int *x);'
 run_checker 1 "a brief does not carry over a pointer-typed declaration" pointer_line.h
 
+# A wrapped parameter list can put the '*' at the start of a line; that is
+# still code, not a comment continuation.
+write_fixture wrapped_pointer.h '/**
+ * @brief add one in place
+ */
+void add_one (int
+    *x);
+void add_two (int *x);'
+run_checker 1 "a brief does not carry over a wrapped pointer parameter" wrapped_pointer.h
+
+# The converse: a ';' inside the comment block must not clear the tag.
+write_fixture semicolon_in_comment.h '/**
+ * @brief add one in place; the caller owns x
+ * usage: add_one (&x);
+ */
+void add_one (int *x);'
+run_checker 0 "a semicolon inside the comment block keeps the brief" semicolon_in_comment.h
+
 write_fixture ends_in_brief.c '/**
  * @brief add one
  */

--- a/.github/workflows/static.check.scripts/test_doxygen_tag.sh
+++ b/.github/workflows/static.check.scripts/test_doxygen_tag.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# @file     test_doxygen_tag.sh
+# @brief    Self-test for doxygen-tag.sh in the advanced (per-function) mode.
+# @see      https://github.com/nnstreamer/nnstreamer
+# @author   MyungJoo Ham <myungjoo.ham@samsung.com>
+#
+# Runs doxygen-tag.sh the way static.check.yml does, with a changed-file list
+# and the advanced flag. The per-function check had passed vacuously for two
+# years because a stray "local" emptied the ctags kind list, so the first
+# property pinned here is the negative control: an undocumented function
+# definition must fail. The rest pin the scope of the check (definitions
+# everywhere, prototypes only in headers), the trailing "/**<" form, and the
+# per-file reset of the tag state.
+#
+# Fixtures are generated into a temporary directory rather than committed, so
+# that the intentionally undocumented ones never appear in a changed-file list.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../../.." && pwd)
+CHECKER="${SCRIPT_DIR}/doxygen-tag.sh"
+workdir=$(mktemp -d)
+failed=0
+
+trap 'rm -rf "$workdir"' EXIT
+
+if ! command -v ctags > /dev/null 2>&1; then
+  echo "::error ctags is required by doxygen-tag.sh but is not installed."
+  exit 1
+fi
+
+# File-level tags every C/C++ fixture needs so that only the per-function
+# rules decide the outcome. The include line matters: the checker treats a
+# @brief as pending until the next code line, and a real file always has one
+# between the header comment and the first function.
+header_block() {
+  printf '/**\n * @file %s\n * @brief fixture\n * @author fixture\n * @bug none\n */\n#include <stddef.h>\n' "$1"
+}
+
+# write_fixture <name> <content>
+# Creates workdir/<name> with the standard file header followed by content.
+write_fixture() {
+  local name=$1 content=$2
+  { header_block "$name"; printf '%s\n' "$content"; } > "${workdir}/${name}"
+}
+
+# run_checker <expected 0|1> <description> <fixture>...
+# Runs the checker on the listed fixtures in advanced mode, from the repo
+# root, and compares the exit status. Also fails on any stderr output, which
+# is how the broken "local" and the unset report_path used to show up.
+run_checker() {
+  local expected=$1 desc=$2
+  shift 2
+  local list errfile actual f
+
+  list=$(mktemp -p "$workdir")
+  errfile=$(mktemp -p "$workdir")
+  for f in "$@"; do
+    printf '%s\n' "${workdir}/${f}" >> "$list"
+  done
+
+  (cd "$REPO_ROOT" && bash "$CHECKER" "$list" 1) > /dev/null 2> "$errfile" < /dev/null
+  actual=$?
+  [[ $actual -ne 0 ]] && actual=1
+
+  if [[ "$actual" != "$expected" ]]; then
+    echo "FAIL: ${desc} expected exit ${expected}, got ${actual}"
+    failed=1
+  elif [[ -s "$errfile" ]]; then
+    echo "FAIL: ${desc} wrote to stderr:"
+    sed 's/^/    /' "$errfile"
+    failed=1
+  else
+    echo "PASS: ${desc} (exit ${actual})"
+  fi
+}
+
+write_fixture documented.c '/**
+ * @brief add one
+ */
+int
+add_one (int x)
+{
+  return x + 1;
+}'
+run_checker 0 "documented definition passes" documented.c
+
+write_fixture undocumented.c 'int
+add_one (int x)
+{
+  return x + 1;
+}'
+run_checker 1 "undocumented definition fails" undocumented.c
+
+write_fixture forward_decl.c 'static int add_one (int x);
+
+/**
+ * @brief add one
+ */
+static int
+add_one (int x)
+{
+  return x + 1;
+}'
+run_checker 0 "undocumented forward declaration in a .c passes" forward_decl.c
+
+write_fixture undocumented_proto.h 'int add_one (int x);'
+run_checker 1 "undocumented prototype in a .h fails" undocumented_proto.h
+
+write_fixture documented_proto.h '/**
+ * @brief add one
+ */
+int add_one (int x);'
+run_checker 0 "documented prototype in a .h passes" documented_proto.h
+
+write_fixture trailing_same_line.hh '/** @brief adder */
+class adder
+{
+  public:
+  /** @brief the class */
+  adder ();
+  int add_one (int x); /**< add one */
+};'
+run_checker 0 "trailing /**< on the declaration line passes" trailing_same_line.hh
+
+write_fixture trailing_next_line.hh '/** @brief adder */
+class adder
+{
+  public:
+  /** @brief the class */
+  adder ();
+  virtual int add_one (int x) = 0;
+  /**< add one */
+  virtual int add_two (int x,
+      int y) = 0;
+  /**< add two, declared over two lines */
+};'
+run_checker 0 "trailing /**< on the following line passes" trailing_next_line.hh
+
+write_fixture trailing_after_body.hh '/** @brief adder */
+class adder
+{
+  public:
+  /** @brief the class */
+  adder ();
+  virtual int add_one (int x)
+  {
+    return x + 1;
+  }
+  /**< add one, documented after the inline body */
+};'
+run_checker 0 "trailing /**< after an inline body passes" trailing_after_body.hh
+
+write_fixture trailing_missing.hh '/** @brief adder */
+class adder
+{
+  public:
+  /** @brief the class */
+  adder ();
+  int add_one (int x);
+  int add_two (int x);
+  /**< documents add_two only */
+};'
+run_checker 1 "declaration without any doc between documented ones fails" trailing_missing.hh
+
+write_fixture undocumented_struct.h 'struct point
+{
+  int x;
+};'
+run_checker 1 "undocumented struct fails" undocumented_struct.h
+
+write_fixture ends_in_brief.c '/**
+ * @brief add one
+ */
+int
+add_one (int x)
+{
+  return x + 1;
+}
+/**
+ * @brief a dangling comment that leaves the tag state set
+ */'
+run_checker 0 "file ending in a brief passes on its own" ends_in_brief.c
+
+# The file-level tags sit at the bottom here so that nothing resets the tag
+# state before the first function; only the per-file reset can fail it.
+{ printf 'int
+add_one (int x)
+{
+  return x + 1;
+}
+'; header_block tail_header.c; } > "${workdir}/tail_header.c"
+run_checker 1 "undocumented first function fails on its own" tail_header.c
+run_checker 1 "tag state does not leak into the next file" ends_in_brief.c tail_header.c
+
+write_fixture no_author.c '/**
+ * @brief add one
+ */
+int
+add_one (int x)
+{
+  return x + 1;
+}'
+sed -i '/@author/d' "${workdir}/no_author.c"
+run_checker 1 "missing file-level @author fails" no_author.c
+
+if [[ "$failed" != "0" ]]; then
+  echo "::error test_doxygen_tag.sh failed."
+  exit 1
+fi
+echo "test_doxygen_tag.sh: all checks passed."

--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -83,6 +83,19 @@ jobs:
         # Need "grep"
         run: |
           bash .github/workflows/static.check.scripts/doxygen-tag.sh $changed_file_list 1
+      - name: /Checker/ doxygen-tag self-test
+        # Runs a repository script unrelated to $changed_file_list, so it
+        # needs the same merge-ref guard as the self-test steps below.
+        run: |
+          selftest=.github/workflows/static.check.scripts/test_doxygen_tag.sh
+          if [ -f "$selftest" ]; then
+            bash "$selftest"
+          elif git show --pretty="format:" --name-only --no-renames --diff-filter=D ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | grep -qxF "$selftest"; then
+            echo "::error::This PR removes $selftest; remove its workflow step too, or restore the script (also update this step if the script moved)."
+            exit 1
+          else
+            echo "Skipped: $selftest is not in this branch's tree and this PR does not remove it."
+          fi
       - name: /Checker/ Indent check
         # Originally from "pr-prebuild-indent"
         # Need "indent"

--- a/ext/nnstreamer/android_source/gstamcsrc.h
+++ b/ext/nnstreamer/android_source/gstamcsrc.h
@@ -64,6 +64,9 @@ struct _GstAMCSrcClass
   GstPushSrcClass parent_class; /**< inherits class object */
 };
 
+/**
+ * @brief Get the GType of the amcsrc element, registering it if needed
+ */
 GST_EXPORT
 GType gst_amc_src_get_type (void);
 

--- a/ext/nnstreamer/android_source/gstamcsrc_looper.h
+++ b/ext/nnstreamer/android_source/gstamcsrc_looper.h
@@ -47,17 +47,24 @@ struct looper_message {
 class Looper {
   public:
     Looper ();
+    /** @brief Flush pending messages and destroy the sync primitives */
     ~Looper ();
 
+    /** @brief Dispatch queued messages to the handler until exit is posted */
     void loop (void);
+    /** @brief Create the detached thread running the message loop */
     void start (void);
+    /** @brief Terminate the loop by posting a flushing exit message */
     void exit (void);
     void post (gint cmd, void *data, bool flush);
     void (*handle) (gint cmd, void *data);  /**< should be implemented */
 
   private:
+    /** @brief Thread entry point; runs loop () on the given Looper instance */
     static void *entry (void *data);
+    /** @brief Append a message to the queue, flushing pending ones if asked */
     void add_msg (looper_message *new_msg, bool flush);
+    /** @brief Drop and free every pending message in the queue */
     void flush_msg (void);
 
     pthread_t thread;
@@ -76,10 +83,15 @@ class Looper {
 extern "C"
 {
 #endif
+  /** @brief Create a Looper, start its thread, and return the opaque handle */
   void *Looper_new (void);
+  /** @brief Destroy a Looper created by Looper_new () */
   void Looper_delete (void *looper);
+  /** @brief Ask the looper thread to terminate */
   void Looper_exit (void *looper);
+  /** @brief Queue a command for the looper thread to handle */
   void Looper_post (void *looper, gint cmd, void *data, gboolean flush);
+  /** @brief Register the callback invoked for each queued command */
   void Looper_set_handle (void *looper, void (*handle) (gint, void*));
 #ifdef __cplusplus
 }

--- a/ext/nnstreamer/android_source/gstamcsrc_looper.h
+++ b/ext/nnstreamer/android_source/gstamcsrc_looper.h
@@ -56,6 +56,7 @@ class Looper {
     void start (void);
     /** @brief Terminate the loop by posting a flushing exit message */
     void exit (void);
+    /** @brief Queue a command for loop () to hand to the handler */
     void post (gint cmd, void *data, bool flush);
     void (*handle) (gint cmd, void *data);  /**< should be implemented */
 

--- a/ext/nnstreamer/extra/nnstreamer_grpc.h
+++ b/ext/nnstreamer/extra/nnstreamer_grpc.h
@@ -86,19 +86,29 @@ enum
 extern "C" {
 #endif
 
+/** @brief Get the grpc_idl enum matching an IDL name such as "protobuf" */
 grpc_idl grpc_get_idl (const gchar *idl_str);
 
+/** @brief Create a gRPC service instance for the given configuration */
 void * grpc_new (const grpc_config * config);
+/** @brief Destroy a gRPC instance created by grpc_new () */
 void grpc_destroy (void * instance);
 
+/** @brief Start the gRPC server or client service of the instance */
 gboolean grpc_start (void * instance);
+/** @brief Stop the gRPC service and join its worker thread */
 void grpc_stop (void * instance);
 
+/** @brief Queue a buffer holding tensors to be sent over gRPC */
 gboolean grpc_send (void * instance, GstBuffer * buffer);
+/** @brief Get the server's listening port, or -EINVAL for a client instance */
 int grpc_get_listening_port (void * instance);
 
+/** @brief Check whether the string is "localhost" or an IP address */
 gboolean _check_hostname (gchar * str);
+/** @brief Handle set-property shared by the gRPC source and sink elements */
 void grpc_common_set_property (GObject * self, gboolean * silent, grpc_private * grpc, guint prop_id, const GValue * value, GParamSpec * pspec);
+/** @brief Handle get-property shared by the gRPC source and sink elements */
 void grpc_common_get_property (GObject * self, gboolean silent, guint out, grpc_private * grpc, guint prop_id, GValue * value, GParamSpec * pspec);
 
 #ifdef __cplusplus

--- a/ext/nnstreamer/extra/nnstreamer_grpc_common.h
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_common.h
@@ -36,8 +36,11 @@ class NNStreamerRPC {
     NNStreamerRPC (const grpc_config *config);
     virtual ~NNStreamerRPC ();
 
+    /** @brief start the gRPC service as a server or a client */
     gboolean start ();
+    /** @brief stop the service, drain the queue and join the worker thread */
     void stop ();
+    /** @brief push a buffer holding tensors into the send queue */
     gboolean send (GstBuffer *buffer);
 
     /** @brief get gRPC listening port (server only) */
@@ -93,11 +96,15 @@ class NNStreamerRPC {
     /** @brief start gRPC client */
     virtual gboolean start_client (std::string address) { return FALSE; }
 
+    /** @brief build the listening address and start the server service */
     gboolean _start_server ();
+    /** @brief build the target address and start the client service */
     gboolean _start_client ();
 
+    /** @brief data queue callback; the queue is never considered full */
     static gboolean _data_queue_check_full_cb (GstDataQueue * queue,
         guint visible, guint bytes, guint64 time, gpointer checkdata);
+    /** @brief data queue callback; unref the buffer and free the item */
     static void _data_queue_item_free (GstDataQueueItem * item);
 };
 

--- a/ext/nnstreamer/extra/nnstreamer_grpc_common.h
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_common.h
@@ -33,7 +33,9 @@ class NNStreamerRPC {
   public:
     static NNStreamerRPC * createInstance (const grpc_config *config);
 
+    /** @brief Construct from the config; the data queue is created here */
     NNStreamerRPC (const grpc_config *config);
+    /** @brief Free the data queue and drop any pending buffers */
     virtual ~NNStreamerRPC ();
 
     /** @brief start the gRPC service as a server or a client */

--- a/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.h
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.h
@@ -35,6 +35,7 @@ class ServiceImplFlatbuf : public NNStreamerRPC
   public:
     ServiceImplFlatbuf (const grpc_config * config);
 
+    /** @brief Parse the flatbuf tensors and deliver the buffer via callback */
     void parse_tensors (Message<Tensors> &tensors);
     /** @brief pop a buffer from the queue and fill the flatbuf tensors */
     gboolean fill_tensors (Message<Tensors> &tensors);
@@ -88,7 +89,9 @@ class AsyncServiceImplFlatbuf final
   : public ServiceImplFlatbuf, public TensorService::AsyncService
 {
   public:
+    /** @brief Construct the async service with no call in flight */
     AsyncServiceImplFlatbuf (const grpc_config * config);
+    /** @brief Delete the last outstanding call, if any */
     ~AsyncServiceImplFlatbuf ();
 
     /** @brief set the last call data */

--- a/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.h
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_flatbuf.h
@@ -36,16 +36,21 @@ class ServiceImplFlatbuf : public NNStreamerRPC
     ServiceImplFlatbuf (const grpc_config * config);
 
     void parse_tensors (Message<Tensors> &tensors);
+    /** @brief pop a buffer from the queue and fill the flatbuf tensors */
     gboolean fill_tensors (Message<Tensors> &tensors);
 
   protected:
+    /** @brief write queued tensors to the given gRPC writer until stopped */
     template <typename T>
     grpc::Status _write_tensors (T writer);
 
+    /** @brief read tensors from the given gRPC reader until the stream ends */
     template <typename T>
     grpc::Status _read_tensors (T reader);
 
+    /** @brief serialize a GstBuffer into a flatbuf tensors message */
     void _get_tensors_from_buffer (GstBuffer *buffer, Message<Tensors> &tensors);
+    /** @brief build a GstBuffer from a flatbuf tensors message */
     void _get_buffer_from_tensors (Message<Tensors> &tensors, GstBuffer **buffer);
 
     std::unique_ptr<nnstreamer::flatbuf::TensorService::Stub> client_stub_;
@@ -70,6 +75,7 @@ class SyncServiceImplFlatbuf final
     gboolean start_server (std::string address) override;
     gboolean start_client (std::string address) override;
 
+    /** @brief thread body streaming tensors to or from the sync server */
     void _client_thread ();
 };
 
@@ -92,7 +98,9 @@ class AsyncServiceImplFlatbuf final
     gboolean start_server (std::string address) override;
     gboolean start_client (std::string address) override;
 
+    /** @brief thread body handling server events from the completion queue */
     void _server_thread ();
+    /** @brief thread body handling client events from the completion queue */
     void _client_thread ();
 
     AsyncCallData * last_call_;

--- a/ext/nnstreamer/extra/nnstreamer_grpc_protobuf.h
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_protobuf.h
@@ -34,6 +34,7 @@ class ServiceImplProtobuf : public NNStreamerRPC
   public:
     ServiceImplProtobuf (const grpc_config * config);
 
+    /** @brief Parse the protobuf tensors and deliver the buffer via callback */
     void parse_tensors (Tensors &tensors);
     /** @brief pop a buffer from the queue and fill the protobuf tensors */
     gboolean fill_tensors (Tensors &tensors);
@@ -87,7 +88,9 @@ class AsyncServiceImplProtobuf final
   : public ServiceImplProtobuf, public TensorService::AsyncService
 {
   public:
+    /** @brief Construct the async service with no call in flight */
     AsyncServiceImplProtobuf (const grpc_config * config);
+    /** @brief Delete the last outstanding call, if any */
     ~AsyncServiceImplProtobuf ();
 
     /** @brief set the last call data */

--- a/ext/nnstreamer/extra/nnstreamer_grpc_protobuf.h
+++ b/ext/nnstreamer/extra/nnstreamer_grpc_protobuf.h
@@ -35,16 +35,21 @@ class ServiceImplProtobuf : public NNStreamerRPC
     ServiceImplProtobuf (const grpc_config * config);
 
     void parse_tensors (Tensors &tensors);
+    /** @brief pop a buffer from the queue and fill the protobuf tensors */
     gboolean fill_tensors (Tensors &tensors);
 
   protected:
+    /** @brief write queued tensors to the given gRPC writer until stopped */
     template <typename T>
     grpc::Status _write_tensors (T writer);
 
+    /** @brief read tensors from the given gRPC reader until the stream ends */
     template <typename T>
     grpc::Status _read_tensors (T reader);
 
+    /** @brief serialize a GstBuffer into a protobuf tensors message */
     void _get_tensors_from_buffer (GstBuffer *buffer, Tensors &tensors);
+    /** @brief build a GstBuffer from a protobuf tensors message */
     void _get_buffer_from_tensors (Tensors &tensors, GstBuffer **buffer);
 
     std::unique_ptr<nnstreamer::protobuf::TensorService::Stub> client_stub_;
@@ -69,6 +74,7 @@ class SyncServiceImplProtobuf final
     gboolean start_server (std::string address) override;
     gboolean start_client (std::string address) override;
 
+    /** @brief thread body streaming tensors to or from the sync server */
     void _client_thread ();
 };
 
@@ -91,7 +97,9 @@ class AsyncServiceImplProtobuf final
     gboolean start_server (std::string address) override;
     gboolean start_client (std::string address) override;
 
+    /** @brief thread body handling server events from the completion queue */
     void _server_thread ();
+    /** @brief thread body handling client events from the completion queue */
     void _client_thread ();
 
     AsyncCallData * last_call_;

--- a/ext/nnstreamer/extra/nnstreamer_python3_helper.h
+++ b/ext/nnstreamer/extra/nnstreamer_python3_helper.h
@@ -59,12 +59,19 @@ extern "C" {
 #define PyEval_InitThreads_IfGood()     do { PyEval_InitThreads(); } while (0)
 #endif
 
+/** @brief Get the NNStreamer tensor type matching the given numpy type */
 extern tensor_type getTensorType (NPY_TYPES npyType);
+/** @brief Get the numpy type matching the given NNStreamer tensor type */
 extern NPY_TYPES getNumpyType (tensor_type tType);
+/** @brief Import the python module and instantiate its class into core_obj */
 extern int loadScript (PyObject **core_obj, const gchar *module_name, const gchar *class_name);
+/** @brief dlopen the libpython shared object with RTLD_GLOBAL */
 extern int openPythonLib (void **handle);
+/** @brief Append the given path and "." to the python sys.path list */
 extern int addToSysPath (const gchar *path);
+/** @brief Fill tensors info from the tensor-shape list returned by python */
 extern int parseTensorsInfo (PyObject *result, GstTensorsInfo *info);
+/** @brief Create a python TensorShape object holding the given tensor info */
 extern PyObject * PyTensorShape_New (PyObject * shape_cls, const GstTensorInfo *info);
 
 /**
@@ -97,15 +104,17 @@ class PyGILGuard
   public:
   PyGILState_STATE gstate;
 
+  /** @brief Acquire the Python GIL for the current thread */
   PyGILGuard () : gstate (PyGILState_Ensure ())
   {
   }
+  /** @brief Release the Python GIL acquired by the constructor */
   ~PyGILGuard ()
   {
     PyGILState_Release (gstate);
   }
 
-  /* Prevent copying to ensure single ownership */
+  /** @brief Copy constructor is deleted to keep single GIL ownership */
   PyGILGuard (const PyGILGuard &) = delete;
   PyGILGuard &operator= (const PyGILGuard &) = delete;
 };

--- a/ext/nnstreamer/tensor_decoder/box_properties/ovdetection.cc
+++ b/ext/nnstreamer/tensor_decoder/box_properties/ovdetection.cc
@@ -29,6 +29,7 @@ class OVDetection : public BoxProperties
   public:
   OVDetection ();
   ~OVDetection ();
+  /** @brief Accept and ignore the option string; this mode has no options */
   int setOptionInternal (const char *param)
   {
     UNUSED (param);

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.h
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.h
@@ -239,27 +239,35 @@ class BoxProperties
   virtual ~BoxProperties () = default;
 
   /* mandatory methods */
+  /** @brief Parse the mode-specific option string into this instance */
   virtual int setOptionInternal (const char *param) = 0;
+  /** @brief Check whether the given tensors config is decodable by this mode */
   virtual int checkCompatible (const GstTensorsConfig *config) = 0;
+  /** @brief Decode the input tensors into a GArray of detectedObject */
   virtual GArray *decode (const GstTensorsConfig *config, const GstTensorMemory *input) = 0;
 
+  /** @brief Set the width of the model input image in pixels */
   void setInputWidth (guint width)
   {
     i_width = width;
   }
+  /** @brief Set the height of the model input image in pixels */
   void setInputHeight (guint height)
   {
     i_height = height;
   }
+  /** @brief Set the number of labels the model classifies boxes into */
   void setTotalLabels (guint labels)
   {
     total_labels = labels;
   }
 
+  /** @brief Get the width of the model input image in pixels */
   guint getInputWidth ()
   {
     return i_width;
   }
+  /** @brief Get the height of the model input image in pixels */
   guint getInputHeight ()
   {
     return i_height;
@@ -281,23 +289,37 @@ class BoundingBox
 {
   public:
   BoundingBox ();
+  /** @brief Free the label data, label path and tracking arrays */
   ~BoundingBox ();
 
+  /** @brief Check the label relevant properties are valid */
   gboolean checkLabelProps ();
+  /** @brief Select the box decoding mode from the option string */
   int setBoxDecodingMode (const char *param);
+  /** @brief Set the label file path and load the labels from it */
   int setLabelPath (const char *param);
+  /** @brief Set the output video width and height from the option string */
   int setVideoSize (const char *param);
+  /** @brief Set the model input width and height from the option string */
   int setInputModelSize (const char *param);
+  /** @brief Draw the decoded boxes and labels onto the output frame */
   void draw (GstMapInfo *out_info, GArray *results);
+  /** @brief Log the decoded boxes at the info level */
   void logBoxes (GArray *results);
+  /** @brief Match boxes to tracked centroids and assign tracking ids */
   void updateCentroids (GArray *boxes);
 
+  /** @brief Set the decoder option given by its option number */
   int setOption (BoundingBoxOption opNum, const char *param);
+  /** @brief Build the output video caps for the given tensors config */
   GstCaps *getOutCaps (const GstTensorsConfig *config);
+  /** @brief Decode the input tensors and render the boxes into outbuf */
   GstFlowReturn decode (const GstTensorsConfig *config,
       const GstTensorMemory *input, GstBuffer *outbuf);
 
+  /** @brief Look up registered box properties by mode name */
   static BoxProperties *getProperties (const gchar *properties_name);
+  /** @brief Register box properties into the mode name table */
   static gboolean addProperties (BoxProperties *boxProperties);
 
   private:

--- a/ext/nnstreamer/tensor_decoder/tensordecutil.h
+++ b/ext/nnstreamer/tensor_decoder/tensordecutil.h
@@ -30,14 +30,18 @@ typedef struct {
   gsize max_word_length; /**< The max size of labels */
 } imglabel_t;
 
+/** @brief Load label file into the internal data */
 extern void
 loadImageLabels (const char * label_path, imglabel_t *l);
 
+/** @brief Initialize ASCII font sprite */
 extern void
 initSingleLineSprite (singleLineSprite_t v, rasters_t r, uint32_t pv);
 
+/** @brief Free image labels */
 extern void _free_labels (imglabel_t *data);
 
+/** @brief Copy framerate caps from tensor config */
 extern void setFramerateFromConfig  (GstCaps *caps, const GstTensorsConfig * config);
 
 #ifdef __cplusplus

--- a/ext/nnstreamer/tensor_filter/tensor_filter_cpp.hh
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_cpp.hh
@@ -100,14 +100,19 @@ class tensor_filter_cpp
   tensor_filter_cpp (
       const char *modelName); /**< modelName is the model property of tensor_filter,
                                  which could be the path to the model file (requires proper extension name) or the registered model name at runtime. */
+  /** @brief Class destructor */
   virtual ~tensor_filter_cpp ();
 
   /** C++ plugin writers need to fill {getInput/Output} inclusive-or {setInput} */
+  /** @brief Fill info with the input tensors dimension of this filter */
   virtual int getInputDim (GstTensorsInfo *info) = 0;
+  /** @brief Fill info with the output tensors dimension of this filter */
   virtual int getOutputDim (GstTensorsInfo *info) = 0;
 
+  /** @brief Derive the output tensors dimension from the given input one */
   virtual int setInputDim (const GstTensorsInfo *in, GstTensorsInfo *out) = 0;
 
+  /** @brief Run the filter for a single frame, writing the result to out */
   virtual int invoke (const GstTensorMemory *in, GstTensorMemory *out) = 0;
 
   virtual bool isAllocatedBeforeInvoke () = 0;
@@ -143,16 +148,23 @@ class tensor_filter_cpp
   /**< Check if it's a valid filter_cpp object. Do not override. */
 
   /** Internal functions for tensor_filter main. Do not override */
+  /** @brief tensor_filter callback dispatching getInputDim to the instance */
   static int getInputDim (const GstTensorFilterProperties *prop,
       void **private_data, GstTensorsInfo *info);
+  /** @brief tensor_filter callback dispatching getOutputDim to the instance */
   static int getOutputDim (const GstTensorFilterProperties *prop,
       void **private_data, GstTensorsInfo *info);
+  /** @brief tensor_filter callback dispatching setInputDim to the instance */
   static int setInputDim (const GstTensorFilterProperties *prop,
       void **private_data, const GstTensorsInfo *in, GstTensorsInfo *out);
+  /** @brief tensor_filter callback dispatching invoke to the instance */
   static int invoke (const GstTensorFilterProperties *prop, void **private_data,
       const GstTensorMemory *input, GstTensorMemory *output);
+  /** @brief tensor_filter callback opening the filter given by model prop */
   static int open (const GstTensorFilterProperties *prop, void **private_data);
+  /** @brief tensor_filter callback releasing a reference to the filter */
   static void close (const GstTensorFilterProperties *prop, void **private_data);
+  /** @brief Call dlclose for all handles opened by open () */
   static void close_all_handles (void);
 };
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_dali.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_dali.cc
@@ -91,6 +91,9 @@
 namespace
 {
 
+/**
+ * @brief Format a vector as a parenthesized, separator-joined string
+ */
 template <typename T>
 inline std::string
 to_string (const std::vector<T> &vec, const char sep = ',')
@@ -408,6 +411,9 @@ dali_subplugin::eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &
   return -ENOENT;
 }
 
+/**
+ * @brief Convert an nnstreamer tensor dimension into a reversed dali shape
+ */
 std::vector<std::int64_t>
 dali_subplugin::convertShape (const GstTensorInfo &tensor_info) const
 {
@@ -423,6 +429,9 @@ dali_subplugin::convertShape (const GstTensorInfo &tensor_info) const
   return shape;
 }
 
+/**
+ * @brief Get the dali pipeline output shape without its leading 1 dimension
+ */
 std::vector<std::int64_t>
 dali_subplugin::getDaliOutputShape ()
 {
@@ -442,6 +451,9 @@ dali_subplugin::getDaliOutputShape ()
   return dali_output_shape;
 }
 
+/**
+ * @brief Map an nnstreamer tensor type to the matching dali data type
+ */
 dali_data_type_t
 dali_subplugin::getDaliDataType (tensor_type nns_tensor_type) const
 {

--- a/ext/nnstreamer/tensor_filter/tensor_filter_executorch_llama.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_executorch_llama.cc
@@ -61,7 +61,9 @@ class executorch_llama_subplugin final : public tensor_filter_subplugin
   static void init_filter_executorch_llama ();
   static void fini_filter_executorch_llama ();
 
+  /** @brief Construct an unconfigured subplugin instance */
   executorch_llama_subplugin (){};
+  /** @brief Destruct the instance, releasing the Llama runner */
   ~executorch_llama_subplugin (){};
 
   tensor_filter_subplugin &getEmptyInstance () override;

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.hh
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.hh
@@ -57,25 +57,41 @@ class TensorFilterOpenvino
     RetEOverFlow = -EOVERFLOW,
   };
 
+  /** @brief Convert an IE tensor data type string to a _nns_tensor_type */
   static tensor_type convertFromIETypeStr (std::string type);
+  /** @brief Convert a tensor container in NNS to a tensor container in IE */
   static InferenceEngine::Blob::Ptr convertGstTensorMemoryToBlobPtr (
       const InferenceEngine::TensorDesc tensorDesc,
       const GstTensorMemory *gstTensor, const tensor_type gstType);
+  /** @brief Check the given hw has a matching device in devsVector */
   static bool isAcclDevSupported (std::vector<std::string> &devsVector, accl_hw hw);
 
+  /** @brief Construct with the paths to the XML and bin model files */
   TensorFilterOpenvino (std::string path_model_xml, std::string path_model_bin);
+  /** @brief Destruct the instance */
   ~TensorFilterOpenvino ();
 
-  /** @todo Need to support other acceleration devices */
+  /**
+   * @brief Load the given neural network into the target device
+   * @todo Need to support other acceleration devices
+   */
   int loadModel (accl_hw hw);
+  /** @brief Check the neural network model is loaded */
   bool isModelLoaded ();
+  /** @brief Get the dimensions of the input tensors of the given model */
   int getInputTensorDim (GstTensorsInfo *info);
+  /** @brief Get the dimensions of the output tensors of the given model */
   int getOutputTensorDim (GstTensorsInfo *info);
+  /** @brief Do inference using Inference Engine of the OpenVino framework */
   int invoke (const GstTensorFilterProperties *prop,
       const GstTensorMemory *input, GstTensorMemory *output);
+  /** @brief Get the path where the model file in XML format is located */
   std::string getPathModelXml ();
+  /** @brief Set the path where the model file in XML format is located */
   void setPathModelXml (std::string pathXml);
+  /** @brief Get the path where the model file in bin format is located */
   std::string getPathModelBin ();
+  /** @brief Set the path where the model file in bin format is located */
   void setPathModelBin (std::string pathBin);
 
   static const std::string extBin;
@@ -86,6 +102,7 @@ class TensorFilterOpenvino
   InferenceEngine::OutputsDataMap _outputsDataMap;
 
   private:
+  /** @brief Hidden default constructor; the model paths are mandatory */
   TensorFilterOpenvino ();
 
   InferenceEngine::Core _ieCore;

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorrt10.cc
@@ -94,6 +94,9 @@ struct NvInferDeleter {
 template <typename T>
 using NvInferUniquePtr = std::unique_ptr<T, NvInferDeleter>;
 
+/**
+ * @brief Wrap a raw TensorRT object pointer into a NvInferUniquePtr
+ */
 template <typename T>
 NvInferUniquePtr<T>
 makeNvInferUniquePtr (T *t)
@@ -443,7 +446,7 @@ tensorrt10_subplugin::constructNetwork (NvInferUniquePtr<nvonnxparser::IParser> 
 }
 
 /**
- * Builds and saves the .engine file.
+ * @brief Builds and saves the .engine file.
  */
 void
 tensorrt10_subplugin::buildSaveEngine () const
@@ -667,7 +670,7 @@ tensorrt10_subplugin::loadModel (const GstTensorFilterProperties *prop)
 }
 
 /**
- * Converts the NvInferTensorInfo's to the nnstreamer GstTensorsInfo.
+ * @brief Converts the NvInferTensorInfo's to the nnstreamer GstTensorsInfo.
  */
 void
 tensorrt10_subplugin::convertTensorsInfo (

--- a/ext/nnstreamer/tensor_filter/tensor_filter_trix_engine.hh
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_trix_engine.hh
@@ -35,22 +35,33 @@ class TensorFilterTRIxEngine : public tensor_filter_subplugin
 {
   public:
   TensorFilterTRIxEngine ();
+  /** @brief Destruct the TRIx-Engine subplugin instance */
   ~TensorFilterTRIxEngine ();
 
   /* mandatory methods */
+  /** @brief Method to get an empty object */
   tensor_filter_subplugin &getEmptyInstance ();
+  /** @brief Configure TRIx-Engine instance */
   void configure_instance (const GstTensorFilterProperties *prop);
+  /** @brief Invoke TRIxEngine using input tensors */
   void invoke (const GstTensorMemory *input, GstTensorMemory *output);
+  /** @brief Get TRIxEngine framework info */
   void getFrameworkInfo (GstTensorFilterFrameworkInfo &info);
+  /** @brief Get TRIxEngine model info */
   int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info);
+  /** @brief Method to handle the event */
   int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data);
 
   /* static methods */
+  /** @brief Register the subplugin */
   static void init_filter_trix_engine ();
+  /** @brief Destruct the subplugin */
   static void fini_filter_trix_engine ();
 
   private:
+  /** @brief Convert data layout (from NNStreamer to TRIx-Engine) */
   static data_layout convert_data_layout (const tensor_layout &layout);
+  /** @brief Convert data type (from NNStreamer to TRIx-Engine) */
   static data_type convert_data_type (const tensor_type &type);
 
   static TensorFilterTRIxEngine *registered;
@@ -58,8 +69,11 @@ class TensorFilterTRIxEngine : public tensor_filter_subplugin
   static const accl_hw hw_list[];
   static const int num_hw;
 
+  /** @brief Set data info of input/output tensors using metadata */
   void set_data_info (const GstTensorFilterProperties *prop);
+  /** @brief Feed the tensor data to input buffers before invoke() */
   void feed_input_data (const GstTensorMemory *input, input_buffers *input_buf);
+  /** @brief Extract the tensor data from output buffers after invoke() */
   void extract_output_data (const output_buffers *output_buf, GstTensorMemory *output);
 
   /* trix-engine vars */

--- a/gst/datarepo/gstdatareposink.h
+++ b/gst/datarepo/gstdatareposink.h
@@ -68,6 +68,9 @@ struct _GstDataRepoSinkClass
   GstBaseSinkClass parent_class;
 };
 
+/**
+ * @brief Get the GType of the datareposink element.
+ */
 GType gst_data_repo_sink_get_type (void);
 
 G_END_DECLS

--- a/gst/datarepo/gstdatareposrc.h
+++ b/gst/datarepo/gstdatareposrc.h
@@ -98,6 +98,9 @@ struct _GstDataRepoSrcClass {
   GstPushSrcClass parent_class;
 };
 
+/**
+ * @brief Get the GType of the datareposrc element.
+ */
 GType gst_data_repo_src_get_type (void);
 
 G_END_DECLS

--- a/gst/edge/edge_sink.h
+++ b/gst/edge/edge_sink.h
@@ -69,6 +69,9 @@ struct _GstEdgeSinkClass
   GstBaseSinkClass parent_class;   /**<parent class */
 };
 
+/**
+ * @brief Get the GType of the edgesink element.
+ */
 GType gst_edgesink_get_type (void);
 
 G_END_DECLS

--- a/gst/edge/edge_src.h
+++ b/gst/edge/edge_src.h
@@ -65,6 +65,9 @@ struct _GstEdgeSrcClass
   GstBaseSrcClass parent_class;
 };
 
+/**
+ * @brief Get the GType of the edgesrc element.
+ */
 GType gst_edgesrc_get_type (void);
 
 G_END_DECLS

--- a/gst/mqtt/mqttsink.h
+++ b/gst/mqtt/mqttsink.h
@@ -103,6 +103,9 @@ struct _GstMqttSinkClass {
   GstBaseSinkClass parent_class;
 };
 
+/**
+ * @brief Get the GType of the mqttsink element.
+ */
 GType gst_mqtt_sink_get_type (void);
 
 G_END_DECLS

--- a/gst/mqtt/mqttsrc.h
+++ b/gst/mqtt/mqttsrc.h
@@ -81,6 +81,9 @@ struct _GstMqttSrcClass {
   GstBaseSrcClass parent_class;
 };
 
+/**
+ * @brief Get the GType of the mqttsrc element.
+ */
 GType gst_mqtt_src_get_type (void);
 
 G_END_DECLS

--- a/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
+++ b/gst/nnstreamer/include/nnstreamer_cppplugin_api_filter.hh
@@ -75,7 +75,7 @@ class tensor_filter_subplugin
                           have different subplugin_data while the C callbacks
                           are identical. Thus, we copy C callbacks from this template to fwdesc and let each subplugin start customizing based on fwdesc, not on fwdesc_template */
 
-  /** Helper function */
+  /** @brief Cast ptr to a subplugin after checking its sanity marker */
   static inline tensor_filter_subplugin *get_tfsp_with_checks (void *ptr);
   /** tensor_filter/C wrapper functions */
   static int cpp_open (const GstTensorFilterProperties *prop, void **private_data); /**< C wrapper function, open */

--- a/gst/nnstreamer/nnstreamer_conf.h
+++ b/gst/nnstreamer/nnstreamer_conf.h
@@ -172,6 +172,9 @@ nnsconf_get_custom_value_bool (const gchar * group, const gchar * key, gboolean 
 extern void
 nnsconf_dump (gchar * str, gulong size);
 
+/**
+ * @brief Print out the information of registered sub-plugins
+ */
 extern void
 nnsconf_subplugin_dump (gchar * str, gulong size);
 

--- a/gst/nnstreamer/nnstreamer_subplugin.h
+++ b/gst/nnstreamer/nnstreamer_subplugin.h
@@ -91,10 +91,16 @@ register_subplugin (subpluginType type, const char *name, const void *data);
 extern gboolean
 unregister_subplugin (subpluginType type, const char *name);
 
+/**
+ * @brief common interface to set custom property description of a sub-plugin.
+ */
 extern void
 subplugin_set_custom_property_desc (subpluginType type, const char *name,
     const gchar * prop, va_list varargs);
 
+/**
+ * @brief common interface to get custom property description of a sub-plugin.
+ */
 extern GData *
 subplugin_get_custom_property_desc (subpluginType type, const char *name);
 

--- a/gst/nnstreamer/tensor_query/tensor_query_client.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_client.h
@@ -73,6 +73,9 @@ struct _GstTensorQueryClientClass
   GstElementClass parent_class; /**< parent class */
 };
 
+/**
+ * @brief Get the GType of the tensor_query_client element.
+ */
 GType gst_tensor_query_client_get_type (void);
 
 G_END_DECLS

--- a/gst/nnstreamer/tensor_query/tensor_query_serversink.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversink.h
@@ -57,6 +57,9 @@ struct _GstTensorQueryServerSinkClass
   GstBaseSinkClass parent_class; /**< parent class */
 };
 
+/**
+ * @brief Get the GType of the tensor_query_serversink element.
+ */
 GType gst_tensor_query_serversink_get_type (void);
 
 G_END_DECLS

--- a/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
+++ b/gst/nnstreamer/tensor_query/tensor_query_serversrc.h
@@ -64,6 +64,9 @@ struct _GstTensorQueryServerSrcClass
   GstPushSrcClass parent_class; /**< parent class */
 };
 
+/**
+ * @brief Get the GType of the tensor_query_serversrc element.
+ */
 GType gst_tensor_query_serversrc_get_type (void);
 
 G_END_DECLS

--- a/tests/cpp_methods/cppfilter_test.hh
+++ b/tests/cpp_methods/cppfilter_test.hh
@@ -14,34 +14,52 @@
 #include <glib.h>
 #include <tensor_filter_cpp.hh>
 
+/** @brief Test C++ filter: uint8 3:4:4:1 in, uint8 3:4:4:2 out */
 class filter_basic : public tensor_filter_cpp
 {
   public:
+  /** @brief Construct the test filter with the given filter name */
   filter_basic (const char *str);
+  /** @brief Destructor of the test filter */
   ~filter_basic ();
 
+  /** @brief Report the fixed input dimension, uint8 3:4:4:1 */
   int getInputDim (GstTensorsInfo *info);
+  /** @brief Report the fixed output dimension, uint8 3:4:4:2 */
   int getOutputDim (GstTensorsInfo *info);
+  /** @brief Reject dimension negotiation; the dimensions are fixed */
   int setInputDim (const GstTensorsInfo *in, GstTensorsInfo *out);
+  /** @brief Tell the framework the output buffer is preallocated */
   bool isAllocatedBeforeInvoke ();
+  /** @brief Write in*2 to the first output frame and in+1 to the second */
   int invoke (const GstTensorMemory *in, GstTensorMemory *out);
 
+  /** @brief Verify the output file holds in*2 and in+1 for each frame */
   static int resultCompare (const char *inputFile, const char *outputFile,
       unsigned int nDropAllowed = 0);
 };
 
+/** @brief Test C++ filter: uint8 3:16:16:1 in, uint8 3:16:16:2 out */
 class filter_basic2 : public tensor_filter_cpp
 {
   public:
+  /** @brief Construct the test filter with the given filter name */
   filter_basic2 (const char *str);
+  /** @brief Destructor of the test filter */
   ~filter_basic2 ();
 
+  /** @brief Report the fixed input dimension, uint8 3:16:16:1 */
   int getInputDim (GstTensorsInfo *info);
+  /** @brief Report the fixed output dimension, uint8 3:16:16:2 */
   int getOutputDim (GstTensorsInfo *info);
+  /** @brief Reject dimension negotiation; the dimensions are fixed */
   int setInputDim (const GstTensorsInfo *in, GstTensorsInfo *out);
+  /** @brief Tell the framework the output buffer is preallocated */
   bool isAllocatedBeforeInvoke ();
+  /** @brief Write in*3 to the first output frame and in+2 to the second */
   int invoke (const GstTensorMemory *in, GstTensorMemory *out);
 
+  /** @brief Verify the output file holds in*3 and in+2 for each frame */
   static int resultCompare (const char *inputFile, const char *outputFile,
       unsigned int nDropAllowed = 0);
 };

--- a/tests/gstreamer_mqtt/GstMqttTestHelper.hh
+++ b/tests/gstreamer_mqtt/GstMqttTestHelper.hh
@@ -183,6 +183,7 @@ class GstMqttTestHelper
         fail_send (false), fail_disconnect (false), fail_subscribe (false),
         fail_unsubscribe (false), is_connected (false){};
 
+  /** @brief Disable the copy constructor to keep this class a singleton */
   GstMqttTestHelper (const GstMqttTestHelper &) = delete;
   GstMqttTestHelper &operator= (const GstMqttTestHelper &) = delete;
 

--- a/tests/nnstreamer_edge/nnstreamer-edge-custom-test.c
+++ b/tests/nnstreamer_edge/nnstreamer-edge-custom-test.c
@@ -26,6 +26,9 @@ typedef struct
   void *user_data;
 } nns_edge_custom_test_s;
 
+/**
+ * @brief Release the private handle of the test custom connection.
+ */
 static int
 nns_edge_custom_close (void *priv)
 {
@@ -42,12 +45,18 @@ nns_edge_custom_close (void *priv)
   return NNS_EDGE_ERROR_NONE;
 }
 
+/**
+ * @brief Return the description string of this custom connection.
+ */
 static const char *
 nns_edge_custom_get_description (void)
 {
   return "custom";
 }
 
+/**
+ * @brief Allocate the private handle of the test custom connection.
+ */
 static int
 nns_edge_custom_create (void **priv)
 {
@@ -68,6 +77,9 @@ nns_edge_custom_create (void **priv)
   return NNS_EDGE_ERROR_NONE;
 }
 
+/**
+ * @brief Start the custom connection, resetting it to the unconnected state.
+ */
 static int
 nns_edge_custom_start (void *priv)
 {
@@ -82,6 +94,9 @@ nns_edge_custom_start (void *priv)
   return NNS_EDGE_ERROR_NONE;
 }
 
+/**
+ * @brief Stop the custom connection and clear its connected flag.
+ */
 static int
 nns_edge_custom_stop (void *priv)
 {
@@ -96,6 +111,9 @@ nns_edge_custom_stop (void *priv)
   return NNS_EDGE_ERROR_NONE;
 }
 
+/**
+ * @brief Mark the connection as connected and push one dummy data event.
+ */
 static int
 nns_edge_custom_connect (void *priv)
 {
@@ -137,6 +155,9 @@ done:
   return ret;
 }
 
+/**
+ * @brief Subscription is not supported by this test custom connection.
+ */
 static int
 nns_edge_custom_subscribe (void *priv)
 {
@@ -144,6 +165,9 @@ nns_edge_custom_subscribe (void *priv)
   return NNS_EDGE_ERROR_NOT_SUPPORTED;
 }
 
+/**
+ * @brief Report whether the test custom connection is connected.
+ */
 static int
 nns_edge_custom_is_connected (void *priv)
 {
@@ -160,6 +184,9 @@ nns_edge_custom_is_connected (void *priv)
   return NNS_EDGE_ERROR_CONNECTION_FAILURE;
 }
 
+/**
+ * @brief Store the event callback and its user data in the handle.
+ */
 static int
 nns_edge_custom_set_event_cb (void *priv, nns_edge_event_cb cb, void *user_data)
 {
@@ -176,6 +203,9 @@ nns_edge_custom_set_event_cb (void *priv, nns_edge_event_cb cb, void *user_data)
   return NNS_EDGE_ERROR_NONE;
 }
 
+/**
+ * @brief Discard the given data after validating the parameters.
+ */
 static int
 nns_edge_custom_send_data (void *priv, nns_edge_data_h data_h)
 {
@@ -187,6 +217,9 @@ nns_edge_custom_send_data (void *priv, nns_edge_data_h data_h)
   return NNS_EDGE_ERROR_NONE;
 }
 
+/**
+ * @brief Store the PEER_ADDRESS value; every other key is ignored.
+ */
 static int
 nns_edge_custom_set_info (void *priv, const char *key, const char *value)
 {
@@ -206,6 +239,9 @@ nns_edge_custom_set_info (void *priv, const char *key, const char *value)
   return NNS_EDGE_ERROR_NONE;
 }
 
+/**
+ * @brief Return a newly allocated copy of the stored PEER_ADDRESS value.
+ */
 static int
 nns_edge_custom_get_info (void *priv, const char *key, char **value)
 {
@@ -240,6 +276,9 @@ nns_edge_custom_s edge_custom_h = {
   .nns_edge_custom_get_info = nns_edge_custom_get_info
 };
 
+/**
+ * @brief Return the callback table of this test custom connection.
+ */
 const nns_edge_custom_s *
 nns_edge_custom_get_instance (void)
 {

--- a/tests/nnstreamer_filter_dali/create_dali_pipeline.cc
+++ b/tests/nnstreamer_filter_dali/create_dali_pipeline.cc
@@ -30,6 +30,9 @@
 
 using namespace dali;
 
+/**
+ * @brief Print the command line usage of this tool.
+ */
 void
 usage ()
 {
@@ -41,6 +44,9 @@ usage ()
   std::cout << "  C: Number of channels of the preprocessed image." << std::endl;
 }
 
+/**
+ * @brief Build a resize/normalize/transpose DALI pipeline and serialize it.
+ */
 int
 main (int argc, char *argv[])
 {

--- a/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.hh
+++ b/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.hh
@@ -84,49 +84,72 @@ class NCSDKTensorFilterTestHelper
         [] () { mInstance.reset (new NCSDKTensorFilterTestHelper); });
     return *(mInstance.get ());
   }
+  /** @brief Destructor releasing the mocked device and graph resources */
   ~NCSDKTensorFilterTestHelper ();
+  /** @brief Set up the fake device, graph and tensor descriptors */
   void init (model_t model);
+  /** @brief Free the resources allocated by init () */
   void release ();
   /* Set/Get fail-stage */
+  /** @brief Set the NCSDK stage at which the mock should report failure */
   void setFailStage (const fail_stage_t stage);
+  /** @brief Get the NCSDK stage at which the mock reports failure */
   fail_stage_t getFailStage ();
 
   /* Mock methods that simulate NCSDK2 APIs */
   /* Mock Global APIs */
+  /** @brief Mock of ncGlobalGetOption (); returns the NCSDK version */
   ncStatus_t ncGlobalGetOption (int option, void *data, unsigned int *dataLength);
   /* Mock Device APIs */
+  /** @brief Mock of ncDeviceCreate (); hands out the fake device handle */
   ncStatus_t ncDeviceCreate (int index, struct ncDeviceHandle_t **deviceHandle);
+  /** @brief Mock of ncDeviceOpen (); checks the given device handle */
   ncStatus_t ncDeviceOpen (struct ncDeviceHandle_t *deviceHandle);
+  /** @brief Mock of ncDeviceClose (); checks the given device handle */
   ncStatus_t ncDeviceClose (struct ncDeviceHandle_t *deviceHandle);
+  /** @brief Mock of ncDeviceDestroy (); frees the fake device handle */
   ncStatus_t ncDeviceDestroy (struct ncDeviceHandle_t **deviceHandle);
 
   /* Mock Graph APIs */
+  /** @brief Mock of ncGraphCreate (); hands out the fake graph handle */
   ncStatus_t ncGraphCreate (const char *name, struct ncGraphHandle_t **graphHandle);
+  /** @brief Mock of ncGraphAllocate (); records the given graph buffer */
   ncStatus_t ncGraphAllocate (struct ncDeviceHandle_t *deviceHandle,
       struct ncGraphHandle_t *graphHandle, const void *graphBuffer,
       unsigned int graphBufferLength);
+  /** @brief Mock of ncGraphGetOption (); returns a tensor descriptor */
   ncStatus_t ncGraphGetOption (struct ncGraphHandle_t *graphHandle, int option,
       void *data, unsigned int *dataLength);
+  /** @brief Mock of ncGraphQueueInference (); does nothing */
   ncStatus_t ncGraphQueueInference (struct ncGraphHandle_t *graphHandle,
       struct ncFifoHandle_t **fifoIn, unsigned int inFifoCount,
       struct ncFifoHandle_t **fifoOut, unsigned int outFifoCount);
+  /** @brief Mock of ncGraphDestroy (); frees the fake graph handle */
   ncStatus_t ncGraphDestroy (struct ncGraphHandle_t **graphHandle);
 
   /* Mock FIFO APIs (returning only NC_OK) */
+  /** @brief Mock of ncFifoCreate (); fails only at the matching fail stage */
   ncStatus_t ncFifoCreate (
       const char *name, ncFifoType_t type, struct ncFifoHandle_t **fifoHandle);
+  /** @brief Mock of ncFifoAllocate (); fails only at the matching fail stage */
   ncStatus_t ncFifoAllocate (struct ncFifoHandle_t *fifoHandle,
       struct ncDeviceHandle_t *device, struct ncTensorDescriptor_t *tensorDesc,
       unsigned int numElem);
+  /** @brief Mock of ncFifoSetOption (); always returns NC_OK */
   ncStatus_t ncFifoSetOption (struct ncFifoHandle_t *fifoHandle, int option,
       const void *data, unsigned int dataLength);
+  /** @brief Mock of ncFifoGetOption (); always returns NC_OK */
   ncStatus_t ncFifoGetOption (struct ncFifoHandle_t *fifoHandle, int option,
       void *data, unsigned int *dataLength);
+  /** @brief Mock of ncFifoDestroy (); always returns NC_OK */
   ncStatus_t ncFifoDestroy (struct ncFifoHandle_t **fifoHandle);
+  /** @brief Mock of ncFifoWriteElem (); drops the given input tensor */
   ncStatus_t ncFifoWriteElem (struct ncFifoHandle_t *fifoHandle,
       const void *inputTensor, unsigned int *inputTensorLength, void *userParam);
+  /** @brief Mock of ncFifoReadElem (); leaves the output buffer untouched */
   ncStatus_t ncFifoReadElem (struct ncFifoHandle_t *fifoHandle,
       void *outputData, unsigned int *outputDataLen, void **userParam);
+  /** @brief Mock of ncFifoRemoveElem (); fails at the matching fail stage */
   ncStatus_t ncFifoRemoveElem (struct ncFifoHandle_t *fifoHandle); /* not supported yet */
 
   private:
@@ -135,7 +158,9 @@ class NCSDKTensorFilterTestHelper
   static std::once_flag mOnceFlag;
 
   /* Constructor and destructor */
+  /** @brief Default constructor; init () must be invoked before use */
   NCSDKTensorFilterTestHelper ();
+  /** @brief Disable the copy constructor to keep this class a singleton */
   NCSDKTensorFilterTestHelper (const NCSDKTensorFilterTestHelper &) = delete;
   NCSDKTensorFilterTestHelper &operator= (const NCSDKTensorFilterTestHelper &) = delete;
 

--- a/tests/nnstreamer_filter_mxnet/Predictor.hh
+++ b/tests/nnstreamer_filter_mxnet/Predictor.hh
@@ -88,27 +88,37 @@ class Predictor
   Predictor ()
   {
   }
+  /** @brief construct a Predictor from the model, params and data iterator */
   Predictor (const std::string &model_json_file, const std::string &model_params_file,
       const Shape &input_shape, const std::string &data_layer_type,
       bool use_gpu, bool enable_tensorrt, MXDataIter *val_iter);
+  /** @brief destructor; releases the bound executor */
   ~Predictor ();
 
+  /** @brief create an ImageRecordIter for the given dataset and shape */
   static MXDataIter *CreateImageRecordIter (const std::string &dataset,
       const Shape &input_shape, const std::string &data_layer_type,
       const std::vector<float> &rgb_mean, const std::vector<float> &rgb_std,
       int shuffle_chunk_seed, int seed, const int data_nthreads, bool use_gpu);
+  /** @brief run the forward pass and log the top class of each batch */
   void LogInferenceResult (std::vector<mx_float> &log_vector, int num_inference_batches);
 
   private:
+  /** @brief skip the given number of batches in the validation iterator */
   bool AdvanceDataIter (int skipped_batches);
+  /** @brief load the model symbol from the given json file */
   void LoadModel (const std::string &model_json_file);
+  /** @brief load the model parameters from the given params file */
   void LoadParameters (const std::string &model_parameters_file);
+  /** @brief split a loaded param map into arg and aux maps */
   void SplitParamMap (const std::map<std::string, NDArray> &paramMap,
       std::map<std::string, NDArray> *argParamInTargetContext,
       std::map<std::string, NDArray> *auxParamInTargetContext, Context targetContext);
+  /** @brief copy the param map into the target context */
   void ConvertParamMapToTargetContext (const std::map<std::string, NDArray> &paramMap,
       std::map<std::string, NDArray> *paramMapInTargetContext, Context targetContext);
 
+  /** @brief map data_layer_type_ to a TypeFlag, or -1 if unsupported */
   int GetDataLayerType ();
 
   MXDataIter *val_iter_;

--- a/tests/nnstreamer_filter_mxnet/Predictor.hh
+++ b/tests/nnstreamer_filter_mxnet/Predictor.hh
@@ -392,14 +392,11 @@ Predictor::LogInferenceResult (std::vector<mx_float> &log_vector, int num_infere
 
   ms = ms_now () - ms;
   auto args_name = net_.ListArguments ();
-  LG << "INFO:"
-     << "Finished inference with: " << nBatch * input_shape_[0] << " images ";
-  LG << "INFO:"
-     << "Batch size = " << input_shape_[0] << " for inference";
-  LG << "INFO:"
-     << "Accuracy: " << val_acc.Get ();
-  LG << "INFO:"
-     << "Throughput: " << (1000.0 * nBatch * input_shape_[0] / ms) << " images per second";
+  LG << "INFO:" << "Finished inference with: " << nBatch * input_shape_[0] << " images ";
+  LG << "INFO:" << "Batch size = " << input_shape_[0] << " for inference";
+  LG << "INFO:" << "Accuracy: " << val_acc.Get ();
+  LG << "INFO:" << "Throughput: " << (1000.0 * nBatch * input_shape_[0] / ms)
+     << " images per second";
 }
 
 /**

--- a/tests/tizen_sensor/dummy_sensor.h
+++ b/tests/tizen_sensor/dummy_sensor.h
@@ -125,41 +125,74 @@ typedef void* sensor_listener_h;
 
 
 /* main */
+/**
+ * @brief Dummy Tizen Sensor API: tell whether the sensor type is supported.
+ */
 extern int
 sensor_is_supported (sensor_type_e type, bool * supported);
 
+/**
+ * @brief Dummy Tizen Sensor API: get the first sensor handle of the type.
+ */
 extern int
 sensor_get_default_sensor (sensor_type_e type, sensor_h *sensor);
 
+/**
+ * @brief Dummy Tizen Sensor API: list every sensor handle of the type.
+ */
 extern int
 sensor_get_sensor_list (sensor_type_e type, sensor_h **list, int *sensor_count);
 
+/**
+ * @brief Dummy Tizen Sensor API: get the type of the given sensor handle.
+ */
 extern int
 sensor_get_type (sensor_h sensor, sensor_type_e *type);
 
 
 
 /* listener */
+/**
+ * @brief Dummy Tizen Sensor API: register a new listener on the sensor.
+ */
 extern int
 sensor_create_listener (sensor_h sensor, sensor_listener_h *listener);
 
+/**
+ * @brief Dummy Tizen Sensor API: unregister the listener from its sensor.
+ */
 extern int
 sensor_destroy_listener (sensor_listener_h listener);
 
+/**
+ * @brief Dummy Tizen Sensor API: let the listener read sensor data.
+ */
 extern int
 sensor_listener_start (sensor_listener_h listener);
 
+/**
+ * @brief Dummy Tizen Sensor API: stop the listener from reading data.
+ */
 extern int
 sensor_listener_stop (sensor_listener_h listener);
 
+/**
+ * @brief Dummy Tizen Sensor API: set the sampling interval of the listener.
+ */
 extern int
 sensor_listener_set_interval (sensor_listener_h listener, unsigned int interval_ms);
 
+/**
+ * @brief Dummy Tizen Sensor API: read the last event recorded by the sensor.
+ */
 extern int
 sensor_listener_read_data_list (sensor_listener_h listener, sensor_event_s ** events, int * count);
 
 
 /* publish data */
+/**
+ * @brief Record the given event as the sensor's latest data for listeners.
+ */
 extern int
 dummy_publish (sensor_h sensor, sensor_event_s * value);
 

--- a/tests/unittest_mlagent/mock_mlagent.h
+++ b/tests/unittest_mlagent/mock_mlagent.h
@@ -90,6 +90,9 @@ gint ml_agent_model_get_activated (
 struct MockModel {
   /* Constructors */
   MockModel () = delete;
+  /**
+   * @brief Construct a mock model with the given attributes
+   */
   MockModel (std::string name, std::string path = {}, std::string app_info = {},
       bool is_activated = false, std::string desc = {}, guint version = 0U)
       : name_{ name }, path_{ path }, app_info_{ app_info },
@@ -97,6 +100,9 @@ struct MockModel {
 
         };
   /* Copy constructor */
+  /**
+   * @brief Copy a mock model by delegating to the attribute constructor
+   */
   MockModel (const MockModel &other)
       : MockModel (other.name_, other.path_, other.app_info_,
           other.is_activated_, other.desc_, other.version_){
@@ -131,55 +137,88 @@ struct MockModel {
   }
 
   /* Getters */
+  /**
+   * @brief Get the model's name
+   */
   std::string name () const
   {
     return name_;
   }
 
+  /**
+   * @brief Get the model's file path
+   */
   std::string path () const
   {
     return path_;
   }
+  /**
+   * @brief Get the model's application info
+   */
   std::string app_info () const
   {
     return app_info_;
   }
+  /**
+   * @brief Get whether the model is activated
+   */
   bool is_activated () const
   {
     return is_activated_;
   }
 
+  /**
+   * @brief Get the model's description
+   */
   std::string desc () const
   {
     return desc_;
   }
 
+  /**
+   * @brief Get the model's version
+   */
   guint version () const
   {
     return version_;
   }
 
   /* Setters */
+  /**
+   * @brief Set the model's file path
+   */
   void path (const std::string &path)
   {
     path_ = path;
   }
 
+  /**
+   * @brief Set whether the model is activated
+   */
   void is_activated (bool flag)
   {
     is_activated_ = flag;
   }
 
+  /**
+   * @brief Set the model's description
+   */
   void desc (const std::string &description)
   {
     desc_ = description;
   }
 
+  /**
+   * @brief Set the model's application info
+   */
   void app_info (const std::string &info)
   {
     app_info_ = info;
   }
 
+  /**
+   * @brief Set the model's version
+   */
   void version (guint ver)
   {
     version_ = ver;

--- a/tools/development/parser/convert.h
+++ b/tools/development/parser/convert.h
@@ -18,6 +18,9 @@
 
 #include "types.h"
 
+/**
+ * @brief Print the parsed pipeline as a pbtxt-style element tree to stdout.
+ */
 void convert_to_pbtxt (_Element *pipeline);
 
 #endif


### PR DESCRIPTION
Fixes #4908.

## What was wrong

`.github/workflows/static.check.scripts/doxygen-tag.sh` declared `local function_check_flag="f+p"` at script top level. Bash rejects `local` outside a function, the script has no `set -e`, so `ctags -x --c-kinds=` ran with an empty kind list and the per-function `@brief` check never fired. It has been that way since the Actions import (487d7e25, January 2024); in TAOS-CI the same block lived inside `function pr-prebuild-doxygen-tag()`.

Two smaller defects in the same script hid behind it: `$report_path` was never set, so every file produced an "ambiguous redirect" on stderr, and `$brief` was not reset between files.

## What this PR does

**Checker** (`doxygen-tag.sh`)
- Drop the `local`, so the ctags kind list is populated again.
- Check function *definitions* everywhere, but *prototypes* only in headers. A `static` forward declaration in a `.c`/`.cc` is documented at its definition; demanding a second `@brief` on each of the 1,119 forward declarations in the tree was never the intent.
- Recognise the trailing `/**< ... */` form, on the declaration line, on the line after a declaration, or after an inline body. The public C++ subplugin API header documents its virtual methods that way, and Doxygen accepts it.
- Default `report_path` to `/dev/null` and reset `brief` per file. The pending tag now survives only inside a `/* ... */` block (the scanner tracks that state) or on a `//` line; before, any line containing `*` kept it alive, so a pointer parameter carried one function's `@brief` onto the next prototype.

**Self-test** (`test_doxygen_tag.sh`, wired into `static.check.yml` next to the other self-tests). Eighteen fixtures generated into a temp dir: the negative control (undocumented definition must fail), prototype scope in `.c` vs `.h`, all three `/**<` placements plus the case where the next line's `/**<` belongs to another member, the pointer-parameter reset (mid-line and at the start of a wrapped line) and its converse (a `;` inside a comment block keeps the tag), struct check, per-file state reset, file-level tags, and "no stderr output". Against the checker on `main` all eighteen fail: the negative controls pass vacuously and every case emits stderr noise. Against this branch all pass.

**Backlog.** With the corrected scope the tree had 248 undocumented functions and 2 undocumented structs in 37 files. All are documented in this PR, grouped by directory in separate commits so they can be reviewed independently. CI runs the checker on changed files only, so the PR's own `Static checks` job exercises the new checker over every file touched here.

## Measurements (Exuberant Ctags 5.9, the CI version, 289 C/C++ files)

| function_check_flag | errors | files |
|---|---|---|
| `f+p` everywhere (one-line fix only) | 1,262 | 132 |
| definitions everywhere, prototypes in headers only | 249 | 35 |
| same, with `/**<` recognised | 237 | 35 |
| same, plus the pointer-parameter reset | 248 | 37 |

`tests/nnstreamer_filter_mxnet/Predictor.hh` also gets the layout clang-format 18 (the runner's current version) wants for four log lines the PR did not otherwise touch; the file had not been edited since the runner moved off 16, so the first PR to touch it trips the check.

## Not in this PR

`nnstreamer/api` and `nnstreamer/nnstreamer-edge` carry the same script with the same `local` and invoke it with `advanced=1`. They need the same checker change and their own backlog pass; that is a separate PR per repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
