### PR TITLE
[Converter] Take the running time only while PLAYING

### DIFF
--- a/Documentation/synchronization-policies-at-mux-merge.md
+++ b/Documentation/synchronization-policies-at-mux-merge.md
@@ -5,7 +5,7 @@ title: Synchronization policies
 # Synchronization policies at Mux and Merge
 There are multiple synchronization policies for tensor_mux and tensor_merge.
 They are based on PTS ( presentation timestamp in nanoseconds (as a GstClockTime) ) and assume that every tensor buffer has PTS and can be accessed by GST_BUFFER_PTS(buf).  
-However, there is stream which does not have PTS such as application/octet-stream. In such cases, tensor_converter generates timestamp and set PTS. If framerate is given, tensor_converter generates proper PTS according to framerate and for the case without framerate, PTS is decided with running time which is calculated as absolute-time - base-time.  
+However, there is stream which does not have PTS such as application/octet-stream. In such cases, tensor_converter generates timestamp and set PTS. If framerate is given, tensor_converter generates proper PTS according to framerate and for the case without framerate, PTS is decided with running time (absolute-time - base-time) while the element is PLAYING; before that, the previous PTS (or the segment start) is reused.  
 Currently, three synchronization policies are implemented.
 
 # No synchronization

--- a/gst/nnstreamer/elements/gsttensor_converter.c
+++ b/gst/nnstreamer/elements/gsttensor_converter.c
@@ -819,18 +819,24 @@ _gst_tensor_converter_chain_timestamp (GstTensorConverter * self,
           pts = self->old_timestamp + duration;
         }
       } else {
-        GstClock *clock;
+        GstClock *clock = NULL;
+        GstClockTime base = GST_CLOCK_TIME_NONE;
 
-        clock = gst_element_get_clock (GST_ELEMENT (self));
+        /* base_time is delivered right before PLAYING is committed */
+        GST_OBJECT_LOCK (self);
+        if (GST_STATE (self) == GST_STATE_PLAYING && GST_ELEMENT_CLOCK (self)) {
+          clock = gst_object_ref (GST_ELEMENT_CLOCK (self));
+          base = GST_ELEMENT_CAST (self)->base_time;
+        }
+        GST_OBJECT_UNLOCK (self);
 
         if (clock) {
-          GstClockTime now, base;
-
-          base = gst_element_get_base_time (GST_ELEMENT (self));
-          now = gst_clock_get_time (clock);
+          GstClockTime now = gst_clock_get_time (clock);
 
           pts = (base < now) ? (now - base) : 0;
           gst_object_unref (clock);
+        } else if (GST_CLOCK_TIME_IS_VALID (self->old_timestamp)) {
+          pts = self->old_timestamp;
         }
       }
 

--- a/gst/nnstreamer/elements/gsttensor_converter.md
+++ b/gst/nnstreamer/elements/gsttensor_converter.md
@@ -75,6 +75,16 @@ When incoming media type is video, audio, or text, each frame (or a set of frame
 - Text
   - TBD.
 
+## Timestamps
+
+With ```set-timestamp=true``` (the default), a frame that arrives without a timestamp gets one:
+
+- If the input caps carry a framerate, the timestamp is the previous timestamp plus one frame duration, starting at the segment start.
+- Otherwise, while the element is PLAYING, the timestamp is the pipeline running time (clock time minus base time).
+- Otherwise (PAUSED, or no clock), the previous timestamp is reused; the very first frame gets the segment start.
+
+The running time is only taken while PLAYING because the base time reaches the element right before that state is committed. Using the clock earlier would stamp the absolute clock time and stall a synchronizing sink (see issue #4898).
+
 ## Properties
 
 - frames-per-tensor: The number of incoming media frames that will be contained in a single instance of tensors. With the value > 1, you can put multiple frames in a single tensor.

--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -369,11 +369,14 @@ gst_tensor_time_sync_buffer_from_collectpad (GstCollectPads * collect,
 
     buf = gst_collect_pads_peek (collect, data);
     if (buf != NULL) {
-      if (pad->buffer != NULL)
-        base_time =
-            MIN ((GstClockTimeDiff) sync->data_basepad.duration,
-            ABS (GST_CLOCK_DIFF (GST_BUFFER_PTS (buf),
-                    GST_BUFFER_PTS (pad->buffer))) - 1);
+      if (pad->buffer != NULL) {
+        GstClockTimeDiff gap = ABS (GST_CLOCK_DIFF (GST_BUFFER_PTS (buf),
+                GST_BUFFER_PTS (pad->buffer)));
+
+        /* equal timestamps must not wrap the tolerance to G_MAXUINT64 */
+        base_time = MIN ((GstClockTimeDiff) sync->data_basepad.duration,
+            (gap > 0) ? (gap - 1) : 0);
+      }
       gst_buffer_unref (buf);
     }
   }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -230,6 +230,15 @@ if gtest_dep.found()
       test('unittest_converter', unittest_converter, env: testenv)
     endif
 
+    unittest_converter_timestamp = executable('unittest_converter_timestamp',
+      join_paths('nnstreamer_converter', 'unittest_converter_timestamp.cc'),
+      dependencies: [nnstreamer_unittest_deps],
+      install: get_option('install-test'),
+      install_dir: unittest_install_dir
+    )
+
+    test('unittest_converter_timestamp', unittest_converter_timestamp, timeout: 120, env: testenv)
+
     unittest_filter_custom = executable('unittest_filter_custom',
       join_paths('nnstreamer_filter_custom', 'unittest_filter_custom.cc'),
       dependencies: [nnstreamer_unittest_deps],

--- a/tests/nnstreamer_converter/runTest.sh
+++ b/tests/nnstreamer_converter/runTest.sh
@@ -92,9 +92,12 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! videos
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=\"test_00.dat\" blocksize=-1 ! application/octet-stream ! tensor_converter input-dim=4:4:4:4:4 input-type=float32 ! fakesink" 8-1 0 0 $PERFORMANCE
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=\"test_01.dat\" blocksize=-1 ! application/octet-stream ! tensor_converter input-dim=3:10:10:4:5:6 input-type=uint8 ! fakesink" 8-2 0 0 $PERFORMANCE
 
-# Timestamp test cases (issue #4898): untimestamped frames without a framerate
-# must get a running time, so a synchronizing sink renders them and the
-# pipeline reaches EOS. A stall here is reported by the timeout.
+# Timestamp test cases (issue #4898). 9-1 to 9-4, 9-9 and 9-10 feed untimestamped
+# frames without a framerate through a widened state-change window into a
+# synchronizing sink; a stall is reported by the timeout. 9-5 and 9-6 are smoke
+# cases for live sources, which stamp their own frames and stream only after
+# their own transition, so they cannot hit the window. 9-7_n and 9-8_n fail at
+# once and run without a timeout so a stall there could never count as a pass.
 TS_PADDING=""
 for i in $(seq 1 40); do
     TS_PADDING="${TS_PADDING}identity ! "
@@ -108,8 +111,8 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} ! tee name=t
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} set-timestamp=false ! ${TS_PADDING}fakesink sync=true" 9-4 0 0 $PERFORMANCE 30
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc is-live=true num-buffers=5 ! video/x-raw,format=GRAY8,width=16,height=16,framerate=0/1 ! tensor_converter ! ${TS_PADDING}fakesink sync=true" 9-5 0 0 $PERFORMANCE 30
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc is-live=true num-buffers=5 samplesperbuffer=800 ! audio/x-raw,format=S16LE,rate=8000,channels=1 ! tensor_converter frames-per-tensor=800 ! ${TS_PADDING}fakesink sync=true" 9-6 0 0 $PERFORMANCE 30
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} set-timestamp=notabool ! fakesink sync=true" 9-7_n 0 1 $PERFORMANCE 30
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! tensor_converter ! fakesink sync=true" 9-8_n 0 1 $PERFORMANCE 30
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} set-timestamp=notabool ! fakesink sync=true" 9-7_n 0 1 $PERFORMANCE
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! tensor_converter ! fakesink sync=true" 9-8_n 0 1 $PERFORMANCE
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} ! mux.sink_0 ${TS_SRC} ! ${TS_CONV} ! mux.sink_1 tensor_mux name=mux ! ${TS_PADDING}fakesink sync=true" 9-9 0 0 $PERFORMANCE 30
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} ! tensor_aggregator frames-in=1 frames-out=5 frames-flush=5 ! ${TS_PADDING}fakesink sync=true" 9-10 0 0 $PERFORMANCE 30
 

--- a/tests/nnstreamer_converter/runTest.sh
+++ b/tests/nnstreamer_converter/runTest.sh
@@ -92,6 +92,27 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! videos
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=\"test_00.dat\" blocksize=-1 ! application/octet-stream ! tensor_converter input-dim=4:4:4:4:4 input-type=float32 ! fakesink" 8-1 0 0 $PERFORMANCE
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=\"test_01.dat\" blocksize=-1 ! application/octet-stream ! tensor_converter input-dim=3:10:10:4:5:6 input-type=uint8 ! fakesink" 8-2 0 0 $PERFORMANCE
 
