### PR TITLE
[Transform] Explain caps failures with the mode and option involved

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -305,9 +305,31 @@ gst_tensor_transform_init (GstTensorTransform * filter)
   filter->operators = NULL;
   filter->acceleration = DEFAULT_ACCELERATION;
   filter->apply = NULL;
+  filter->data_typecast.to = _NNS_END;
 
   gst_tensors_config_init (&filter->in_config);
   gst_tensors_config_init (&filter->out_config);
+}
+
+/**
+ * @brief Get the nickname of the given transform mode for log messages
+ * @param[in] mode transform mode
+ * @return nickname string owned by the enum class (do not free)
+ */
+static const gchar *
+gst_tensor_transform_get_mode_string (tensor_transform_mode mode)
+{
+  GEnumClass *klass;
+  GEnumValue *val;
+  const gchar *nick = "unknown";
+
+  klass = g_type_class_ref (GST_TYPE_TENSOR_TRANSFORM_MODE);
+  val = g_enum_get_value (klass, mode);
+  if (val)
+    nick = val->value_nick;
+  g_type_class_unref (klass);
+
+  return nick;
 }
 
 /**
@@ -1777,7 +1799,7 @@ gst_tensor_transform_padding (GstTensorTransform * filter,
 
   in_loop_size = (gsize) in_info->dimension[2] * in_info->dimension[1]
       * in_info->dimension[0] * element_size;
-  out_loop_size =(gsize) out_info->dimension[2] * out_info->dimension[1]
+  out_loop_size = (gsize) out_info->dimension[2] * out_info->dimension[1]
       * out_info->dimension[0] * element_size;
   copy_block_size = in_info->dimension[0] * element_size;
 
@@ -1839,7 +1861,14 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
 
   filter = GST_TENSOR_TRANSFORM_CAST (trans);
 
-  g_return_val_if_fail (filter->loaded, GST_FLOW_ERROR);
+  if (!filter->loaded) {
+    GST_ELEMENT_ERROR (filter, STREAM, FAILED, (NULL),
+        ("Transform is not configured (mode=%s, option=%s).",
+            gst_tensor_transform_get_mode_string (filter->mode),
+            GST_STR_NULL (filter->option)));
+    return GST_FLOW_ERROR;
+  }
+
   inbuf = gst_tensor_buffer_from_config (inbuf, &filter->in_config);
 
   in_flexible =
@@ -2181,8 +2210,49 @@ gst_tensor_transform_transform_caps (GstBaseTransform * trans,
     intersection =
         gst_caps_intersect_full (result, filtercap, GST_CAPS_INTERSECT_FIRST);
 
+    if (gst_caps_is_empty (intersection)) {
+      gchar *str_from = gst_caps_to_string (caps);
+      gchar *str_to = gst_caps_to_string (result);
+      gchar *str_filter = gst_caps_to_string (filtercap);
+
+      GST_WARNING_OBJECT (filter,
+          "mode=%s option=%s cannot produce %s caps compatible with [%s]: "
+          "input [%s] is transformed into [%s].",
+          gst_tensor_transform_get_mode_string (filter->mode),
+          GST_STR_NULL (filter->option),
+          (direction == GST_PAD_SINK) ? "src" : "sink", str_filter, str_from,
+          str_to);
+
+      g_free (str_from);
+      g_free (str_to);
+      g_free (str_filter);
+    }
+
     gst_caps_unref (result);
     result = intersection;
+  } else if (direction == GST_PAD_SINK && gst_caps_is_fixed (caps)
+      && !gst_caps_is_empty (result)) {
+    GstCaps *peercaps = gst_pad_peer_query_caps (pad, NULL);
+
+    if (peercaps) {
+      if (!gst_caps_can_intersect (result, peercaps)) {
+        gchar *str_from = gst_caps_to_string (caps);
+        gchar *str_to = gst_caps_to_string (result);
+        gchar *str_peer = gst_caps_to_string (peercaps);
+
+        GST_WARNING_OBJECT (filter,
+            "mode=%s option=%s transforms input [%s] into [%s], "
+            "which the downstream element cannot accept: [%s].",
+            gst_tensor_transform_get_mode_string (filter->mode),
+            GST_STR_NULL (filter->option), str_from, str_to, str_peer);
+
+        g_free (str_from);
+        g_free (str_to);
+        g_free (str_peer);
+      }
+
+      gst_caps_unref (peercaps);
+    }
   }
 
   silent_debug_caps (filter, result, "to");
@@ -2230,12 +2300,23 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
   gboolean in_flexible, out_flexible;
   gboolean allowed = FALSE;
   guint i;
+  const gchar *mode_str;
 
   filter = GST_TENSOR_TRANSFORM_CAST (trans);
 
   silent_debug (filter, "Calling SetCaps\n");
   silent_debug_caps (filter, incaps, "incaps");
   silent_debug_caps (filter, outcaps, "outcaps");
+
+  mode_str = gst_tensor_transform_get_mode_string (filter->mode);
+
+  if (!filter->loaded) {
+    GST_ERROR_OBJECT (filter,
+        "Transform is not configured (mode=%s, option=%s). "
+        "Set valid 'mode' and 'option' properties before negotiating caps.",
+        mode_str, GST_STR_NULL (filter->option));
+    goto error;
+  }
 
   if (!gst_tensors_config_from_caps (&in_config, incaps, TRUE)) {
     GST_ERROR_OBJECT (filter, "Cannot read cap of incaps\n");
@@ -2266,7 +2347,9 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
       if (!gst_tensor_transform_convert_dimension (filter, GST_PAD_SINK,
               i, in_info, out_info)) {
         GST_ERROR_OBJECT (filter,
-            "Tensor info is not matched with given properties.");
+            "Cannot derive the output info of tensor %u from the input caps "
+            "with mode=%s option=%s.", i, mode_str,
+            GST_STR_NULL (filter->option));
         goto error;
       }
     }
@@ -2279,8 +2362,16 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
     if (!in_flexible)
       out_config = config;
   } else if (!gst_tensors_config_is_equal (&out_config, &config)) {
+    gchar *cmp;
+
+    cmp = gst_tensors_info_compare_to_string (&config.info, &out_config.info);
     GST_ERROR_OBJECT (filter,
-        "Tensor info is not matched with given properties.\n");
+        "The output caps does not match the result of mode=%s option=%s "
+        "applied to the input caps. Framerate expected %d/%d, given %d/%d. "
+        "Tensors expected (left) vs given (right):\n%s",
+        mode_str, GST_STR_NULL (filter->option), config.rate_n, config.rate_d,
+        out_config.rate_n, out_config.rate_d, GST_STR_NULL (cmp));
+    g_free (cmp);
     goto error;
   }
 

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -321,15 +321,12 @@ gst_tensor_transform_get_mode_string (tensor_transform_mode mode)
 {
   GEnumClass *klass;
   GEnumValue *val;
-  const gchar *nick = "unknown";
 
-  klass = g_type_class_ref (GST_TYPE_TENSOR_TRANSFORM_MODE);
-  val = g_enum_get_value (klass, mode);
-  if (val)
-    nick = val->value_nick;
-  g_type_class_unref (klass);
+  /* the class is kept alive by the "mode" property spec */
+  klass = (GEnumClass *) g_type_class_peek (GST_TYPE_TENSOR_TRANSFORM_MODE);
+  val = klass ? g_enum_get_value (klass, mode) : NULL;
 
