### PR TITLE
[CI] Bound the Valgrind unittest step and examine every binary

### DIFF
--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -188,6 +188,19 @@ jobs:
           else
             echo "Skipped: $selftest is not in this branch's tree and this PR does not remove it."
           fi
+      - name: /Checker/ unittest runner self-test
+        # Runs a repository script unrelated to $changed_file_list, so it
+        # needs the same merge-ref guard as the steps above.
+        run: |
+          selftest=packaging/test_run_unittests_binaries.sh
+          if [ -f "$selftest" ]; then
+            bash "$selftest"
+          elif git show --pretty="format:" --name-only --no-renames --diff-filter=D ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | grep -qxF "$selftest"; then
+            echo "::error::This PR removes $selftest; remove its workflow step too, or restore the script (also update this step if the script moved)."
+            exit 1
+          else
+            echo "Skipped: $selftest is not in this branch's tree and this PR does not remove it."
+          fi
       - name: /Checker/ SSAT install list is in sync
         # Same guard as the check-rebuild self-test above: the step list comes
         # from the merge ref while the checkout is the PR head, so a branch that

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -210,9 +210,67 @@ jobs:
     - name: SSAT run on filter-ncnn
       if: env.rebuild == '1'
       run: if [ '${{ matrix.os }}' == 'ubuntu-22.04' ]; then export NNSTREAMER_BUILD_ROOT_PATH=`pwd`/build && export NNSTREAMER_FILTERS=`pwd`/build/ext/nnstreamer/tensor_filter && export NNSTREAMER_DECODERS=`pwd`/build/ext/nnstreamer/tensor_decoder && export NNSTREAMER_CONVERTERS=`pwd`/build/ext/nnstreamer/tensor_converter && export GST_PLUGIN_PATH=`pwd`/build/gst && export NNSTREAMER_CONF=`pwd`/build/nnstreamer-test.ini && pushd tests/nnstreamer_filter_ncnn && ssat -n -p=1 --summary summary.txt && popd; fi
+    # This memcheck pass is the longest step of the job, and what it costs is
+    # decided almost entirely by a few cases that drive a third-party inference
+    # runtime, every instruction of which memcheck instruments. Two runners
+    # measured, 33728622232 (fast) and 33723985896 (slow), per case:
+    #
+    #   nnstreamerFilterArmnn.invokeAdvanced                    11.0 / 11.2 min
+    #   nnstreamerFilterLiteRT.sharedEnvInvokeDuringConfigure    9.9 / 30.1 min
+    #   four more LiteRT cases that compile the model repeatedly 4.3 /  6.5 min
+    #
+    # Those are excluded by name below. Every other LiteRT and ArmNN case still
+    # runs, so each sub-plugin's open, configure and invoke paths stay covered;
+    # what is dropped is repeated inference, whose cost is the runtime's and
+    # not this project's. They are written out one at a time on purpose: a
+    # wildcard would silently take future cases with it.
+    #
+    # llama.cpp is handled the other way round, by naming the cases to keep.
+    # Generating a token under memcheck costs about 1 s on a fast runner and
+    # about 8 s on a slow one, while the tests wait 10 s for samples, so on a
+    # slow runner every case that generates anything at all times out and then
+    # pays for the whole generation in the NULL transition: 87 to 305 s each,
+    # measured in 33847412951. That is unbounded from this step's point of
+    # view, and a new test would inherit it, so the safe default is to leave a
+    # case out until it is known to be cheap. The ones kept here load the model
+    # and tear it down without generating; the lora cases stay out because the
+    # model they need is not in the tree and would be a 7B one if it were.
+    #
+    # Either way gtest exits 0 when a name matches nothing, so renaming a case
+    # on one of these lists takes it out of memcheck silently; keep them in
+    # step with the test sources.
+    #
+    # The excluded cases all still run, without memcheck, in the "build and
+    # unit test" step above. See
+    # https://github.com/nnstreamer/nnstreamer/issues/4894 for the measurements
+    # and for restoring them in a job that can afford them.
     - name: GTEST run with Valgrind on a case