+# Timestamp test cases (issue #4898): untimestamped frames without a framerate
+# must get a running time, so a synchronizing sink renders them and the
+# pipeline reaches EOS. A stall here is reported by the timeout.
+TS_PADDING=""
+for i in $(seq 1 40); do
+    TS_PADDING="${TS_PADDING}identity ! "
+done
+TS_SRC="fakesrc num-buffers=5 sizetype=fixed sizemax=10 ! application/octet-stream"
+TS_CONV="tensor_converter input-dim=10 input-type=uint8"
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} ! ${TS_PADDING}fakesink sync=true" 9-1 0 0 $PERFORMANCE 30
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} ! ${TS_PADDING}queue ! fakesink sync=true" 9-2 0 0 $PERFORMANCE 30
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} ! tee name=ts ts. ! queue ! fakesink sync=true ts. ! queue ! ${TS_PADDING}fakesink sync=true" 9-3 0 0 $PERFORMANCE 30
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} set-timestamp=false ! ${TS_PADDING}fakesink sync=true" 9-4 0 0 $PERFORMANCE 30
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc is-live=true num-buffers=5 ! video/x-raw,format=GRAY8,width=16,height=16,framerate=0/1 ! tensor_converter ! ${TS_PADDING}fakesink sync=true" 9-5 0 0 $PERFORMANCE 30
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc is-live=true num-buffers=5 samplesperbuffer=800 ! audio/x-raw,format=S16LE,rate=8000,channels=1 ! tensor_converter frames-per-tensor=800 ! ${TS_PADDING}fakesink sync=true" 9-6 0 0 $PERFORMANCE 30
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} set-timestamp=notabool ! fakesink sync=true" 9-7_n 0 1 $PERFORMANCE 30
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! tensor_converter ! fakesink sync=true" 9-8_n 0 1 $PERFORMANCE 30
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} ! mux.sink_0 ${TS_SRC} ! ${TS_CONV} ! mux.sink_1 tensor_mux name=mux ! ${TS_PADDING}fakesink sync=true" 9-9 0 0 $PERFORMANCE 30
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${TS_SRC} ! ${TS_CONV} ! tensor_aggregator frames-in=1 frames-out=5 frames-flush=5 ! ${TS_PADDING}fakesink sync=true" 9-10 0 0 $PERFORMANCE 30
+
 rm *.log *.bmp *.png *.golden *.dat
 
 report

--- a/tests/nnstreamer_converter/unittest_converter_timestamp.cc
+++ b/tests/nnstreamer_converter/unittest_converter_timestamp.cc
@@ -793,7 +793,7 @@ run_basepad_duplicate_timestamps (const gchar *muxer, guint mem_index, guint byt
   pipeline_push_tensor (src0, 2, MSEC (10));
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (src0)), GST_FLOW_OK);
   pipeline_push_tensor (src1, 100, 0);