-  return nick;
+  return val ? val->value_nick : "unknown";
 }
 
 /**
@@ -1862,7 +1859,7 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
   filter = GST_TENSOR_TRANSFORM_CAST (trans);
 
   if (!filter->loaded) {
-    GST_ELEMENT_ERROR (filter, STREAM, FAILED, (NULL),
+    GST_ELEMENT_ERROR (filter, CORE, NEGOTIATION, (NULL),
         ("Transform is not configured (mode=%s, option=%s).",
             gst_tensor_transform_get_mode_string (filter->mode),
             GST_STR_NULL (filter->option)));

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -305,7 +305,6 @@ gst_tensor_transform_init (GstTensorTransform * filter)
   filter->operators = NULL;
   filter->acceleration = DEFAULT_ACCELERATION;
   filter->apply = NULL;
-  filter->data_typecast.to = _NNS_END;
 
   gst_tensors_config_init (&filter->in_config);
   gst_tensors_config_init (&filter->out_config);
@@ -690,8 +689,10 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
   gchar *filter_name;
   gboolean ret = FALSE;
 
-  if (filter->mode == GTT_UNKNOWN || filter->option == NULL)
+  if (filter->mode == GTT_UNKNOWN || filter->option == NULL) {
+    filter->loaded = FALSE;
     return TRUE;
+  }
 
   filter_name = gst_object_get_name ((GstObject *) filter);
 
@@ -1053,6 +1054,9 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       GST_ERROR_OBJECT (filter, "Cannot identify mode\n");
       ret = FALSE;
   }
+
+  if (!ret)
+    filter->loaded = FALSE;
 
   g_free (filter_name);
   return ret;
@@ -2180,7 +2184,7 @@ gst_tensor_transform_transform_caps (GstBaseTransform * trans,
     if (out_config.info.format == _NNS_TENSOR_FORMAT_END) {
       out_caps = gst_pad_get_pad_template_caps (pad);
     } else {
-      if (gst_tensors_config_is_static (&out_config)) {
+      if (filter->loaded && gst_tensors_config_is_static (&out_config)) {
         for (j = 0; j < in_config.info.num_tensors; j++) {
           in_info = gst_tensors_info_get_nth_info (&in_config.info, j);
           out_info = gst_tensors_info_get_nth_info (&out_config.info, j);
@@ -2228,7 +2232,9 @@ gst_tensor_transform_transform_caps (GstBaseTransform * trans,
     gst_caps_unref (result);
     result = intersection;
   } else if (direction == GST_PAD_SINK && gst_caps_is_fixed (caps)
-      && !gst_caps_is_empty (result)) {
+      && !gst_caps_is_empty (result)
+      && gst_debug_category_get_threshold (GST_CAT_DEFAULT) >=
+      GST_LEVEL_WARNING) {
     GstCaps *peercaps = gst_pad_peer_query_caps (pad, NULL);
 
     if (peercaps) {

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -13,6 +13,7 @@
 #include <gst/check/gstharness.h>
 #include <gst/check/gsttestclock.h>
 #include <gst/gst.h>
+#include <nnstreamer_conf.h>
 #include <nnstreamer_cppplugin_api_filter.hh>
 #include <nnstreamer_plugin_api_converter.h>
 #include <nnstreamer_plugin_api_decoder.h>
@@ -1179,12 +1180,16 @@ TEST (testTensorTransform, setCapsConfiguredAfterLink)
 /**
  * @brief Caps negotiation through a chain of tensor_transform and
  *        tensor_filter, both of which query their peers from transform_caps.
- *        Guards against caps-query recursion between the two (#4103).
+ *        Guards against caps-query recursion between the two. The
+ *        tensor_transform debug threshold is raised to WARNING because the
+ *        downstream peer query in transform_caps is now skipped unless that
+ *        threshold is at least WARNING, so raising it is required to
+ *        actually exercise the peer-query path (#4103).
  */
 TEST (testTensorTransform, negotiationChainWithFilter)
 {
   const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
-  gchar *model_file, *str_pipeline;
+  gchar *model_file, *str_pipeline, *lib_name;
   GstElement *pipeline;
   GstBus *bus;
   GstMessage *msg;
@@ -1192,9 +1197,14 @@ TEST (testTensorTransform, negotiationChainWithFilter)
   if (root_path == NULL)
     root_path = "..";
 
-  model_file = g_build_filename (root_path, "build", "tests", "nnstreamer_example",
-      "libnnstreamer_customfilter_passthrough_variable.so", NULL);
+  lib_name = g_strdup_printf ("libnnstreamer_customfilter_passthrough_variable%s",
+      NNSTREAMER_SO_FILE_EXTENSION);
+  model_file = g_build_filename (
+      root_path, "build", "tests", "nnstreamer_example", lib_name, NULL);
+  g_free (lib_name);
   ASSERT_TRUE (g_file_test (model_file, G_FILE_TEST_EXISTS));
+
+  gst_debug_set_threshold_for_name ("tensor_transform", GST_LEVEL_WARNING);
 
   str_pipeline = g_strdup_printf (
       "videotestsrc num-buffers=3 ! video/x-raw,format=RGB,width=8,height=8,framerate=30/1 ! "
@@ -1221,7 +1231,325 @@ TEST (testTensorTransform, negotiationChainWithFilter)
   gst_object_unref (bus);
 
   EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  gst_debug_unset_threshold_for_name ("tensor_transform");
   gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Test transform_caps/set_caps when mode is configured but has no
+ *        option; downstream caps are the real, untransformed caps. Before
+ *        the fix, transform_caps advertised padding's default dimension
+ *        change and negotiation failed before set_caps ever ran, so the
+ *        "not configured" message never appeared (#4103).
+ */
+TEST (testTensorTransform, setCapsUnconfiguredPaddingWithDownstreamCaps_n)
+{
+  GstHarness *h;
+  GstTensorsConfig config;
+  GstBuffer *in_buf;
+  GString *log;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  /* Mode is set, but no option is given: filter->loaded stays FALSE. */
+  g_object_set (h->element, "mode", GTT_PADDING, NULL);
+
+  gst_harness_set_sink_caps_str (h, "other/tensors,format=static,num_tensors=1,types=uint8,"
+                                    "dimensions=5:1:1:1,framerate=0/1");
+
+  log = g_string_new (NULL);
+  gst_debug_add_log_function (_collect_transform_log, log, NULL);
+  gst_debug_set_threshold_for_name ("tensor_transform", GST_LEVEL_WARNING);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  in_buf = gst_harness_create_buffer (h, 5);
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_NOT_NEGOTIATED);
+
+  gst_debug_remove_log_function (_collect_transform_log);
+  gst_debug_unset_threshold_for_name ("tensor_transform");
+
+#ifndef GST_DISABLE_GST_DEBUG
+  EXPECT_TRUE (strstr (log->str, "Transform is not configured") != NULL);
+  EXPECT_TRUE (strstr (log->str, "mode=padding") != NULL);
+#endif
+
+  gst_harness_teardown (h);
+  g_string_free (log, TRUE);
+}
+
+/**
+ * @brief Test set_caps failure after a mode change makes the previously
+ *        parsed option invalid, resetting filter->loaded to FALSE (#4103).
+ */
+TEST (testTensorTransform, setCapsAfterModeChangeUnparsable_n)
+{
+  GstHarness *h;
+  GstTensorsConfig config;
+  GstBuffer *in_buf;
+  GString *log;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  /* "float32" is not a valid dimchg option: the element is unconfigured again */
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
+  g_object_set (h->element, "mode", GTT_DIMCHG, NULL);
+
+  log = g_string_new (NULL);
+  gst_debug_add_log_function (_collect_transform_log, log, NULL);
+  gst_debug_set_threshold_for_name ("tensor_transform", GST_LEVEL_WARNING);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  in_buf = gst_harness_create_buffer (h, 5);
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_NOT_NEGOTIATED);
+
+  gst_debug_remove_log_function (_collect_transform_log);
+  gst_debug_unset_threshold_for_name ("tensor_transform");
+
+#ifndef GST_DISABLE_GST_DEBUG
+  EXPECT_TRUE (strstr (log->str, "Transform is not configured") != NULL);
+  EXPECT_TRUE (strstr (log->str, "mode=dimchg") != NULL);
+#endif
+
+  gst_harness_teardown (h);
+  g_string_free (log, TRUE);
+}
+
+/**
+ * @brief Test transform_caps warning when a caps query's filter cannot be
+ *        satisfied by the transformed caps, for both pad directions (#4103).
+ */
+TEST (testTensorTransform, transformCapsFilterIntersectionEmpty_n)
+{
+  GstHarness *h;
+  GstTensorsConfig config;
+  GString *log;
+  GstPad *pad;
+  GstCaps *filter, *res;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
+
+  gst_harness_set_sink_caps_str (h, "other/tensors,format=static,num_tensors=1,types=float32,"
+                                    "dimensions=5:1:1:1,framerate=0/1");
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  log = g_string_new (NULL);
+  gst_debug_add_log_function (_collect_transform_log, log, NULL);
+  gst_debug_set_threshold_for_name ("tensor_transform", GST_LEVEL_WARNING);
+
+  pad = gst_element_get_static_pad (h->element, "src");
+  filter = gst_caps_from_string ("other/tensors,format=static,num_tensors=1,"
+                                 "types=float16,dimensions=5:1:1:1");
+  res = gst_pad_query_caps (pad, filter);
+  EXPECT_TRUE (gst_caps_is_empty (res));
+  gst_caps_unref (res);
+  gst_caps_unref (filter);
+  gst_object_unref (pad);
+
+  pad = gst_element_get_static_pad (h->element, "sink");
+  filter = gst_caps_from_string ("other/tensors,format=static,num_tensors=1,"
+                                 "types=uint8,dimensions=7:1:1:1");
+  res = gst_pad_query_caps (pad, filter);
+  EXPECT_TRUE (gst_caps_is_empty (res));
+  gst_caps_unref (res);
+  gst_caps_unref (filter);
+  gst_object_unref (pad);
+
+  gst_debug_remove_log_function (_collect_transform_log);
+  gst_debug_unset_threshold_for_name ("tensor_transform");
+
+#ifndef GST_DISABLE_GST_DEBUG
+  EXPECT_TRUE (strstr (log->str, "cannot produce src caps") != NULL);
+  EXPECT_TRUE (strstr (log->str, "cannot produce sink caps") != NULL);
+#endif
+
+  gst_harness_teardown (h);
+  g_string_free (log, TRUE);
+}
+
+/**
+ * @brief Positive control: elements are linked before tensor_transform's
+ *        mode/option are set, matching the app pattern from issue #4102.
+ *        Linking must succeed while the element is still unconfigured, and
+ *        the pipeline must still negotiate and transform once mode/option
+ *        are set afterward (#4103).
+ */
+TEST (testTensorTransform, linkThenConfigure)
+{
+  GstElement *pipeline, *src, *capsfilter1, *converter, *transform;
+  GstElement *capsfilter2, *sink;
+  GstCaps *caps;
+  GstBus *bus;
+  GstMessage *msg;
+
+  pipeline = gst_pipeline_new (NULL);
+  ASSERT_TRUE (pipeline != nullptr);
+
+  src = gst_element_factory_make ("videotestsrc", NULL);
+  capsfilter1 = gst_element_factory_make ("capsfilter", NULL);
+  converter = gst_element_factory_make ("tensor_converter", NULL);
+  transform = gst_element_factory_make ("tensor_transform", NULL);
+  capsfilter2 = gst_element_factory_make ("capsfilter", NULL);
+  sink = gst_element_factory_make ("fakesink", NULL);
+  ASSERT_TRUE (src != nullptr);
+  ASSERT_TRUE (capsfilter1 != nullptr);
+  ASSERT_TRUE (converter != nullptr);
+  ASSERT_TRUE (transform != nullptr);
+  ASSERT_TRUE (capsfilter2 != nullptr);
+  ASSERT_TRUE (sink != nullptr);
+
+  g_object_set (src, "num-buffers", 3, NULL);
+
+  caps = gst_caps_from_string ("video/x-raw,format=RGB,width=8,height=8,framerate=30/1");
+  g_object_set (capsfilter1, "caps", caps, NULL);
+  gst_caps_unref (caps);
+
+  caps = gst_caps_from_string ("other/tensors,format=static,num_tensors=1,"
+                               "types=float32,dimensions=3:8:8:1");
+  g_object_set (capsfilter2, "caps", caps, NULL);
+  gst_caps_unref (caps);
+
+  gst_bin_add_many (GST_BIN (pipeline), src, capsfilter1, converter, transform,
+      capsfilter2, sink, NULL);
+
+  /* Linking must succeed while tensor_transform is still unconfigured. */
+  ASSERT_TRUE (gst_element_link_many (
+      src, capsfilter1, converter, transform, capsfilter2, sink, NULL));
+
+  g_object_set (transform, "mode", GTT_TYPECAST, "option", "float32", NULL);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  bus = gst_element_get_bus (pipeline);
+  msg = gst_bus_timed_pop_filtered (bus, 10 * GST_SECOND,
+      (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+  ASSERT_TRUE (msg != nullptr);
+  EXPECT_EQ (GST_MESSAGE_TYPE (msg), GST_MESSAGE_EOS);
+  gst_message_unref (msg);
+  gst_object_unref (bus);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Positive control: mode/option can be changed while the pipeline is
+ *        streaming. Re-setting the same mode must keep the element
+ *        configured, and an invalid option is rejected while the previously
+ *        parsed option is kept in effect (#4103).
+ */
+TEST (testTensorTransform, optionChangeWhileStreaming)
+{
+  GstHarness *h;
+  GstTensorsConfig config;
+  GstBuffer *in_buf, *out_buf;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:1", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  /* First buffer: 0..4 -> 1..5 with option "add:1". */
+  in_buf = gst_harness_create_buffer (h, 5);
+  mem = gst_buffer_peek_memory (in_buf, 0);
+  ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+  for (i = 0; i < 5; i++)
+    info.data[i] = i;
+  gst_memory_unmap (mem, &info);
+
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+  out_buf = gst_harness_pull (h);
+  ASSERT_TRUE (out_buf != NULL);
+  mem = gst_buffer_peek_memory (out_buf, 0);
+  ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+  for (i = 0; i < 5; i++)
+    EXPECT_EQ (info.data[i], i + 1);
+  gst_memory_unmap (mem, &info);
+  gst_buffer_unref (out_buf);
+
+  /* Change option to "add:2" and re-set the same mode: stays configured. */
+  g_object_set (h->element, "option", "add:2", NULL);
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, NULL);
+
+  in_buf = gst_harness_create_buffer (h, 5);
+  mem = gst_buffer_peek_memory (in_buf, 0);
+  ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+  for (i = 0; i < 5; i++)
+    info.data[i] = i;
+  gst_memory_unmap (mem, &info);
+
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+  out_buf = gst_harness_pull (h);
+  ASSERT_TRUE (out_buf != NULL);
+  mem = gst_buffer_peek_memory (out_buf, 0);
+  ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+  for (i = 0; i < 5; i++)
+    EXPECT_EQ (info.data[i], i + 2);
+  gst_memory_unmap (mem, &info);
+  gst_buffer_unref (out_buf);
+
+  /* Invalid option is rejected; the previous "add:2" stays in effect. */
+  g_object_set (h->element, "option", "nonsense", NULL);
+
+  in_buf = gst_harness_create_buffer (h, 5);
+  mem = gst_buffer_peek_memory (in_buf, 0);
+  ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+  for (i = 0; i < 5; i++)
+    info.data[i] = i;
+  gst_memory_unmap (mem, &info);
+
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+  out_buf = gst_harness_pull (h);
+  ASSERT_TRUE (out_buf != NULL);
+  mem = gst_buffer_peek_memory (out_buf, 0);
+  ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+  for (i = 0; i < 5; i++)
+    EXPECT_EQ (info.data[i], i + 2);
+  gst_memory_unmap (mem, &info);
+  gst_buffer_unref (out_buf);
+
+  gst_harness_teardown (h);
 }
 
 /**

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -205,6 +205,28 @@ _harness_wait_for_output_buffer (GstHarness *h, guint expected)
 }
 
 /**
+ * @brief Log function collecting messages of the tensor_transform category
+ */
+static void
+_collect_transform_log (GstDebugCategory *category, GstDebugLevel level,
+    const gchar *file, const gchar *function, gint line, GObject *object,
+    GstDebugMessage *message, gpointer user_data)
+{
+  GString *log = (GString *) user_data;
+
+  UNUSED (level);
+  UNUSED (file);
+  UNUSED (function);
+  UNUSED (line);
+  UNUSED (object);
+
+  if (g_strcmp0 (gst_debug_category_get_name (category), "tensor_transform") == 0) {
+    g_string_append (log, gst_debug_message_get (message));
+    g_string_append (log, "\n");
+  }
+}
+
+/**
  * @brief Test for setting/getting properties of tensor_transform
  */
 TEST (testTensorTransform, properties01)
@@ -948,6 +970,208 @@ TEST (testTensorTransform, standProperties5_n)
 
   g_object_get (h->element, "option", &str, NULL);
   EXPECT_TRUE (str == NULL);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test set_caps failure when mode/option is never configured (#4103)
+ */
+TEST (testTensorTransform, setCapsNotConfigured_n)
+{
+  GstHarness *h;
+  GstTensorsConfig config;
+  GstBuffer *in_buf;
+  GString *log;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  log = g_string_new (NULL);
+  gst_debug_add_log_function (_collect_transform_log, log, NULL);
+  gst_debug_set_threshold_for_name ("tensor_transform", GST_LEVEL_WARNING);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  in_buf = gst_harness_create_buffer (h, 5);
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_NOT_NEGOTIATED);
+
+  gst_debug_remove_log_function (_collect_transform_log);
+  gst_debug_unset_threshold_for_name ("tensor_transform");
+
+#ifndef GST_DISABLE_GST_DEBUG
+  EXPECT_TRUE (strstr (log->str, "Transform is not configured") != NULL);
+  EXPECT_TRUE (strstr (log->str, "mode=unknown") != NULL);
+#endif
+
+  gst_harness_teardown (h);
+  g_string_free (log, TRUE);
+}
+
+/**
+ * @brief Test set_caps failure when mode is set without option (#4103).
+ *        Before the fix, this case passed set_caps and crashed with a
+ *        CRITICAL assertion on the first buffer.
+ */
+TEST (testTensorTransform, setCapsModeWithoutOption_n)
+{
+  GstHarness *h;
+  GstTensorsConfig config;
+  GstBuffer *in_buf;
+  GString *log;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_TYPECAST, NULL);
+
+  log = g_string_new (NULL);
+  gst_debug_add_log_function (_collect_transform_log, log, NULL);
+  gst_debug_set_threshold_for_name ("tensor_transform", GST_LEVEL_WARNING);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  in_buf = gst_harness_create_buffer (h, 5);
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_NOT_NEGOTIATED);
+
+  gst_debug_remove_log_function (_collect_transform_log);
+  gst_debug_unset_threshold_for_name ("tensor_transform");
+
+#ifndef GST_DISABLE_GST_DEBUG
+  EXPECT_TRUE (strstr (log->str, "Transform is not configured") != NULL);
+  EXPECT_TRUE (strstr (log->str, "mode=typecast") != NULL);
+#endif
+
+  gst_harness_teardown (h);
+  g_string_free (log, TRUE);
+}
+
+/**
+ * @brief Test set_caps failure when the given option fails to parse (#4103)
+ */
+TEST (testTensorTransform, setCapsInvalidOption_n)
+{
+  GstHarness *h;
+  GstTensorsConfig config;
+  GstBuffer *in_buf;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  /* "casttype" is a typo of "typecast"; the option fails to parse */
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option",
+      "casttype:uint64,mul:65535", NULL);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  in_buf = gst_harness_create_buffer (h, 5);
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_NOT_NEGOTIATED);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test transform_caps warning when downstream caps are incompatible
+ *        with the configured mode/option (#4103)
+ */
+TEST (testTensorTransform, transformCapsIncompatibleDownstream_n)
+{
+  GstHarness *h;
+  GstTensorsConfig config;
+  GstBuffer *in_buf;
+  GString *log;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
+
+  log = g_string_new (NULL);
+  gst_debug_add_log_function (_collect_transform_log, log, NULL);
+  gst_debug_set_threshold_for_name ("tensor_transform", GST_LEVEL_WARNING);
+
+  gst_harness_set_sink_caps_str (h, "other/tensors,format=static,num_tensors=1,types=uint8,"
+                                    "dimensions=5:1:1:1,framerate=0/1");
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  in_buf = gst_harness_create_buffer (h, 5);
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_NOT_NEGOTIATED);
+
+  gst_debug_remove_log_function (_collect_transform_log);
+  gst_debug_unset_threshold_for_name ("tensor_transform");
+
+#ifndef GST_DISABLE_GST_DEBUG
+  EXPECT_TRUE (strstr (log->str, "downstream element cannot accept") != NULL);
+  EXPECT_TRUE (strstr (log->str, "option=float32") != NULL);
+#endif
+
+  gst_harness_teardown (h);
+  g_string_free (log, TRUE);
+}
+
+/**
+ * @brief Positive control: configuring mode/option after the harness is
+ *        created and linked should still negotiate and transform (#4103)
+ */
+TEST (testTensorTransform, setCapsConfiguredAfterLink)
+{
+  GstHarness *h;
+  GstTensorsConfig config;
+  GstBuffer *in_buf, *out_buf;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
+
+  gst_harness_set_sink_caps_str (h, "other/tensors,format=static,num_tensors=1,types=float32,"
+                                    "dimensions=5:1:1:1,framerate=0/1");
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("5", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  in_buf = gst_harness_create_buffer (h, 5);
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+  out_buf = gst_harness_pull (h);
+  ASSERT_TRUE (out_buf != NULL);
+  EXPECT_EQ (gst_buffer_get_size (out_buf), 5 * sizeof (float));
+  gst_buffer_unref (out_buf);
 
   gst_harness_teardown (h);
 }

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -1177,6 +1177,54 @@ TEST (testTensorTransform, setCapsConfiguredAfterLink)
 }
 
 /**
+ * @brief Caps negotiation through a chain of tensor_transform and
+ *        tensor_filter, both of which query their peers from transform_caps.
+ *        Guards against caps-query recursion between the two (#4103).
+ */
+TEST (testTensorTransform, negotiationChainWithFilter)
+{
+  const gchar *root_path = g_getenv ("NNSTREAMER_SOURCE_ROOT_PATH");
+  gchar *model_file, *str_pipeline;
+  GstElement *pipeline;
+  GstBus *bus;
+  GstMessage *msg;
+
+  if (root_path == NULL)
+    root_path = "..";
+
+  model_file = g_build_filename (root_path, "build", "tests", "nnstreamer_example",
+      "libnnstreamer_customfilter_passthrough_variable.so", NULL);
+  ASSERT_TRUE (g_file_test (model_file, G_FILE_TEST_EXISTS));
+
+  str_pipeline = g_strdup_printf (
+      "videotestsrc num-buffers=3 ! video/x-raw,format=RGB,width=8,height=8,framerate=30/1 ! "
+      "tensor_converter ! tensor_transform mode=typecast option=float32 ! "
+      "tensor_filter framework=custom model=%s ! "
+      "tensor_transform mode=arithmetic option=add:1.0 ! "
+      "tensor_filter framework=custom model=%s ! "
+      "tensor_transform mode=typecast option=uint8 ! "
+      "other/tensors,format=static,num_tensors=1,types=uint8 ! fakesink",
+      model_file, model_file);
+  pipeline = gst_parse_launch (str_pipeline, NULL);
+  g_free (str_pipeline);
+  g_free (model_file);
+  ASSERT_TRUE (pipeline != nullptr);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  bus = gst_element_get_bus (pipeline);
+  msg = gst_bus_timed_pop_filtered (bus, 10 * GST_SECOND,
+      (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+  ASSERT_TRUE (msg != nullptr);
+  EXPECT_EQ (GST_MESSAGE_TYPE (msg), GST_MESSAGE_EOS);
+  gst_message_unref (msg);
+  gst_object_unref (bus);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  gst_object_unref (pipeline);
+}
+
+/**
  * @brief Test for tensor_transform typecast (uint8 > uint32)
  */
 TEST_TRANSFORM_TYPECAST (typecast_1, 3U, 5U, uint8_t, _NNS_UINT8, uint32_t,

--- a/tests/transform_typecast/runTest.sh
+++ b/tests/transform_typecast/runTest.sh
@@ -163,6 +163,11 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! video/
 # when there is a typo in format
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! video/x-raw,format=RGB,width=4,height=4 ! tensor_converter ! other/tensors,format=flexibler ! tensor_transform mode=typecast option=float32 ! other/tensors,format=flexible ! fakesink" 24_n 0 1 $PERFORMANCE
 
+# tensor_transform without mode/option must fail negotiation instead of
+# crashing on the first buffer (#4103)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! video/x-raw,format=RGB,width=4,height=4 ! tensor_converter ! tensor_transform ! fakesink" 25_n 0 1 $PERFORMANCE
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=3 ! video/x-raw,format=RGB,width=4,height=4 ! tensor_converter ! tensor_transform mode=typecast ! fakesink" 26_n 0 1 $PERFORMANCE
+
 rm *.log *.bmp *.png *.golden *.raw *.dat
 
 report


### PR DESCRIPTION
Fixes #4103.

## Problem

`tensor_transform` reported every `set_caps` failure as `Tensor info is not matched with given properties`, regardless of the actual cause, and an element whose `mode`/`option` were not configured passed caps negotiation and then died on the first buffer with a bare `assertion 'filter->loaded' failed` CRITICAL. The details that would explain the failure (type/dimension comparison) are emitted at `g_debug` level by the util library and are invisible under `GST_DEBUG=2`.

Reproduced on current main with six pipelines (see the table). The log quoted in #4103 (originally from #4102) has identical in/out caps and comes from the `convert_dimension` path, which means the element's `mode` was never applied in that application.

| Scenario | Before | After |
|---|---|---|
| `tensor_transform` with no mode | "Tensor info is not matched…" ×4 | `Transform is not configured (mode=unknown, option=(NULL)). Set valid 'mode' and 'option' properties before negotiating caps.` |
| `mode=typecast`, no option | caps accepted, then CRITICAL on first buffer | rejected at set_caps with `mode=typecast, option=(NULL)` |
| `mode=arithmetic option=casttype:…` (typo) | parse error, then CRITICAL | parse error, then rejected at set_caps with `mode=arithmetic, option=(NULL)` |
| `typecast:float32` vs downstream `types=float16` | only basetransform's generic "could not transform … in anything we support" | `mode=typecast option=float32 transforms input [uint8 …] into [float32 …], which the downstream element cannot accept: [float16 …]` |
| out caps that do not equal the transform result | "Tensor info is not matched…" | mode/option, framerate expected vs given, and a per-tensor expected-vs-given table |

## Change (`gst/nnstreamer/elements/gsttensor_transform.c` only)

- `set_caps` rejects an unconfigured element up front (`!filter->loaded`), naming the current mode and option. The two remaining failure paths name the tensor index, or print `gst_tensors_info_compare_to_string` output plus the framerates.
- While unconfigured, `transform_caps` advertises identity caps instead of running the per-mode conversion on unparsed option data. This is what makes the rejection above the one that users see even with a downstream capsfilter, and it removes the earlier attempt to pre-initialise the option union (which, being a union, leaked `_NNS_END` into `dimchg`/`padding`/`transpose` fields).
- `loaded` now means "the current mode and option parsed successfully": it is cleared when the mode is unknown or the option is unset, and when a (re-)parse fails, e.g. after switching `mode` to one under which the stored option is invalid. A successful re-parse never passes through an unconfigured state, so changing `option` at runtime keeps working.
- `transform_caps` warns with mode/option when the transformed caps cannot intersect the filter caps, and when fixed input caps are transformed into caps the downstream peer cannot accept. The downstream peer query mirrors what `tensor_filter` already does in the same direction and is skipped unless the category threshold is at least WARNING, so it costs nothing in production. The opposite direction (querying upstream from the SRC direction) is deliberately **not** done: with a `tensor_filter` upstream it would ping-pong caps queries forever. So a `dimchg`/`transpose` result that the upstream element cannot feed still fails silently inside the upstream element's negotiation; that is outside this element.
- `transform()` posts `GST_ELEMENT_ERROR (CORE, NEGOTIATION)` instead of the CRITICAL if it is ever reached unconfigured.
- One pre-existing spacing nit (`=(gsize)`) fixed so `gst-indent` leaves the file clean.

## Tests

GTest `testTensorTransform`:

- Negative, each asserting `GST_FLOW_NOT_NEGOTIATED` on the first buffer and the new message text through a `gst_debug_add_log_function` collector: `setCapsNotConfigured_n`, `setCapsModeWithoutOption_n` (fails on main, which returns `GST_FLOW_ERROR` after the CRITICAL), `setCapsInvalidOption_n`, `setCapsUnconfiguredPaddingWithDownstreamCaps_n` (the union side effect: an unconfigured `padding` with the real caps downstream must still reach the set_caps message), `setCapsAfterModeChangeUnparsable_n` (`loaded` is cleared when the stored option stops parsing under a new mode), `transformCapsIncompatibleDownstream_n` (peer-query warning) and `transformCapsFilterIntersectionEmpty_n` (filter-caps warning, both directions, via `gst_pad_query_caps` with a filter).
- Positive regression guards for existing pipelines and applications: `setCapsConfiguredAfterLink` and `linkThenConfigure` (elements linked with `gst_element_link_many` **before** properties are set, the pattern from #4102, with a fixed downstream capsfilter), `optionChangeWhileStreaming` (runtime `option` change, re-setting the same `mode`, and an invalid runtime option being rejected and the previous one kept), and `negotiationChainWithFilter` (`tensor_transform → tensor_filter → tensor_transform → tensor_filter → tensor_transform`, with the WARNING threshold raised so the peer-query path is really taken; a caps-query loop would fail with a bus timeout instead of hanging a job).

SSAT `transform_typecast` 25_n / 26_n: no mode, and mode without option. Note that these two also fail on main (via the CRITICAL), so they are pipeline-level guards rather than the regression guard for #4103; the GTest cases are.

Local run (WSL, meson build): `testTensorTransform.*`, `unittest_plugins`, `unittest_sink`, `unittest_common`, `unittest_if` all passed; SSAT `transform_*`, `nnstreamer_decoder_boundingbox`, `nnstreamer_decoder_pose`, `nnstreamer_filter_custom` all passed. `gst-indent` and `clang-format --dry-run -Werror` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
