### PR TITLE
[Element] Fix property/streaming-thread races in tensor_demux and tensor_split

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_demux.c
+++ b/gst/nnstreamer/elements/gsttensor_demux.c
@@ -222,6 +222,7 @@ gst_tensor_demux_dispose (GObject * object)
 
   gst_tensor_demux_remove_src_pads (tensor_demux);
   g_list_free_full (tensor_demux->tensorpick, g_free);
+  tensor_demux->tensorpick = NULL;
   G_OBJECT_CLASS (parent_class)->dispose (object);
 }
 
@@ -260,8 +261,37 @@ gst_tensor_demux_event (GstPad * pad, GstObject * parent, GstEvent * event)
 }
 
 /**
+ * @brief Copy a tensorpick entry.
+ */
+static gpointer
+gst_tensor_demux_copy_pick (gconstpointer src, gpointer data)
+{
+  UNUSED (data);
+  return g_strdup ((const gchar *) src);
+}
+
+/**
+ * @brief Get a private copy of the tensorpick property.
+ * @param tensor_demux "this" pointer
+ * @return copied list, which should be released with g_list_free_full()
+ */
+static GList *
+gst_tensor_demux_get_tensorpick (GstTensorDemux * tensor_demux)
+{
+  GList *tensorpick;
+
+  GST_OBJECT_LOCK (tensor_demux);
+  tensorpick = g_list_copy_deep (tensor_demux->tensorpick,
+      gst_tensor_demux_copy_pick, NULL);
+  GST_OBJECT_UNLOCK (tensor_demux);
+
+  return tensorpick;
+}
+
+/**
  * @brief Get tensor config info from configured tensors
  * @param tensor_demux "this" pointer
+ * @param tensorpick private copy of the tensorpick property
  * @param config tensor config to be filled
  * @param nth source ordering
  * @param total number of tensors
@@ -269,18 +299,20 @@ gst_tensor_demux_event (GstPad * pad, GstObject * parent, GstEvent * event)
  */
 static gboolean
 gst_tensor_demux_get_tensor_config (GstTensorDemux * tensor_demux,
-    GstTensorsConfig * config, const guint nth, const guint total)
+    GList * tensorpick, GstTensorsConfig * config, const guint nth,
+    const guint total)
 {
   gst_tensors_config_init (config);
 
-  if (tensor_demux->tensorpick != NULL) {
+  if (tensorpick != NULL) {
     gchar *selected_tensor;
     gchar **strv;
     guint i, num, idx;
 
-    g_assert (g_list_length (tensor_demux->tensorpick) >= nth);
+    selected_tensor = (gchar *) g_list_nth_data (tensorpick, nth);
+    if (selected_tensor == NULL)
+      return FALSE;
 
-    selected_tensor = (gchar *) g_list_nth_data (tensor_demux->tensorpick, nth);
     strv = g_strsplit_set (selected_tensor, ":+", -1);
     num = g_strv_length (strv);
 
@@ -320,6 +352,7 @@ gst_tensor_demux_get_tensor_config (GstTensorDemux * tensor_demux,
 /**
  * @brief Checking if the source pad is created and if not, create TensorPad
  * @param tensor_demux TensorDemux Object
+ * @param tensorpick private copy of the tensorpick property
  * @param[out] created will be updated in this function
  * @param nth source ordering
  * @param total number of tensors
@@ -328,7 +361,7 @@ gst_tensor_demux_get_tensor_config (GstTensorDemux * tensor_demux,
  */
 static GstTensorPad *
 gst_tensor_demux_get_tensor_pad (GstTensorDemux * tensor_demux,
-    gboolean * created, const guint nth, const guint total)
+    GList * tensorpick, gboolean * created, const guint nth, const guint total)
 {
   GstElement *element = GST_ELEMENT_CAST (tensor_demux);
   g_autofree gchar *element_name = gst_element_get_name (element);
@@ -399,7 +432,8 @@ gst_tensor_demux_get_tensor_pad (GstTensorDemux * tensor_demux,
   gst_event_unref (event);
 
   /* configure nth pad caps */
-  if (gst_tensor_demux_get_tensor_config (tensor_demux, &config, nth, total)) {
+  if (gst_tensor_demux_get_tensor_config (tensor_demux, tensorpick, &config,
+          nth, total)) {
     caps = gst_tensor_pad_caps_from_config (pad, &config);
 
     gst_pad_set_caps (pad, caps);
@@ -412,9 +446,9 @@ gst_tensor_demux_get_tensor_pad (GstTensorDemux * tensor_demux,
     *created = TRUE;
   }
 
-  if (tensor_demux->tensorpick != NULL) {
+  if (tensorpick != NULL) {
     GST_DEBUG_OBJECT (tensor_demux, "TensorPick is set! : %dth tensor\n", nth);
-    if (g_list_length (tensor_demux->tensorpick) == tensor_demux->num_srcpads) {
+    if (g_list_length (tensorpick) == tensor_demux->num_srcpads) {
       gst_element_no_more_pads (GST_ELEMENT_CAST (tensor_demux));
     }
   }
@@ -459,11 +493,12 @@ gst_tensor_demux_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
   guint num_tensors, num_srcs, i, idx;
   GstFlowReturn res = GST_FLOW_OK;
   GstTensorDemux *tensor_demux;
-  GList *list = NULL;
+  GList *tensorpick, *list = NULL;
   GstTensorInfo *_info;
 
   UNUSED (pad);
   tensor_demux = GST_TENSOR_DEMUX (parent);
+  tensorpick = gst_tensor_demux_get_tensorpick (tensor_demux);
 
   buf = gst_tensor_buffer_from_config (buf, &tensor_demux->tensors_config);
 
@@ -479,9 +514,9 @@ gst_tensor_demux_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
   GST_DEBUG_OBJECT (tensor_demux, " Number of Tensors: %d", num_tensors);
 
   num_srcs = num_tensors;
-  if (tensor_demux->tensorpick != NULL) {
-    num_srcs = g_list_length (tensor_demux->tensorpick);
-    list = tensor_demux->tensorpick;
+  if (tensorpick != NULL) {
+    num_srcs = g_list_length (tensorpick);
+    list = tensorpick;
   }
 
   for (i = 0; i < num_srcs; i++) {
@@ -491,11 +526,11 @@ gst_tensor_demux_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
     gboolean created;
     GstClockTime ts;
 
-    srcpad = gst_tensor_demux_get_tensor_pad (tensor_demux, &created, i,
-        num_tensors);
+    srcpad = gst_tensor_demux_get_tensor_pad (tensor_demux, tensorpick,
+        &created, i, num_tensors);
     outbuf = gst_buffer_new ();
 
-    if (tensor_demux->tensorpick != NULL) {
+    if (list != NULL) {
       guint num, j;
       gchar **strv = g_strsplit_set ((gchar *) list->data, ":+", -1);
 
@@ -507,6 +542,7 @@ gst_tensor_demux_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
             idx);
         mem = gst_tensor_buffer_get_nth_memory (buf, idx);
         if (!gst_tensor_buffer_append_memory (outbuf, mem, _info)) {
+          g_strfreev (strv);
           gst_buffer_unref (outbuf);
           res = GST_FLOW_ERROR;
           goto error;
@@ -556,6 +592,7 @@ gst_tensor_demux_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
   }
 
 error:
+  g_list_free_full (tensorpick, g_free);
   gst_buffer_unref (buf);
   return res;
 }
@@ -597,6 +634,8 @@ gst_tensor_demux_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
   GstTensorDemux *filter = GST_TENSOR_DEMUX (object);
+
+  GST_OBJECT_LOCK (filter);
   switch (prop_id) {
     case PROP_SILENT:
       filter->silent = g_value_get_boolean (value);
@@ -624,6 +663,7 @@ gst_tensor_demux_set_property (GObject * object, guint prop_id,
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
   }
+  GST_OBJECT_UNLOCK (filter);
 }
 
 /**
@@ -634,6 +674,8 @@ gst_tensor_demux_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec)
 {
   GstTensorDemux *filter = GST_TENSOR_DEMUX (object);
+
+  GST_OBJECT_LOCK (filter);
   switch (prop_id) {
     case PROP_SILENT:
       g_value_set_boolean (value, filter->silent);
@@ -659,4 +701,5 @@ gst_tensor_demux_get_property (GObject * object, guint prop_id,
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
   }
+  GST_OBJECT_UNLOCK (filter);
 }

--- a/gst/nnstreamer/elements/gsttensor_split.c
+++ b/gst/nnstreamer/elements/gsttensor_split.c
@@ -206,7 +206,8 @@ gst_tensor_split_finalize (GObject * object)
   split = GST_TENSOR_SPLIT (object);
   gst_tensor_split_remove_src_pads (split);
   g_list_free (split->tensorpick);
-  g_array_free (split->tensorseg, TRUE);
+  if (split->tensorseg)
+    g_array_unref (split->tensorseg);
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 
@@ -251,15 +252,18 @@ gst_tensor_split_event (GstPad * pad, GstObject * parent, GstEvent * event)
 /**
  * @brief Checking if the source pad is created and if not, create TensorPad
  * @param split TensorSplit Object
+ * @param tensorseg private reference of the tensorseg property
+ * @param tensorpick private copy of the tensorpick property
  * @param inbuf inputbuf GstBuffer Object including GstMeta
  * @param[out] created will be updated in this function
  * @param nth source ordering
  * @return TensorPad if pad is already created, then return created pad.
- *         If not return new pad after creation.
+ *         If not return new pad after creation, or NULL if no segment rule
+ *         is left for it.
  */
 static GstTensorPad *
-gst_tensor_split_get_tensor_pad (GstTensorSplit * split, GstBuffer * inbuf,
-    gboolean * created, guint nth)
+gst_tensor_split_get_tensor_pad (GstTensorSplit * split, GArray * tensorseg,
+    GList * tensorpick, GstBuffer * inbuf, gboolean * created, guint nth)
 {
   GstElement *element = GST_ELEMENT_CAST (split);
   g_autofree gchar *element_name = gst_element_get_name (element);
@@ -287,6 +291,13 @@ gst_tensor_split_get_tensor_pad (GstTensorSplit * split, GstBuffer * inbuf,
     walk = g_slist_next (walk);
   }
 
+  if (split->num_srcpads >= tensorseg->len) {
+    GST_ERROR_OBJECT (split,
+        "The tensorseg has %u rules, which leaves none for the %uth source pad.",
+        tensorseg->len, split->num_srcpads);
+    return NULL;
+  }
+
   tensorpad = g_new0 (GstTensorPad, 1);
   g_assert (tensorpad != NULL);
   GST_DEBUG_OBJECT (split, "creating pad: %d(%dth)", split->num_srcpads, nth);
@@ -303,7 +314,7 @@ gst_tensor_split_get_tensor_pad (GstTensorSplit * split, GstBuffer * inbuf,
   tensorpad->last_ts = GST_CLOCK_TIME_NONE;
 
   split->srcpads = g_slist_append (split->srcpads, tensorpad);
-  dim = g_array_index (split->tensorseg, tensor_dim *, split->num_srcpads);
+  dim = g_array_index (tensorseg, tensor_dim *, split->num_srcpads);
 
   split->num_srcpads++;
 
@@ -351,9 +362,9 @@ gst_tensor_split_get_tensor_pad (GstTensorSplit * split, GstBuffer * inbuf,
     *created = TRUE;
   }
 
-  if (split->tensorpick != NULL) {
+  if (tensorpick != NULL) {
     GST_DEBUG_OBJECT (split, "TensorPick is set! : %dth tensor\n", nth);
-    if (g_list_length (split->tensorpick) == split->num_srcpads) {
+    if (g_list_length (tensorpick) == split->num_srcpads) {
       gst_element_no_more_pads (GST_ELEMENT_CAST (split));
     }
   }
@@ -392,13 +403,14 @@ done:
 /**
  * @brief Make splitted tensor
  * @param split TensorSplit object
+ * @param tensorseg private reference of the tensorseg property
  * @param buffer gstbuffer form src
  * @param nth orther of tensor
  * @return return GstMemory for splitted tensor
  */
 static GstMemory *
-gst_tensor_split_get_splitted (GstTensorSplit * split, GstBuffer * buffer,
-    gint nth)
+gst_tensor_split_get_splitted (GstTensorSplit * split, GArray * tensorseg,
+    GstBuffer * buffer, gint nth)
 {
   GstMemory *mem;
   tensor_dim *dim;
@@ -406,18 +418,18 @@ gst_tensor_split_get_splitted (GstTensorSplit * split, GstBuffer * buffer,
   gsize size, offset;
   GstMapInfo src_info, dest_info;
 
-  dim = g_array_index (split->tensorseg, tensor_dim *, nth);
+  dim = g_array_index (tensorseg, tensor_dim *, nth);
   size = gst_tensor_get_element_count (*dim) *
       gst_tensor_get_element_size (split->in_config.info.info[0].type);
 
   mem = gst_allocator_alloc (NULL, size, NULL);
   if (!gst_memory_map (mem, &dest_info, GST_MAP_WRITE)) {
-    ml_logf ("Cannot map memory for destination buffer.\n");
+    GST_ERROR_OBJECT (split, "Cannot map memory for destination buffer.");
     gst_memory_unref (mem);
     return NULL;
   }
   if (!gst_buffer_map (buffer, &src_info, GST_MAP_READ)) {
-    ml_logf ("Cannot map src-memory to gst buffer at tensor-split.\n");
+    GST_ERROR_OBJECT (split, "Cannot map src-memory to gst buffer.");
     gst_memory_unmap (mem, &dest_info);
     gst_memory_unref (mem);
     return NULL;
@@ -425,9 +437,19 @@ gst_tensor_split_get_splitted (GstTensorSplit * split, GstBuffer * buffer,
 
   offset = 0;
   for (i = 0; i < nth; i++) {
-    dim = g_array_index (split->tensorseg, tensor_dim *, i);
+    dim = g_array_index (tensorseg, tensor_dim *, i);
     offset += gst_tensor_get_element_count (*dim) *
         gst_tensor_get_element_size (split->in_config.info.info[0].type);
+  }
+
+  if (offset + size > src_info.size) {
+    GST_ERROR_OBJECT (split, "The tensorseg needs %" G_GSIZE_FORMAT
+        " bytes at offset %" G_GSIZE_FORMAT ", but the incoming buffer is %"
+        G_GSIZE_FORMAT " bytes.", size, offset, src_info.size);
+    gst_buffer_unmap (buffer, &src_info);
+    gst_memory_unmap (mem, &dest_info);
+    gst_memory_unref (mem);
+    return NULL;
   }
 
   nns_memcpy (dest_info.data, src_info.data + offset, size);
@@ -444,17 +466,26 @@ static GstFlowReturn
 gst_tensor_split_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
 {
   GstTensorSplit *split;
+  GArray *tensorseg;
+  GList *tensorpick;
   guint num_tensors, i;
   GstFlowReturn res = GST_FLOW_OK;
   UNUSED (pad);
 
   split = GST_TENSOR_SPLIT (parent);
 
+  GST_OBJECT_LOCK (split);
   num_tensors = split->num_tensors;
+  tensorseg = split->tensorseg ? g_array_ref (split->tensorseg) : NULL;
+  tensorpick = g_list_copy (split->tensorpick);
+  GST_OBJECT_UNLOCK (split);
+
   GST_DEBUG_OBJECT (split, " Number of Tensors: %d", num_tensors);
 
-  if (split->tensorseg == NULL) {
+  if (tensorseg == NULL) {
     GST_ERROR_OBJECT (split, "No rule to split incoming buffers.");
+    g_list_free (tensorpick);
+    gst_buffer_unref (buf);
     return GST_FLOW_ERROR;
   }
 
@@ -465,10 +496,10 @@ gst_tensor_split_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
     gboolean created;
     GstClockTime ts;
 
-    if (split->tensorpick != NULL) {
+    if (tensorpick != NULL) {
       gboolean found = FALSE;
       GList *list;
-      for (list = split->tensorpick; list != NULL; list = list->next) {
+      for (list = tensorpick; list != NULL; list = list->next) {
         if (i == GPOINTER_TO_UINT (list->data)) {
           found = TRUE;
           break;
@@ -478,10 +509,20 @@ gst_tensor_split_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
         continue;
     }
 
-    srcpad = gst_tensor_split_get_tensor_pad (split, buf, &created, i);
+    srcpad = gst_tensor_split_get_tensor_pad (split, tensorseg, tensorpick, buf,
+        &created, i);
+    if (srcpad == NULL) {
+      res = GST_FLOW_ERROR;
+      break;
+    }
 
     outbuf = gst_buffer_new ();
-    mem = gst_tensor_split_get_splitted (split, buf, i);
+    mem = gst_tensor_split_get_splitted (split, tensorseg, buf, i);
+    if (mem == NULL) {
+      gst_buffer_unref (outbuf);
+      res = GST_FLOW_ERROR;
+      break;
+    }
     gst_buffer_append_memory (outbuf, mem);
     ts = GST_BUFFER_TIMESTAMP (buf);
 
@@ -511,6 +552,8 @@ gst_tensor_split_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
       break;
   }
 
+  g_list_free (tensorpick);
+  g_array_unref (tensorseg);
   gst_buffer_unref (buf);
   return res;
 }
@@ -567,68 +610,73 @@ gst_tensor_split_set_property (GObject * object, guint prop_id,
 
   split = GST_TENSOR_SPLIT (object);
 
+  GST_OBJECT_LOCK (split);
   switch (prop_id) {
     case PROP_SILENT:
       split->silent = g_value_get_boolean (value);
       break;
     case PROP_TENSORPICK:
     {
-      gint i;
+      guint i, num;
       gint64 val;
       const gchar *param = g_value_get_string (value);
       gchar **strv = g_strsplit_set (param, ",.;/", -1);
-      gint num = g_strv_length (strv);
+      GList *tensorpick = NULL;
+
+      num = g_strv_length (strv);
       for (i = 0; i < num; i++) {
         val = g_ascii_strtoll (strv[i], NULL, 10);
-        split->tensorpick =
-            g_list_append (split->tensorpick, GINT_TO_POINTER (val));
+        tensorpick = g_list_append (tensorpick, GINT_TO_POINTER (val));
       }
       g_strfreev (strv);
+
+      g_list_free (split->tensorpick);
+      split->tensorpick = tensorpick;
       break;
     }
     case PROP_TENSORSEG:
     {
-      guint i;
+      guint i, num;
       const gchar *param = g_value_get_string (value);
       gchar **strv = g_strsplit_set (param, ",.;/", -1);
-      GArray *tensorseg = split->tensorseg;
+      GArray *tensorseg;
 
-      split->num_tensors = g_strv_length (strv);
-      if (NULL == tensorseg) {
-        split->tensorseg =
-            g_array_sized_new (FALSE, FALSE, sizeof (tensor_dim *),
-            split->num_tensors);
-        g_array_set_clear_func (split->tensorseg,
-            (GDestroyNotify) _clear_tensorseg);
+      num = g_strv_length (strv);
+      tensorseg = g_array_sized_new (FALSE, FALSE, sizeof (tensor_dim *), num);
+      g_array_set_clear_func (tensorseg, (GDestroyNotify) _clear_tensorseg);
 
-        for (i = 0; i < split->num_tensors; i++) {
-          tensor_dim *d = g_new0 (tensor_dim, 1);
-          g_array_append_val (split->tensorseg, d);
+      for (i = 0; i < num; i++) {
+        tensor_dim *d = g_new0 (tensor_dim, 1);
+        gchar **p = g_strsplit_set (strv[i], ":", -1);
+        guint k, rank = g_strv_length (p);
+
+        if (rank > NNS_TENSOR_RANK_LIMIT) {
+          GST_WARNING_OBJECT (split,
+              "The rank of '%s' exceeds the limit %d, the rest is ignored.",
+              strv[i], NNS_TENSOR_RANK_LIMIT);
+          rank = NNS_TENSOR_RANK_LIMIT;
         }
-        tensorseg = split->tensorseg;
-      }
-      for (i = 0; i < split->num_tensors; i++) {
-        gchar **p;
-        gint num, k;
-        tensor_dim *d;
-        p = g_strsplit_set (strv[i], ":", -1);
-        num = g_strv_length (p);
 
-        d = g_array_index (tensorseg, tensor_dim *, i);
-
-        for (k = 0; k < num; k++) {
+        for (k = 0; k < rank; k++) {
           (*d)[k] = g_ascii_strtod (p[k], NULL);
         }
 
         g_strfreev (p);
+        g_array_append_val (tensorseg, d);
       }
       g_strfreev (strv);
+
+      if (split->tensorseg)
+        g_array_unref (split->tensorseg);
+      split->tensorseg = tensorseg;
+      split->num_tensors = num;
       break;
     }
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
   }
+  GST_OBJECT_UNLOCK (split);
 }
 
 /**
@@ -642,6 +690,7 @@ gst_tensor_split_get_property (GObject * object, guint prop_id,
 
   split = GST_TENSOR_SPLIT (object);
 
+  GST_OBJECT_LOCK (split);
   switch (prop_id) {
     case PROP_SILENT:
       g_value_set_boolean (value, split->silent);
@@ -710,4 +759,5 @@ gst_tensor_split_get_property (GObject * object, guint prop_id,
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
   }
+  GST_OBJECT_UNLOCK (split);
 }

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -9357,6 +9357,210 @@ TEST (testTensorSparse, decInvalidProperty_n)
 }
 
 /**
+ * @brief Rendezvous used to set a property from the test thread exactly while
+ *        the streaming thread is adding a source pad.
+ */
+typedef struct {
+  GMutex lock;
+  GCond cond;
+  gboolean pad_added;
+  gboolean prop_set;
+} padRaceSync;
+
+/**
+ * @brief Handler of "pad-added", which runs on the streaming thread.
+ */
+static void
+_pad_race_pad_added (GstElement *element, GstPad *pad, gpointer user_data)
+{
+  padRaceSync *sync = (padRaceSync *) user_data;
+  gint64 until = g_get_monotonic_time () + TEST_TIMEOUT_LIMIT;
+
+  UNUSED (element);
+  UNUSED (pad);
+
+  g_mutex_lock (&sync->lock);
+  sync->pad_added = TRUE;
+  g_cond_broadcast (&sync->cond);
+  while (!sync->prop_set) {
+    if (!g_cond_wait_until (&sync->cond, &sync->lock, until))
+      break;
+  }
+  g_mutex_unlock (&sync->lock);
+}
+
+/**
+ * @brief Set the given property while the streaming thread is blocked in
+ *        _pad_race_pad_added(), then release the streaming thread.
+ * @return TRUE if the element reported a new pad before the time-out
+ */
+static gboolean
+_pad_race_set_property (padRaceSync *sync, GstElement *element,
+    const gchar *name, const gchar *value)
+{
+  gint64 until = g_get_monotonic_time () + TEST_TIMEOUT_LIMIT;
+  gboolean pad_added;
+
+  g_mutex_lock (&sync->lock);
+  while (!sync->pad_added) {
+    if (!g_cond_wait_until (&sync->cond, &sync->lock, until))
+      break;
+  }
+  pad_added = sync->pad_added;
+  g_mutex_unlock (&sync->lock);
+
+  if (pad_added)
+    g_object_set (G_OBJECT (element), name, value, NULL);
+
+  g_mutex_lock (&sync->lock);
+  sync->prop_set = TRUE;
+  g_cond_broadcast (&sync->cond);
+  g_mutex_unlock (&sync->lock);
+
+  return pad_added;
+}
+
+/**
+ * @brief Initialize the rendezvous.
+ */
+static void
+_pad_race_sync_init (padRaceSync *sync)
+{
+  g_mutex_init (&sync->lock);
+  g_cond_init (&sync->cond);
+  sync->pad_added = FALSE;
+  sync->prop_set = FALSE;
+}
+
+/**
+ * @brief Release the rendezvous.
+ */
+static void
+_pad_race_sync_clear (padRaceSync *sync)
+{
+  g_mutex_clear (&sync->lock);
+  g_cond_clear (&sync->cond);
+}
+
+/**
+ * @brief Set tensorpick while tensor_demux is creating its first source pad.
+ * @details The application thread may touch a property at any time, and the
+ *          first buffer keeps the streaming thread inside the pad creation for
+ *          a long while (caps negotiation and the delayed link downstream).
+ */
+TEST (testTensorDemux, setTensorpickWhileAddingPad)
+{
+  gchar *pipeline_desc;
+  GstElement *pipeline, *demux, *sink;
+  padRaceSync sync;
+  guint data_received = 0;
+  gchar *tensorpick = NULL;
+
+  _pad_race_sync_init (&sync);
+
+  pipeline_desc = g_strdup (
+      "videotestsrc num-buffers=3 ! "
+      "video/x-raw,format=RGB,width=16,height=16,framerate=30/1 ! "
+      "tensor_converter ! tensor_demux name=demux ! tensor_sink name=sinkx");
+  pipeline = gst_parse_launch (pipeline_desc, NULL);
+  g_free (pipeline_desc);
+  ASSERT_TRUE (pipeline != NULL);
+
+  demux = gst_bin_get_by_name (GST_BIN (pipeline), "demux");
+  sink = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_TRUE (demux != NULL);
+  ASSERT_TRUE (sink != NULL);
+
+  g_signal_connect (demux, "pad-added", G_CALLBACK (_pad_race_pad_added), &sync);
+  g_signal_connect (sink, "new-data", G_CALLBACK (count_output), &data_received);
+
+  gst_element_set_state (pipeline, GST_STATE_PLAYING);
+  EXPECT_TRUE (_pad_race_set_property (&sync, demux, "tensorpick", "0"));
+  EXPECT_TRUE (wait_pipeline_process_buffers (&data_received, 1, TEST_TIMEOUT_LIMIT_MS));
+
+  g_object_get (demux, "tensorpick", &tensorpick, NULL);
+  EXPECT_STREQ (tensorpick, "0");
+  g_free (tensorpick);
+
+  gst_element_set_state (pipeline, GST_STATE_NULL);
+  gst_object_unref (sink);
+  gst_object_unref (demux);
+  gst_object_unref (pipeline);
+  _pad_race_sync_clear (&sync);
+}
+
+/**
+ * @brief Setting tensorpick again replaces the previous selection.
+ */
+TEST (testTensorDemux, setTensorpickTwice)
+{
+  GstElement *demux = gst_element_factory_make ("tensor_demux", NULL);
+  gchar *tensorpick = NULL;
+
+  ASSERT_TRUE (demux != NULL);
+  gst_object_ref_sink (demux);
+
+  g_object_set (demux, "tensorpick", "0,1", NULL);
+  g_object_set (demux, "tensorpick", "2", NULL);
+
+  g_object_get (demux, "tensorpick", &tensorpick, NULL);
+  EXPECT_STREQ (tensorpick, "2");
+  g_free (tensorpick);
+
+  gst_object_unref (demux);
+}
+
+/**
+ * @brief Disposing twice does not free the tensorpick list twice.
+ * @details GObject allows dispose to run more than once, so it has to leave
+ *          the member it released in a state the next run can survive.
+ */
+TEST (testTensorDemux, disposeTwice)
+{
+  GstElement *demux = gst_element_factory_make ("tensor_demux", NULL);
+
+  ASSERT_TRUE (demux != NULL);
+  gst_object_ref_sink (demux);
+
+  g_object_set (demux, "tensorpick", "0,1", NULL);
+  g_object_run_dispose (G_OBJECT (demux));
+  g_object_run_dispose (G_OBJECT (demux));
+
+  gst_object_unref (demux);
+}
+
+/**
+ * @brief A tensorpick naming a tensor the buffer does not have is refused.
+ * @details This is the only way into the chain function's error exit, so it is
+ *          also what puts a buffer on the path that used to leak the split
+ *          pick string on the way out.
+ */
+TEST (testTensorDemux, pushOutOfRangeTensorpick_n)
+{
+  GstHarness *h = gst_harness_new_with_padnames ("tensor_demux", "sink", NULL);
+  GstTensorsConfig config;
+  GstBuffer *buf;
+
+  ASSERT_TRUE (h != NULL);
+
+  g_object_set (h->element, "tensorpick", "5", NULL);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("3:4:4", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  buf = gst_harness_create_buffer (h, gst_tensors_info_get_size (&config.info, 0));
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_ERROR);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+}
+
+/**
  * @brief Main function for unit test.
  */
 int

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -9365,6 +9365,8 @@ typedef struct {
   GCond cond;
   gboolean pad_added;
   gboolean prop_set;
+  guint pads_added;
+  guint pads_at_no_more;
 } padRaceSync;
 
 /**
@@ -9381,6 +9383,7 @@ _pad_race_pad_added (GstElement *element, GstPad *pad, gpointer user_data)
 
   g_mutex_lock (&sync->lock);
   sync->pad_added = TRUE;
+  sync->pads_added++;
   g_cond_broadcast (&sync->cond);
   while (!sync->prop_set) {
     if (!g_cond_wait_until (&sync->cond, &sync->lock, until))
@@ -9421,6 +9424,43 @@ _pad_race_set_property (padRaceSync *sync, GstElement *element,
 }
 
 /**
+ * @brief Handler of "no-more-pads", which runs on the streaming thread.
+ */
+static void
+_pad_race_no_more_pads (GstElement *element, gpointer user_data)
+{
+  padRaceSync *sync = (padRaceSync *) user_data;
+
+  UNUSED (element);
+
+  g_mutex_lock (&sync->lock);
+  sync->pads_at_no_more = sync->pads_added;
+  g_cond_broadcast (&sync->cond);
+  g_mutex_unlock (&sync->lock);
+}
+
+/**
+ * @brief Wait until the element reports that it has no more pads.
+ * @return the number of pads it had added by then, 0 if it never reported
+ */
+static guint
+_pad_race_wait_no_more_pads (padRaceSync *sync)
+{
+  gint64 until = g_get_monotonic_time () + TEST_TIMEOUT_LIMIT;
+  guint pads;
+
+  g_mutex_lock (&sync->lock);
+  while (sync->pads_at_no_more == 0) {
+    if (!g_cond_wait_until (&sync->cond, &sync->lock, until))
+      break;
+  }
+  pads = sync->pads_at_no_more;
+  g_mutex_unlock (&sync->lock);
+
+  return pads;
+}
+
+/**
  * @brief Initialize the rendezvous.
  */
 static void
@@ -9430,6 +9470,8 @@ _pad_race_sync_init (padRaceSync *sync)
   g_cond_init (&sync->cond);
   sync->pad_added = FALSE;
   sync->prop_set = FALSE;
+  sync->pads_added = 0;
+  sync->pads_at_no_more = 0;
 }
 
 /**
@@ -9511,6 +9553,246 @@ TEST (testTensorDemux, setTensorpickTwice)
 }
 
 /**
+ * @brief Set tensorseg while tensor_split is creating its first source pad.
+ */
+TEST (testTensorSplit, setTensorsegWhileAddingPad)
+{
+  gchar *pipeline_desc;
+  GstElement *pipeline, *split, *sink;
+  padRaceSync sync;
+  guint data_received = 0;
+
+  _pad_race_sync_init (&sync);
+
+  pipeline_desc = g_strdup ("videotestsrc num-buffers=5 ! "
+                            "video/x-raw,format=RGB,width=4,height=4,framerate=30/1 ! "
+                            "tensor_converter ! tensor_split name=split tensorseg=3:4:4 ! "
+                            "tensor_sink name=sinkx");
+  pipeline = gst_parse_launch (pipeline_desc, NULL);
+  g_free (pipeline_desc);
+  ASSERT_TRUE (pipeline != NULL);
+
+  split = gst_bin_get_by_name (GST_BIN (pipeline), "split");
+  sink = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_TRUE (split != NULL);
+  ASSERT_TRUE (sink != NULL);
+
+  g_signal_connect (split, "pad-added", G_CALLBACK (_pad_race_pad_added), &sync);
+  g_signal_connect (sink, "new-data", G_CALLBACK (count_output), &data_received);
+
+  gst_element_set_state (pipeline, GST_STATE_PLAYING);
+  EXPECT_TRUE (_pad_race_set_property (&sync, split, "tensorseg", "1:4:4,2:4:4"));
+  EXPECT_TRUE (wait_pipeline_process_buffers (&data_received, 1, TEST_TIMEOUT_LIMIT_MS));
+
+  gst_element_set_state (pipeline, GST_STATE_NULL);
+  gst_object_unref (sink);
+  gst_object_unref (split);
+  gst_object_unref (pipeline);
+  _pad_race_sync_clear (&sync);
+}
+
+/**
+ * @brief Setting tensorseg again replaces the previous rule.
+ */
+TEST (testTensorSplit, setTensorsegTwice)
+{
+  GstElement *split = gst_element_factory_make ("tensor_split", NULL);
+  gchar *tensorseg = NULL;
+  gchar **strv;
+
+  ASSERT_TRUE (split != NULL);
+  gst_object_ref_sink (split);
+
+  g_object_set (split, "tensorseg", "1:4:4,1:4:4", NULL);
+  g_object_set (split, "tensorseg", "1:4:4,1:4:4,1:4:4", NULL);
+
+  g_object_get (split, "tensorseg", &tensorseg, NULL);
+  strv = g_strsplit (tensorseg, ",", -1);
+  EXPECT_EQ (g_strv_length (strv), 3U);
+  g_strfreev (strv);
+  g_free (tensorseg);
+
+  g_object_set (split, "tensorseg", "2:4:4", NULL);
+  g_object_get (split, "tensorseg", &tensorseg, NULL);
+  strv = g_strsplit (tensorseg, ",", -1);
+  EXPECT_EQ (g_strv_length (strv), 1U);
+  g_strfreev (strv);
+  g_free (tensorseg);
+
+  gst_object_unref (split);
+}
+
+/**
+ * @brief A tensorseg rule longer than the tensor rank limit is truncated.
+ */
+TEST (testTensorSplit, setTensorsegOverRank_n)
+{
+  GstElement *split = gst_element_factory_make ("tensor_split", NULL);
+  gchar *tensorseg = NULL;
+  guint i;
+  GString *param = g_string_new (NULL);
+  GString *expected = g_string_new (NULL);
+
+  ASSERT_TRUE (split != NULL);
+  gst_object_ref_sink (split);
+
+  for (i = 0; i < NNS_TENSOR_RANK_LIMIT + 4; i++) {
+    if (i > 0)
+      g_string_append_c (param, ':');
+    g_string_append_printf (param, "%u", i + 1);
+  }
+  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
+    if (i > 0)
+      g_string_append_c (expected, ':');
+    g_string_append_printf (expected, "%u", i + 1);
+  }
+
+  g_object_set (split, "tensorseg", param->str, NULL);
+
+  g_object_get (split, "tensorseg", &tensorseg, NULL);
+  EXPECT_STREQ (tensorseg, expected->str);
+  g_free (tensorseg);
+
+  g_string_free (param, TRUE);
+  g_string_free (expected, TRUE);
+  gst_object_unref (split);
+}
+
+/**
+ * @brief Setting tensorpick again replaces the previous selection.
+ */
+TEST (testTensorSplit, setTensorpickTwice)
+{
+  GstElement *split = gst_element_factory_make ("tensor_split", NULL);
+  gchar *tensorpick = NULL;
+
+  ASSERT_TRUE (split != NULL);
+  gst_object_ref_sink (split);
+
+  g_object_set (split, "tensorpick", "0,1", NULL);
+  g_object_set (split, "tensorpick", "2", NULL);
+
+  g_object_get (split, "tensorpick", &tensorpick, NULL);
+  EXPECT_STREQ (tensorpick, "2");
+  g_free (tensorpick);
+
+  gst_object_unref (split);
+}
+
+/**
+ * @brief Set tensorpick while tensor_split is creating its first source pad.
+ * @details The pad creation decides whether to report no-more-pads by comparing
+ *          the pick count with the pads created so far. Reading the property
+ *          instead of the snapshot the buffer is being split by ends that
+ *          report after src_0, and src_1 is then added behind it.
+ */
+TEST (testTensorSplit, setTensorpickWhileAddingPad)
+{
+  gchar *pipeline_desc;
+  GstElement *pipeline, *split, *sink;
+  padRaceSync sync;
+  guint data_received = 0;
+  gchar *tensorpick = NULL;
+
+  _pad_race_sync_init (&sync);
+
+  pipeline_desc = g_strdup ("videotestsrc num-buffers=5 ! "
+                            "video/x-raw,format=RGB,width=4,height=4,framerate=30/1 ! "
+                            "tensor_converter ! tensor_split name=split tensorseg=1:4:4,2:4:4 "
+                            "tensorpick=0,1 ! tensor_sink name=sinkx");
+  pipeline = gst_parse_launch (pipeline_desc, NULL);
+  g_free (pipeline_desc);
+  ASSERT_TRUE (pipeline != NULL);
+
+  split = gst_bin_get_by_name (GST_BIN (pipeline), "split");
+  sink = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_TRUE (split != NULL);
+  ASSERT_TRUE (sink != NULL);
+
+  g_signal_connect (split, "pad-added", G_CALLBACK (_pad_race_pad_added), &sync);
+  g_signal_connect (split, "no-more-pads", G_CALLBACK (_pad_race_no_more_pads), &sync);
+  g_signal_connect (sink, "new-data", G_CALLBACK (count_output), &data_received);
+
+  gst_element_set_state (pipeline, GST_STATE_PLAYING);
+  EXPECT_TRUE (_pad_race_set_property (&sync, split, "tensorpick", "0"));
+  EXPECT_TRUE (wait_pipeline_process_buffers (&data_received, 1, TEST_TIMEOUT_LIMIT_MS));
+  EXPECT_EQ (_pad_race_wait_no_more_pads (&sync), 2U);
+
+  g_object_get (split, "tensorpick", &tensorpick, NULL);
+  EXPECT_STREQ (tensorpick, "0");
+  g_free (tensorpick);
+
+  gst_element_set_state (pipeline, GST_STATE_NULL);
+  gst_object_unref (sink);
+  gst_object_unref (split);
+  gst_object_unref (pipeline);
+  _pad_race_sync_clear (&sync);
+}
+
+/**
+ * @brief A buffer arriving before tensorseg is set is rejected and released.
+ */
+TEST (testTensorSplit, pushWithoutTensorseg_n)
+{
+  GstHarness *h = gst_harness_new_with_padnames ("tensor_split", "sink", NULL);
+  GstTensorsConfig config;
+  GstBuffer *buf;
+
+  ASSERT_TRUE (h != NULL);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("3:4:4", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  buf = gst_harness_create_buffer (h, gst_tensors_info_get_size (&config.info, 0));
+  gst_buffer_ref (buf);
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_ERROR);
+  EXPECT_EQ (GST_MINI_OBJECT_REFCOUNT_VALUE (buf), 1);
+  gst_buffer_unref (buf);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief A tensorseg asking for more bytes than the incoming tensor is refused.
+ * @details Nothing bounds the copy against the input, and with HAVE_ORC the
+ *          copy runs through orc_memcpy(), where neither a sanitizer nor
+ *          valgrind sees the over-read - so the element has to say no itself.
+ */
+TEST (testTensorSplit, pushOversizedTensorseg_n)
+{
+  GstHarness *h = gst_harness_new_with_padnames ("tensor_split", "sink", NULL);
+  GstTensorsConfig config;
+  GstBuffer *buf;
+
+  ASSERT_TRUE (h != NULL);
+
+  g_object_set (h->element, "tensorseg", "6:4:4", NULL);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("3:4:4", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  buf = gst_harness_create_buffer (h, gst_tensors_info_get_size (&config.info, 0));
+  gst_buffer_ref (buf);
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_ERROR);
+  EXPECT_EQ (GST_MINI_OBJECT_REFCOUNT_VALUE (buf), 1);
+  gst_buffer_unref (buf);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+}
+
+/**
  * @brief Disposing twice does not free the tensorpick list twice.
  * @details GObject allows dispose to run more than once, so it has to leave
  *          the member it released in a state the next run can survive.
@@ -9558,6 +9840,80 @@ TEST (testTensorDemux, pushOutOfRangeTensorpick_n)
 
   gst_tensors_config_free (&config);
   gst_harness_teardown (h);
+}
+
+/**
+ * @brief A source pad with no segment rule left for it is refused.
+ * @details The rule array is replaced on every tensorseg set, so it can shrink
+ *          under source pads that already exist. The pad created after that
+ *          takes the next ordinal, which is then past the end of the array.
+ */
+TEST (testTensorSplit, addPadBeyondTensorseg_n)
+{
+  GstHarness *h = gst_harness_new_with_padnames ("tensor_split", "sink", NULL);
+  GstTensorsConfig config;
+  gsize data_size;
+
+  ASSERT_TRUE (h != NULL);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("2:8:8", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+
+  /* picking the second of two rules puts src_0 at ordinal 0 of two */
+  g_object_set (h->element, "tensorseg", "1:8:8,1:8:8", "tensorpick", "1", NULL);
+  EXPECT_NE (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_ERROR);
+
+  /* one rule now, but src_0 already took ordinal 0 */
+  g_object_set (h->element, "tensorseg", "2:8:8", "tensorpick", "0", NULL);
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_ERROR);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+}
+
+/* set by _record_critical() when a critical is logged */
+static gboolean tensor_split_logged_critical;
+
+/**
+ * @brief Log handler that records whether a critical was issued.
+ */
+static void
+_record_critical (const gchar *domain, GLogLevelFlags level,
+    const gchar *message, gpointer user_data)
+{
+  UNUSED (domain);
+  UNUSED (message);
+  UNUSED (user_data);
+
+  if (level & G_LOG_LEVEL_CRITICAL)
+    tensor_split_logged_critical = TRUE;
+}
+
+/**
+ * @brief Releasing a tensor_split that never got a tensorseg says nothing.
+ * @details finalize releases the rule array, which is unset here; releasing an
+ *          unset one the wrong way logs a critical rather than doing nothing.
+ */
+TEST (testTensorSplit, finalizeWithoutTensorseg)
+{
+  GstElement *split = gst_element_factory_make ("tensor_split", NULL);
+  GLogFunc old_handler;
+
+  ASSERT_TRUE (split != NULL);
+  gst_object_ref_sink (split);
+
+  tensor_split_logged_critical = FALSE;
+  old_handler = g_log_set_default_handler (_record_critical, NULL);
+  gst_object_unref (split);
+  g_log_set_default_handler (old_handler, NULL);
+
+  EXPECT_FALSE (tensor_split_logged_critical);
 }
 
 /**


### PR DESCRIPTION
## Why

Issue #4769 reports an occasional crash while running the C# TCT for the Tizen ML API,
always at `PipelineNodeInfoTests.SetValue_string_NO_Exception`, on a pipeline of

```
videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! videorate max-rate=1
  ! tensor_converter ! tensor_mux ! tensor_demux name=demux ! tensor_sink
```

The crash is a NULL dereference in `gst_tensor_demux_chain()` on a streaming thread
(the reports show a tid different from the app thread, right after the NULL→READY
transition). `TizenFX`'s `Pipeline.NodeInfo.SetValue(string, string)` reaches
`ml_pipeline_element_set_property_string()`, which is a plain `g_object_set()` from the
application thread - exactly what GStreamer's threading contract says must be safe. The
element was not holding up its end.

`gst_tensor_demux_chain()` sampled `tensorpick` once before the output loop, to derive
`num_srcs` and the list cursor, and then re-read the same member *inside* the loop. On
the first buffer the gap between the two reads spans
`gst_tensor_demux_get_tensor_pad()`, which creates `src_0`, negotiates caps and
completes gst_parse's delayed link to `tensor_sink` - tens of milliseconds. A property
set landing in that window leaves the second read non-NULL while the cursor is still
NULL, and `list->data` segfaults. A set at a slightly different moment frees the strings
the cursor points at instead, turning the same window into a use-after-free.

`tensor_split` has the same shape of hazard, plus two defects that do not need any
concurrency: setting `tensorseg` a second time updated `num_tensors` but reused the
existing `GArray`, so a longer rule indexed past its end; and a rule with more than
`NNS_TENSOR_RANK_LIMIT` dimensions overflowed the `tensor_dim` it was written into.
`tensorpick` also appended to, rather than replaced, the previous selection.

## What

Two commits, one element each.

- **tensor_demux** - take a private copy of `tensorpick` under `GST_OBJECT_LOCK` at the
  top of the chain function and pass it down, so one buffer is served from one
  consistent snapshot; guard the property handlers with the same lock; fix the off-by-one
  bound check that reached `g_list_nth_data()` through a `g_assert()`; clear the member
  in `dispose()`, which GObject may run more than once; free the split pick string on the
  chain function's error exit.
- **tensor_split** - build the segment array anew on every set and swap it in under the
  lock, and let the chain function hold its own reference to it plus a copy of the pick
  list, both passed down to the pad creation; clamp the per-rule rank and say so;
  replace instead of append for `tensorpick`; refuse a `tensorseg` that asks for more
  bytes than the incoming tensor; refuse a source pad whose ordinal is past the end of
  the rule array, which replacing rather than reusing the array newly makes possible;
  unref the input buffer on the "no rule to split" exit, which was the one path that
  leaked it.

`gst_tensor_split_get_splitted()` reported its failures with `ml_logf()`, which is
`g_error()` and aborts, so its three `return NULL` paths were unreachable and the chain
function never had to handle NULL. They report with `GST_ERROR_OBJECT()` now and the
chain function ends the buffer instead of appending nothing. That also matters for the
new bounds check: with `HAVE_ORC` the copy runs through `orc_memcpy()`, where neither a
sanitizer nor valgrind sees the over-read, so refusing it is the only defence.

The pad-caps-versus-data segment mismatch found in the same function is filed separately
as #4927 - it needs a semantics decision and changes the caps existing `tensorpick`
pipelines see, so it is not folded in here.

No header, API or caps change; the element structs are untouched.

The per-buffer copy is not a new cost class - the demux chain function already splits
the pick strings once per output pad per buffer, and the split chain function only takes
a `GArray` reference plus a shallow copy of a list of integers.

## Tests

Thirteen cases added to `tests/nnstreamer_plugins/unittest_plugins.cc`. Eleven of them
fail under plain `meson test` - no valgrind or sanitizer needed - without the change they
cover, and pass with it:

| test | on `main` |
| --- | --- |
| `testTensorDemux.setTensorpickWhileAddingPad` | SIGSEGV |
| `testTensorDemux.disposeTwice` | abort (double free) |
| `testTensorSplit.setTensorsegWhileAddingPad` | SIGTRAP (glib abort) |
| `testTensorSplit.setTensorsegTwice` | SIGSEGV |
| `testTensorSplit.setTensorsegOverRank_n` | SIGABRT (heap corruption) |
| `testTensorSplit.setTensorpickTwice` | assertion failure |
| `testTensorSplit.setTensorpickWhileAddingPad` | assertion failure - no-more-pads reported after one pad, and src_1 is then added behind it |
| `testTensorSplit.pushWithoutTensorseg_n` | assertion failure - the buffer keeps a refcount of 2 |
| `testTensorSplit.pushOversizedTensorseg_n` | assertion failure - the over-read succeeds and the flow is not an error |
| `testTensorSplit.addPadBeyondTensorseg_n` | core dump - the pad ordinal reads past the rule array |
| `testTensorSplit.finalizeWithoutTensorseg` | assertion failure - releasing an unset rule array logs a critical |
| `testTensorDemux.setTensorpickTwice` | passes - locks the round-trip contract |
| `testTensorDemux.pushOutOfRangeTensorpick_n` | passes - puts a buffer on the chain function's error exit, the one that leaked the pick string |

The two `*WhileAddingPad` cases reproduce the reported window deterministically: a
`pad-added` handler parks the streaming thread inside the pad creation while the test
thread sets the property, which is the same interleaving the TCT hits by coincidence.

Locally: `unittest_plugins` 162/162; `meson test` 21/22 (the one failure,
`unittest_filter_python3`, is a NumPy 1.x/2.x ABI mismatch in the local environment and
fails identically on unmodified `main`); SSAT `nnstreamer_demux`, `nnstreamer_split`,
`nnstreamer_mux`, `nnstreamer_merge` all pass.

Fixes #4769

🤖 Generated with [Claude Code](https://claude.com/claude-code)




