### PR TITLE
[Element/Transform] Fix the memory handling of more tensors than the memory limit

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -1902,7 +1902,11 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
         gst_memory_unref (old);
       }
 
-      gst_tensor_buffer_append_memory (outbuf, mem, out_info);
+      if (!gst_tensor_buffer_append_memory (outbuf, mem, out_info)) {
+        ml_loge ("Failed to append memory to output buffer.\n");
+        res = GST_FLOW_ERROR;
+        goto done;
+      }
       continue;
     }
 
@@ -1910,6 +1914,8 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
     in_mem[i] = gst_tensor_buffer_get_nth_memory (inbuf, i);
     if (!gst_memory_map (in_mem[i], &in_map[i], GST_MAP_READ)) {
       ml_loge ("Cannot map input buffer to gst-buf at tensor-transform.\n");
+      gst_memory_unref (in_mem[i]);
+      in_mem[i] = NULL;
       res = GST_FLOW_ERROR;
       goto done;
     }
@@ -1942,10 +1948,10 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
     }
 
     out_mem[i] = gst_allocator_alloc (NULL, buf_size, NULL);
-    gst_tensor_buffer_append_memory (outbuf, out_mem[i], out_info);
-
     if (!gst_memory_map (out_mem[i], &out_map[i], GST_MAP_WRITE)) {
       ml_loge ("Cannot map output buffer to gst-buf at tensor-transform.\n");
+      gst_memory_unref (out_mem[i]);
+      out_mem[i] = NULL;
       res = GST_FLOW_ERROR;
       goto done;
     }
@@ -1990,6 +1996,23 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
         res = GST_FLOW_NOT_SUPPORTED;
         goto done;
     }
+
+    /* append the memory after filling it, appending may copy and release it */
+    gst_memory_unmap (out_mem[i], &out_map[i]);
+    if (res != GST_FLOW_OK) {
+      gst_memory_unref (out_mem[i]);
+      out_mem[i] = NULL;
+      goto done;
+    }
+
+    if (!gst_tensor_buffer_append_memory (outbuf, out_mem[i], out_info)) {
+      ml_loge ("Failed to append memory to output buffer.\n");
+      out_mem[i] = NULL;
+      res = GST_FLOW_ERROR;
+      goto done;
+    }
+
+    out_mem[i] = NULL;
   }
 
 done:
@@ -1998,8 +2021,10 @@ done:
       gst_memory_unmap (in_mem[i], &in_map[i]);
       gst_memory_unref (in_mem[i]);
     }
-    if (out_mem[i])
+    if (out_mem[i]) {
       gst_memory_unmap (out_mem[i], &out_map[i]);
+      gst_memory_unref (out_mem[i]);
+    }
   }
 
   return res;

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -1851,7 +1851,7 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
 {
   GstTensorTransform *filter;
   GstTensorInfo *in_info, *out_info;
-  GstFlowReturn res = GST_FLOW_ERROR;
+  GstFlowReturn res = GST_FLOW_OK;
   GstMemory *in_mem[NNS_TENSOR_SIZE_LIMIT] = { 0, };
   GstMemory *out_mem[NNS_TENSOR_SIZE_LIMIT] = { 0, };
   GstMapInfo in_map[NNS_TENSOR_SIZE_LIMIT];

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -1210,6 +1210,9 @@ gst_tensor_transform_finalize (GObject * object)
     filter->apply = NULL;
   }
 
+  gst_tensors_config_free (&filter->in_config);
+  gst_tensors_config_free (&filter->out_config);
+
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 
@@ -2346,6 +2349,10 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
 
   filter = GST_TENSOR_TRANSFORM_CAST (trans);
 
+  gst_tensors_config_init (&in_config);
+  gst_tensors_config_init (&out_config);
+  gst_tensors_config_init (&config);
+
   silent_debug (filter, "Calling SetCaps\n");
   silent_debug_caps (filter, incaps, "incaps");
   silent_debug_caps (filter, outcaps, "outcaps");
@@ -2374,7 +2381,6 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
   out_flexible = gst_tensors_config_is_flexible (&out_config);
 
   /* compare type and dimension */