-  pipeline_push_tensor (src1, 101, GST_SECOND);
+  pipeline_push_tensor (src1, 101, SEC (1));
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (src1)), GST_FLOW_OK);
 
   while ((sample = gst_app_sink_try_pull_sample (GST_APP_SINK (sink), MSEC (TEST_TIMEOUT_MS)))

--- a/tests/nnstreamer_converter/unittest_converter_timestamp.cc
+++ b/tests/nnstreamer_converter/unittest_converter_timestamp.cc
@@ -708,6 +708,8 @@ TEST (tensorConverterTimestampPipeline, syncSinkNoTimestampCompletes_p)
 
 /**
  * @brief Positive: a live video source without a framerate still completes.
+ * The source stamps its frames and streams only after its own transition,
+ * so this is a smoke test of the live path rather than a window regression.
  */
 TEST (tensorConverterTimestampPipeline, liveVideoNoFramerateCompletes_p)
 {

--- a/tests/nnstreamer_converter/unittest_converter_timestamp.cc
+++ b/tests/nnstreamer_converter/unittest_converter_timestamp.cc
@@ -1,0 +1,784 @@
+/**
+ * @file        unittest_converter_timestamp.cc
+ * @date        02 Sep 2026
+ * @brief       Unit test for the timestamp handling of tensor_converter
+ * @see         https://github.com/nnstreamer/nnstreamer
+ * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug         No known bugs
+ */
+
+#include <gtest/gtest.h>
+#include <glib.h>
+#include <gst/app/gstappsink.h>
+#include <gst/app/gstappsrc.h>
+#include <gst/check/gstharness.h>
+#include <gst/check/gsttestclock.h>
+#include <gst/gst.h>
+#include <unittest_util.h>
+
+#define FRAME_SIZE (8U)
+#define OCTET_CAPS "application/octet-stream"
+#define OCTET_FPS_CAPS "application/octet-stream,framerate=(fraction)5/1"
+#define VIDEO_FPS_CAPS \
+  "video/x-raw,format=GRAY8,width=8,height=1,framerate=(fraction)10/1"
+#define CONVERTER_LAUNCH "tensor_converter input-dim=8 input-type=uint8"
+#define FAKESRC_LAUNCH "fakesrc num-buffers=5 sizetype=fixed sizemax=8"
+#define ONE_HOUR (3600 * GST_SECOND)
+#define TEST_TIMEOUT_MS (10000U)
+#define IDENTITY_PADDING (40U)
+
+/**
+ * @brief Create a harness around a bare tensor_converter with the given caps.
+ */
+static GstHarness *
+harness_new_full (const gchar *caps, gboolean set_timestamp, guint frames_per_tensor)
+{
+  GstHarness *h = gst_harness_new ("tensor_converter");
+
+  if (g_str_has_prefix (caps, OCTET_CAPS))
+    g_object_set (h->element, "input-dim", "8", "input-type", "uint8", NULL);
+  g_object_set (h->element, "set-timestamp", set_timestamp, "frames-per-tensor",
+      frames_per_tensor, NULL);
+  gst_harness_set_src_caps_str (h, caps);
+  return h;
+}
+
+#define harness_new(caps) harness_new_full (caps, TRUE, 1)
+
+/**
+ * @brief Set the state of the harnessed element synchronously.
+ */
+static void
+harness_set_state (GstHarness *h, GstState state)
+{
+  EXPECT_EQ (gst_element_set_state (h->element, state), GST_STATE_CHANGE_SUCCESS);
+  EXPECT_EQ (GST_STATE (h->element), state);
+}
+
+/**
+ * @brief Push one frame through the harness and return the output buffer.
+ */
+static GstBuffer *
+harness_push_frame (GstHarness *h, GstClockTime pts, GstClockTime duration)
+{
+  GstBuffer *in = gst_harness_create_buffer (h, FRAME_SIZE);
+
+  GST_BUFFER_PTS (in) = pts;
+  GST_BUFFER_DURATION (in) = duration;
+  EXPECT_EQ (gst_harness_push (h, in), GST_FLOW_OK);
+
+  return gst_harness_try_pull (h);
+}
+
+/**
+ * @brief Push an untimestamped frame and return the timestamp assigned to it.
+ */
+static GstClockTime
+harness_push_get_pts (GstHarness *h)
+{
+  GstBuffer *out = harness_push_frame (h, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE);
+  GstClockTime pts;
+
+  if (out == NULL) {
+    ADD_FAILURE () << "no output buffer";
+    return GST_CLOCK_TIME_NONE;
+  }
+
+  pts = GST_BUFFER_PTS (out);
+  gst_buffer_unref (out);
+  return pts;
+}
+
+/**
+ * @brief Positive: while PLAYING, an untimestamped frame gets the running time.
+ */
+TEST (tensorConverterTimestamp, playingRunningTime_p)
+{
+  GstHarness *h = harness_new (OCTET_CAPS);
+  GstBuffer *out;
+
+  gst_harness_set_time (h, 10 * GST_SECOND);
+  gst_element_set_base_time (h->element, 10 * GST_SECOND);
+
+  out = harness_push_frame (h, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE);
+  ASSERT_TRUE (out != NULL);
+  EXPECT_EQ (GST_BUFFER_PTS (out), 0U);
+  EXPECT_FALSE (GST_BUFFER_DURATION_IS_VALID (out));
+  gst_buffer_unref (out);
+
+  gst_harness_set_time (h, 10 * GST_SECOND + 500 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+
+  gst_harness_set_time (h, 10 * GST_SECOND + 700 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), 700 * GST_MSECOND);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Positive: a clock behind the base time yields a zero timestamp.
+ */
+TEST (tensorConverterTimestamp, playingClockBehindBaseTime_p)
+{
+  GstHarness *h = harness_new (OCTET_CAPS);
+
+  gst_harness_set_time (h, 10 * GST_SECOND);
+  gst_element_set_base_time (h->element, 20 * GST_SECOND);
+
+  EXPECT_EQ (harness_push_get_pts (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Regression (#4898): a clock without a base time must not leak the
+ * absolute clock value into the timestamp.
+ */
+TEST (tensorConverterTimestamp, pausedBeforeFirstPlaying_p)
+{
+  GstHarness *h = harness_new (OCTET_CAPS);
+
+  harness_set_state (h, GST_STATE_PAUSED);
+  ASSERT_EQ (gst_element_get_base_time (h->element), 0U);
+  gst_harness_set_time (h, ONE_HOUR);
+
+  EXPECT_EQ (harness_push_get_pts (h), 0U);
+  EXPECT_EQ (harness_push_get_pts (h), 0U);
+
+  harness_set_state (h, GST_STATE_PLAYING);
+  gst_element_set_base_time (h->element, ONE_HOUR);
+  EXPECT_EQ (harness_push_get_pts (h), 0U);
+
+  gst_harness_set_time (h, ONE_HOUR + 50 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), 50 * GST_MSECOND);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Positive: frames pushed while PAUSED keep the last timestamp and the
+ * running time continues after resuming.
+ */
+TEST (tensorConverterTimestamp, pausedAfterPlayingKeepsLast_p)
+{
+  GstHarness *h = harness_new (OCTET_CAPS);
+
+  gst_element_set_base_time (h->element, 10 * GST_SECOND);
+  gst_harness_set_time (h, 10 * GST_SECOND + 500 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+
+  harness_set_state (h, GST_STATE_PAUSED);
+  gst_harness_set_time (h, ONE_HOUR);
+  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+
+  harness_set_state (h, GST_STATE_PLAYING);
+  gst_element_set_base_time (h->element, ONE_HOUR - 500 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+
+  gst_harness_set_time (h, ONE_HOUR + 100 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), 600 * GST_MSECOND);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Positive: without a previous timestamp, the fallback is the segment start.
+ */
+TEST (tensorConverterTimestamp, pausedUsesSegmentStart_p)
+{
+  GstHarness *h = harness_new (OCTET_CAPS);
+  GstSegment segment;
+
+  gst_segment_init (&segment, GST_FORMAT_TIME);
+  segment.start = segment.time = 2 * GST_SECOND;
+  EXPECT_TRUE (gst_harness_push_event (h, gst_event_new_segment (&segment)));
+
+  harness_set_state (h, GST_STATE_PAUSED);
+  gst_harness_set_time (h, ONE_HOUR);
+  EXPECT_EQ (harness_push_get_pts (h), 2 * GST_SECOND);
+  EXPECT_EQ (harness_push_get_pts (h), 2 * GST_SECOND);
+
+  harness_set_state (h, GST_STATE_PLAYING);
+  gst_element_set_base_time (h->element, ONE_HOUR);
+  EXPECT_LT (harness_push_get_pts (h), GST_SECOND);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Positive: a frame that already carries timestamps is left untouched.
+ */
+TEST (tensorConverterTimestamp, validInputTimestampUntouched_p)
+{
+  GstHarness *h = harness_new (OCTET_CAPS);
+  GstBuffer *out;
+
+  gst_harness_set_time (h, ONE_HOUR);
+
+  out = harness_push_frame (h, 42 * GST_MSECOND, 7 * GST_MSECOND);
+  ASSERT_TRUE (out != NULL);
+  EXPECT_EQ (GST_BUFFER_PTS (out), 42 * GST_MSECOND);
+  EXPECT_EQ (GST_BUFFER_DURATION (out), 7 * GST_MSECOND);
+  gst_buffer_unref (out);
+
+  harness_set_state (h, GST_STATE_PAUSED);
+  out = harness_push_frame (h, 43 * GST_MSECOND, GST_CLOCK_TIME_NONE);
+  ASSERT_TRUE (out != NULL);
+  EXPECT_EQ (GST_BUFFER_PTS (out), 43 * GST_MSECOND);
+  EXPECT_FALSE (GST_BUFFER_DURATION_IS_VALID (out));
+  gst_buffer_unref (out);
+
+  EXPECT_EQ (harness_push_get_pts (h), 43 * GST_MSECOND);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Negative: with set-timestamp=false nothing is stamped in any state.
+ */
+TEST (tensorConverterTimestamp, setTimestampFalse_n)
+{
+  GstHarness *h = harness_new_full (OCTET_CAPS, FALSE, 1);
+  GstBuffer *out;
+
+  gst_harness_set_time (h, ONE_HOUR);
+  gst_element_set_base_time (h->element, 10 * GST_SECOND);
+  EXPECT_FALSE (GST_CLOCK_TIME_IS_VALID (harness_push_get_pts (h)));
+
+  harness_set_state (h, GST_STATE_PAUSED);
+  EXPECT_FALSE (GST_CLOCK_TIME_IS_VALID (harness_push_get_pts (h)));
+
+  out = harness_push_frame (h, 42 * GST_MSECOND, GST_CLOCK_TIME_NONE);
+  ASSERT_TRUE (out != NULL);
+  EXPECT_EQ (GST_BUFFER_PTS (out), 42 * GST_MSECOND);
+  gst_buffer_unref (out);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Positive: without a clock the timestamp falls back to the history.
+ */
+TEST (tensorConverterTimestamp, playingWithoutClock_p)
+{
+  GstHarness *h = harness_new (OCTET_CAPS);
+
+  EXPECT_TRUE (gst_element_set_clock (h->element, NULL));
+  gst_element_set_base_time (h->element, 10 * GST_SECOND);
+
+  EXPECT_EQ (harness_push_get_pts (h), 0U);
+  EXPECT_EQ (harness_push_get_pts (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Positive: with a framerate the clock is never consulted.
+ */
+TEST (tensorConverterTimestamp, framerateIgnoresClock_p)
+{
+  GstHarness *h = harness_new (VIDEO_FPS_CAPS);
+  GstBuffer *out;
+
+  gst_harness_set_time (h, ONE_HOUR);
+
+  out = harness_push_frame (h, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE);
+  ASSERT_TRUE (out != NULL);
+  EXPECT_EQ (GST_BUFFER_PTS (out), 0U);
+  EXPECT_EQ (GST_BUFFER_DURATION (out), 100 * GST_MSECOND);
+  gst_buffer_unref (out);
+
+  EXPECT_EQ (harness_push_get_pts (h), 100 * GST_MSECOND);
+
+  harness_set_state (h, GST_STATE_PAUSED);
+  gst_harness_set_time (h, 2 * ONE_HOUR);
+  EXPECT_EQ (harness_push_get_pts (h), 200 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), 300 * GST_MSECOND);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Positive: an octet stream with a framerate takes the framerate branch.
+ */
+TEST (tensorConverterTimestamp, octetFramerate_p)
+{
+  GstHarness *h = harness_new (OCTET_FPS_CAPS);
+  GstBuffer *out;
+
+  gst_harness_set_time (h, ONE_HOUR);
+
+  out = harness_push_frame (h, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE);
+  ASSERT_TRUE (out != NULL);
+  EXPECT_EQ (GST_BUFFER_PTS (out), 0U);
+  EXPECT_EQ (GST_BUFFER_DURATION (out), 200 * GST_MSECOND);
+  gst_buffer_unref (out);
+
+  EXPECT_EQ (harness_push_get_pts (h), 200 * GST_MSECOND);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Positive: a flush clears the timestamp history.
+ */
+TEST (tensorConverterTimestamp, flushResetsHistory_p)
+{
+  GstHarness *h = harness_new (OCTET_CAPS);
+  GstSegment segment;
+
+  gst_element_set_base_time (h->element, 10 * GST_SECOND);
+  gst_harness_set_time (h, 10 * GST_SECOND + 500 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+
+  EXPECT_TRUE (gst_harness_push_event (h, gst_event_new_flush_start ()));
+  EXPECT_TRUE (gst_harness_push_event (h, gst_event_new_flush_stop (TRUE)));
+  gst_segment_init (&segment, GST_FORMAT_TIME);
+  EXPECT_TRUE (gst_harness_push_event (h, gst_event_new_segment (&segment)));
+
+  harness_set_state (h, GST_STATE_PAUSED);
+  gst_harness_set_time (h, ONE_HOUR);
+  EXPECT_EQ (harness_push_get_pts (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Positive: a BYTES segment is replaced by a TIME segment starting at 0.
+ */
+TEST (tensorConverterTimestamp, bytesSegmentConverted_p)
+{
+  GstHarness *h = harness_new (OCTET_CAPS);
+  GstSegment segment;
+  GstEvent *event;
+  const GstSegment *out_segment = NULL;
+  guint num_segments = 0;
+
+  gst_segment_init (&segment, GST_FORMAT_BYTES);
+  EXPECT_TRUE (gst_harness_push_event (h, gst_event_new_segment (&segment)));
+
+  harness_set_state (h, GST_STATE_PAUSED);
+  gst_harness_set_time (h, ONE_HOUR);
+  EXPECT_EQ (harness_push_get_pts (h), 0U);
+
+  while ((event = gst_harness_try_pull_event (h)) != NULL) {
+    if (GST_EVENT_TYPE (event) == GST_EVENT_SEGMENT) {
+      gst_event_parse_segment (event, &out_segment);
+      EXPECT_EQ (out_segment->format, GST_FORMAT_TIME);
+      num_segments++;
+    }
+    gst_event_unref (event);
+  }
+  EXPECT_EQ (num_segments, 2U);
+
+  harness_set_state (h, GST_STATE_PLAYING);
+  gst_element_set_base_time (h->element, ONE_HOUR);
+  gst_harness_set_time (h, ONE_HOUR + 10 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), 10 * GST_MSECOND);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Positive: aggregated frames carry the timestamp of their first frame.
+ */
+TEST (tensorConverterTimestamp, framesPerTensorAggregation_p)
+{
+  GstHarness *h = harness_new_full (OCTET_CAPS, TRUE, 2);
+  GstBuffer *out;
+
+  gst_element_set_base_time (h->element, 10 * GST_SECOND);
+
+  gst_harness_set_time (h, 10 * GST_SECOND + 100 * GST_MSECOND);
+  out = harness_push_frame (h, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE);
+  EXPECT_TRUE (out == NULL);
+
+  gst_harness_set_time (h, 10 * GST_SECOND + 200 * GST_MSECOND);
+  out = harness_push_frame (h, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE);
+  ASSERT_TRUE (out != NULL);
+  EXPECT_EQ (gst_buffer_get_size (out), 2 * FRAME_SIZE);
+  EXPECT_EQ (GST_BUFFER_PTS (out), 100 * GST_MSECOND);
+  gst_buffer_unref (out);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Positive: going through READY clears the timestamp history.
+ */
+TEST (tensorConverterTimestamp, readyResetsHistory_p)
+{
+  GstHarness *h = harness_new (OCTET_CAPS);
+
+  gst_element_set_base_time (h->element, 10 * GST_SECOND);
+  gst_harness_set_time (h, 10 * GST_SECOND + 500 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+
+  harness_set_state (h, GST_STATE_READY);
+  harness_set_state (h, GST_STATE_PAUSED);
+  EXPECT_TRUE (gst_harness_push_event (h, gst_event_new_stream_start ("ready")));
+  gst_harness_set_src_caps_str (h, OCTET_CAPS);
+
+  gst_harness_set_time (h, ONE_HOUR);
+  EXPECT_EQ (harness_push_get_pts (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Wait until the pipeline reaches the given state.
+ */
+static gboolean
+wait_for_state (GstElement *pipeline, GstState state)
+{
+  GstState current = GST_STATE_VOID_PENDING;
+  GstStateChangeReturn ret;
+
+  ret = gst_element_get_state (pipeline, &current, NULL, TEST_TIMEOUT_MS * GST_MSECOND);
+  return (ret == GST_STATE_CHANGE_SUCCESS && current == state);
+}
+
+/**
+ * @brief Push an untimestamped frame into the appsrc of a pipeline.
+ */
+static void
+pipeline_push_frame (GstElement *appsrc)
+{
+  GstBuffer *buffer = gst_buffer_new_allocate (NULL, FRAME_SIZE, NULL);
+
+  EXPECT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc), buffer), GST_FLOW_OK);
+}
+
+/**
+ * @brief Pull a sample from the appsink and return its timestamp.
+ */
+static GstClockTime
+pipeline_pull_pts (GstElement *appsink, gboolean preroll)
+{
+  GstSample *sample;
+  GstClockTime pts;
+
+  if (preroll)
+    sample = gst_app_sink_try_pull_preroll (
+        GST_APP_SINK (appsink), TEST_TIMEOUT_MS * GST_MSECOND);
+  else
+    sample = gst_app_sink_try_pull_sample (
+        GST_APP_SINK (appsink), TEST_TIMEOUT_MS * GST_MSECOND);
+
+  if (sample == NULL) {
+    ADD_FAILURE () << "no sample";
+    return GST_CLOCK_TIME_NONE;
+  }
+
+  pts = GST_BUFFER_PTS (gst_sample_get_buffer (sample));
+  gst_sample_unref (sample);
+  return pts;
+}
+
+/**
+ * @brief Build the appsrc-to-appsink pipeline used by the pipeline tests.
+ */
+static GstElement *
+pipeline_new (GstElement **appsrc, GstElement **appsink, GstElement **converter)
+{
+  GstElement *pipeline
+      = gst_parse_launch ("appsrc name=src format=bytes ! " OCTET_CAPS " ! " CONVERTER_LAUNCH
+                          " name=conv ! queue ! appsink name=sink sync=false",
+          NULL);
+
+  if (pipeline == NULL)
+    return NULL;
+
+  *appsrc = gst_bin_get_by_name (GST_BIN (pipeline), "src");
+  *appsink = gst_bin_get_by_name (GST_BIN (pipeline), "sink");
+  *converter = gst_bin_get_by_name (GST_BIN (pipeline), "conv");
+  return pipeline;
+}
+
+/**
+ * @brief Positive: in a pipeline driven by a test clock, timestamps are exact
+ * running times and do not advance while PAUSED.
+ */
+TEST (tensorConverterTimestampPipeline, testClockRunningTime_p)
+{
+  GstElement *pipeline, *appsrc, *appsink, *converter;
+  GstClock *clock = gst_test_clock_new_with_start_time (ONE_HOUR);
+
+  pipeline = pipeline_new (&appsrc, &appsink, &converter);
+  ASSERT_TRUE (pipeline != NULL);
+  gst_pipeline_use_clock (GST_PIPELINE (pipeline), clock);
+
+  EXPECT_EQ (gst_element_set_state (pipeline, GST_STATE_PLAYING), GST_STATE_CHANGE_ASYNC);
+  pipeline_push_frame (appsrc);
+  ASSERT_TRUE (wait_for_state (pipeline, GST_STATE_PLAYING));
+  EXPECT_EQ (pipeline_pull_pts (appsink, FALSE), 0U);
+  EXPECT_EQ (gst_element_get_base_time (converter), ONE_HOUR);
+
+  gst_test_clock_advance_time (GST_TEST_CLOCK (clock), 300 * GST_MSECOND);
+  pipeline_push_frame (appsrc);
+  EXPECT_EQ (pipeline_pull_pts (appsink, FALSE), 300 * GST_MSECOND);
+
+  gst_element_set_state (pipeline, GST_STATE_PAUSED);
+  gst_test_clock_advance_time (GST_TEST_CLOCK (clock), 5 * GST_SECOND);
+  pipeline_push_frame (appsrc);
+  EXPECT_EQ (pipeline_pull_pts (appsink, TRUE), 300 * GST_MSECOND);
+  ASSERT_TRUE (wait_for_state (pipeline, GST_STATE_PAUSED));
+
+  gst_element_set_state (pipeline, GST_STATE_PLAYING);
+  ASSERT_TRUE (wait_for_state (pipeline, GST_STATE_PLAYING));
+  EXPECT_EQ (pipeline_pull_pts (appsink, FALSE), 300 * GST_MSECOND);
+
+  gst_test_clock_advance_time (GST_TEST_CLOCK (clock), 100 * GST_MSECOND);
+  pipeline_push_frame (appsrc);
+  EXPECT_EQ (pipeline_pull_pts (appsink, FALSE), 400 * GST_MSECOND);
+
+  EXPECT_EQ (gst_element_set_state (pipeline, GST_STATE_NULL), GST_STATE_CHANGE_SUCCESS);
+  gst_object_unref (appsrc);
+  gst_object_unref (appsink);
+  gst_object_unref (converter);
+  gst_object_unref (pipeline);
+  gst_object_unref (clock);
+}
+
+/**
+ * @brief Timestamp recorder attached to the converter source pad.
+ */
+typedef struct {
+  gint count;
+  GstClockTime pts;
+} probe_data_s;
+
+/**
+ * @brief Record the timestamp of every buffer leaving the converter.
+ */
+static GstPadProbeReturn
+probe_record_pts (GstPad *pad, GstPadProbeInfo *info, gpointer user_data)
+{
+  probe_data_s *data = (probe_data_s *) user_data;
+
+  data->pts = GST_BUFFER_PTS (GST_PAD_PROBE_INFO_BUFFER (info));
+  g_atomic_int_inc (&data->count);
+  return GST_PAD_PROBE_OK;
+}
+
+/**
+ * @brief Wait until the probe has seen the expected number of buffers.
+ */
+static gboolean
+wait_for_probe (probe_data_s *data, gint expected)
+{
+  guint waited = 0;
+
+  while (g_atomic_int_get (&data->count) < expected && waited < TEST_TIMEOUT_MS) {
+    g_usleep (10000);
+    waited += 10;
+  }
+  return g_atomic_int_get (&data->count) >= expected;
+}
+
+/**
+ * @brief Regression (#4898): emulate the state-change window in a real
+ * pipeline. The converter already holds a clock but no base time yet.
+ */
+TEST (tensorConverterTimestampPipeline, clockWithoutBaseTime_p)
+{
+  GstElement *pipeline, *appsrc, *appsink, *converter;
+  GstClock *clock = gst_system_clock_obtain ();
+  GstPad *srcpad;
+  probe_data_s data = { 0, GST_CLOCK_TIME_NONE };
+
+  pipeline = pipeline_new (&appsrc, &appsink, &converter);
+  ASSERT_TRUE (pipeline != NULL);
+
+  srcpad = gst_element_get_static_pad (converter, "src");
+  ASSERT_TRUE (srcpad != NULL);
+  gst_pad_add_probe (srcpad, GST_PAD_PROBE_TYPE_BUFFER, probe_record_pts, &data, NULL);
+
+  EXPECT_EQ (gst_element_set_state (pipeline, GST_STATE_PAUSED), GST_STATE_CHANGE_ASYNC);
+  pipeline_push_frame (appsrc);
+  ASSERT_TRUE (wait_for_state (pipeline, GST_STATE_PAUSED));
+  EXPECT_EQ (pipeline_pull_pts (appsink, TRUE), 0U);
+  ASSERT_TRUE (wait_for_probe (&data, 1));
+
+  ASSERT_EQ (gst_element_get_base_time (converter), 0U);
+  EXPECT_TRUE (gst_element_set_clock (converter, clock));
+  EXPECT_GT (gst_clock_get_time (clock), GST_SECOND);
+
+  pipeline_push_frame (appsrc);
+  ASSERT_TRUE (wait_for_probe (&data, 2));
+  EXPECT_EQ (data.pts, 0U);
+
+  EXPECT_EQ (gst_element_set_state (pipeline, GST_STATE_NULL), GST_STATE_CHANGE_SUCCESS);
+  gst_object_unref (srcpad);
+  gst_object_unref (appsrc);
+  gst_object_unref (appsink);
+  gst_object_unref (converter);
+  gst_object_unref (pipeline);
+  gst_object_unref (clock);
+}
+
+/**
+ * @brief Run a gst-launch style pipeline to EOS and return the final message type.
+ */
+static GstMessageType
+run_pipeline_to_end (const gchar *description)
+{
+  GstElement *pipeline = gst_parse_launch (description, NULL);
+  GstBus *bus;
+  GstMessage *message;
+  GstMessageType type = GST_MESSAGE_UNKNOWN;
+
+  if (pipeline == NULL)
+    return GST_MESSAGE_UNKNOWN;
+
+  bus = gst_element_get_bus (pipeline);
+  gst_element_set_state (pipeline, GST_STATE_PLAYING);
+  message = gst_bus_timed_pop_filtered (bus, TEST_TIMEOUT_MS * GST_MSECOND,
+      (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+  if (message != NULL) {
+    type = GST_MESSAGE_TYPE (message);
+    gst_message_unref (message);
+  }
+
+  gst_element_set_state (pipeline, GST_STATE_NULL);
+  gst_object_unref (bus);
+  gst_object_unref (pipeline);
+  return type;
+}
+
+/**
+ * @brief Build a converter pipeline padded with identity elements before a
+ * synchronizing sink, widening the state-change window of #4898.
+ */
+static gchar *
+padded_sync_pipeline (const gchar *source, const gchar *converter, const gchar *sink)
+{
+  GString *desc = g_string_new (source);
+  guint i;
+
+  g_string_append_printf (desc, " ! %s ! ", converter);
+  for (i = 0; i < IDENTITY_PADDING; i++)
+    g_string_append (desc, "identity ! ");
+  g_string_append (desc, sink);
+
+  return g_string_free (desc, FALSE);
+}
+
+/**
+ * @brief Positive: untimestamped octet frames reach a synchronizing sink.
+ */
+TEST (tensorConverterTimestampPipeline, syncSinkCompletes_p)
+{
+  gchar *desc = padded_sync_pipeline (
+      FAKESRC_LAUNCH " ! " OCTET_CAPS, CONVERTER_LAUNCH, "fakesink sync=true");
+  guint i;
+
+  for (i = 0; i < 3; i++)
+    EXPECT_EQ (run_pipeline_to_end (desc), GST_MESSAGE_EOS);
+
+  g_free (desc);
+}
+
+/**
+ * @brief Positive: the same holds with a queue thread before the sink.
+ */
+TEST (tensorConverterTimestampPipeline, syncSinkWithQueueCompletes_p)
+{
+  gchar *desc = padded_sync_pipeline (FAKESRC_LAUNCH " ! " OCTET_CAPS,
+      CONVERTER_LAUNCH, "queue ! fakesink sync=true");
+
+  EXPECT_EQ (run_pipeline_to_end (desc), GST_MESSAGE_EOS);
+
+  g_free (desc);
+}
+
+/**
+ * @brief Positive: with set-timestamp=false the sink does not wait either.
+ */
+TEST (tensorConverterTimestampPipeline, syncSinkNoTimestampCompletes_p)
+{
+  gchar *desc = padded_sync_pipeline (FAKESRC_LAUNCH " ! " OCTET_CAPS,
+      CONVERTER_LAUNCH " set-timestamp=false", "fakesink sync=true");
+
+  EXPECT_EQ (run_pipeline_to_end (desc), GST_MESSAGE_EOS);
+
+  g_free (desc);
+}
+
+/**
+ * @brief Positive: a live video source without a framerate still completes.
+ */
+TEST (tensorConverterTimestampPipeline, liveVideoNoFramerateCompletes_p)
+{
+  gchar *desc = padded_sync_pipeline ("videotestsrc is-live=true num-buffers=5 ! "
+                                      "video/x-raw,format=GRAY8,width=16,height=16,framerate=0/1",
+      "tensor_converter", "fakesink sync=true");
+
+  EXPECT_EQ (run_pipeline_to_end (desc), GST_MESSAGE_EOS);
+
+  g_free (desc);
+}
+
+/**
+ * @brief Positive: tensor_mux keeps synchronizing two untimestamped branches.
+ */
+TEST (tensorConverterTimestampPipeline, muxSyncSinkCompletes_p)
+{
+  gchar *desc = g_strdup_printf ("%s ! %s ! %s ! mux.sink_0 %s ! %s ! %s ! mux.sink_1 "
+                                 "tensor_mux name=mux ! fakesink sync=true",
+      FAKESRC_LAUNCH, OCTET_CAPS, CONVERTER_LAUNCH, FAKESRC_LAUNCH, OCTET_CAPS,
+      CONVERTER_LAUNCH);
+
+  EXPECT_EQ (run_pipeline_to_end (desc), GST_MESSAGE_EOS);
+
+  g_free (desc);
+}
+
+/**
+ * @brief Positive: tensor_aggregator consumes converter-stamped frames.
+ */
+TEST (tensorConverterTimestampPipeline, aggregatorSyncSinkCompletes_p)
+{
+  gchar *desc = padded_sync_pipeline (FAKESRC_LAUNCH " ! " OCTET_CAPS, CONVERTER_LAUNCH,
+      "tensor_aggregator frames-in=1 frames-out=5 frames-flush=5 ! fakesink sync=true");
+
+  EXPECT_EQ (run_pipeline_to_end (desc), GST_MESSAGE_EOS);
+
+  g_free (desc);
+}
+
+/**
+ * @brief Negative: an octet stream without dimensions fails to negotiate.
+ */
+TEST (tensorConverterTimestampPipeline, octetWithoutDimension_n)
+{
+  EXPECT_EQ (run_pipeline_to_end ("fakesrc num-buffers=1 sizetype=fixed sizemax=10 ! " OCTET_CAPS
+                                  " ! tensor_converter ! fakesink sync=true"),
+      GST_MESSAGE_ERROR);
+}
+
+/**
+ * @brief Main GTest
+ */
+int
+main (int argc, char **argv)
+{
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
+
+  gst_init (&argc, &argv);
+
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+
+  return result;
+}

--- a/tests/nnstreamer_converter/unittest_converter_timestamp.cc
+++ b/tests/nnstreamer_converter/unittest_converter_timestamp.cc
@@ -23,7 +23,9 @@
   "video/x-raw,format=GRAY8,width=8,height=1,framerate=(fraction)10/1"
 #define CONVERTER_LAUNCH "tensor_converter input-dim=8 input-type=uint8"
 #define FAKESRC_LAUNCH "fakesrc num-buffers=5 sizetype=fixed sizemax=8"
-#define ONE_HOUR (3600 * GST_SECOND)
+#define MSEC(n) ((GstClockTime) (GST_MSECOND * (n)))
+#define SEC(n) ((GstClockTime) (GST_SECOND * (n)))
+#define ONE_HOUR SEC (3600)
 #define TEST_TIMEOUT_MS (10000U)
 #define IDENTITY_PADDING (40U)
 
@@ -97,8 +99,8 @@ TEST (tensorConverterTimestamp, playingRunningTime_p)
   GstHarness *h = harness_new (OCTET_CAPS);
   GstBuffer *out;
 
-  gst_harness_set_time (h, 10 * GST_SECOND);
-  gst_element_set_base_time (h->element, 10 * GST_SECOND);
+  gst_harness_set_time (h, SEC (10));
+  gst_element_set_base_time (h->element, SEC (10));
 
   out = harness_push_frame (h, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE);
   ASSERT_TRUE (out != NULL);
@@ -106,11 +108,11 @@ TEST (tensorConverterTimestamp, playingRunningTime_p)
   EXPECT_FALSE (GST_BUFFER_DURATION_IS_VALID (out));
   gst_buffer_unref (out);
 
-  gst_harness_set_time (h, 10 * GST_SECOND + 500 * GST_MSECOND);
-  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+  gst_harness_set_time (h, SEC (10) + MSEC (500));
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (500));
 
-  gst_harness_set_time (h, 10 * GST_SECOND + 700 * GST_MSECOND);
-  EXPECT_EQ (harness_push_get_pts (h), 700 * GST_MSECOND);
+  gst_harness_set_time (h, SEC (10) + MSEC (700));
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (700));
 
   gst_harness_teardown (h);
 }
@@ -122,8 +124,8 @@ TEST (tensorConverterTimestamp, playingClockBehindBaseTime_p)
 {
   GstHarness *h = harness_new (OCTET_CAPS);
 
-  gst_harness_set_time (h, 10 * GST_SECOND);
-  gst_element_set_base_time (h->element, 20 * GST_SECOND);
+  gst_harness_set_time (h, SEC (10));
+  gst_element_set_base_time (h->element, SEC (20));
 
   EXPECT_EQ (harness_push_get_pts (h), 0U);
 
@@ -149,8 +151,8 @@ TEST (tensorConverterTimestamp, pausedBeforeFirstPlaying_p)
   gst_element_set_base_time (h->element, ONE_HOUR);
   EXPECT_EQ (harness_push_get_pts (h), 0U);
 
-  gst_harness_set_time (h, ONE_HOUR + 50 * GST_MSECOND);
-  EXPECT_EQ (harness_push_get_pts (h), 50 * GST_MSECOND);
+  gst_harness_set_time (h, ONE_HOUR + MSEC (50));
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (50));
 
   gst_harness_teardown (h);
 }
@@ -163,21 +165,21 @@ TEST (tensorConverterTimestamp, pausedAfterPlayingKeepsLast_p)
 {
   GstHarness *h = harness_new (OCTET_CAPS);
 
-  gst_element_set_base_time (h->element, 10 * GST_SECOND);
-  gst_harness_set_time (h, 10 * GST_SECOND + 500 * GST_MSECOND);
-  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+  gst_element_set_base_time (h->element, SEC (10));
+  gst_harness_set_time (h, SEC (10) + MSEC (500));
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (500));
 
   harness_set_state (h, GST_STATE_PAUSED);
   gst_harness_set_time (h, ONE_HOUR);
-  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
-  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (500));
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (500));
 
   harness_set_state (h, GST_STATE_PLAYING);
-  gst_element_set_base_time (h->element, ONE_HOUR - 500 * GST_MSECOND);
-  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+  gst_element_set_base_time (h->element, ONE_HOUR - MSEC (500));
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (500));
 
-  gst_harness_set_time (h, ONE_HOUR + 100 * GST_MSECOND);
-  EXPECT_EQ (harness_push_get_pts (h), 600 * GST_MSECOND);
+  gst_harness_set_time (h, ONE_HOUR + MSEC (100));
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (600));
 
   gst_harness_teardown (h);
 }
@@ -191,17 +193,17 @@ TEST (tensorConverterTimestamp, pausedUsesSegmentStart_p)
   GstSegment segment;
 
   gst_segment_init (&segment, GST_FORMAT_TIME);
-  segment.start = segment.time = 2 * GST_SECOND;
+  segment.start = segment.time = SEC (2);
   EXPECT_TRUE (gst_harness_push_event (h, gst_event_new_segment (&segment)));
 
   harness_set_state (h, GST_STATE_PAUSED);
   gst_harness_set_time (h, ONE_HOUR);
-  EXPECT_EQ (harness_push_get_pts (h), 2 * GST_SECOND);
-  EXPECT_EQ (harness_push_get_pts (h), 2 * GST_SECOND);
+  EXPECT_EQ (harness_push_get_pts (h), SEC (2));
+  EXPECT_EQ (harness_push_get_pts (h), SEC (2));
 
   harness_set_state (h, GST_STATE_PLAYING);
   gst_element_set_base_time (h->element, ONE_HOUR);
-  EXPECT_LT (harness_push_get_pts (h), GST_SECOND);
+  EXPECT_LT (harness_push_get_pts (h), SEC (1));
 
   gst_harness_teardown (h);
 }
@@ -216,20 +218,20 @@ TEST (tensorConverterTimestamp, validInputTimestampUntouched_p)
 
   gst_harness_set_time (h, ONE_HOUR);
 
-  out = harness_push_frame (h, 42 * GST_MSECOND, 7 * GST_MSECOND);
+  out = harness_push_frame (h, MSEC (42), MSEC (7));
   ASSERT_TRUE (out != NULL);
-  EXPECT_EQ (GST_BUFFER_PTS (out), 42 * GST_MSECOND);
-  EXPECT_EQ (GST_BUFFER_DURATION (out), 7 * GST_MSECOND);
+  EXPECT_EQ (GST_BUFFER_PTS (out), MSEC (42));
+  EXPECT_EQ (GST_BUFFER_DURATION (out), MSEC (7));
   gst_buffer_unref (out);
 
   harness_set_state (h, GST_STATE_PAUSED);
-  out = harness_push_frame (h, 43 * GST_MSECOND, GST_CLOCK_TIME_NONE);
+  out = harness_push_frame (h, MSEC (43), GST_CLOCK_TIME_NONE);
   ASSERT_TRUE (out != NULL);
-  EXPECT_EQ (GST_BUFFER_PTS (out), 43 * GST_MSECOND);
+  EXPECT_EQ (GST_BUFFER_PTS (out), MSEC (43));
   EXPECT_FALSE (GST_BUFFER_DURATION_IS_VALID (out));
   gst_buffer_unref (out);
 
-  EXPECT_EQ (harness_push_get_pts (h), 43 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (43));
 
   gst_harness_teardown (h);
 }
@@ -243,15 +245,15 @@ TEST (tensorConverterTimestamp, setTimestampFalse_n)
   GstBuffer *out;
 
   gst_harness_set_time (h, ONE_HOUR);
-  gst_element_set_base_time (h->element, 10 * GST_SECOND);
+  gst_element_set_base_time (h->element, SEC (10));
   EXPECT_FALSE (GST_CLOCK_TIME_IS_VALID (harness_push_get_pts (h)));
 
   harness_set_state (h, GST_STATE_PAUSED);
   EXPECT_FALSE (GST_CLOCK_TIME_IS_VALID (harness_push_get_pts (h)));
 
-  out = harness_push_frame (h, 42 * GST_MSECOND, GST_CLOCK_TIME_NONE);
+  out = harness_push_frame (h, MSEC (42), GST_CLOCK_TIME_NONE);
   ASSERT_TRUE (out != NULL);
-  EXPECT_EQ (GST_BUFFER_PTS (out), 42 * GST_MSECOND);
+  EXPECT_EQ (GST_BUFFER_PTS (out), MSEC (42));
   gst_buffer_unref (out);
 
   gst_harness_teardown (h);
@@ -265,7 +267,7 @@ TEST (tensorConverterTimestamp, playingWithoutClock_p)
   GstHarness *h = harness_new (OCTET_CAPS);
 
   EXPECT_TRUE (gst_element_set_clock (h->element, NULL));
-  gst_element_set_base_time (h->element, 10 * GST_SECOND);
+  gst_element_set_base_time (h->element, SEC (10));
 
   EXPECT_EQ (harness_push_get_pts (h), 0U);
   EXPECT_EQ (harness_push_get_pts (h), 0U);
@@ -286,15 +288,15 @@ TEST (tensorConverterTimestamp, framerateIgnoresClock_p)
   out = harness_push_frame (h, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE);
   ASSERT_TRUE (out != NULL);
   EXPECT_EQ (GST_BUFFER_PTS (out), 0U);
-  EXPECT_EQ (GST_BUFFER_DURATION (out), 100 * GST_MSECOND);
+  EXPECT_EQ (GST_BUFFER_DURATION (out), MSEC (100));
   gst_buffer_unref (out);
 
-  EXPECT_EQ (harness_push_get_pts (h), 100 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (100));
 
   harness_set_state (h, GST_STATE_PAUSED);
   gst_harness_set_time (h, 2 * ONE_HOUR);
-  EXPECT_EQ (harness_push_get_pts (h), 200 * GST_MSECOND);
-  EXPECT_EQ (harness_push_get_pts (h), 300 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (200));
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (300));
 
   gst_harness_teardown (h);
 }
@@ -312,10 +314,10 @@ TEST (tensorConverterTimestamp, octetFramerate_p)
   out = harness_push_frame (h, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE);
   ASSERT_TRUE (out != NULL);
   EXPECT_EQ (GST_BUFFER_PTS (out), 0U);
-  EXPECT_EQ (GST_BUFFER_DURATION (out), 200 * GST_MSECOND);
+  EXPECT_EQ (GST_BUFFER_DURATION (out), MSEC (200));
   gst_buffer_unref (out);
 
-  EXPECT_EQ (harness_push_get_pts (h), 200 * GST_MSECOND);
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (200));
 
   gst_harness_teardown (h);
 }
@@ -328,9 +330,9 @@ TEST (tensorConverterTimestamp, flushResetsHistory_p)
   GstHarness *h = harness_new (OCTET_CAPS);
   GstSegment segment;
 
-  gst_element_set_base_time (h->element, 10 * GST_SECOND);
-  gst_harness_set_time (h, 10 * GST_SECOND + 500 * GST_MSECOND);
-  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+  gst_element_set_base_time (h->element, SEC (10));
+  gst_harness_set_time (h, SEC (10) + MSEC (500));
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (500));
 
   EXPECT_TRUE (gst_harness_push_event (h, gst_event_new_flush_start ()));
   EXPECT_TRUE (gst_harness_push_event (h, gst_event_new_flush_stop (TRUE)));
@@ -374,8 +376,8 @@ TEST (tensorConverterTimestamp, bytesSegmentConverted_p)
 
   harness_set_state (h, GST_STATE_PLAYING);
   gst_element_set_base_time (h->element, ONE_HOUR);
-  gst_harness_set_time (h, ONE_HOUR + 10 * GST_MSECOND);
-  EXPECT_EQ (harness_push_get_pts (h), 10 * GST_MSECOND);
+  gst_harness_set_time (h, ONE_HOUR + MSEC (10));
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (10));
 
   gst_harness_teardown (h);
 }
@@ -388,17 +390,17 @@ TEST (tensorConverterTimestamp, framesPerTensorAggregation_p)
   GstHarness *h = harness_new_full (OCTET_CAPS, TRUE, 2);
   GstBuffer *out;
 
-  gst_element_set_base_time (h->element, 10 * GST_SECOND);
+  gst_element_set_base_time (h->element, SEC (10));
 
-  gst_harness_set_time (h, 10 * GST_SECOND + 100 * GST_MSECOND);
+  gst_harness_set_time (h, SEC (10) + MSEC (100));
   out = harness_push_frame (h, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE);
   EXPECT_TRUE (out == NULL);
 
-  gst_harness_set_time (h, 10 * GST_SECOND + 200 * GST_MSECOND);
+  gst_harness_set_time (h, SEC (10) + MSEC (200));
   out = harness_push_frame (h, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE);
   ASSERT_TRUE (out != NULL);
   EXPECT_EQ (gst_buffer_get_size (out), 2 * FRAME_SIZE);
-  EXPECT_EQ (GST_BUFFER_PTS (out), 100 * GST_MSECOND);
+  EXPECT_EQ (GST_BUFFER_PTS (out), MSEC (100));
   gst_buffer_unref (out);
 
   gst_harness_teardown (h);
@@ -411,9 +413,9 @@ TEST (tensorConverterTimestamp, readyResetsHistory_p)
 {
   GstHarness *h = harness_new (OCTET_CAPS);
 
-  gst_element_set_base_time (h->element, 10 * GST_SECOND);
-  gst_harness_set_time (h, 10 * GST_SECOND + 500 * GST_MSECOND);
-  EXPECT_EQ (harness_push_get_pts (h), 500 * GST_MSECOND);
+  gst_element_set_base_time (h->element, SEC (10));
+  gst_harness_set_time (h, SEC (10) + MSEC (500));
+  EXPECT_EQ (harness_push_get_pts (h), MSEC (500));
 
   harness_set_state (h, GST_STATE_READY);
   harness_set_state (h, GST_STATE_PAUSED);
@@ -435,7 +437,7 @@ wait_for_state (GstElement *pipeline, GstState state)
   GstState current = GST_STATE_VOID_PENDING;
   GstStateChangeReturn ret;
 
-  ret = gst_element_get_state (pipeline, &current, NULL, TEST_TIMEOUT_MS * GST_MSECOND);
+  ret = gst_element_get_state (pipeline, &current, NULL, MSEC (TEST_TIMEOUT_MS));
   return (ret == GST_STATE_CHANGE_SUCCESS && current == state);
 }
 
@@ -460,11 +462,9 @@ pipeline_pull_pts (GstElement *appsink, gboolean preroll)
   GstClockTime pts;
 
   if (preroll)
-    sample = gst_app_sink_try_pull_preroll (
-        GST_APP_SINK (appsink), TEST_TIMEOUT_MS * GST_MSECOND);
+    sample = gst_app_sink_try_pull_preroll (GST_APP_SINK (appsink), MSEC (TEST_TIMEOUT_MS));
   else
-    sample = gst_app_sink_try_pull_sample (
-        GST_APP_SINK (appsink), TEST_TIMEOUT_MS * GST_MSECOND);
+    sample = gst_app_sink_try_pull_sample (GST_APP_SINK (appsink), MSEC (TEST_TIMEOUT_MS));
 
   if (sample == NULL) {
     ADD_FAILURE () << "no sample";
@@ -515,23 +515,23 @@ TEST (tensorConverterTimestampPipeline, testClockRunningTime_p)
   EXPECT_EQ (pipeline_pull_pts (appsink, FALSE), 0U);
   EXPECT_EQ (gst_element_get_base_time (converter), ONE_HOUR);
 
-  gst_test_clock_advance_time (GST_TEST_CLOCK (clock), 300 * GST_MSECOND);
+  gst_test_clock_advance_time (GST_TEST_CLOCK (clock), MSEC (300));
   pipeline_push_frame (appsrc);
-  EXPECT_EQ (pipeline_pull_pts (appsink, FALSE), 300 * GST_MSECOND);
+  EXPECT_EQ (pipeline_pull_pts (appsink, FALSE), MSEC (300));
 
   gst_element_set_state (pipeline, GST_STATE_PAUSED);
-  gst_test_clock_advance_time (GST_TEST_CLOCK (clock), 5 * GST_SECOND);
+  gst_test_clock_advance_time (GST_TEST_CLOCK (clock), SEC (5));
   pipeline_push_frame (appsrc);
-  EXPECT_EQ (pipeline_pull_pts (appsink, TRUE), 300 * GST_MSECOND);
+  EXPECT_EQ (pipeline_pull_pts (appsink, TRUE), MSEC (300));
   ASSERT_TRUE (wait_for_state (pipeline, GST_STATE_PAUSED));
 
   gst_element_set_state (pipeline, GST_STATE_PLAYING);
   ASSERT_TRUE (wait_for_state (pipeline, GST_STATE_PLAYING));
-  EXPECT_EQ (pipeline_pull_pts (appsink, FALSE), 300 * GST_MSECOND);
+  EXPECT_EQ (pipeline_pull_pts (appsink, FALSE), MSEC (300));
 
-  gst_test_clock_advance_time (GST_TEST_CLOCK (clock), 100 * GST_MSECOND);
+  gst_test_clock_advance_time (GST_TEST_CLOCK (clock), MSEC (100));
   pipeline_push_frame (appsrc);
-  EXPECT_EQ (pipeline_pull_pts (appsink, FALSE), 400 * GST_MSECOND);
+  EXPECT_EQ (pipeline_pull_pts (appsink, FALSE), MSEC (400));
 
   EXPECT_EQ (gst_element_set_state (pipeline, GST_STATE_NULL), GST_STATE_CHANGE_SUCCESS);
   gst_object_unref (appsrc);
@@ -603,7 +603,7 @@ TEST (tensorConverterTimestampPipeline, clockWithoutBaseTime_p)
 
   ASSERT_EQ (gst_element_get_base_time (converter), 0U);
   EXPECT_TRUE (gst_element_set_clock (converter, clock));
-  EXPECT_GT (gst_clock_get_time (clock), GST_SECOND);
+  EXPECT_GT (gst_clock_get_time (clock), SEC (1));
 
   pipeline_push_frame (appsrc);
   ASSERT_TRUE (wait_for_probe (&data, 2));
@@ -634,7 +634,7 @@ run_pipeline_to_end (const gchar *description)
 
   bus = gst_element_get_bus (pipeline);
   gst_element_set_state (pipeline, GST_STATE_PLAYING);
-  message = gst_bus_timed_pop_filtered (bus, TEST_TIMEOUT_MS * GST_MSECOND,
+  message = gst_bus_timed_pop_filtered (bus, MSEC (TEST_TIMEOUT_MS),
       (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
   if (message != NULL) {
     type = GST_MESSAGE_TYPE (message);
@@ -790,13 +790,13 @@ run_basepad_duplicate_timestamps (const gchar *muxer, guint mem_index, guint byt
 
   pipeline_push_tensor (src0, 0, 0);
   pipeline_push_tensor (src0, 1, 0);
-  pipeline_push_tensor (src0, 2, 10 * GST_MSECOND);
+  pipeline_push_tensor (src0, 2, MSEC (10));
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (src0)), GST_FLOW_OK);
   pipeline_push_tensor (src1, 100, 0);
   pipeline_push_tensor (src1, 101, GST_SECOND);
   EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (src1)), GST_FLOW_OK);
 
-  while ((sample = gst_app_sink_try_pull_sample (GST_APP_SINK (sink), TEST_TIMEOUT_MS * GST_MSECOND))
+  while ((sample = gst_app_sink_try_pull_sample (GST_APP_SINK (sink), MSEC (TEST_TIMEOUT_MS)))
          != NULL) {
     GstBuffer *buffer = gst_sample_get_buffer (sample);
     GstMapInfo map;

--- a/tests/nnstreamer_converter/unittest_converter_timestamp.cc
+++ b/tests/nnstreamer_converter/unittest_converter_timestamp.cc
@@ -749,6 +749,98 @@ TEST (tensorConverterTimestampPipeline, aggregatorSyncSinkCompletes_p)
 }
 
 /**
+ * @brief Push a one-byte tensor with an explicit timestamp into an appsrc.
+ */
+static void
+pipeline_push_tensor (GstElement *appsrc, guint8 value, GstClockTime pts)
+{
+  GstBuffer *buffer = gst_buffer_new_allocate (NULL, 1, NULL);
+
+  gst_buffer_fill (buffer, 0, &value, 1);
+  GST_BUFFER_PTS (buffer) = pts;
+  EXPECT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc), buffer), GST_FLOW_OK);
+}
+
+/**
+ * @brief Feed a basepad-synchronized muxer two equal timestamps on its base
+ * pad, the pattern the converter emits while PAUSED, and check that the far
+ * frame on the other pad is held back every time.
+ */
+static void
+run_basepad_duplicate_timestamps (const gchar *muxer, guint mem_index, guint byte_index)
+{
+  const gchar *caps = "other/tensor,dimension=(string)1:1:1:1,type=(string)uint8,"
+                      "framerate=(fraction)0/1";
+  gchar *desc = g_strdup_printf ("appsrc name=src0 format=time ! %s ! mux.sink_0 "
+                                 "appsrc name=src1 format=time ! %s ! mux.sink_1 "
+                                 "%s name=mux sync-mode=basepad sync-option=0:50000000 ! "
+                                 "appsink name=sink sync=false",
+      caps, caps, muxer);
+  GstElement *pipeline = gst_parse_launch (desc, NULL);
+  GstElement *src0, *src1, *sink;
+  GstSample *sample;
+  guint received = 0;
+
+  g_free (desc);
+  ASSERT_TRUE (pipeline != NULL);
+  src0 = gst_bin_get_by_name (GST_BIN (pipeline), "src0");
+  src1 = gst_bin_get_by_name (GST_BIN (pipeline), "src1");
+  sink = gst_bin_get_by_name (GST_BIN (pipeline), "sink");
+  gst_element_set_state (pipeline, GST_STATE_PLAYING);
+
+  pipeline_push_tensor (src0, 0, 0);
+  pipeline_push_tensor (src0, 1, 0);
+  pipeline_push_tensor (src0, 2, 10 * GST_MSECOND);
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (src0)), GST_FLOW_OK);
+  pipeline_push_tensor (src1, 100, 0);
+  pipeline_push_tensor (src1, 101, GST_SECOND);
+  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (src1)), GST_FLOW_OK);
+
+  while ((sample = gst_app_sink_try_pull_sample (GST_APP_SINK (sink), TEST_TIMEOUT_MS * GST_MSECOND))
+         != NULL) {
+    GstBuffer *buffer = gst_sample_get_buffer (sample);
+    GstMapInfo map;
+
+    EXPECT_GT (gst_buffer_n_memory (buffer), mem_index);
+    if (gst_buffer_map (buffer, &map, GST_MAP_READ)) {
+      EXPECT_GT (map.size, byte_index);
+      EXPECT_EQ (map.data[byte_index], 100U);
+      gst_buffer_unmap (buffer, &map);
+    } else {
+      ADD_FAILURE () << "cannot map the muxed buffer";
+    }
+    gst_sample_unref (sample);
+    received++;
+  }
+  EXPECT_EQ (received, 3U);
+  EXPECT_TRUE (gst_app_sink_is_eos (GST_APP_SINK (sink)));
+
+  gst_element_set_state (pipeline, GST_STATE_NULL);
+  gst_object_unref (src0);
+  gst_object_unref (src1);
+  gst_object_unref (sink);
+  gst_object_unref (pipeline);
+}
+
+/**
+ * @brief Positive: tensor_mux basepad sync keeps its tolerance across equal
+ * base-pad timestamps.
+ */
+TEST (tensorConverterTimestampPipeline, muxBasepadDuplicateTimestamps_p)
+{
+  run_basepad_duplicate_timestamps ("tensor_mux", 1, 1);
+}
+
+/**
+ * @brief Positive: tensor_merge basepad sync keeps its tolerance across equal
+ * base-pad timestamps.
+ */
+TEST (tensorConverterTimestampPipeline, mergeBasepadDuplicateTimestamps_p)
+{
+  run_basepad_duplicate_timestamps ("tensor_merge mode=linear option=0", 0, 1);
+}
+
+/**
  * @brief Negative: an octet stream without dimensions fails to negotiate.
  */
 TEST (tensorConverterTimestampPipeline, octetWithoutDimension_n)


### PR DESCRIPTION
Fixes #4898. Root cause of the intermittent stall in #4883 (the llamacpp sync-mode test); #4891 only works around it on the test side.

## Problem

`_gst_tensor_converter_chain_timestamp()` stamps an untimestamped frame with `clock time - base time` when the caps carry no framerate. GStreamer distributes the clock to every element at once at the start of PAUSED→PLAYING (`gst_pipeline_change_state` → `gst_element_set_clock` on the bin), but each element receives its base time only inside `gst_bin_element_set_state`, right before its own transition, sinks first. A frame that passes the converter after the sink released its preroll but before the converter itself is switched sees a clock and `base_time == 0`, so its PTS becomes the absolute clock value (system uptime). A synchronizing sink then waits minutes or hours for it; nothing errors, nothing is dropped.

Reproduced deterministically without llama.cpp: `fakesrc ! application/octet-stream ! tensor_converter ! identity ×30 ! fakesink sync=true` under `taskset -c 0-3` stamps buffer 2 with `0:26:42` (WSL uptime) 10/10 with `sync=false`, and stalls 8/10 with `sync=true`.

## Fix

Read clock, base time and state under one `GST_OBJECT_LOCK` and use the clock branch only while PLAYING; the state is committed under that lock after the base time is set, so PLAYING implies a delivered base time. Otherwise reuse the previous timestamp (segment start for the very first frame). Behaviour change to be aware of: frames processed while PAUSED after a pause now keep the last timestamp instead of `now - base_time`; the old value was wrong there too (base time is re-derived on resume, so those frames landed in the future by the paused duration).

`gst_element_get_current_running_time()` does not help: it treats `base_time == 0` as valid.

## Tests

- **New `unittest_converter_timestamp`** (GstHarness + GstTestClock, deterministic, no dependency on the race):
  - running time while PLAYING, clamp when clock < base time
  - the window itself: clock present, base time 0, PAUSED → segment start / previous PTS, then PLAYING → running time
  - pause/resume keeps the last PTS and continues monotonically
  - non-zero segment start fallback, valid input PTS/duration untouched, `set-timestamp=false` (negative), no clock
  - framerate branches (video GRAY8, octet with framerate) never consult the clock
  - flush and READY reset the history, BYTES segment converted to TIME, `frames-per-tensor` aggregation keeps the first frame's PTS
  - pipeline with `gst_pipeline_use_clock(GstTestClock)`: exact running times across PLAYING→PAUSED→PLAYING via appsink preroll/sample pulls
  - pipeline in PAUSED with a system clock injected into the converter (`base_time == 0`): PTS stays 0
  - `sync=true` end-to-end runs with 40 identity elements of padding: plain, with `queue`, with `set-timestamp=false`, live video without framerate, `tensor_mux` with two untimestamped branches, `tensor_aggregator`; negative: octet stream without dimensions errors out
- **SSAT** (`tests/nnstreamer_converter/runTest.sh`, cases 9-1 … 9-10): the same end-to-end pipelines as gst-launch runs, so the pdebuild, GBS x86_64 and RISC-V jobs cover them. The positive cases (9-1 … 9-6, 9-9, 9-10) run in gstTest timeout mode so a stall is scored as a failure; 9-5 and 9-6 are live-source smoke cases that cannot reach the window. The negative cases `9-7_n`/`9-8_n` fail at once and run without a timeout, so a stall there could never count as the expected failure.
- Existing converter golden tests unchanged.

Negative control (local WSL, converter change reverted, everything else identical): 10 of the 25 gtest cases fail (the live-source and framerate cases are smoke coverage of unchanged paths and pass either way), including `syncSinkCompletes_p` which times out on all three runs; the harness values equal the test-clock time. The identity padding was chosen from measurements on the unfixed converter with plain `gst-launch` and no CPU pinning: 20 identities stall 5/10 runs, 40 stall 10/10, 80 stall 10/10; with the fix 80 identities stall 0/10. Local run with the fix: 25/25 gtest, converter SSAT 42/42, plus unittest_sink 120/120, unittest_plugins 138/138, and the mux/merge/rate SSAT suites unchanged.

## Follow-up from review: basepad tolerance wrap (second commit)

The review pointed out that `gst_tensor_time_sync_buffer_from_collectpad()` (shared by `tensor_mux`/`tensor_merge`, `sync-mode=basepad`) computes its tolerance as `|PTS(new) - PTS(prev)| - 1` on the base pad, which is -1 for two equal timestamps and wraps to `G_MAXUINT64` in the unsigned `base_time`, defeating the tolerance check for that cycle. Equal consecutive timestamps were already ordinary before this PR (every frame stamped before the pipeline has a clock carries the segment start), and the PAUSED fallback here adds another source, so the clamp is fixed in-PR rather than deferred: the tolerance is now clamped at 0. Two pipeline tests (`muxBasepadDuplicateTimestamps_p`, `mergeBasepadDuplicateTimestamps_p`) push two equal timestamps on the base pad and a far frame on the other pad; without the clamp the far frame gets paired and one output disappears (verified locally against the unfixed core).

## Docs

`gst/nnstreamer/elements/gsttensor_converter.md` gains a Timestamps section; the mux/merge synchronization document is updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
