### PR TITLE
[CI] Add the Ubuntu 26.04 (resolute) pdebuild leg

### DIFF
--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -1,4 +1,4 @@
-name: Build and unit test/ Pdebuild Ubuntu 22.04
+name: Build and unit test/ Pdebuild Ubuntu
 
 # ${{ github.event.pull_request.commits }} : # commits in this PR
 # - changed_file_list in GITHUB_ENV: the list of files updated in this pull-request.
@@ -11,15 +11,25 @@ on:
 
 jobs:
   build:
-    name: Ubuntu pdebuild on Ubuntu
+    name: Ubuntu pdebuild on ${{ matrix.distroname }} (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-22.04 ]
         arch: [ amd64 ]
         include:
           - distroname: jammy
             os: ubuntu-22.04
+          # Ubuntu 26.04 is bootstrapped from the 24.04 runner; its debootstrap
+          # learns the series name in the "prepare pdebuild" step. Plain pdebuild
+          # runs "debian/rules clean" on the host, whose /etc/os-release would make
+          # rules pick the 24.04 control for the .dsc; the internal mode runs it in
+          # the chroot, as the Launchpad recipe build does.
+          - distroname: resolute
+            os: ubuntu-24.04
+            arch: amd64
+            pdebuild_opts: --use-pdebuild-internal
 
     steps:
     - uses: actions/checkout@v4
@@ -51,10 +61,10 @@ jobs:
         path: |
           /var/cache/pbuilder/aptcache
           /var/cache/pbuilder/base.tgz
-        key: pbuilder-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('**/debian/control') }}-${{ steps.get-date.outputs.date }}
+        key: pbuilder-cache-${{ matrix.os }}-${{ matrix.distroname }}-${{ matrix.arch }}-${{ hashFiles('**/debian/control') }}-${{ steps.get-date.outputs.date }}
         restore-keys: |
-          pbuilder-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('**/debian/control') }}-
-          pbuilder-cache-${{ matrix.os }}-${{ matrix.arch }}-
+          pbuilder-cache-${{ matrix.os }}-${{ matrix.distroname }}-${{ matrix.arch }}-${{ hashFiles('**/debian/control') }}-
+          pbuilder-cache-${{ matrix.os }}-${{ matrix.distroname }}-${{ matrix.arch }}-
 
     - name: prepare pdebuild
       if: env.rebuild == '1'
@@ -82,6 +92,11 @@ jobs:
         echo "::group::apt-get install"
         sudo apt-get install -y pbuilder debootstrap curl ubuntu-dev-tools qemu-user-static debian-archive-keyring ubuntu-keyring debhelper
         echo "::endgroup::"
+        # debootstrap ships scripts only for the series known when it was
+        # released, and every Ubuntu series uses the same one. Alias it.
+        if [ ! -e /usr/share/debootstrap/scripts/${{ matrix.distroname }} ]; then
+          sudo ln -sf gutsy /usr/share/debootstrap/scripts/${{ matrix.distroname }}
+        fi
         echo "DISTRIBUTION=${{ matrix.distroname }}" > ~/.pbuilderrc
         echo "OTHERMIRROR=\"deb [trusted=yes] http://archive.ubuntu.com/ubuntu ${{ matrix.distroname }}-backports universe |deb [trusted=yes] http://ppa.launchpad.net/nnstreamer/ppa/ubuntu ${{ matrix.distroname }} main\"" >> ~/.pbuilderrc
         cat ~/.pbuilderrc
@@ -106,4 +121,8 @@ jobs:
     - name: run pdebuild
       if: env.rebuild == '1'
       run: |
-        pdebuild --architecture ${{ matrix.arch }} -- --distribution ${{ matrix.distroname }}
+        # Results go to a runner-owned directory: in the internal mode pdebuild
+        # copies them itself, as the runner user, and the default
+        # /var/cache/pbuilder/result is root-owned.
+        mkdir -p ~/pdebuild_result
+        pdebuild ${{ matrix.pdebuild_opts }} --buildresult ~/pdebuild_result --architecture ${{ matrix.arch }} -- --distribution ${{ matrix.distroname }}