-  gst_tensors_config_init (&config);
   config.info.format = out_config.info.format;
 
   config.rate_n = in_config.rate_n;
@@ -2401,8 +2407,11 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
     GST_INFO_OBJECT (filter, "Output tensor is flexible.");
 
     /* set output configuration if input is static */
-    if (!in_flexible)
+    if (!in_flexible) {
+      gst_tensors_config_free (&out_config);
       out_config = config;
+      gst_tensors_config_init (&config);
+    }
   } else if (!gst_tensors_config_is_equal (&out_config, &config)) {
     gchar *cmp;
 
@@ -2418,13 +2427,20 @@ gst_tensor_transform_set_caps (GstBaseTransform * trans,
   }
 
   /* set in/out tensor info */
+  gst_tensors_config_free (&filter->in_config);
+  gst_tensors_config_free (&filter->out_config);
   filter->in_config = in_config;
   filter->out_config = out_config;
   allowed = TRUE;
 
 error:
-  if (!allowed)
+  gst_tensors_config_free (&config);
+
+  if (!allowed) {
+    gst_tensors_config_free (&in_config);
+    gst_tensors_config_free (&out_config);
     GST_ERROR_OBJECT (filter, "Set Caps Failed!\n");
+  }
 
   return allowed;
 }

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -1870,7 +1870,12 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
     return GST_FLOW_ERROR;
   }
 
-  inbuf = gst_tensor_buffer_from_config (inbuf, &filter->in_config);
+  inbuf = gst_tensor_buffer_from_config (gst_buffer_ref (inbuf),
+      &filter->in_config);
+  if (!inbuf) {
+    ml_loge ("Cannot configure input buffer at tensor-transform.\n");
+    return GST_FLOW_ERROR;
+  }
 
   in_flexible =
       gst_tensor_pad_caps_is_flexible (GST_BASE_TRANSFORM_SINK_PAD (trans));
@@ -1880,10 +1885,18 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
   num_mems = gst_tensor_buffer_get_count (inbuf);
   if (in_flexible) {
     num_tensors = num_mems;
-    g_return_val_if_fail (out_flexible, GST_FLOW_ERROR);
+    if (!out_flexible) {
+      ml_loge ("Invalid caps, the output should be flexible tensor.\n");
+      res = GST_FLOW_ERROR;
+      goto done;
+    }
   } else {
     num_tensors = filter->in_config.info.num_tensors;
-    g_return_val_if_fail (num_mems == num_tensors, GST_FLOW_ERROR);
+    if (num_mems != num_tensors) {
+      ml_loge ("Invalid buffer, the number of tensors is not matched.\n");
+      res = GST_FLOW_ERROR;
+      goto done;
+    }
   }
 
   for (i = 0; i < num_tensors; i++) {
@@ -2027,6 +2040,7 @@ done:
     }
   }
 
+  gst_buffer_unref (inbuf);
   return res;
 }
 

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -1063,6 +1063,25 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
 }
 
 /**
+ * @brief Check whether the transform is applied to the given tensor.
+ * @param filter "this" pointer
+ * @param idx index of the tensor
+ * @return TRUE if the operator should be applied to the tensor
+ */
+static gboolean
+gst_tensor_transform_is_applied (GstTensorTransform * filter, guint idx)
+{
+  gboolean applied;
+
+  GST_OBJECT_LOCK (filter);
+  applied = (filter->apply == NULL
+      || g_list_find (filter->apply, GINT_TO_POINTER (idx)) != NULL);
+  GST_OBJECT_UNLOCK (filter);
+
+  return applied;
+}
+
+/**
  * @brief Set property (gst element vmethod)
  */
 static void
