### PR TITLE
[Element/If] Bound the number of the supplied values

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_if.c
+++ b/gst/nnstreamer/elements/gsttensor_if.c
@@ -424,6 +424,7 @@ gst_tensor_if_set_property_supplied_value (const GValue * value,
     is_float = TRUE;
   }
 
+  memset (sv->data, 0, sizeof (sv->data));
   sv->num = num;
   for (i = 0; i < num; i++) {
     if (is_float) {

--- a/gst/nnstreamer/elements/gsttensor_if.c
+++ b/gst/nnstreamer/elements/gsttensor_if.c
@@ -394,20 +394,29 @@ gst_tensor_if_set_property_cv_option (const GValue * value, GList ** prop_list)
 }
 
 /**
- * @brief Convert GValue to GList according to delimiters
+ * @brief Convert GValue to the supplied values according to delimiters
  */
 static void
 gst_tensor_if_set_property_supplied_value (const GValue * value,
     tensor_if_sv_s * sv, const gchar * delimiters)
 {
-  gint i;
+  guint i, num;
   gboolean is_float = FALSE;
   const gchar *param = g_value_get_string (value);
-  gchar **strv = g_strsplit_set (param, delimiters, -1);
-  gint num = g_strv_length (strv);
+  gchar **strv;
 
   if (!param) {
     ml_loge ("Invalid supplied value. The value is NULL.");
+    return;
+  }
+
+  strv = g_strsplit_set (param, delimiters, -1);
+  num = g_strv_length (strv);
+
+  if (num > G_N_ELEMENTS (sv->data)) {
+    ml_loge ("Invalid supplied value (%s). Up to %u values are allowed.",
+        param, (guint) G_N_ELEMENTS (sv->data));
+    g_strfreev (strv);
     return;
   }
 
@@ -642,7 +651,7 @@ gst_tensor_if_install_properties (GObjectClass * gobject_class)
 
   g_object_class_install_property (gobject_class, PROP_SV,
       g_param_spec_string ("supplied-value", "SV",
-          " Supplied Value by user ", "",
+          " Supplied Value by user, up to two values ", "",
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_OP,

--- a/gst/nnstreamer/elements/gsttensor_if.md
+++ b/gst/nnstreamer/elements/gsttensor_if.md
@@ -23,6 +23,7 @@ The input and output stream data type is either `other/tensor` or `other/tensors
 - supplied-value: Specifies the supplied value (SV) from the user.
   * SV
   * SV1, SV2 (used for RANGE operators)
+  * A value with more than two elements is rejected and the previous value is kept.
 
 - operator: Comparison Operator
   * EQ: Check if CV == SV

--- a/tests/nnstreamer_if/unittest_if.cc
+++ b/tests/nnstreamer_if/unittest_if.cc
@@ -315,6 +315,7 @@ TEST (tensorIfProp, suppliedValue)
   gchar *pipeline;
   GstElement *gstpipe, *tif_handle;
   gchar *str_val = NULL;
+  gchar **strv;
 
   pipeline = g_strdup_printf (
       "videotestsrc num-buffers=1 pattern=13 ! videoconvert ! videoscale ! "
@@ -335,7 +336,11 @@ TEST (tensorIfProp, suppliedValue)
 
   g_object_set (tif_handle, "supplied-value", "1.5,2.5", NULL);
   g_object_get (tif_handle, "supplied-value", &str_val, NULL);
-  EXPECT_DOUBLE_EQ (1.5, g_ascii_strtod (str_val, NULL));
+  strv = g_strsplit (str_val, ",", -1);
+  ASSERT_EQ (2U, g_strv_length (strv));
+  EXPECT_DOUBLE_EQ (1.5, g_ascii_strtod (strv[0], NULL));
+  EXPECT_DOUBLE_EQ (2.5, g_ascii_strtod (strv[1], NULL));
+  g_strfreev (strv);
   g_free (str_val);
 
   g_object_set (tif_handle, "supplied-value", "", NULL);
@@ -696,7 +701,7 @@ new_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
 
   data_received++;
   /* Index 100 means a callback that is not allowed. */
-  EXPECT_NE (100, index);
+  ASSERT_NE (100, index);
   mem_res = gst_buffer_get_memory (buffer, 0);
   ret = gst_memory_map (mem_res, &info_res, GST_MAP_READ);
   ASSERT_TRUE (ret);
@@ -790,6 +795,76 @@ TEST (tensorIfAppsrc, action0)
 
   EXPECT_EQ (1, data_received);
 
+  gst_object_unref (appsrc_handle);
+  gst_object_unref (tif_handle);
+  gst_object_unref (pipeline);
+  g_free (str_pipeline);
+}
+
+/**
+ * @brief Test that a new supplied value fully replaces the previous one
+ */
+TEST (tensorIfAppsrc, suppliedValueReset)
+{
+  GstBuffer *buf_0, *buf_1;
+  GstMemory *mem;
+  GstMapInfo info;
+  GstElement *appsrc_handle, *sink_handle, *tif_handle;
+  gint idx;
+  gboolean ret;
+  gchar *str_pipeline = g_strdup (
+      "appsrc name=appsrc ! other/tensor,dimension=(string)3:4:2:2,type=(string)int32,framerate=(fraction)0/1 ! "
+      "tensor_if name=tif compared-value=A_VALUE compared-value-option=1:1:1:1,0 supplied-value=1000,2000 "
+      "operator=RANGE_INCLUSIVE then=PASSTHROUGH else=SKIP ! "
+      "other/tensors,num_tensors=1,dimensions=(string)3:4:2:2, types=(string)int32, framerate=(fraction)0/1 ! "
+      "tensor_sink name=sinkx async=false");
+
+  GstElement *pipeline = gst_parse_launch (str_pipeline, NULL);
+  ASSERT_NE (pipeline, nullptr);
+
+  appsrc_handle = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc");
+  ASSERT_NE (appsrc_handle, nullptr);
+
+  tif_handle = gst_bin_get_by_name (GST_BIN (pipeline), "tif");
+  ASSERT_NE (tif_handle, nullptr);
+
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_NE (sink_handle, nullptr);
+
+  g_signal_connect (sink_handle, "new-data", (GCallback) new_data_cb, (gpointer) &idx);
+
+  buf_0 = gst_buffer_new ();
+  mem = gst_allocator_alloc (NULL, 192, NULL);
+  ret = gst_memory_map (mem, &info, GST_MAP_WRITE);
+  ASSERT_TRUE (ret);
+  memcpy (info.data, test_frames[0], 192);
+  gst_memory_unmap (mem, &info);
+  gst_buffer_append_memory (buf_0, mem);
+  buf_1 = gst_buffer_copy (buf_0);
+
+  data_received = 0;
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  g_usleep (100000);
+
+  /* the compared value 1217 is within [1000, 2000] */
+  idx = 0;
+  EXPECT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_handle), buf_0), GST_FLOW_OK);
+  g_usleep (100000);
+
+  /* the second operand of the previous value should not survive */
+  g_object_set (tif_handle, "supplied-value", "1000", NULL);
+
+  idx = 100;
+  EXPECT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc_handle), buf_1), GST_FLOW_OK);
+  g_usleep (100000);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+  g_usleep (100000);
+
+  EXPECT_EQ (1, data_received);
+
+  gst_object_unref (sink_handle);
   gst_object_unref (appsrc_handle);
   gst_object_unref (tif_handle);
   gst_object_unref (pipeline);

--- a/tests/nnstreamer_if/unittest_if.cc
+++ b/tests/nnstreamer_if/unittest_if.cc
@@ -296,6 +296,147 @@ TEST (tensorIfProp, properties5_n)
   g_free (str_pipeline);
 }
 
+static guint glib_critical_cnt = 0;
+
+/**
+ * @brief Log handler counting the critical messages reported by glib itself
+ */
+static void
+_count_glib_critical (const gchar *, GLogLevelFlags, const gchar *, gpointer)
+{
+  glib_critical_cnt++;
+}
+
+/**
+ * @brief Test for the supplied value property of tensor_if
+ */
+TEST (tensorIfProp, suppliedValue)
+{
+  gchar *pipeline;
+  GstElement *gstpipe, *tif_handle;
+  gchar *str_val = NULL;
+
+  pipeline = g_strdup_printf (
+      "videotestsrc num-buffers=1 pattern=13 ! videoconvert ! videoscale ! "
+      "video/x-raw,format=RGB,width=160,height=120 ! tensor_converter ! "
+      "tensor_if name=tif compared-value=A_VALUE compared-value-option=1:2:1:1,1 "
+      "supplied-value=100 operator=GE then=PASSTHROUGH else=SKIP ! tensor_sink");
+  gstpipe = gst_parse_launch (pipeline, NULL);
+  ASSERT_NE (gstpipe, nullptr);
+
+  tif_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "tif");
+  ASSERT_NE (tif_handle, nullptr);
+
+  /* the maximum number of the supplied values */
+  g_object_set (tif_handle, "supplied-value", "10,100", NULL);
+  g_object_get (tif_handle, "supplied-value", &str_val, NULL);
+  EXPECT_STREQ ("10,100", str_val);
+  g_free (str_val);
+
+  g_object_set (tif_handle, "supplied-value", "1.5,2.5", NULL);
+  g_object_get (tif_handle, "supplied-value", &str_val, NULL);
+  EXPECT_DOUBLE_EQ (1.5, g_ascii_strtod (str_val, NULL));
+  g_free (str_val);
+
+  g_object_set (tif_handle, "supplied-value", "", NULL);
+  g_object_get (tif_handle, "supplied-value", &str_val, NULL);
+  EXPECT_STREQ ("", str_val);
+  g_free (str_val);
+
+  gst_object_unref (tif_handle);
+  gst_object_unref (gstpipe);
+  g_free (pipeline);
+}
+
+/**
+ * @brief Test for tensor_if supplied value with more values than it can hold
+ */
+TEST (tensorIfProp, suppliedValue1_n)
+{
+  gchar *pipeline;
+  GstElement *gstpipe, *tif_handle;
+  gchar *str_val = NULL;
+
+  pipeline = g_strdup_printf (
+      "videotestsrc num-buffers=1 pattern=13 ! videoconvert ! videoscale ! "
+      "video/x-raw,format=RGB,width=160,height=120 ! tensor_converter ! "
+      "tensor_if name=tif compared-value=A_VALUE compared-value-option=1:2:1:1,1 "
+      "supplied-value=100 operator=GE then=PASSTHROUGH else=SKIP ! tensor_sink");
+  gstpipe = gst_parse_launch (pipeline, NULL);
+  ASSERT_NE (gstpipe, nullptr);
+
+  tif_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "tif");
+  ASSERT_NE (tif_handle, nullptr);
+
+  g_object_set (tif_handle, "then-option", "1", NULL);
+  g_object_set (tif_handle, "else-option", "2", NULL);
+  g_object_set (tif_handle, "supplied-value", "10,100", NULL);
+
+  /* the values beyond the second one used to be written past the array */
+  g_object_set (tif_handle, "supplied-value", "1,2,3,4,5,6,7,8", NULL);
+
+  g_object_get (tif_handle, "supplied-value", &str_val, NULL);
+  EXPECT_STREQ ("10,100", str_val);
+  g_free (str_val);
+
+  /* the members stored next to the supplied value should be intact */
+  g_object_get (tif_handle, "compared-value-option", &str_val, NULL);
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal ("1:2:1:1,1", str_val));
+  g_free (str_val);
+
+  g_object_get (tif_handle, "then-option", &str_val, NULL);
+  EXPECT_STREQ ("1", str_val);
+  g_free (str_val);
+
+  g_object_get (tif_handle, "else-option", &str_val, NULL);
+  EXPECT_STREQ ("2", str_val);
+  g_free (str_val);
+
+  gst_object_unref (tif_handle);
+  gst_object_unref (gstpipe);
+  g_free (pipeline);
+}
+
+/**
+ * @brief Test for tensor_if supplied value set to null
+ */
+TEST (tensorIfProp, suppliedValue2_n)
+{
+  gchar *pipeline;
+  GstElement *gstpipe, *tif_handle;
+  gchar *str_val = NULL;
+  guint handler_id;
+
+  pipeline = g_strdup_printf (
+      "videotestsrc num-buffers=1 pattern=13 ! videoconvert ! videoscale ! "
+      "video/x-raw,format=RGB,width=160,height=120 ! tensor_converter ! "
+      "tensor_if name=tif compared-value=A_VALUE compared-value-option=1:2:1:1,1 "
+      "supplied-value=100 operator=GE then=PASSTHROUGH else=SKIP ! tensor_sink");
+  gstpipe = gst_parse_launch (pipeline, NULL);
+  ASSERT_NE (gstpipe, nullptr);
+
+  tif_handle = gst_bin_get_by_name (GST_BIN (gstpipe), "tif");
+  ASSERT_NE (tif_handle, nullptr);
+
+  glib_critical_cnt = 0;
+  handler_id = g_log_set_handler ("GLib",
+      (GLogLevelFlags) (G_LOG_LEVEL_CRITICAL | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION),
+      _count_glib_critical, NULL);
+  g_object_set (tif_handle, "supplied-value", NULL, NULL);
+  g_log_remove_handler ("GLib", handler_id);
+
+  /* the null value should be rejected before glib is fed with it */
+  EXPECT_EQ (0U, glib_critical_cnt);
+
+  g_object_get (tif_handle, "supplied-value", &str_val, NULL);
+  EXPECT_STREQ ("100", str_val);
+  g_free (str_val);
+
+  gst_object_unref (tif_handle);
+  gst_object_unref (gstpipe);
+  g_free (pipeline);
+}
+
 /**
  * @brief Test tensor_if behavior: PASSTHROUGH, SKIP
  */


### PR DESCRIPTION
Item **C16** of the memory-safety audit in #4920.

## The defect

`tensor_if` stores the supplied value in `tensor_if_sv_s`, whose `data[]` holds two elements, and `gst_tensor_if_get_comparison_result()` reads exactly two of them (`SV1`, `SV2` of the range operators) — `gst/nnstreamer/elements/gsttensor_if.md` documents `SV` or `SV1, SV2`.

`gst_tensor_if_set_property_supplied_value()` nevertheless wrote one element per token of the property string:

```c
sv->num = num;
for (i = 0; i < num; i++)
  sv->data[i]._int64_t = g_ascii_strtoll (strv[i], NULL, 10);
```

`sv` points at `GstTensorIf.sv[2]`, which is followed by `cv_option`, `then_option` and `else_option`. So `supplied-value=1,2,3,4,5,6,7,8` — a plain property string, no pipeline data involved — overwrites those three `GList *` with the supplied integers. Reading the property back walks the same out-of-bounds memory, and `dispose()` calls `g_list_free()` on the fake pointers, which segfaults.

The same function also called `g_strsplit_set (param, ...)` before its own `if (!param)` test, so a null property value reached glib and produced two criticals before the check ever ran.

## The fix

Reject a supplied value that carries more values than the element can hold (the previous value is kept, as for any other rejected property), and move the null test ahead of the split.

## Tests

`tests/nnstreamer_if/unittest_if.cc`:

- `tensorIfProp.suppliedValue` — the accepted forms: none, one, two values, and the float variant.
- `tensorIfProp.suppliedValue1_n` — the over-long value; asserts the property is unchanged and that `compared-value-option`, `then-option` and `else-option` are intact. Without the fix this fails and then dies with SIGSEGV (verified locally: `exit=139`).
- `tensorIfProp.suppliedValue2_n` — a null value; asserts glib itself reports no critical. Without the fix it counts two.

Locally: `unittest_if` 21/21 pass, `tests/gstreamer_join` SSAT 11/11 pass, `gst-indent` and `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
