### PR TITLE
[Doc] Update contributing.md's C++ standard from C++11 to C++17

### DIFF
--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -32,7 +32,7 @@ The submitter has the first responsibility of keeping the created PR clean and n
 * Each feature should come with a rich set of test cases that can be executed as unit tests during build. If the feature is more invasive or richer, you need more and richer test cases. Refer to other test cases in /tests directory, which use either GTest or SSAT.
 * When new test cases are introduced, the number of new negative test cases should be larger than or equal to the number of new positive test cases.
 * For C-code, try to stick with C89.
-* For C++-code, try to be compatible with C++11. C++ code should be able to be built optionally. In other words, by disabling C++ build option, we should be able to build the whole system without C++ compilers.
+* For C++-code, try to be compatible with C++17 (the project's `cpp_std`, set in [meson.build](https://github.com/nnstreamer/nnstreamer/blob/main/meson.build)). C++ code should be able to be built optionally. In other words, by disabling C++ build option, we should be able to build the whole system without C++ compilers.
 * Avoid introducing additional dependencies of libraries. If you are going to use additional libraries, your codes may be located at /ext/* so that they can be "optional" features.
 * If your functions or structs/classes are going to be accessed by other modules or NNStreamer users, provide full descriptions of all entries with Doxygen.
 * Passing all the tests of TAOS-CI is a necessary condition, but not a satisfying condition.


### PR DESCRIPTION
## Summary
- `Documentation/contributing.md` still told contributors to "try to be compatible with C++11", but the actual build requirement (`cpp_std` in `meson.build`) has been C++17 since commit 76a469d2 (2023-12-08, "Recent neural network frameworks needs c++17 standards to use its APIs"), itself preceded by a C++11 → C++14 bump in commit c81eb165 (2019-11-20, to support the armnn subplugin's C++14 headers).
- This PR just aligns the doc with the real requirement so new contributors don't target a stale standard.

## Test plan
- Documentation-only change; no functional/behavioral change.
- N/A for GTest/SSAT per CLAUDE.md's test-case policy (doc/build-script-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)