--- a/.github/workflows/update_pbuilder_cache.yml
+++ b/.github/workflows/update_pbuilder_cache.yml
@@ -10,13 +10,23 @@ on:
 
 jobs:
   cache_pbuilder:
+    name: Update pbuilder cache for ${{ matrix.distroname }} (${{ matrix.arch }})
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-22.04 ]
         arch: [ amd64 ]
         include:
           - distroname: jammy
             os: ubuntu-22.04
+          # Ubuntu 26.04 is bootstrapped from the 24.04 runner; its debootstrap
+          # learns the series name in the "prepare pdebuild" step. The internal
+          # mode keeps "debian/rules clean" inside the chroot, so rules reads the
+          # chroot's /etc/os-release, not the runner's (see pdebuild.yml).
+          - distroname: resolute
+            os: ubuntu-24.04
+            arch: amd64
+            pdebuild_opts: --use-pdebuild-internal
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,6 +63,11 @@ jobs:
           echo "::group::apt-get install"
           sudo apt-get install -y pbuilder debootstrap curl ubuntu-dev-tools qemu-user-static debian-archive-keyring ubuntu-keyring debhelper
           echo "::endgroup::"
+          # debootstrap ships scripts only for the series known when it was
+          # released, and every Ubuntu series uses the same one. Alias it.
+          if [ ! -e /usr/share/debootstrap/scripts/${{ matrix.distroname }} ]; then
+            sudo ln -sf gutsy /usr/share/debootstrap/scripts/${{ matrix.distroname }}
+          fi
           echo "DISTRIBUTION=${{ matrix.distroname }}" > ~/.pbuilderrc
           echo "OTHERMIRROR=\"deb [trusted=yes] http://archive.ubuntu.com/ubuntu ${{ matrix.distroname }}-backports universe |deb [trusted=yes] http://ppa.launchpad.net/nnstreamer/ppa/ubuntu ${{ matrix.distroname }} main\"" >> ~/.pbuilderrc
           cat ~/.pbuilderrc
@@ -83,7 +98,7 @@ jobs:
         id: pdebuild
         run: |
           mkdir -p ~/daily_build/ubuntu
-          pdebuild --logfile ~/daily_build/pdebuild_log.txt --buildresult ~/daily_build/ubuntu --architecture ${{ matrix.arch }} -- --distribution ${{ matrix.distroname }}
+          pdebuild ${{ matrix.pdebuild_opts }} --logfile ~/daily_build/pdebuild_log.txt --buildresult ~/daily_build/ubuntu --architecture ${{ matrix.arch }} -- --distribution ${{ matrix.distroname }}
 
       - name: save pbuilder cache
         uses: actions/cache/save@v4
@@ -96,7 +111,7 @@ jobs:
           path: |
             /var/cache/pbuilder/aptcache
             /var/cache/pbuilder/base.tgz
-          key: pbuilder-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('**/debian/control') }}-${{ steps.get-date.outputs.date }}
+          key: pbuilder-cache-${{ matrix.os }}-${{ matrix.distroname }}-${{ matrix.arch }}-${{ hashFiles('**/debian/control') }}-${{ steps.get-date.outputs.date }}
 
       - name: generate badge
         run: |
@@ -107,8 +122,10 @@ jobs:
             python3 -m pybadges --left-text=test --right-text=failure --right-color=red > ~/daily_build/pdebuild_result.svg
           fi
 
+      # The published result, log and badge are single files: keep them for the
+      # jammy build as before, rather than whichever matrix leg finishes last.
       - name: Release daily build result to release.nnstreamer.com
-        if: steps.pdebuild.outcome == 'success'
+        if: steps.pdebuild.outcome == 'success' && matrix.distroname == 'jammy'
         uses: ./.github/actions/s3_upload
         with:
           source: ~/daily_build/ubuntu/
@@ -118,6 +135,7 @@ jobs:
           s3_option: --recursive
 
       - name: Release daily build log to release.nnstreamer.com
+        if: matrix.distroname == 'jammy'
         uses: ./.github/actions/s3_upload
         with:
           source: ~/daily_build/pdebuild_log.txt
@@ -126,6 +144,7 @@ jobs:
           s3_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
 
       - name: update daily result badge
