### PR TITLE
[Decoder/BoundingBox] Clamp box drawing to the output frame

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
@@ -776,13 +776,23 @@ BoundingBox::draw (GstMapInfo *out_info, GArray *results)
       }
     } else {
       int x1, x2, y1, y2; /* Box positions on the output surface */
+      gint64 bx1, bx2, by1, by2;
       int j;
       uint32_t *pos1, *pos2;
       /* 1. Draw Boxes */
-      x1 = (width * a->x) / i_width;
-      x2 = MIN (width - 1, (width * (a->x + a->width)) / i_width);
-      y1 = (height * a->y) / i_height;
-      y2 = MIN (height - 1, (height * (a->y + a->height)) / i_height);
+      bx1 = ((gint64) width * a->x) / i_width;
+      bx2 = ((gint64) width * ((gint64) a->x + a->width)) / i_width;
+      by1 = ((gint64) height * a->y) / i_height;
+      by2 = ((gint64) height * ((gint64) a->y + a->height)) / i_height;
+
+      if (bx2 < bx1 || by2 < by1 || bx2 < 0 || by2 < 0 || bx1 >= (gint64) width
+          || by1 >= (gint64) height)
+        continue;
+
+      x1 = (int) CLAMP (bx1, 0, (gint64) width - 1);
+      x2 = (int) CLAMP (bx2, 0, (gint64) width - 1);
+      y1 = (int) CLAMP (by1, 0, (gint64) height - 1);
+      y2 = (int) CLAMP (by2, 0, (gint64) height - 1);
 
       /* 1-1. Horizontal */
       pos1 = &frame[y1 * width + x1];
@@ -795,13 +805,9 @@ BoundingBox::draw (GstMapInfo *out_info, GArray *results)
       }
 
       /* 1-2. Vertical */
-      pos1 = &frame[(y1 + 1) * width + x1];
-      pos2 = &frame[(y1 + 1) * width + x2];
       for (j = y1 + 1; j < y2; j++) {
-        *pos1 = PIXEL_VALUE;
-        *pos2 = PIXEL_VALUE;
-        pos1 += width;
-        pos2 += width;
+        frame[j * width + x1] = PIXEL_VALUE;
+        frame[j * width + x2] = PIXEL_VALUE;
       }
 
       /* 2. Write Labels + tracking ID */
@@ -817,7 +823,6 @@ BoundingBox::draw (GstMapInfo *out_info, GArray *results)
 
         label_len = label ? strlen (label) : 0;
 