@@ -1111,16 +1130,24 @@ gst_tensor_transform_set_property (GObject * object, guint prop_id,
       gchar **strv = g_strsplit_set (param, ",", -1);
       guint i, num = g_strv_length (strv);
       gchar *endptr = NULL;
+      GList *apply = NULL;
 
       for (i = 0; i < num; i++) {
         errno = 0;
         val = g_ascii_strtoll (strv[i], &endptr, 10);
         if (errno == ERANGE || errno == EINVAL || (endptr == strv[i])) {
           ml_loge ("Cannot convert string %s to a gint64 value", strv[i]);
+          continue;
         }
-        filter->apply = g_list_append (filter->apply, GINT_TO_POINTER (val));
+        apply = g_list_append (apply, GINT_TO_POINTER (val));
       }
       g_strfreev (strv);
+
+      /* the list is walked by the streaming thread, replace it under the lock */
+      GST_OBJECT_LOCK (filter);
+      g_list_free (filter->apply);
+      filter->apply = apply;
+      GST_OBJECT_UNLOCK (filter);
       break;
     }
     default:
@@ -1158,16 +1185,15 @@ gst_tensor_transform_get_property (GObject * object, guint prop_id,
       GPtrArray *arr;
       gchar **strings;
 
-      if (filter->apply == NULL) {
-        g_value_set_string (value, "");
-        return;
-      }
-
       arr = g_ptr_array_new ();
+
+      GST_OBJECT_LOCK (filter);
       for (list = filter->apply; list != NULL; list = list->next) {
         g_ptr_array_add (arr, g_strdup_printf ("%i",
                 GPOINTER_TO_INT (list->data)));
       }
+      GST_OBJECT_UNLOCK (filter);
+
       g_ptr_array_add (arr, NULL);
       strings = (gchar **) g_ptr_array_free (arr, FALSE);
       p = g_strjoinv (",", strings);
@@ -1906,7 +1932,7 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
     in_info = gst_tensors_info_get_nth_info (&filter->in_config.info, i);
     out_info = gst_tensors_info_get_nth_info (&filter->out_config.info, i);
 
-    if (filter->apply && !g_list_find (filter->apply, GINT_TO_POINTER (i))) {
+    if (!gst_tensor_transform_is_applied (filter, i)) {
       GstMemory *mem = gst_tensor_buffer_get_nth_memory (inbuf, i);
 
       if (!in_flexible && out_flexible) {
@@ -2066,7 +2092,7 @@ gst_tensor_transform_convert_dimension (GstTensorTransform * filter,
   /* copy input info first, then update output info */
   gst_tensor_info_copy (out_info, in_info);
 
-  if (filter->apply && !g_list_find (filter->apply, GINT_TO_POINTER (idx)))
+  if (!gst_tensor_transform_is_applied (filter, idx))
     return TRUE;
 
   switch (filter->mode) {

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -2840,6 +2840,232 @@ TEST (testTensorTransform, arithmeticStaticToFlexTensor)
 }
 
 /**
+ * @brief The number of tensors to test extra tensors (more than NNS_TENSOR_MEMORY_MAX).
+ */
+#define TEST_EXTRA_TENSORS_NUM (18U)
+
+/**
+ * @brief The number of elements of each tensor to test extra tensors.
+ */
+#define TEST_EXTRA_TENSORS_SIZE (64U)
+
+/**
+ * @brief Prepare tensors config to test extra tensors.
+ */
+static void
+_setup_extra_tensors_config (GstTensorsConfig *config)
+{
+  GstTensorInfo *_info;
+  guint i;
+
+  gst_tensors_config_init (config);
+  config->info.num_tensors = TEST_EXTRA_TENSORS_NUM;
+  config->rate_n = 0;
+  config->rate_d = 1;
+
+  for (i = 0; i < TEST_EXTRA_TENSORS_NUM; i++) {
+    _info = gst_tensors_info_get_nth_info (&config->info, i);
+    _info->type = _NNS_FLOAT32;
+    gst_tensor_parse_dimension ("64", _info->dimension);
+  }
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic (more tensors than NNS_TENSOR_MEMORY_MAX)
+ */
+TEST (testTensorTransform, arithmeticExtraTensors)
+{
+  const guint num_buffers = 2U;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorsConfig config;
+  GstMemory *mem;
+  GstMapInfo map;
+  guint i, j, b;
+  gint refcount;
+  gsize dsize;
+  float *_data;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:1", NULL);
+
+  _setup_extra_tensors_config (&config);
+  dsize = gst_tensors_info_get_size (&config.info, 0);
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_buffer_new ();
+
+    for (i = 0; i < TEST_EXTRA_TENSORS_NUM; i++) {
+      mem = gst_allocator_alloc (NULL, dsize, NULL);
+      ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_WRITE));
+
+      _data = (float *) map.data;
+      for (j = 0; j < TEST_EXTRA_TENSORS_SIZE; j++)
+        _data[j] = (float) (b * 10000 + i * 100 + j);
+
+      gst_memory_unmap (mem, &map);
+      ASSERT_TRUE (gst_tensor_buffer_append_memory (
+          in_buf, mem, gst_tensors_info_get_nth_info (&config.info, i)));
+    }
+
+    /* keep the reference to check the ownership of the input buffer */
+    gst_buffer_ref (in_buf);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    refcount = GST_MINI_OBJECT_REFCOUNT_VALUE (in_buf);
+    EXPECT_EQ (refcount, 1);
+    gst_buffer_unref (in_buf);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_tensor_buffer_get_count (out_buf), TEST_EXTRA_TENSORS_NUM);
+
+    for (i = 0; i < TEST_EXTRA_TENSORS_NUM; i++) {
+      mem = gst_tensor_buffer_get_nth_memory (out_buf, i);
+      ASSERT_TRUE (mem != NULL);
+      ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));
+      ASSERT_EQ (map.size, dsize);
+
+      _data = (float *) map.data;
+      for (j = 0; j < TEST_EXTRA_TENSORS_SIZE; j++)
+        EXPECT_FLOAT_EQ (_data[j], (float) (b * 10000 + i * 100 + j + 1));
+
+      gst_memory_unmap (mem, &map);
+      gst_memory_unref (mem);
+    }
+
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic with 'apply' property (more tensors than NNS_TENSOR_MEMORY_MAX)
+ */
+TEST (testTensorTransform, arithmeticExtraTensorsApply)
+{
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorsConfig config;
+  GstMemory *mem;
+  GstMapInfo map;
+  guint i, j;
+  gint refcount;
+  gsize dsize;
+  float *_data;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:1", "apply",
+      "0,16,17", NULL);
+
+  _setup_extra_tensors_config (&config);
+  dsize = gst_tensors_info_get_size (&config.info, 0);
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  /* set input buffer */
+  in_buf = gst_buffer_new ();
+
+  for (i = 0; i < TEST_EXTRA_TENSORS_NUM; i++) {
+    mem = gst_allocator_alloc (NULL, dsize, NULL);
+    ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_WRITE));
+
+    _data = (float *) map.data;
+    for (j = 0; j < TEST_EXTRA_TENSORS_SIZE; j++)
+      _data[j] = (float) (i * 100 + j);
+
+    gst_memory_unmap (mem, &map);
+    ASSERT_TRUE (gst_tensor_buffer_append_memory (
+        in_buf, mem, gst_tensors_info_get_nth_info (&config.info, i)));
+  }
+
+  /* keep the reference to check the ownership of the input buffer */
+  gst_buffer_ref (in_buf);
+
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+  refcount = GST_MINI_OBJECT_REFCOUNT_VALUE (in_buf);
+  EXPECT_EQ (refcount, 1);
+  gst_buffer_unref (in_buf);
+
+  /* get output buffer */
+  out_buf = gst_harness_pull (h);
+
+  ASSERT_TRUE (out_buf != NULL);
+  ASSERT_EQ (gst_tensor_buffer_get_count (out_buf), TEST_EXTRA_TENSORS_NUM);
+
+  for (i = 0; i < TEST_EXTRA_TENSORS_NUM; i++) {
+    /* the operator is applied to the tensor 0, 16 and 17 */
+    float diff = (i == 0U || i >= 16U) ? 1.0f : 0.0f;
+
+    mem = gst_tensor_buffer_get_nth_memory (out_buf, i);
+    ASSERT_TRUE (mem != NULL);
+    ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));
+    ASSERT_EQ (map.size, dsize);
+
+    _data = (float *) map.data;
+    for (j = 0; j < TEST_EXTRA_TENSORS_SIZE; j++)
+      EXPECT_FLOAT_EQ (_data[j], (float) (i * 100 + j) + diff);
+
+    gst_memory_unmap (mem, &map);
+    gst_memory_unref (mem);
+  }
+
+  gst_buffer_unref (out_buf);
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform with insufficient buffer size (more tensors than NNS_TENSOR_MEMORY_MAX)
+ */
+TEST (testTensorTransform, arithmeticExtraTensorsInvalidSize_n)
+{
+  GstHarness *h;
+  GstBuffer *in_buf;
+  GstTensorsConfig config;
+  gint refcount;
+  gsize dsize;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:1", NULL);
+
+  _setup_extra_tensors_config (&config);
+  dsize = gst_tensors_info_get_size (&config.info, 0);
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  /* the buffer has the data of a single tensor */
+  in_buf = gst_harness_create_buffer (h, dsize);
+  gst_buffer_ref (in_buf);
+
+  EXPECT_NE (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+  refcount = GST_MINI_OBJECT_REFCOUNT_VALUE (in_buf);
+  EXPECT_EQ (refcount, 1);
+  gst_buffer_unref (in_buf);
+
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+}
+
+/**
  * @brief Test data for tensor_aggregator (2 frames with dimension 3:4:2:2 or 3:2:2:2:2)
  */
 const gint aggr_test_frames[2][48]

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -3030,6 +3030,83 @@ TEST (testTensorTransform, arithmeticExtraTensorsApply)
 }
 
 /**
+ * @brief Test for tensor_transform arithmetic with 'apply' property which selects no tensor
+ */
+TEST (testTensorTransform, arithmeticExtraTensorsApplyNone)
+{
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorsConfig config;
+  GstMemory *mem;
+  GstMapInfo map;
+  guint i, j;
+  gint refcount;
+  gsize dsize;
+  float *_data;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:1", NULL);
+
+  /* no tensor of the stream is selected */
+  g_object_set (h->element, "apply", "99", NULL);
+
+  _setup_extra_tensors_config (&config);
+  dsize = gst_tensors_info_get_size (&config.info, 0);
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  /* set input buffer */
+  in_buf = gst_buffer_new ();
+
+  for (i = 0; i < TEST_EXTRA_TENSORS_NUM; i++) {
+    mem = gst_allocator_alloc (NULL, dsize, NULL);
+    ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_WRITE));
+
+    _data = (float *) map.data;
+    for (j = 0; j < TEST_EXTRA_TENSORS_SIZE; j++)
+      _data[j] = (float) (i * 100 + j);
+
+    gst_memory_unmap (mem, &map);
+    ASSERT_TRUE (gst_tensor_buffer_append_memory (
+        in_buf, mem, gst_tensors_info_get_nth_info (&config.info, i)));
+  }
+
+  /* keep the reference to check the ownership of the input buffer */
+  gst_buffer_ref (in_buf);
+
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+  refcount = GST_MINI_OBJECT_REFCOUNT_VALUE (in_buf);
+  EXPECT_EQ (refcount, 1);
+  gst_buffer_unref (in_buf);
+
+  /* get output buffer, every tensor is passed through */
+  out_buf = gst_harness_pull (h);
+
+  ASSERT_TRUE (out_buf != NULL);
+  ASSERT_EQ (gst_tensor_buffer_get_count (out_buf), TEST_EXTRA_TENSORS_NUM);
+
+  for (i = 0; i < TEST_EXTRA_TENSORS_NUM; i++) {
+    mem = gst_tensor_buffer_get_nth_memory (out_buf, i);
+    ASSERT_TRUE (mem != NULL);
+    ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));
+    ASSERT_EQ (map.size, dsize);
+
+    _data = (float *) map.data;
+    for (j = 0; j < TEST_EXTRA_TENSORS_SIZE; j++)
+      EXPECT_FLOAT_EQ (_data[j], (float) (i * 100 + j));
+
+    gst_memory_unmap (mem, &map);
+    gst_memory_unref (mem);
+  }
+
+  gst_buffer_unref (out_buf);
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+}
+
+/**
  * @brief Test for tensor_transform with insufficient buffer size (more tensors than NNS_TENSOR_MEMORY_MAX)
  */
 TEST (testTensorTransform, arithmeticExtraTensorsInvalidSize_n)

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -290,6 +290,146 @@ TEST (testTensorTransform, properties01)
 }
 
 /**
+ * @brief Test for setting the 'apply' property of tensor_transform
+ */
+TEST (testTensorTransform, applyProperty)
+{
+  GstHarness *h;
+  gchar *str = NULL;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_get (h->element, "apply", &str, NULL);
+  EXPECT_STREQ (str, "");
+  g_free (str);
+
+  g_object_set (h->element, "apply", "1,2", NULL);
+  g_object_get (h->element, "apply", &str, NULL);
+  EXPECT_STREQ (str, "1,2");
+  g_free (str);
+
+  /* setting the property again replaces the old list */
+  g_object_set (h->element, "apply", "3", NULL);
+  g_object_get (h->element, "apply", &str, NULL);
+  EXPECT_STREQ (str, "3");
+  g_free (str);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for setting the 'apply' property of tensor_transform with invalid value
+ */
+TEST (testTensorTransform, applyPropertyInvalid_n)
+{
+  GstHarness *h;
+  gchar *str = NULL;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "apply", "1,invalid,3", NULL);
+  g_object_get (h->element, "apply", &str, NULL);
+  EXPECT_STREQ (str, "1,3");
+  g_free (str);
+
+  g_object_set (h->element, "apply", "invalid", NULL);
+  g_object_get (h->element, "apply", &str, NULL);
+  EXPECT_STREQ (str, "");
+  g_free (str);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for changing the 'apply' property between the buffers
+ */
+TEST (testTensorTransform, applyChangedWhileStreaming)
+{
+  const guint num_tensors = 2U;
+  const guint array_size = 64U;
+  const gchar *apply_values[] = { "1", "0", "invalid" };
+  /* the operator is applied to the tensor selected by each value above */
+  const gboolean applied[3][2] = { { FALSE, TRUE }, { TRUE, FALSE }, { TRUE, TRUE } };
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorsConfig config;
+  GstTensorInfo *_info;
+  GstMemory *mem;
+  GstMapInfo map;
+  guint i, j, p;
+  gsize dsize;
+  float *_data;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:1", NULL);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = num_tensors;
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  for (i = 0; i < num_tensors; i++) {
+    _info = gst_tensors_info_get_nth_info (&config.info, i);
+    _info->type = _NNS_FLOAT32;
+    gst_tensor_parse_dimension ("64", _info->dimension);
+  }
+
+  dsize = gst_tensors_info_get_size (&config.info, 0);
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  for (p = 0; p < G_N_ELEMENTS (apply_values); p++) {
+    g_object_set (h->element, "apply", apply_values[p], NULL);
+
+    /* set input buffer */
+    in_buf = gst_buffer_new ();
+
+    for (i = 0; i < num_tensors; i++) {
+      mem = gst_allocator_alloc (NULL, dsize, NULL);
+      ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_WRITE));
+
+      _data = (float *) map.data;
+      for (j = 0; j < array_size; j++)
+        _data[j] = (float) (i * 100 + j);
+
+      gst_memory_unmap (mem, &map);
+      ASSERT_TRUE (gst_tensor_buffer_append_memory (
+          in_buf, mem, gst_tensors_info_get_nth_info (&config.info, i)));
+    }
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_tensor_buffer_get_count (out_buf), num_tensors);
+
+    for (i = 0; i < num_tensors; i++) {
+      float diff = applied[p][i] ? 1.0f : 0.0f;
+
+      mem = gst_tensor_buffer_get_nth_memory (out_buf, i);
+      ASSERT_TRUE (mem != NULL);
+      ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));
+      ASSERT_EQ (map.size, dsize);
+
+      _data = (float *) map.data;
+      for (j = 0; j < array_size; j++)
+        EXPECT_FLOAT_EQ (_data[j], (float) (i * 100 + j) + diff);
+
+      gst_memory_unmap (mem, &map);
+      gst_memory_unref (mem);
+    }
+
+    gst_buffer_unref (out_buf);
+  }
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+}
+
+/**
  * @brief Test for invalid properties of tensor_transform
  */
 TEST (testTensorTransform, properties02_n)