-      if: env.rebuild == '1'
-      run: if [ '${{ matrix.os }}' == 'ubuntu-22.04' ]; then export NNSTREAMER_BUILD_ROOT_PATH=`pwd`/build && export NNSTREAMER_FILTERS=`pwd`/build/ext/nnstreamer/tensor_filter && export NNSTREAMER_DECODERS=`pwd`/build/ext/nnstreamer/tensor_decoder && export NNSTREAMER_CONVERTERS=`pwd`/build/ext/nnstreamer/tensor_converter && export GST_PLUGIN_PATH=`pwd`/build/gst && export NNSTREAMER_CONF=`pwd`/build/nnstreamer-test.ini && G_SLICE=always-malloc G_DEBUG=gc-friendly ./packaging/run_unittests_binaries.sh --valgrind ./tests/ || echo "There are Valgrind errors. Please fix it. As we have a lot of Valgrind errors from different libraries and possible from nnstreamer itself, we are not halting the build with Valgrind errors until we get them all."; fi
+      if: env.rebuild == '1' && matrix.os == 'ubuntu-22.04'
+      timeout-minutes: 30
+      run: |
+        export NNSTREAMER_BUILD_ROOT_PATH=`pwd`/build
+        export NNSTREAMER_FILTERS=`pwd`/build/ext/nnstreamer/tensor_filter
+        export NNSTREAMER_DECODERS=`pwd`/build/ext/nnstreamer/tensor_decoder
+        export NNSTREAMER_CONVERTERS=`pwd`/build/ext/nnstreamer/tensor_converter
+        export GST_PLUGIN_PATH=`pwd`/build/gst
+        export NNSTREAMER_CONF=`pwd`/build/nnstreamer-test.ini
+        export G_SLICE=always-malloc
+        export G_DEBUG=gc-friendly
+        note="There are Valgrind errors. Please fix it. As we have a lot of Valgrind errors from different libraries and possible from nnstreamer itself, we are not halting the build with Valgrind errors until we get them all."
+        skip_cases="nnstreamerFilterArmnn.invokeAdvanced"
+        skip_cases="${skip_cases}:nnstreamerFilterLiteRT.sharedEnvInvokeDuringConfigure"
+        skip_cases="${skip_cases}:nnstreamerFilterLiteRT.zeroCopyRepeatedInvoke"
+        skip_cases="${skip_cases}:nnstreamerFilterLiteRT.zeroCopyPathEquivalence"
+        skip_cases="${skip_cases}:nnstreamerFilterLiteRT.sharedEnvConcurrentOpen"
+        skip_cases="${skip_cases}:nnstreamerFilterLiteRT.sharedEnvMultiInstance"
+        llamacpp_cases="NNStreamerFilterLlamaCppTest.negativeNumPredict_n"
+        llamacpp_cases="${llamacpp_cases}:NNStreamerFilterLlamaCppTest.invalidBatchSize_n"
+        llamacpp_cases="${llamacpp_cases}:NNStreamerFilterLlamaCppTest.invalidContextLength_n"
+        llamacpp_cases="${llamacpp_cases}:NNStreamerFilterLlamaCppTest.invalidModel_n"
+        llamacpp_cases="${llamacpp_cases}:NNStreamerFilterLlamaCppTest.zeroTokenGenerationSync_p"
+        llamacpp_cases="${llamacpp_cases}:NNStreamerFilterLlamaCppTest.zeroTokenGenerationAsync_p"
+        GTEST_FILTER="-${skip_cases}" ./packaging/run_unittests_binaries.sh --valgrind --skip unittest_filter_llamacpp ./tests/ || echo "${note}"
+        GTEST_FILTER="${llamacpp_cases}" ./packaging/run_unittests_binaries.sh --valgrind ./tests/unittest_filter_llamacpp || echo "${note}"
     - name: get NNStreamer example apps
       if: env.rebuild == '1' && matrix.os == 'ubuntu-22.04'
       uses: actions/checkout@v4

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -269,7 +269,7 @@ jobs:
         llamacpp_cases="${llamacpp_cases}:NNStreamerFilterLlamaCppTest.invalidModel_n"
         llamacpp_cases="${llamacpp_cases}:NNStreamerFilterLlamaCppTest.zeroTokenGenerationSync_p"
         llamacpp_cases="${llamacpp_cases}:NNStreamerFilterLlamaCppTest.zeroTokenGenerationAsync_p"