-        /* x1 is the same: x1 = MAX (0, (width * a->x) / i_width); */
         y1 = MAX (0, (y1 - 14));
         pos1 = &frame[y1 * width + x1];
         for (k = 0; k < label_len; k++) {
@@ -825,7 +830,7 @@ BoundingBox::draw (GstMapInfo *out_info, GArray *results)
           if ((x1 + 8) > (int) width)
             break; /* Stop drawing if it may overfill */
           pos2 = pos1;
-          for (y2 = 0; y2 < 13; y2++) {
+          for (y2 = 0; y2 < 13 && (y1 + y2) < (int) height; y2++) {
             /* 13 : character height */
             for (x2 = 0; x2 < 8; x2++) {
               /* 8: character width */

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -103,6 +103,15 @@ if gtest_dep.found()
     )
     test('unittest_tensor_region', unittest_tensor_region, env: testenv)
 
+    # RUN unittest_decoder_boundingbox
+    unittest_decoder_boundingbox = executable('unittest_decoder_boundingbox',
+      join_paths('nnstreamer_decoder_boundingbox', 'unittest_decoder_boundingbox.cc'),
+      dependencies: [nnstreamer_unittest_deps],
+      install: get_option('install-test'),
+      install_dir: unittest_install_dir
+    )
+    test('unittest_decoder_boundingbox', unittest_decoder_boundingbox, env: testenv)
+
     # Run unittest_plugins
     unittest_plugins = executable('unittest_plugins',
       join_paths('nnstreamer_plugins', 'unittest_plugins.cc'),

--- a/tests/nnstreamer_decoder_boundingbox/runTest.sh
+++ b/tests/nnstreamer_decoder_boundingbox/runTest.sh
@@ -160,6 +160,12 @@ callCompareTest yolov8_obb_decoder_result_golden.raw yolo11n-obb_result.log "10 
 
 rm dota8-obb-label.txt
 
+# The label sprite must stay inside an output frame shorter than a character
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decoder mode=bounding_boxes option1=mobilenet-ssd option2=coco_labels_list.txt option3=box_priors.txt option4=160:12 option5=300:300 ! video/x-raw,format=RGBA ! filesink location=mobilenetssd_short_output.log  multifilesrc name=fs1 location=mobilenetssd_tensors.0.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=4:1:1917:1 input-type=float32 ! mux.sink_0  multifilesrc name=fs2 location=mobilenetssd_tensors.1.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=91:1917:1 input-type=float32 ! mux.sink_1  " 12 0 0 $PERFORMANCE
+
+rm mobilenetssd_short_output.log
+
 # negative case for box properties
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=10 ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! videoconvert ! tensor_converter ! tensor_decoder mode=bounding_boxes option1=wrong_mode_name ! fakesink " 11_n 0 1

--- a/tests/nnstreamer_decoder_boundingbox/runTest.sh
+++ b/tests/nnstreamer_decoder_boundingbox/runTest.sh
@@ -160,15 +160,15 @@ callCompareTest yolov8_obb_decoder_result_golden.raw yolo11n-obb_result.log "10 
 
 rm dota8-obb-label.txt
 
+# negative case for box properties
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=10 ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! videoconvert ! tensor_converter ! tensor_decoder mode=bounding_boxes option1=wrong_mode_name ! fakesink " 11_n 0 1
+
 # The label sprite must stay inside an output frame shorter than a character
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decoder mode=bounding_boxes option1=mobilenet-ssd option2=coco_labels_list.txt option3=box_priors.txt option4=160:12 option5=300:300 ! video/x-raw,format=RGBA ! filesink location=mobilenetssd_short_output.log  multifilesrc name=fs1 location=mobilenetssd_tensors.0.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=4:1:1917:1 input-type=float32 ! mux.sink_0  multifilesrc name=fs2 location=mobilenetssd_tensors.1.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=91:1917:1 input-type=float32 ! mux.sink_1  " 12 0 0 $PERFORMANCE
 
 rm mobilenetssd_short_output.log
-
-# negative case for box properties
-
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=10 ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! videoconvert ! tensor_converter ! tensor_decoder mode=bounding_boxes option1=wrong_mode_name ! fakesink " 11_n 0 1
 
 rm yolov*.log
 

--- a/tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc
+++ b/tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc
@@ -1,0 +1,259 @@
+/**
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * @file        unittest_decoder_boundingbox.cc
+ * @date        04 Sep 2026
+ * @brief       Unit test for the bounding_boxes mode of tensor_decoder
+ * @see         https://github.com/nnstreamer/nnstreamer
+ * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug         No known bugs
+ */
+
+#include <gtest/gtest.h>
+#include <glib.h>
+#include <gst/gst.h>
+#include <string.h>
+#include <unittest_util.h>
+
+#define OV_DESC_SIZE (7U)
+#define OV_DETECTION_MAX (200U)
+#define OV_TENSOR_ELEMENTS (OV_DESC_SIZE * OV_DETECTION_MAX)
+#define OV_TENSOR_SIZE (OV_TENSOR_ELEMENTS * sizeof (float))
+
+#define MODEL_WIDTH (640U)
+#define MODEL_HEIGHT (480U)
+#define OUT_WIDTH (64U)
+#define OUT_HEIGHT (48U)
+#define OUT_PIXELS (OUT_WIDTH * OUT_HEIGHT)
+
+#define BOX_PIXEL (0xFF0000FFU)
+
+/**
+ * @brief Fill the first descriptor of an ov-person-detection output tensor.
+ * @details The model emits coordinates normalized to its own input size, which
+ *          the decoder scales to the output frame. The second descriptor gets a
+ *          negative image id, which terminates the list of detections.
+ */
+static void
+setDetection (float *tensor, float x_min, float y_min, float x_max, float y_max)
+{
+  tensor[0] = 0.0f;
+  tensor[1] = 0.0f;
+  tensor[2] = 1.0f;
+  tensor[3] = x_min;
+  tensor[4] = y_min;
+  tensor[5] = x_max;
+  tensor[6] = y_max;
+  tensor[OV_DESC_SIZE] = -1.0f;
+}
+
+/**
+ * @brief Decode the given tensor with the bounding_boxes decoder.
+ * @param[in] tensor OV_TENSOR_ELEMENTS floats of ov-person-detection output
+ * @param[out] frame OUT_PIXELS RGBA pixels drawn by the decoder
+ */
+static gboolean
+decodeBoundingBoxes (const float *tensor, uint32_t *frame)
+{
+  gchar *in_file = getTempFilename ();
+  gchar *out_file = getTempFilename ();
+  gchar *pipeline_str;
+  gchar *content = NULL;
+  gsize len = 0;
+  GstElement *pipeline;
+  gboolean ret = FALSE;
+
+  if (in_file == NULL || out_file == NULL)
+    return FALSE;
+
+  if (g_file_set_contents (in_file, (const gchar *) tensor, OV_TENSOR_SIZE, NULL)) {
+    pipeline_str = g_strdup_printf (
+        "filesrc location=%s blocksize=%u ! application/octet-stream ! "
+        "tensor_converter input-dim=%u:%u:1:1 input-type=float32 ! "
+        "tensor_decoder mode=bounding_boxes option1=ov-person-detection "
+        "option4=%u:%u option5=%u:%u ! "
+        "filesink location=%s buffer-mode=unbuffered sync=false async=false",
+        in_file, (guint) OV_TENSOR_SIZE, OV_DESC_SIZE, OV_DETECTION_MAX,
+        OUT_WIDTH, OUT_HEIGHT, MODEL_WIDTH, MODEL_HEIGHT, out_file);
+
+    pipeline = gst_parse_launch (pipeline_str, NULL);
+    g_free (pipeline_str);
+
+    if (pipeline != NULL) {
+      if (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT) == 0) {
+        GstBus *bus = gst_element_get_bus (pipeline);
+        GstMessage *msg = gst_bus_timed_pop_filtered (bus, 10 * GST_SECOND,
+            (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+
+        if (msg != NULL) {
+          ret = (GST_MESSAGE_TYPE (msg) == GST_MESSAGE_EOS);
+          gst_message_unref (msg);
+        }
+        gst_object_unref (bus);
+      }
+
+      setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT);
+      gst_object_unref (pipeline);
+    }
+  }
+
+  if (ret) {
+    ret = g_file_get_contents (out_file, &content, &len, NULL)
+          && len == OUT_PIXELS * sizeof (uint32_t);
+    if (ret)
+      memcpy (frame, content, len);
+    g_free (content);
+  }
+
+  removeTempFile (&in_file);
+  removeTempFile (&out_file);
+
+  return ret;
+}
+
+/**
+ * @brief Count the pixels the decoder has drawn.
+ */
+static guint
+countDrawnPixels (const uint32_t *frame)
+{
+  guint i, count = 0;
+
+  for (i = 0; i < OUT_PIXELS; i++) {
+    if (frame[i] != 0U)
+      count++;
+  }
+
+  return count;
+}
+
+/**
+ * @brief A box inside the frame is drawn on its four edges.
+ */
+TEST (tensorDecoderBoundingBox, drawBoxInFrame)
+{
+  float tensor[OV_TENSOR_ELEMENTS] = { 0.0f };
+  uint32_t frame[OUT_PIXELS] = { 0U };
+
+  setDetection (tensor, 0.25f, 0.25f, 0.75f, 0.75f);
+  ASSERT_TRUE (decodeBoundingBoxes (tensor, frame));
+
+  /* The box covers x 16 to 48 and y 12 to 36 of the 64x48 output frame */
+  EXPECT_EQ (frame[12 * OUT_WIDTH + 16], BOX_PIXEL);
+  EXPECT_EQ (frame[12 * OUT_WIDTH + 48], BOX_PIXEL);
+  EXPECT_EQ (frame[36 * OUT_WIDTH + 16], BOX_PIXEL);
+  EXPECT_EQ (frame[36 * OUT_WIDTH + 48], BOX_PIXEL);
+  EXPECT_EQ (frame[24 * OUT_WIDTH + 16], BOX_PIXEL);
+  EXPECT_EQ (frame[24 * OUT_WIDTH + 48], BOX_PIXEL);
+  EXPECT_EQ (frame[24 * OUT_WIDTH + 32], 0U);
+  EXPECT_EQ (frame[11 * OUT_WIDTH + 16], 0U);
+}
+
+/**
+ * @brief A box starting left of the frame is clamped to the frame.
+ * @details Without clamping the negative position is promoted to a huge
+ *          unsigned offset, which the vertical edge loop writes through.
+ */
+TEST (tensorDecoderBoundingBox, drawBoxAcrossLeftEdge)
+{
+  float tensor[OV_TENSOR_ELEMENTS] = { 0.0f };
+  uint32_t frame[OUT_PIXELS] = { 0U };
+
+  setDetection (tensor, -0.25f, 0.25f, 0.5f, 0.75f);
+  ASSERT_TRUE (decodeBoundingBoxes (tensor, frame));
+
+  /* x -16 is clamped to 0, the right edge stays at 32 */
+  EXPECT_EQ (frame[12 * OUT_WIDTH + 0], BOX_PIXEL);
+  EXPECT_EQ (frame[12 * OUT_WIDTH + 32], BOX_PIXEL);
+  EXPECT_EQ (frame[36 * OUT_WIDTH + 0], BOX_PIXEL);
+  EXPECT_EQ (frame[36 * OUT_WIDTH + 32], BOX_PIXEL);
+  EXPECT_EQ (frame[24 * OUT_WIDTH + 0], BOX_PIXEL);
+  EXPECT_EQ (frame[24 * OUT_WIDTH + 32], BOX_PIXEL);
+  EXPECT_EQ (frame[24 * OUT_WIDTH + 33], 0U);
+}
+
+/**
+ * @brief A box that ends below the frame is clamped to the last row.
+ */
+TEST (tensorDecoderBoundingBox, drawBoxAcrossBottomEdge)
+{
+  float tensor[OV_TENSOR_ELEMENTS] = { 0.0f };
+  uint32_t frame[OUT_PIXELS] = { 0U };
+
+  setDetection (tensor, 0.25f, 0.5f, 0.75f, 1.5f);
+  ASSERT_TRUE (decodeBoundingBoxes (tensor, frame));
+
+  EXPECT_EQ (frame[24 * OUT_WIDTH + 16], BOX_PIXEL);
+  EXPECT_EQ (frame[(OUT_HEIGHT - 1) * OUT_WIDTH + 16], BOX_PIXEL);
+  EXPECT_EQ (frame[(OUT_HEIGHT - 1) * OUT_WIDTH + 48], BOX_PIXEL);
+  EXPECT_EQ (frame[30 * OUT_WIDTH + 16], BOX_PIXEL);
+}
+
+/**
+ * @brief A box entirely right of the frame draws nothing.
+ * @details The unclamped left edge used to wrap into the following rows and
+ *          paint a vertical line where no box is.
+ */
+TEST (tensorDecoderBoundingBox, skipBoxRightOfFrame)
+{
+  float tensor[OV_TENSOR_ELEMENTS] = { 0.0f };
+  uint32_t frame[OUT_PIXELS] = { 0U };
+
+  setDetection (tensor, 1.5f, 0.25f, 1.75f, 0.75f);
+  ASSERT_TRUE (decodeBoundingBoxes (tensor, frame));
+
+  EXPECT_EQ (countDrawnPixels (frame), 0U);
+}
+
+/**
+ * @brief A box entirely below the frame draws nothing.
+ */
+TEST (tensorDecoderBoundingBox, skipBoxBelowFrame)
+{
+  float tensor[OV_TENSOR_ELEMENTS] = { 0.0f };
+  uint32_t frame[OUT_PIXELS] = { 0U };
+
+  setDetection (tensor, 0.25f, 1.2f, 0.75f, 1.5f);
+  ASSERT_TRUE (decodeBoundingBoxes (tensor, frame));
+
+  EXPECT_EQ (countDrawnPixels (frame), 0U);
+}
+
+/**
+ * @brief A box with a negative size draws nothing.
+ */
+TEST (tensorDecoderBoundingBox, skipInvertedBox_n)
+{
+  float tensor[OV_TENSOR_ELEMENTS] = { 0.0f };
+  uint32_t frame[OUT_PIXELS] = { 0U };
+
+  setDetection (tensor, 0.75f, 0.75f, 0.25f, 0.25f);
+  ASSERT_TRUE (decodeBoundingBoxes (tensor, frame));
+
+  EXPECT_EQ (countDrawnPixels (frame), 0U);
+}
+
+/**
+ * @brief Main GTest
+ */
+int
+main (int argc, char **argv)
+{
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch testing::internal::ClassUniqueToAlwaysTrue");
+  }
+
+  gst_init (&argc, &argv);
+
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch testing::internal::GoogleTestFailureException");
+  }
+
+  return result;
+}

--- a/tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc
+++ b/tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc
@@ -26,6 +26,10 @@
 #define OUT_HEIGHT (48U)
 #define OUT_PIXELS (OUT_WIDTH * OUT_HEIGHT)
 
+#define LABEL_HEIGHT (12U)
+#define LABEL_PIXELS (OUT_WIDTH * LABEL_HEIGHT)
+#define LABEL_TEXT "X\n"
+
 #define BOX_PIXEL (0xFF0000FFU)
 
 /**
@@ -48,6 +52,62 @@ setDetection (float *tensor, float x_min, float y_min, float x_max, float y_max)
 }
 
 /**
+ * @brief Write the given floats to a new temp file.
+ * @return the file name, to be released with removeTempFile ()
+ */
+static gchar *
+writeTensorFile (const float *data, guint elements)
+{
+  gchar *name = getTempFilename ();
+
+  if (name != NULL
+      && !g_file_set_contents (name, (const gchar *) data, elements * sizeof (float), NULL))
+    removeTempFile (&name);
+
+  return name;
+}
+
+/**
+ * @brief Run the pipeline to EOS and read back the frame the decoder wrote.
+ */
+static gboolean
+runAndReadFrame (const gchar *pipeline_str, const gchar *out_file, uint32_t *frame, guint pixels)
+{
+  GstElement *pipeline = gst_parse_launch (pipeline_str, NULL);
+  gchar *content = NULL;
+  gsize len = 0;
+  gboolean ret = FALSE;
+
+  if (pipeline == NULL)
+    return FALSE;
+
+  if (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT) == 0) {
+    GstBus *bus = gst_element_get_bus (pipeline);
+    GstMessage *msg = gst_bus_timed_pop_filtered (bus, 10 * GST_SECOND,
+        (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+
+    if (msg != NULL) {
+      ret = (GST_MESSAGE_TYPE (msg) == GST_MESSAGE_EOS);
+      gst_message_unref (msg);
+    }
+    gst_object_unref (bus);
+  }
+
+  setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT);
+  gst_object_unref (pipeline);
+
+  if (ret) {
+    ret = g_file_get_contents (out_file, &content, &len, NULL)
+          && len == pixels * sizeof (uint32_t);
+    if (ret)
+      memcpy (frame, content, len);
+    g_free (content);
+  }
+
+  return ret;
+}
+
+/**
  * @brief Decode the given tensor with the bounding_boxes decoder.
  * @param[in] tensor OV_TENSOR_ELEMENTS floats of ov-person-detection output
  * @param[out] frame OUT_PIXELS RGBA pixels drawn by the decoder
@@ -55,18 +115,12 @@ setDetection (float *tensor, float x_min, float y_min, float x_max, float y_max)
 static gboolean
 decodeBoundingBoxes (const float *tensor, uint32_t *frame)
 {
-  gchar *in_file = getTempFilename ();
+  gchar *in_file = writeTensorFile (tensor, OV_TENSOR_ELEMENTS);
   gchar *out_file = getTempFilename ();
   gchar *pipeline_str;
-  gchar *content = NULL;
-  gsize len = 0;
-  GstElement *pipeline;
   gboolean ret = FALSE;
 
-  if (in_file == NULL || out_file == NULL)
-    return FALSE;
-
-  if (g_file_set_contents (in_file, (const gchar *) tensor, OV_TENSOR_SIZE, NULL)) {
+  if (in_file != NULL && out_file != NULL) {
     pipeline_str = g_strdup_printf (
         "filesrc location=%s blocksize=%u ! application/octet-stream ! "
         "tensor_converter input-dim=%u:%u:1:1 input-type=float32 ! "
@@ -76,33 +130,8 @@ decodeBoundingBoxes (const float *tensor, uint32_t *frame)
         in_file, (guint) OV_TENSOR_SIZE, OV_DESC_SIZE, OV_DETECTION_MAX,
         OUT_WIDTH, OUT_HEIGHT, MODEL_WIDTH, MODEL_HEIGHT, out_file);
 
-    pipeline = gst_parse_launch (pipeline_str, NULL);
+    ret = runAndReadFrame (pipeline_str, out_file, frame, OUT_PIXELS);
     g_free (pipeline_str);
-
-    if (pipeline != NULL) {
-      if (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT) == 0) {
-        GstBus *bus = gst_element_get_bus (pipeline);
-        GstMessage *msg = gst_bus_timed_pop_filtered (bus, 10 * GST_SECOND,
-            (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
-
-        if (msg != NULL) {
-          ret = (GST_MESSAGE_TYPE (msg) == GST_MESSAGE_EOS);
-          gst_message_unref (msg);
-        }
-        gst_object_unref (bus);
-      }
-
-      setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT);
-      gst_object_unref (pipeline);
-    }
-  }
-
-  if (ret) {
-    ret = g_file_get_contents (out_file, &content, &len, NULL)
-          && len == OUT_PIXELS * sizeof (uint32_t);
-    if (ret)
-      memcpy (frame, content, len);
-    g_free (content);
   }
 
   removeTempFile (&in_file);
@@ -112,14 +141,71 @@ decodeBoundingBoxes (const float *tensor, uint32_t *frame)
 }
 
 /**
+ * @brief Decode one labelled detection into a frame shorter than a character cell.
+ * @details mobilenet-ssd-postprocess is the simplest mode that draws labels: the box,
+ *          its class and its score come straight from four small tensors. The box sits
+ *          low enough that the label is written from row 0, and the output frame is
+ *          shorter than the 13 rows of a character, which is what the sprite loop has
+ *          to be clipped against.
+ * @param[out] frame LABEL_PIXELS RGBA pixels drawn by the decoder
+ */
+static gboolean
+decodeLabelledBox (uint32_t *frame)
+{
+  const float num[] = { 1.0f };
+  const float classes[] = { 0.0f };
+  const float scores[] = { 0.9f };
+  const float boxes[] = { 0.5f, 0.25f, 0.75f, 0.5f }; /* y_min, x_min, y_max, x_max */
+  gchar *num_file = writeTensorFile (num, 1);
+  gchar *class_file = writeTensorFile (classes, 1);
+  gchar *score_file = writeTensorFile (scores, 1);
+  gchar *box_file = writeTensorFile (boxes, 4);
+  gchar *label_file = getTempFilename ();
+  gchar *out_file = getTempFilename ();
+  gchar *pipeline_str;
+  gboolean ret = FALSE;
+
+  if (num_file != NULL && class_file != NULL && score_file != NULL
+      && box_file != NULL && label_file != NULL && out_file != NULL
+      && g_file_set_contents (label_file, LABEL_TEXT, -1, NULL)) {
+    pipeline_str = g_strdup_printf (
+        "tensor_mux name=mux ! tensor_decoder mode=bounding_boxes "
+        "option1=mobilenet-ssd-postprocess option2=%s option4=%u:%u option5=%u:%u ! "
+        "filesink location=%s buffer-mode=unbuffered sync=false async=false "
+        "filesrc location=%s blocksize=4 ! application/octet-stream ! "
+        "tensor_converter input-dim=1 input-type=float32 ! mux.sink_0 "
+        "filesrc location=%s blocksize=4 ! application/octet-stream ! "
+        "tensor_converter input-dim=1:1 input-type=float32 ! mux.sink_1 "
+        "filesrc location=%s blocksize=4 ! application/octet-stream ! "
+        "tensor_converter input-dim=1:1 input-type=float32 ! mux.sink_2 "
+        "filesrc location=%s blocksize=16 ! application/octet-stream ! "
+        "tensor_converter input-dim=4:1 input-type=float32 ! mux.sink_3",
+        label_file, OUT_WIDTH, LABEL_HEIGHT, MODEL_WIDTH, MODEL_HEIGHT,
+        out_file, num_file, class_file, score_file, box_file);
+
+    ret = runAndReadFrame (pipeline_str, out_file, frame, LABEL_PIXELS);
+    g_free (pipeline_str);
+  }
+
+  removeTempFile (&num_file);
+  removeTempFile (&class_file);
+  removeTempFile (&score_file);
+  removeTempFile (&box_file);
+  removeTempFile (&label_file);
+  removeTempFile (&out_file);
+
+  return ret;
+}
+
+/**
  * @brief Count the pixels the decoder has drawn.
  */
 static guint
-countDrawnPixels (const uint32_t *frame)
+countDrawnPixels (const uint32_t *frame, guint pixels)
 {
   guint i, count = 0;
 
-  for (i = 0; i < OUT_PIXELS; i++) {
+  for (i = 0; i < pixels; i++) {
     if (frame[i] != 0U)
       count++;
   }
@@ -202,7 +288,35 @@ TEST (tensorDecoderBoundingBox, skipBoxRightOfFrame)
   setDetection (tensor, 1.5f, 0.25f, 1.75f, 0.75f);
   ASSERT_TRUE (decodeBoundingBoxes (tensor, frame));
 
-  EXPECT_EQ (countDrawnPixels (frame), 0U);
+  EXPECT_EQ (countDrawnPixels (frame, OUT_PIXELS), 0U);
+}
+
+/**
+ * @brief A box entirely left of the frame draws nothing.
+ */
+TEST (tensorDecoderBoundingBox, skipBoxLeftOfFrame)
+{
+  float tensor[OV_TENSOR_ELEMENTS] = { 0.0f };
+  uint32_t frame[OUT_PIXELS] = { 0U };
+
+  setDetection (tensor, -1.5f, 0.25f, -1.25f, 0.75f);
+  ASSERT_TRUE (decodeBoundingBoxes (tensor, frame));
+
+  EXPECT_EQ (countDrawnPixels (frame, OUT_PIXELS), 0U);
+}
+
+/**
+ * @brief A box entirely above the frame draws nothing.
+ */
+TEST (tensorDecoderBoundingBox, skipBoxAboveFrame)
+{
+  float tensor[OV_TENSOR_ELEMENTS] = { 0.0f };
+  uint32_t frame[OUT_PIXELS] = { 0U };
+
+  setDetection (tensor, 0.25f, -1.5f, 0.75f, -1.25f);
+  ASSERT_TRUE (decodeBoundingBoxes (tensor, frame));
+
+  EXPECT_EQ (countDrawnPixels (frame, OUT_PIXELS), 0U);
 }
 
 /**
@@ -216,7 +330,7 @@ TEST (tensorDecoderBoundingBox, skipBoxBelowFrame)
   setDetection (tensor, 0.25f, 1.2f, 0.75f, 1.5f);
   ASSERT_TRUE (decodeBoundingBoxes (tensor, frame));
 
-  EXPECT_EQ (countDrawnPixels (frame), 0U);
+  EXPECT_EQ (countDrawnPixels (frame, OUT_PIXELS), 0U);
 }
 
 /**
@@ -230,7 +344,32 @@ TEST (tensorDecoderBoundingBox, skipInvertedBox_n)
   setDetection (tensor, 0.75f, 0.75f, 0.25f, 0.25f);
   ASSERT_TRUE (decodeBoundingBoxes (tensor, frame));
 
-  EXPECT_EQ (countDrawnPixels (frame), 0U);
+  EXPECT_EQ (countDrawnPixels (frame, OUT_PIXELS), 0U);
+}
+
+/**
+ * @brief The label of a box is clipped by an output frame shorter than a character.
+ * @details The character rows that do not fit are written past the end of the frame, so
+ *          the overrun itself is only observable to a memory checker; this case pins the
+ *          label being drawn and gives the sprite path coverage the memcheck runs reach.
+ */
+TEST (tensorDecoderBoundingBox, drawLabelInShortFrame)
+{
+  uint32_t frame[LABEL_PIXELS] = { 0U };
+  guint i, label_pixels = 0;
+
+  ASSERT_TRUE (decodeLabelledBox (frame));
+
+  /* The box covers x 16 to 32 and y 6 to 9; its left columns are behind the label */
+  EXPECT_EQ (frame[6 * OUT_WIDTH + 32], BOX_PIXEL);
+  EXPECT_EQ (frame[9 * OUT_WIDTH + 32], BOX_PIXEL);
+
+  /* The label is written from row 0, above the box */
+  for (i = 0; i < 6 * OUT_WIDTH; i++) {
+    if (frame[i] != 0U)
+      label_pixels++;
+  }
+  EXPECT_GT (label_pixels, 0U);
 }
 
 /**


### PR DESCRIPTION
Fixes item **G3** of #4920: `BoundingBox::draw()` writes bounding boxes outside the RGBA output frame.

## Problem

`draw()` scales each detected box to the output surface and clamps only the right and bottom edge:

```c
x1 = (width * a->x) / i_width;
x2 = MIN (width - 1, (width * (a->x + a->width)) / i_width);   /* only x2 is clamped */
y1 = (height * a->y) / i_height;
y2 = MIN (height - 1, (height * (a->y + a->height)) / i_height);
```

`width` and `height` are `guint`, so the products are evaluated as unsigned:

* **A box that starts left of / above the frame** (`ov-person-detection` passes the model's coordinates through without any clamp, and OpenVINO's person-detection models do emit slightly negative corners) turns into a huge offset: for `width = 640, a->x = -1` the left edge becomes `6710885`. The vertical edge loop then writes `PIXEL_VALUE` tens of megabytes past the frame. Locally this segfaults.
* **A box entirely right of / below the frame** keeps an in-range partner coordinate, so one of the two edge loops still runs and writes outside the frame - or, when the offset happens to wrap into a later row, paints a line where no box is. No decoder clamps the box against the *upper* bound, so any model whose output extends past its input reaches this.
* **The label sprite** always draws 13 rows, which do not fit an output frame shorter than one character cell.

The rotated-box path in the same function (`draw_line()`) already range-checks every pixel; only the rectangle path was missing it.

## Fix

`ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc`:

* compute the four edges in `gint64`, which removes the unsigned promotion,
* skip boxes that do not overlap the frame or have a negative size,
* `CLAMP` the remaining edges to the frame,
* draw the vertical edges by index instead of by pointer, and stop the label sprite at the last row.

Boxes that already fitted inside the frame are scaled to exactly the same pixels as before, so no golden output changes.

## Tests

`tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc` (new, registered in `tests/meson.build`) drives the decoder through a pipeline with `ov-person-detection` output - the only in-tree mode that emits unclamped coordinates - and asserts on the drawn pixels. Against the unfixed decoder:

| case | unfixed | fixed |
| --- | --- | --- |
| `drawBoxInFrame` | pass (behaviour preserved) | pass |
| `drawBoxAcrossLeftEdge` | **SIGSEGV** | pass |
| `drawBoxAcrossBottomEdge` | pass (behaviour preserved) | pass |
| `skipBoxRightOfFrame` | **fail**, 46 stray pixels | pass |
| `skipBoxBelowFrame` | **fail**, 33 stray pixels | pass |
| `skipInvertedBox_n` | pass (behaviour preserved) | pass |

`tests/nnstreamer_decoder_boundingbox/runTest.sh` gains case 12: mobilenet-ssd rendering labels into a 160x12 frame. That directory is run under valgrind with a fatal gate in `ubuntu_clean_meson_build.yml`, and the case is what catches the sprite overrun:

```
Invalid write of size 4
   at BoundingBox::draw(GstMapInfo*, _GArray*) (tensordec-boundingbox.cc:832)
   by BoundingBox::decode(...) (tensordec-boundingbox.cc:1107)
ERROR SUMMARY: 34 errors from 1 contexts     <- unfixed
ERROR SUMMARY: 0 errors from 0 contexts      <- fixed
```

## Verification

* `ssat` in `tests/nnstreamer_decoder_boundingbox`: 51/51 pass, every golden (mobilenet-ssd, ssd-postprocess, mp-palm-detection, yolov5 incl. track mode, yolov8, yolov10, yolov8-obb) byte-identical - which is the regression check for the other decoder modes that feed `draw()`.
* `meson test`: 22/23, the only failure being `unittest_filter_python3`, a numpy 1.x/2.x mismatch in the local environment.
* `clang-format` clean; the changed objects recompile without warnings under `-Wall -Wextra -Werror` with `-Wno-sign-compare` stripped.

`draw()` has a single caller and the header is shared only with the `box_properties/` decoders, which do not call it, so nothing outside this decoder is touched.

Not addressed here, and left as their own items of #4920: G2 (the signed `char` label index in the same loop) and G4 (`logBoxes()` indexing `labels[]` with an unchecked class id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