### PR DESCRIPTION
Streams with more tensors than `NNS_TENSOR_MEMORY_MAX` (16) never worked in `tensor_transform`: the element fails the buffer, writes into released memory and releases the input buffer of the base transform twice. This series fixes the three defects and adds the test cases that were missing for that path.

### What is fixed

- **Output memory was appended before it was filled** (C1, C2 of #4920).
  `gst_tensor_buffer_append_memory()` takes the ownership of the memory, parses it to tell a static tensor from a flexible one, and - once the buffer holds 16 blocks - copies it into the merged block of extra tensors and releases it. Appending first meant the format check read uninitialised bytes (the memcheck job reports it on every transform) and, from the 17th tensor on, the kernel wrote into released memory while the copy delivered downstream stayed uninitialised. In practice the push failed with `GST_FLOW_ERROR`, because appending cannot map the 16th output memory while it is still mapped for writing.
- **The input buffer was released twice** (C3 of #4920).
  `gst_tensor_buffer_from_config()` always takes the ownership of the buffer it is given. A static stream of more than 16 tensors always takes its re-split path, so the buffer owned by `GstBaseTransform` was released here and again by the base transform, and the returned buffer leaked.
- **The tensors info of the negotiated caps was never released** (C7 of #4920).
  With more than 16 tensors the info is heap allocated; `set_caps` dropped three such blocks per element and `finalize` released none. Fixed here because the new test cases would otherwise leak in the memcheck job.

Two more defects of the same element, both raised in review and small enough to close here rather than leave behind:

- **`apply` selecting no tensor of the stream returned an error.** `res` was only ever assigned by the mode switch, which a tensor excluded by `apply` never reaches, so the element built the output buffer correctly and still returned the `GST_FLOW_ERROR` its declaration starts with. It now starts from `GST_FLOW_OK`; every path that leaves the loop early assigns the error it reports.
- **Setting `apply` twice selected the union of both values.** The setter appended to the list left by the previous set, and also appended the value of a token it had just failed to parse (tensor 0 for any malformed string). It now replaces the list and skips a token that does not parse.

### Test cases

`tests/nnstreamer_plugins/unittest_plugins.cc` gains four cases driving 18 tensors through the element - the arithmetic result of every tensor, the `apply` property (which passes the untouched tensors through the same append path), an `apply` naming no tensor of the stream, and a buffer smaller than the caps describe (`_n`) - and two cases for the `apply` property setter (one `_n`). Every case that pushes a buffer also asserts that the element leaves the reference of the input buffer to its caller, which is what detects the double release.

Against the current main the first cases abort, the `_n` case releases the input buffer twice, and each of the other cases fails without the fix it belongs to.

### Verification

- `meson test`: 21/22 (`unittest_filter_python3` fails on this box for an unrelated numpy 2.x environment issue).
- SSAT: `transform_arithmetic` 36, `transform_typecast` 43, `transform_transpose` 16, `transform_dimchg` 13, `transform_clamp` 10, `transform_padding` 10, `transform_stand` 9, `nnstreamer_mux` 84, `nnstreamer_merge` 89, `nnstreamer_demux` 43, `nnstreamer_repo_dynamicity` 10 - no failure.
- valgrind memcheck over `unittest_plugins`: no invalid read/write, and fewer leak contexts than main (the new cases add none).

### Not in this PR

While writing the flexible variant of the test I found a separate defect in the buffer helpers: `gst_tensor_buffer_append_memory()` records the *data* size of a flexible extra tensor in the extra header, so `gst_tensor_buffer_get_nth_memory()` misses the 128-byte meta header of every extra tensor and the 18th tensor of a flexible stream comes back as garbage. That is in `nnstreamer_plugin_api_impl.c`, which #4926 is already touching, so it is filed as a separate item of #4920 instead.