-        GTEST_FILTER="-${skip_cases}" ./packaging/run_unittests_binaries.sh --valgrind --skip unittest_filter_llamacpp ./tests/ || echo "${note}"
+        GTEST_FILTER="-${skip_cases}" ./packaging/run_unittests_binaries.sh --valgrind --recursive --skip unittest_filter_llamacpp ./tests/ || echo "${note}"
         GTEST_FILTER="${llamacpp_cases}" ./packaging/run_unittests_binaries.sh --valgrind ./tests/unittest_filter_llamacpp || echo "${note}"
     - name: get NNStreamer example apps
       if: env.rebuild == '1' && matrix.os == 'ubuntu-22.04'

--- a/packaging/run_unittests_binaries.sh
+++ b/packaging/run_unittests_binaries.sh
@@ -11,6 +11,7 @@ input=""
 skip_tests=""
 this_script="$(basename -- $0)"
 VALGRIND=""
+RECURSIVE=""
 while (( "$#" )); do
   case "$1" in
     -k|--skip)
@@ -27,7 +28,13 @@ while (( "$#" )); do
       echo "$this_script: usage: $this_script [options] target" >&2
       echo "    -k | --skip  BINARY_NAME[,*]" >&2
       echo "        Skip the test cases whose names are...(valid only if target is a directory)" >&2
+      echo "    -r | --recursive" >&2
+      echo "        Look in sub-directories too (valid only if target is a directory)" >&2
       exit 0
+      ;;
+    -r|--recursive)
+      RECURSIVE="1"
+      shift 1
       ;;
     --valgrind)
       VALGRIND="valgrind"
@@ -86,32 +93,77 @@ run_entry() {
   return ${retval}
 }
 
+##
+# @brief Tell an actual test binary from a file that merely matches the name.
+# @param $1 path to the candidate
+# Meson copies generated test sources next to the binaries it builds them into,
+# and a checkout whose files carry the executable bit leaves those copies
+# executable as well, so the name and the mode alone do not identify a binary.
+is_test_binary() {
+  [ -f "$1" ] && [ -x "$1" ] || return 1
+  # The first four bytes of an ELF file are 0x7f 'E' 'L' 'F'.
+  [ "$(od -A n -N 4 -t x1 < "$1" | tr -d ' ')" = "7f454c46" ]
+}
+
+##
+# @brief Run every entry of the given list, and remember the ones that failed.
+# @param $@ the test binaries to run
+# The list is run to the end even after a failure: stopping at the first one
+# would leave every binary after it unexamined, and which binaries those are
+# depends on the order the file system hands them over.
+run_list() {
+  local entry
+  for entry in "$@"
+  do
+    if ! is_test_binary "${entry}"; then
+      continue
+    fi
+    run_entry ${entry}
+    entry_ret=$?
+    if [ ${entry_ret} -ne 0 ]; then
+      failed_entries+=("${entry}")
+      ret=${entry_ret}
+    fi
+  done
+}
+
 ret=0
+failed_entries=()
 if [ -f "${input}" ]; then
   run_entry $input
   ret=$?
 elif [ -d "${input}" ]; then