+        if: matrix.distroname == 'jammy'
         uses: ./.github/actions/gitpush
         with:
           source: ~/daily_build/pdebuild_result.svg


### PR DESCRIPTION
## Why

#4916 made the packaging build on Ubuntu 26.04 but, at the reviewer's request, left the CI leg out because `ppa:nnstreamer/ppa` had no resolute Release file yet and the leg was red for reasons unrelated to that PR. That precondition is gone: the PPA now publishes `nnstreamer 2.7.0.0-0~202609041423~ubuntu26.04.1` (27 binaries, amd64 and arm64) together with nnstreamer-edge, ssat, tensorflow2-lite-dev and edgetpu for resolute, and the Launchpad builders ran the full test suite there (SSAT 1019 passed, 0 failed).

## What

One commit adding a `resolute` leg to `pdebuild.yml` (per-PR) and `update_pbuilder_cache.yml` (daily). The leg runs on the `ubuntu-24.04` runner and differs from the jammy leg in three ways, each found by actually running it during #4916:

- `debootstrap` on the runner predates the series, so the series name is aliased to the shared Ubuntu script.
- Plain `pdebuild` runs `debian/rules clean` on the **host**, and rules now selects the control file from `/etc/os-release`, so the resolute `.dsc` would carry the 24.04 control and never resolve. The leg uses `--use-pdebuild-internal`, which keeps the clean and the dependency resolution inside the chroot, exactly like the Launchpad recipe build. Both workflows get it.
- In internal mode pdebuild copies results as the runner user into root-owned `/var/cache/pbuilder/result`, so `--buildresult` points at a runner-owned directory.

Three consequences of having two legs instead of one, all in both workflows:

- `fail-fast: false`, so a failing leg no longer cancels the other. In the daily workflow that matters most: a resolute failure would otherwise cancel the jammy job that saves the cache, uploads to S3 and pushes the badge.
- The pbuilder cache key and its restore-keys gain `${{ matrix.distroname }}`. The legs were told apart only by the runner image, so the first time two series shared one — a noble leg on the 24.04 runner — the restore-keys prefix would hand one series the other's chroot.
- Each job is named after the series and architecture it builds, so the checks read `Ubuntu pdebuild on jammy (amd64)` and `Ubuntu pdebuild on resolute (amd64)`. Without an explicit `name:` GitHub appends the whole matrix entry, so the new leg would show up as `(ubuntu-24.04, amd64, resolute, --use-pdebuild-internal)` beside a jammy job whose name did not mention jammy at all. Naming exactly the two axes that identify a leg keeps the check contexts stable when an `include` key is added or renamed, and keeps them distinct if `arch` ever grows a second value. Neither pdebuild job is a required status check, so the rename is safe.

The daily workflow's S3 upload, log and badge are single files and stay with jammy.

## Tests

Workflow-only change, so there is no test case to add; the resolute leg of this PR's own CI run is the test. Expected: the chroot is created from the aliased script, `pbuilder create` finds `dists/resolute` in the PPA, and the package builds and runs its tests inside the chroot. The run confirms it end to end — `debian/rules clean` and `dpkg-source -b .` execute inside the chroot against the 26.04 `debian/control`, every gtest binary passes, and SSAT reports 1019 passed / 0 failed / 4 ignored.

The resolute leg is **not** equivalent coverage to jammy and is not meant to replace it. It builds 30 binary packages to jammy's 38 and runs 1019 SSAT cases to jammy's 1029, because `debian/rules` drops `nnstreamer-caffe2`, `nnstreamer-nnfw`, `nnstreamer-openvino`, `nnstreamer-pytorch` and `nnstreamer-tvm` for `VERSION_ID >= 26.04` — the PPA carries no openvino, onert, tvm or pytorch for that series. A regression in those five subplugins is still caught only by the jammy leg.

Note for after merge: the cache key change orphans the caches saved under the old prefix, and the per-PR workflow only restores. Running the `Update pbuilder cache once a day` workflow manually once will save both series under the new key and stop PRs from paying a cold `pbuilder create`.

Follows up nnstreamer#4902 / #4916.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