-  filelist=(`find "${input}" -mindepth 1 -maxdepth 1 -type f -executable $(for stest in "${skip_tests[@]}"; do [[ ! -z ${stest} ]] && echo -n "! -name ${stest} "; done) -name "unittest_*"`)
-  for entry in "${filelist[@]}"
-  do
-    run_entry $entry
-    ret=$?
-    if [ $ret -ne 0 ]; then
-      break
-    fi
-  done
+  # With --recursive, sub-directories are searched too: several test binaries
+  # are built one level down (tests/cpp_methods, tests/nnstreamer_datarepo,
+  # ...) and a search that stops at the top level never sees them. It is not
+  # the default because callers that already walk those sub-directories
+  # themselves, as nnstreamer.spec does, would otherwise run them twice and
+  # without the library paths they set up for each one. The list is sorted so
+  # that a run is reproducible rather than following directory order.
+  #
+  # Recursion relies on the naming convention: an executable called unittest_*
+  # is a gtest binary that runs to completion on its own. A helper program that
+  # an SSAT script drives - one that builds a pipeline and waits on a main loop
+  # - must not be given that name, or it will be started here with no arguments
+  # and hang until the caller's timeout. tensor_repo_dynamic_test and
+  # tensor_filter_reload_test were named unittest_* once and did exactly that.
+  if [ -n "${RECURSIVE}" ]; then
+    depth_args=""
+  else
+    depth_args="-maxdepth 1"
+  fi
+  filelist=(`find "${input}" -mindepth 1 ${depth_args} -type f -executable $(for stest in "${skip_tests[@]}"; do [[ ! -z ${stest} ]] && echo -n "! -name ${stest} "; done) -name "unittest_*" | sort`)
+  run_list "${filelist[@]}"
 else
   filename=${input##*/}
   dirname=${input%/*}
-  filelist=(`find "${dirname}" -mindepth 1 -maxdepth 1 -type f -executable -name "${filename}"`)
-  for entry in "${filelist[@]}"
-  do
-    run_entry $entry
-    ret=$?
-    if [ $ret -ne 0 ]; then
-      break
-    fi
-  done
+  filelist=(`find "${dirname}" -mindepth 1 -maxdepth 1 -type f -executable -name "${filename}" | sort`)
+  run_list "${filelist[@]}"
+fi
+
+if [ ${#failed_entries[@]} -ne 0 ]; then
+  echo "$this_script: these test binaries reported a failure:" >&2
+  for entry in "${failed_entries[@]}"; do echo "  ${entry}" >&2; done
 fi
 
 popd

--- a/packaging/test_run_unittests_binaries.sh
+++ b/packaging/test_run_unittests_binaries.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# @file     test_run_unittests_binaries.sh
+# @brief    Self-test for run_unittests_binaries.sh.
+# @see      https://github.com/nnstreamer/nnstreamer
+# @author   MyungJoo Ham <myungjoo.ham@samsung.com>
+#
+# Pins the three properties the Valgrind job depends on and that a plain
+# reading of the script cannot show: every binary in the tree is run even when
+# an earlier one fails, --recursive finds the binaries built one directory down
+# while a plain run still does not, and a file that merely looks like a test
+# binary is not executed. Each was wrong before: the loop stopped at the first
+# failure, so whichever binaries the file system happened to list after it went
+# unexamined, and there was no way to reach the binaries under
+# tests/cpp_methods and tests/nnstreamer_datarepo at all.
+#
+# Both kinds of fixture name themselves in their output, through the
+# --gtest_output argument the runner builds from the binary's own name: a
+# passing one is a copy of echo, a failing one a copy of env, which rejects
+# that argument and exits non-zero. That is what makes "did this one run"
+# observable without a test framework, for the failing entries too.
+#
+# Two of the fixtures fail, which is what makes the fail-fast check independent
+# of the order the file system lists them in: whichever order that is, a loop
+# that stopped at the first failure would leave at least one later entry
+# unrun, because a second failing entry is always there to follow it.
+#
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+RUNNER="${SCRIPT_DIR}/run_unittests_binaries.sh"
+ECHO_BIN=$(type -P echo || true)
+ENV_BIN=$(type -P env || true)
+workdir=$(mktemp -d)
+failed=0
+
+trap 'rm -rf "$workdir"' EXIT
+
+##
+# @brief Report one expectation and remember a failure.
+# @param $1 0 when the expectation held, anything else when it did not
+# @param $2 description of the expectation
+report() {
+  if [ "$1" -eq 0 ]; then
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+    failed=1
+  fi
+}
+
+##
+# @brief Assert that the captured output contains the given text.
+# @param $1 captured output
+# @param $2 text that must appear
+# @param $3 description of the expectation
+expect_in() {
+  case "$1" in
+    *"$2"*) report 0 "$3" ;;
+    *) report 1 "$3" ;;
+  esac
+}
+
+##
+# @brief Assert that the captured output does not contain the given text.
+# @param $1 captured output
+# @param $2 text that must not appear
+# @param $3 description of the expectation
+expect_not_in() {
+  case "$1" in
+    *"$2"*) report 1 "$3" ;;
+    *) report 0 "$3" ;;
+  esac
+}
+
+##
+# @brief Build a throwaway build/tests tree of fixture binaries.
+# @param $1 directory to build the tree in
+make_tree() {
+  local root=$1
+  mkdir -p "${root}/build/tests/sub"
+  cp "${ECHO_BIN}" "${root}/build/tests/unittest_alpha"
+  cp "${ENV_BIN}" "${root}/build/tests/unittest_beta"
+  cp "${ECHO_BIN}" "${root}/build/tests/unittest_gamma"
+  cp "${ENV_BIN}" "${root}/build/tests/unittest_epsilon"
+  cp "${ECHO_BIN}" "${root}/build/tests/sub/unittest_delta"
+  printf '#!/bin/sh\necho ran-the-text-file\n' > "${root}/build/tests/unittest_zeta.cc"
+  chmod +x "${root}/build/tests/unittest_zeta.cc"
+}
+
+if [ ! -f "${RUNNER}" ]; then
+  echo "FAIL: ${RUNNER} is missing."
+  exit 1
+fi
+
+if [ -z "${ECHO_BIN}" ] || [ -z "${ENV_BIN}" ]; then
+  echo "FAIL: this test needs the echo and env binaries on PATH."
+  exit 1
+fi
+
+tree="${workdir}/whole"
+make_tree "${tree}"
+
+# Negative controls. Without these, the check that the runner does not run the
+# text file and the checks that read a fixture's own output would all hold for
+# the wrong reason if the fixtures did not behave as assumed.
+control=$("${tree}/build/tests/unittest_zeta.cc" 2>&1 || true)
+expect_in "${control}" "ran-the-text-file" \
+    "the text fixture does run when it is invoked directly"
+control=$("${tree}/build/tests/unittest_beta" --gtest_output=probe 2>&1 || true)
+expect_in "${control}" "probe" "the failing fixture echoes the argument it rejected"
+"${tree}/build/tests/unittest_beta" --gtest_output=probe > /dev/null 2>&1
+[ $? -ne 0 ] && report 0 "the failing fixture exits non-zero" \
+    || report 1 "the failing fixture exits non-zero"
+
+out=$(cd "${tree}" && bash "${RUNNER}" --recursive ./tests/ 2>&1)
+status=$?
+
+[ ${status} -ne 0 ] && report 0 "a failing binary makes the run report a failure" \
+    || report 1 "a failing binary makes the run report a failure"
+expect_in "${out}" "unittest_alpha.xml" "a passing binary is run"
+expect_in "${out}" "unittest_gamma.xml" "every passing binary is run, not just the first"
+expect_in "${out}" "unittest_beta.xml" "a failing binary is run"
+expect_in "${out}" "unittest_epsilon.xml" "a failure does not stop the binaries after it"
+expect_in "${out}" "unittest_delta.xml" "--recursive runs a binary in a sub-directory"
+expect_in "${out}" "unittest_beta" "the failing binaries are named in the summary"
+expect_in "${out}" "unittest_epsilon" "the summary names every failing binary"
+expect_not_in "${out}" "ran-the-text-file" \
+    "an executable file that is not an ELF binary is not run"
+
+# Without --recursive the search must stay where it was, so that the callers
+# that walk the sub-directories themselves do not run them a second time.
+out=$(cd "${tree}" && bash "${RUNNER}" ./tests/ 2>&1)
+expect_in "${out}" "unittest_alpha.xml" "the top level is searched without --recursive"
+expect_not_in "${out}" "unittest_delta.xml" \
+    "a sub-directory is left alone without --recursive"
+
+tree="${workdir}/skipped"
+make_tree "${tree}"
+out=$(cd "${tree}" && bash "${RUNNER}" --skip unittest_gamma ./tests/ 2>&1)
+expect_not_in "${out}" "unittest_gamma.xml" "--skip keeps the named binary from running"
+expect_in "${out}" "unittest_alpha.xml" "--skip leaves the other binaries running"
+
+tree="${workdir}/single"
+make_tree "${tree}"
+out=$(cd "${tree}" && bash "${RUNNER}" ./tests/unittest_alpha 2>&1)
+status=$?
+[ ${status} -eq 0 ] && report 0 "a single passing binary is accepted by path" \
+    || report 1 "a single passing binary is accepted by path"
+expect_in "${out}" "unittest_alpha.xml" "a single binary given by path is run"
+expect_not_in "${out}" "unittest_gamma.xml" "a single binary given by path runs alone"
+
+if [ ${failed} -ne 0 ]; then
+  echo "run_unittests_binaries.sh self-test failed."
+  exit 1
+fi
+
+echo "run_unittests_binaries.sh self-test passed."
+exit 0

--- a/tests/nnstreamer_filter_reload/meson.build
+++ b/tests/nnstreamer_filter_reload/meson.build
@@ -1,4 +1,4 @@
-executable('unittest_filter_reload',
+executable('tensor_filter_reload_test',
   'tensor_filter_reload_test.c',
   dependencies: [unittest_util_dep, gst_dep, glib_dep],
   install: get_option('install-test'),

--- a/tests/nnstreamer_filter_reload/runTest.sh
+++ b/tests/nnstreamer_filter_reload/runTest.sh
@@ -81,10 +81,10 @@ else
     TESTBINDIR="../../build/tests"
 fi
 
-${TESTBINDIR}/nnstreamer_filter_reload/unittest_filter_reload --input_img=${PATH_TO_INPUT} --first_model=${PATH_TO_MODEL1} --second_model=${PATH_TO_MODEL1}
+${TESTBINDIR}/nnstreamer_filter_reload/tensor_filter_reload_test --input_img=${PATH_TO_INPUT} --first_model=${PATH_TO_MODEL1} --second_model=${PATH_TO_MODEL1}
 testResult $? 1 "reload tflite model case 1 (same model)" 0 1
 
-${TESTBINDIR}/nnstreamer_filter_reload/unittest_filter_reload --input_img=${PATH_TO_INPUT} --first_model=${PATH_TO_MODEL1} --second_model=${PATH_TO_MODEL2}
+${TESTBINDIR}/nnstreamer_filter_reload/tensor_filter_reload_test --input_img=${PATH_TO_INPUT} --first_model=${PATH_TO_MODEL1} --second_model=${PATH_TO_MODEL2}
 testResult $? 2 "reload tflite model case 2 (diff model)" 0 1
 
 report

--- a/tests/nnstreamer_repo_dynamicity/meson.build
+++ b/tests/nnstreamer_repo_dynamicity/meson.build
@@ -1,4 +1,4 @@
-executable('unittest_repo',
+executable('tensor_repo_dynamic_test',
   'tensor_repo_dynamic_test.c',
   dependencies: [nnstreamer_dep, gst_dep, glib_dep],
   install: get_option('install-test'),

--- a/tests/nnstreamer_repo_dynamicity/runTest.sh
+++ b/tests/nnstreamer_repo_dynamicity/runTest.sh
@@ -38,7 +38,7 @@ else
     TESTBINDIR="../../build/tests/nnstreamer_repo_dynamicity"
 fi
 
-${TESTBINDIR}/unittest_repo --gst-plugin-path=../../build
+${TESTBINDIR}/tensor_repo_dynamic_test --gst-plugin-path=../../build
 
 callCompareTest testsequence_1.golden tensorsequence01_1.log 1-1 "Compare 1-1" 1 0
 callCompareTest testsequence_2.golden tensorsequence01_2.log 1-2 "Compare 1-2" 1 0


### PR DESCRIPTION
The `GTEST run with Valgrind on a case` step of *Minimal meson build in Ubuntu with Valgrind* is the longest step of that job and the critical path of a pull request. It has been reported at 51 min and at 80 min. Measured now, it is bimodal, the spread is not noise, and a small set of cases explains all of it.

Addresses #4894 and the coverage half of #4888.

## What it costs

Per-case cost from the log timestamps of the x86 job, on [33728622232](https://github.com/nnstreamer/nnstreamer/actions/runs/33728622232) (a fast runner) and [33723985896](https://github.com/nnstreamer/nnstreamer/actions/runs/33723985896) (a slow one). The gtest-reported per-case times agree with the timestamps, so these are per-case costs and not log interleaving.

| | fast run | slow run |
|---|---|---|
| **step total** | **35.9 min** | **86.0 min** |
| `nnstreamerFilterLiteRT.sharedEnvInvokeDuringConfigure` | 9.9 min | 30.1 min |
| `nnstreamerFilterArmnn.invokeAdvanced` | 11.0 min | 11.2 min |
| four more LiteRT cases that recompile the model | 4.3 min | 6.5 min |
| the llama.cpp cases that generate tokens | 3.4 min | 28.5 min |
| everything else | 7.3 min | 9.7 min |

Every one of those drives a third-party inference runtime that memcheck instruments instruction by instruction: ArmNN's reference backend, a LiteRT model compile repeated until a churn thread finishes ten cycles, and llama.cpp token generation. None of the cost is this project's code.

## Bounding it

**ArmNN and LiteRT: name what to drop.** Six cases by full name, no wildcards, so a future case is not swept in silently. Every other case of both binaries still runs, which keeps each sub-plugin's open, configure and invoke paths under memcheck; what is dropped is repeated inference.

**llama.cpp: name what to keep.** Generating a token under memcheck costs about 1 s on a fast runner and about 8 s on a slow one, while the tests wait 10 s for samples. On a slow runner every case that generates anything times out and then pays for the whole generation during the NULL transition, 87 to 305 s each. That is unbounded from this step's point of view and a new test would inherit it, so the binary runs a named list instead: the cases that load the model and tear it down without generating, plus the property validation that never loads one. The lora cases stay out; the model they want is not in the tree and would be a 7B one if it were.

Nothing is lost from the job's coverage. Every excluded case still runs, without memcheck, in the `build and unit test` step of the same job.

## Result

On this branch the step takes **12.1 min** in [33850823484](https://github.com/nnstreamer/nnstreamer/actions/runs/33850823484) and **7.3 min** in [33853964542](https://github.com/nnstreamer/nnstreamer/actions/runs/33853964542), and examines **22 binaries** either way, against 36-86 min for 13 to 16 binaries before. Every check passes at the current head, `Ubuntu pdebuild` and `Tizen GBS x86_64` included; both of those failed at the first attempt's head and are the legs that proved the recursion problem.

| | binary time |
|---|---|
| `unittest_filter_litert` | 241.3 s |
| `unittest_join` | 160.1 s |
| `unittest_filter_single` | 82.8 s |
| `unittest_sink` | 57.1 s |
| `unittest_filter_llamacpp` | 28.6 s |
| `unittest_src_iio` | 25.8 s |
| the five newly reached sub-directory binaries | 32.6 s |
| the remaining nine | 75.5 s |

`unittest_filter_armnn` is 2.1 s, down from 11 min.

The step gets a 30-minute timeout to hold that budget, and is now a script block rather than one 900-character line, which is what makes room to explain the list next to it.

Two things to know about that bound. The 18 minutes of headroom are smaller than they look: the runner spread measured here is about 1.3x for the ordinary binaries but 3x for LiteRT, which is still 241 s of the total, so a slow runner plausibly lands in the low twenties. And a step timeout is the one failure this step cannot absorb with `|| echo`, so if it ever trips, the thing to change is the exclusion list rather than the timeout. Separately, gtest exits 0 when a filter name matches nothing, so renaming a case on either list drops it from memcheck with no signal; the comment above the step says so next to the lists.

Measured and rejected first: valgrind's `--fair-sched=yes`, which sounded promising because ggml spins in a thread-pool barrier that valgrind's serialised scheduler handles badly. It moves the two worst cases by 7% (LiteRT, 409 s to 380 s) and 20% (llama.cpp). `OMP_NUM_THREADS=1` does nothing; the pinned prebuilt llama.cpp is not the OpenMP build.

## Widening what it examines

The pass was examining 13 of the 21 binaries the job builds, and which 13 depended on where it stopped.

- `run_unittests_binaries.sh` searched only the top level, so `unittest_cppfilter`, `unittest_datareposrc`, `unittest_datareposink`, `unittest_tizen_custom` and `unittest_tizen_custom-set` had never run under memcheck at all. They cost 38.6 s together in CI. The deeper search is opt-in through a new `--recursive` that only this step passes, for the reason in the next section.
- The loop stopped at the first failing binary, leaving whatever came after it unexamined. In the 86-minute run that was `unittest_tensor_region`, `unittest_if` and `unittest_filter_single`, none of which had anything to do with the llama.cpp failure that stopped the pass. The list is now sorted, so what a run covers no longer depends on directory order, and the binaries that failed are named at the end.
- Meson copies the generated subplugin test sources next to the binaries, and a checkout that leaves those copies executable would hand `unittest_tizen_custom.cc` to gtest. Entries are checked for the ELF magic.

The step keeps `|| echo`, so it still cannot fail the build; that half of #4888 is deliberately left alone.

## What the earlier attempts got wrong

Three corrections came out of CI on this branch rather than out of review, and each is the reason for one piece of the current shape.

**Recursion cannot be the default.** `nnstreamer.spec` calls this same script on `./tests` and then again on each sub-directory it cares about, one at a time and with the library path each one needs. Searching sub-directories unconditionally made the Tizen/GBS build run three binaries it never used to, and fail on all three: `unittest_edge` without its `LD_LIBRARY_PATH`, `unittest_openvino` without OpenVINO, and `unittest_filter_reload` without the arguments it expects. Hence `--recursive`.

**Two helper programs were named like tests.** `tests/nnstreamer_repo_dynamicity` and `tests/nnstreamer_filter_reload` build GStreamer programs that an SSAT `runTest.sh` drives with arguments; meson does not register either with `test()`, but they were called `unittest_repo` and `unittest_filter_reload`. Started with no arguments, `unittest_repo` built its pipeline, waited on its main loop and took the entire step budget by itself in [33843038794](https://github.com/nnstreamer/nnstreamer/actions/runs/33843038794). The third commit renames both after their source files; nothing outside their own `meson.build` and `runTest.sh` refers to them, and no packaging file names them.

**Dropping the fourteen worst llama.cpp cases was not enough.** The five that were kept had been cheap on the runner they were measured on, and cost 841 s between them on the next one. That is what moved llama.cpp from a list of exclusions to a list of inclusions.

## Testing

`packaging/test_run_unittests_binaries.sh` pins the runner's behaviour: `--recursive` reaches a sub-directory while a plain run still does not, a failure does not stop the binaries after it, the failing ones are named, and a file that is not an ELF binary is not run. It is wired into *Static checks* with the same merge-ref guard as the other self-tests, and passed there on the first run of this branch. Its fixtures name themselves in their output, so "did this one run" is observable; two of them fail, which makes the fail-fast check independent of the order the file system lists entries in. It fails against the previous script.

Everything above was also measured locally under the same memcheck flags (valgrind 3.18.1, Ubuntu 22.04): the llama.cpp list runs its six cases in 10 s, the LiteRT exclusions take exactly the named cases out and nothing else, and the modified runner walks a real build tree of 22 binaries in 277 s, reporting the four that failed.

## Not in this change

- `tensorFilterOpenvino.getTensorDim2_n` fails. The earlier unconditional sweep was the first thing ever to run `unittest_openvino`, and it found a real pre-existing failure: the test builds its map keys with `std::string ((char *) &i)`, which does not give it `NNS_TENSOR_SIZE_LIMIT + 1` distinct names, so the limit it means to exceed is not exceeded. With the search now opt-in nothing in this branch runs that binary, and fixing an OpenVINO sub-plugin test is a different subject, so it is reported here rather than folded in.
- Restoring the excluded cases in a scheduled job. This workflow has no `schedule:` trigger and its steps are gated on the `check-rebuild` action, which needs a pull-request context, so adding one is its own change.
- A static check that every `unittest_*` executable is registered with meson's `test()`. That would have caught the naming problem above before CI did. Two things it would have to handle: `unittest_mlagent` is a real gtest binary that no `test()` call registers, and `unittest_ntp_util` is registered under the test name `gstreamer_ntp_util_mock`, so the check has to key on the executable target rather than the test name. Probing each candidate with `--gtest_list_tests` instead of the ELF magic would need a `timeout` around it, because a `gst_init` helper accepts the unknown flag and walks straight into its main loop.
- Making the excluded cases cheap enough to come back: bounding `sharedEnvInvokeDuringConfigure` by wall clock the way #4875 bounded `join.padReleaseWhileStreaming`, and giving the llamacpp sub-plugin a thread-count property so it can run single-threaded under a memory checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
