### PR TITLE
[CI] Fail the Valgrind step on a memcheck error of our own

### DIFF
--- a/.github/workflows/static.check.yml
+++ b/.github/workflows/static.check.yml
@@ -201,6 +201,19 @@ jobs:
           else
             echo "Skipped: $selftest is not in this branch's tree and this PR does not remove it."
           fi
+      - name: /Checker/ Valgrind log checker self-test
+        # Runs a repository script unrelated to $changed_file_list, so it
+        # needs the same merge-ref guard as the steps above.
+        run: |
+          selftest=tools/debugging/test_check_valgrind_log.sh
+          if [ -f "$selftest" ]; then
+            bash "$selftest"
+          elif git show --pretty="format:" --name-only --no-renames --diff-filter=D ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | grep -qxF "$selftest"; then
+            echo "::error::This PR removes $selftest; remove its workflow step too, or restore the script (also update this step if the script moved)."
+            exit 1
+          else
+            echo "Skipped: $selftest is not in this branch's tree and this PR does not remove it."
+          fi
       - name: /Checker/ SSAT install list is in sync
         # Same guard as the check-rebuild self-test above: the step list comes
         # from the merge ref while the checkout is the PR head, so a branch that

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -244,6 +244,17 @@ jobs:
     # unit test" step above. See
     # https://github.com/nnstreamer/nnstreamer/issues/4894 for the measurements
     # and for restoring them in a job that can afford them.
+    #
+    # What is left is then checked, and an error memcheck blames on a frame of
+    # ours fails the step. Errors blamed on a library do not - they are not
+    # ours to fix and there is a steady population of them - and leaks do not
+    # either, because a leak is reported at its allocation, which for most of
+    # ours is inside GLib. Both are still printed. The gate starts with nothing
+    # to forgive: the last errors of our own went with the tensor_transform fix
+    # in #4929, so there is no baseline file to keep in step with the code. A
+    # test failure in this pass still does not fail the step. Each run is
+    # checked on its own log, so one falling silent cannot be covered by the
+    # other having run.
     - name: GTEST run with Valgrind on a case
       if: env.rebuild == '1' && matrix.os == 'ubuntu-22.04'
       timeout-minutes: 30
@@ -256,7 +267,6 @@ jobs:
         export NNSTREAMER_CONF=`pwd`/build/nnstreamer-test.ini
         export G_SLICE=always-malloc
         export G_DEBUG=gc-friendly
-        note="There are Valgrind errors. Please fix it. As we have a lot of Valgrind errors from different libraries and possible from nnstreamer itself, we are not halting the build with Valgrind errors until we get them all."
         skip_cases="nnstreamerFilterArmnn.invokeAdvanced"
         skip_cases="${skip_cases}:nnstreamerFilterLiteRT.sharedEnvInvokeDuringConfigure"
         skip_cases="${skip_cases}:nnstreamerFilterLiteRT.zeroCopyRepeatedInvoke"
@@ -269,8 +279,18 @@ jobs:
         llamacpp_cases="${llamacpp_cases}:NNStreamerFilterLlamaCppTest.invalidModel_n"
         llamacpp_cases="${llamacpp_cases}:NNStreamerFilterLlamaCppTest.zeroTokenGenerationSync_p"
         llamacpp_cases="${llamacpp_cases}:NNStreamerFilterLlamaCppTest.zeroTokenGenerationAsync_p"
-        GTEST_FILTER="-${skip_cases}" ./packaging/run_unittests_binaries.sh --valgrind --recursive --skip unittest_filter_llamacpp ./tests/ || echo "${note}"
-        GTEST_FILTER="${llamacpp_cases}" ./packaging/run_unittests_binaries.sh --valgrind ./tests/unittest_filter_llamacpp || echo "${note}"
+        GTEST_FILTER="-${skip_cases}" ./packaging/run_unittests_binaries.sh --valgrind --recursive --skip unittest_filter_llamacpp ./tests/ 2>&1 | tee valgrind-tests.log
+        GTEST_FILTER="${llamacpp_cases}" ./packaging/run_unittests_binaries.sh --valgrind ./tests/unittest_filter_llamacpp 2>&1 | tee valgrind-llamacpp.log
+        checked=0
+        bash ./tools/debugging/check_valgrind_log.sh --require-output valgrind-tests.log || checked=1
+        bash ./tools/debugging/check_valgrind_log.sh --require-output valgrind-llamacpp.log || checked=1
+        exit ${checked}
+    - name: Upload the Valgrind logs if something went wrong
+      if: failure() && env.rebuild == '1' && matrix.os == 'ubuntu-22.04'
+      uses: actions/upload-artifact@v4
+      with:
+        name: Valgrind_logs
+        path: valgrind-*.log
     - name: get NNStreamer example apps
       if: env.rebuild == '1' && matrix.os == 'ubuntu-22.04'
       uses: actions/checkout@v4

--- a/tools/debugging/check_valgrind_log.sh
+++ b/tools/debugging/check_valgrind_log.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# @file     check_valgrind_log.sh
+# @brief    Fail when a memcheck error comes from this repository's own code.
+# @see      https://github.com/nnstreamer/nnstreamer
+# @author   MyungJoo Ham <myungjoo.ham@samsung.com>
+#
+# usage: check_valgrind_log.sh [--repo-root DIR] [--require-output] LOGFILE...
+#
+# Reads the text memcheck writes and reports each error twice over: once by
+# what kind of error it is, and once by whose code the reported frame is in.
+# Only a non-leak error whose reported frame is ours makes this exit non-zero.
+#
+# An error is attributed to the frame memcheck blames for it - the first one
+# that is not valgrind's own allocation wrapper - and that frame is ours when
+# it names a source file this repository holds or an object under the build
+# directory. Nothing below that frame counts, so neither the origin stack that
+# --track-origins appends nor the stack of the block an address belongs to can
+# make an error ours; both are usually ours even when the error is not.
+#
+# The cost of that is an error blamed on a library function we called badly,
+# where our frame is the one below. Memcheck redirects the string and memory
+# functions through its own wrappers, which this skips, so in practice the
+# blame lands on our caller anyway; across the two runs this was measured on,
+# no error blamed on a library had a frame of ours beneath it.
+#
+# An error every one of whose frames is a wrapper therefore has nothing to be
+# blamed on, and is counted as neither. Deciding otherwise would mean carrying
+# the error past the end of its own stack, which is the mistake this rule
+# exists to prevent; neither of the two runs holds such an error.
+#
+# Both halves of "ours" carry an assumption. A file is matched by its base
+# name, so a source of ours sharing a name with one a library was built from
+# would start gating on that library's bug - no name in the tree does today.
+# The object half looks for /build/gst, /build/ext or /build/tests anywhere in
+# the path, which is what lets a log recorded on another machine be checked
+# here, and which stops recognising objects if the build directory is ever
+# renamed; the file-name half still covers everything built with debug info.
+#
+# A report whose first line matches none of the kinds below is neither passed
+# nor failed on, so it is printed as a warning instead of disappearing.
+#
+# Leaks are counted and printed but never gate, because a leak is reported at
+# its allocation, which for most of ours is inside GLib; deciding who was
+# responsible for freeing it needs a rule this script does not have.
+#
+# --require-output additionally fails when the log holds no memcheck output at
+# all. A caller that always runs memcheck wants that, because a log that lost
+# it - a runner that died early, a flag that stopped matching - would otherwise
+# be indistinguishable here from a clean one.
+#
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+repo_root=$(cd "${SCRIPT_DIR}/../.." && pwd)
+require_output=""
+logs=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-root)
+      if [ $# -lt 2 ]; then
+        echo "$0: --repo-root requires an argument" >&2
+        exit 2
+      fi
+      repo_root=$2
+      shift 2
+      ;;
+    --require-output)
+      require_output=1
+      shift
+      ;;
+    -h|--help)
+      echo "usage: $(basename "$0") [--repo-root DIR] [--require-output] LOGFILE..." >&2
+      exit 0
+      ;;
+    *)
+      logs+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ ${#logs[@]} -eq 0 ]; then
+  echo "$0: no log file given" >&2
+  exit 2
+fi
+
+for log in "${logs[@]}"; do
+  if [ ! -f "${log}" ]; then
+    echo "$0: ${log}: no such file" >&2
+    exit 2
+  fi
+done
+
+if [ ! -d "${repo_root}" ]; then
+  echo "$0: ${repo_root}: no such directory" >&2
+  exit 2
+fi
+
+if ! sources=$(mktemp); then
+  echo "$0: cannot create a temporary file" >&2
+  exit 2
+fi
+trap 'rm -f "${sources}"' EXIT
+
+find "${repo_root}" \
+    -path "${repo_root}/.git" -prune -o \
+    -path "${repo_root}/build" -prune -o \
+    -type f \( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o \
+               -name '*.h' -o -name '*.hh' -o -name '*.hpp' \) -print |
+  sed 's|.*/||' | sort -u > "${sources}"
+
+# Without this list every frame looks like a library's, and the check would
+# pass whatever it was given.
+if [ ! -s "${sources}" ]; then
+  echo "$0: ${repo_root}: no source file found; is that the repository root?" >&2
+  exit 2
+fi
+
+awk -v sources="${sources}" -v require_output="${require_output}" '
+BEGIN {
+  while ((getline name < sources) > 0)
+    ours_source[name] = 1
+  close(sources)
+  binary = "(unknown)"
+}
+
+# Errors are reported by the frame memcheck blames, so skip the wrappers it
+# substitutes for the allocator and for the string functions.
+function is_valgrind_own(where) {
+  return where ~ /^vg_replace_/
+}
+
+function is_ours(where,   file) {
+  if (where ~ /^in /) {
+    return (where ~ /\/build\/(gst|ext|tests)\//)
+  }
+  file = where
+  sub(/:[0-9]+$/, "", file)
+  return (file in ours_source)
+}
+
+function record(kind, where, frame,   key) {
+  key = binary SUBSEP kind SUBSEP where
+  if (key in seen)
+    return
+  seen[key] = 1
+  if (is_ours(where)) {
+    ours_count++
+    ours_binary[ours_count] = binary
+    ours_kind[ours_count] = kind
+    ours_frame[ours_count] = frame
+  } else {
+    library_count++
+  }
+}
+
+{
+  line = $0
+  sub(/^[0-9-]+T[0-9:.]+Z /, "", line)
+  if (line !~ /^==[0-9]+== /)
+    next
+  sub(/^==[0-9]+== /, "", line)
+}
+
+line ~ /^Command: / {
+  examined++
+  binary = line
+  sub(/^Command: /, "", binary)
+  sub(/ .*$/, "", binary)
+  sub(/.*\//, "", binary)
+  next
+}
+
+line ~ /^[0-9,]+ (\([^)]*\) )?bytes in [0-9,]+ blocks are .*lost/ {
+  leak_count++
+  pending = 0
+  candidate = ""
+  next
+}
+
+# Memcheck writes these above a stack of their own; they are part of an error
+# already counted, or an announcement, not a kind this script should classify.
+# Ending the error here matters as much as not classifying it: the stack that
+# follows is where the block was allocated, and blaming an error on that is
+# how a bug in a library becomes ours.
+line ~ /^ *(Address 0x|Uninitialised value was created|Block was alloc|Location 0x|At least one of|Process terminating|Thread [0-9]+|Access not within mapped region|Bad permissions for mapped region|General Protection Fault|Stack overflow in thread)/ {
+  pending = 0
+  candidate = ""
+  next
+}
+
+line ~ /^(Invalid (read|write|free|memory pool|alignment)|Mismatched free|Conditional jump or move depends on uninitialised|Use of uninitialised|Syscall param |Source and destination overlap|Jump to the invalid address|Argument .* has a (fishy|bad)|realloc\(\) with size 0)/ {
+  pending = 1
+  pending_kind = line
+  sub(/ of size [0-9]+$/, "", pending_kind)
+  candidate = ""
+  next
+}
+
+line ~ /^ +(at|by) 0x[0-9A-Fa-f]+: / {
+  if (candidate != "") {
+    unclassified_count++
+    unclassified[unclassified_count] = candidate
+    candidate = ""
+  }
+  if (!pending)
+    next
+  where = line
+  if (where ~ /\([^)]*\)$/) {
+    sub(/^.*\(/, "", where)
+    sub(/\)$/, "", where)
+  } else {
+    next
+  }
+  if (is_valgrind_own(where))
+    next
+  frame = line
+  sub(/^ +/, "", frame)
+  record(pending_kind, where, frame)
+  pending = 0
+  next
+}
+
+{
+  pending = 0
+  candidate = (line ~ /^ *$/) ? "" : line
+}
+
+END {
+  if (require_output != "" && examined == 0) {
+    print "valgrind log check: the log holds no memcheck output at all."
+    exit 1
+  }
+  printf "valgrind log check: %d error contexts from this repository, ", ours_count
+  printf "%d from libraries, %d leak reports, %d binaries examined\n", library_count, leak_count, examined
+  for (i = 1; i <= unclassified_count; i++)
+    printf "::warning::valgrind log check does not classify this report, so it can neither pass nor fail on it: %s\n", unclassified[i]
+  if (ours_count == 0)
+    exit 0
+  print ""
+  print "Memcheck errors reported in this repository'\''s own code:"
+  for (i = 1; i <= ours_count; i++) {
+    printf "  [%s] %s\n", ours_binary[i], ours_kind[i]
+    printf "      %s\n", ours_frame[i]
+  }
+  exit 1
+}
+' "${logs[@]}"

--- a/tools/debugging/test_check_valgrind_log.sh
+++ b/tools/debugging/test_check_valgrind_log.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+
+##
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# @file     test_check_valgrind_log.sh
+# @brief    Self-test for check_valgrind_log.sh.
+# @see      https://github.com/nnstreamer/nnstreamer
+# @author   MyungJoo Ham <myungjoo.ham@samsung.com>
+#
+# Each case is a hand-written memcheck log against a throwaway source tree, so
+# that what the checker is supposed to key on - the file a frame names, the
+# object a frame names, whether the error is a leak - is the only thing that
+# varies between them.
+#
+# The cases that expect a pass also assert the counts in the summary line. A
+# checker that parsed nothing at all would exit 0 for every log, and without
+# those counts every one of them would agree with it.
+#
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+CHECKER="${SCRIPT_DIR}/check_valgrind_log.sh"
+workdir=$(mktemp -d)
+repo="${workdir}/repo"
+failed=0
+
+trap 'rm -rf "${workdir}"' EXIT
+
+mkdir -p "${repo}/gst"
+touch "${repo}/gst/myelement.c" "${repo}/gst/myelement.h"
+
+##
+# @brief Report one expectation and remember a failure.
+# @param $1 0 when the expectation held, anything else when it did not
+# @param $2 description of the expectation
+report() {
+  if [ "$1" -eq 0 ]; then
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+    failed=1
+  fi
+}
+
+##
+# @brief Run the checker on a log written from stdin.
+# @param $1 name of the case, used for the log file
+# @param $@ further options handed to the checker
+# Sets `status` and `output`.
+run_case() {
+  local name=$1
+  local log="${workdir}/${name}.log"
+  shift
+  cat > "${log}"
+  output=$(bash "${CHECKER}" --repo-root "${repo}" "$@" "${log}" 2>&1)
+  status=$?
+}
+
+##
+# @brief Assert the checker's exit status.
+# @param $1 expected status
+# @param $2 description of the expectation
+expect_status() {
+  if [ "${status}" -eq "$1" ]; then
+    report 0 "$2"
+  else
+    report 1 "$2 (got status ${status}: ${output})"
+  fi
+}
+
+##
+# @brief Assert that the checker's output contains the given text.
+# @param $1 text that must appear
+# @param $2 description of the expectation
+expect_in() {
+  case "${output}" in
+    *"$1"*) report 0 "$2" ;;
+    *) report 1 "$2 (output: ${output})" ;;
+  esac
+}
+
+##
+# @brief Assert that the checker's output does not contain the given text.
+# @param $1 text that must not appear
+# @param $2 description of the expectation
+expect_not_in() {
+  case "${output}" in
+    *"$1"*) report 1 "$2 (output: ${output})" ;;
+    *) report 0 "$2" ;;
+  esac
+}
+
+if [ ! -f "${CHECKER}" ]; then
+  echo "FAIL: ${CHECKER} is missing."
+  exit 1
+fi
+
+run_case ours <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid read of size 4
+==1==    at 0x1111: my_element_chain (myelement.c:42)
+==1==    by 0x2222: g_closure_invoke (in /usr/lib/libgobject-2.0.so.0)
+==1==
+EOF
+expect_status 1 "an error reported in a source of this repository fails the check"
+expect_in "myelement.c:42" "the failing error is printed with its frame"
+expect_in "unittest_demo" "the failing error is printed with its binary"
+
+run_case library <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid read of size 8
+==1==    at 0x3333: strncmp (strcmp.S:172)
+==1==    by 0x4444: my_element_chain (myelement.c:42)
+==1==
+EOF
+expect_status 0 "an error blamed on a library passes even when we called it"
+expect_in "1 from libraries" "the library error is still counted"
+
+run_case wrapper_then_ours <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid write of size 1
+==1==    at 0x5555: malloc (vg_replace_malloc.c:381)
+==1==    by 0x6666: my_element_init (myelement.c:11)
+==1==
+EOF
+expect_status 1 "valgrind's own wrapper is skipped when attributing an error"
+expect_in "myelement.c:11" "attribution lands on the first frame that is not the wrapper"
+
+run_case wrapper_then_library_n <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid write of size 1
+==1==    at 0x5555: malloc (vg_replace_malloc.c:381)
+==1==    by 0x6666: g_malloc (in /usr/lib/libglib-2.0.so.0)
+==1==
+EOF
+expect_status 0 "skipping the wrapper does not by itself make an error ours"
+expect_in "1 from libraries" "that error is counted as a library one"
+
+run_case object_ours <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid read of size 4
+==1==    at 0x7777: some_symbol (in /home/runner/work/nnstreamer/build/gst/libnnstreamer.so)
+==1==
+EOF
+expect_status 1 "a frame naming an object under the build directory is ours"
+
+run_case object_library_n <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid read of size 4
+==1==    at 0x7777: some_symbol (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0)
+==1==
+EOF
+expect_status 0 "a frame naming a system object is not ours"
+expect_in "1 from libraries" "that error is counted as a library one"
+
+run_case leak <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== 400 bytes in 1 blocks are definitely lost in loss record 3 of 9
+==1==    at 0x8888: my_element_init (myelement.c:11)
+==1==
+EOF
+expect_status 0 "a leak allocated by this repository does not fail the check"
+expect_in "1 leak reports" "the leak is counted"
+expect_not_in "myelement.c:11" "the leak is not reported as a failing error"
+
+run_case timestamped <<'EOF'
+2026-09-07T07:21:27.4959062Z ==1== Command: ./tests/unittest_demo
+2026-09-07T07:21:27.4959062Z ==1== Invalid read of size 4
+2026-09-07T07:21:27.4959062Z ==1==    at 0x1111: my_element_chain (myelement.c:42)
+2026-09-07T07:21:27.4959062Z ==1==
+EOF
+expect_status 1 "a log carrying the timestamps a CI run adds is still parsed"
+
+run_case repeated <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid read of size 4
+==1==    at 0x1111: my_element_chain (myelement.c:42)
+==1==
+==1== Invalid read of size 4
+==1==    at 0x1111: my_element_chain (myelement.c:42)
+==1==
+EOF
+expect_status 1 "a repeated error still fails the check"
+expect_in "1 error contexts from this repository" "the same error in one binary is counted once"
+
+run_case two_binaries <<'EOF'
+==1== Command: ./tests/unittest_one
+==1== Invalid read of size 4
+==1==    at 0x1111: my_element_chain (myelement.c:42)
+==1==
+==2== Command: ./tests/unittest_two
+==2== Invalid read of size 4
+==2==    at 0x1111: my_element_chain (myelement.c:42)
+==2==
+EOF
+expect_in "2 error contexts from this repository" "the same error in two binaries is counted twice"
+
+run_case quiet <<'EOF'
+[  PASSED  ] 12 tests.
+EOF
+expect_status 0 "a log with no memcheck output passes"
+expect_in "0 error contexts" "and reports nothing"
+
+run_case overlap <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Source and destination overlap in memcpy(0x1000, 0x1004, 12)
+==1==    at 0x1111: my_element_chain (myelement.c:42)
+==1==
+EOF
+expect_status 1 "an overlapping copy is an error like any other"
+
+run_case fishy_argument <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Argument 'size' of function malloc has a fishy (possibly negative) value: -1
+==1==    at 0x1111: my_element_init (myelement.c:11)
+==1==
+EOF
+expect_status 1 "an allocation of a fishy size is an error like any other"
+
+# --track-origins=yes appends the stack of the allocation the uninitialised
+# value came from. That stack is often ours even when the error is not, so an
+# error is decided by the frame memcheck blames and not by anything below it.
+run_case origin_stack_n <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Conditional jump or move depends on uninitialised value(s)
+==1==    at 0x1111: g_str_equal (in /usr/lib/libglib-2.0.so.0)
+==1==  Uninitialised value was created by a heap allocation
+==1==    at 0x2222: malloc (vg_replace_malloc.c:381)
+==1==    by 0x3333: my_element_init (myelement.c:11)
+==1==
+EOF
+expect_status 0 "the origin stack of an uninitialised value does not decide the error"
+expect_in "1 from libraries" "the error is counted where memcheck blamed it"
+
+run_case address_stack_n <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid read of size 4
+==1==    at 0x1111: g_hash_table_lookup (in /usr/lib/libglib-2.0.so.0)
+==1==  Address 0x5204040 is 0 bytes after a block of size 8 alloc'd
+==1==    at 0x2222: malloc (vg_replace_malloc.c:381)
+==1==    by 0x3333: my_element_init (myelement.c:11)
+==1==
+EOF
+expect_status 0 "the stack of the block an address belongs to does not decide the error"
+expect_in "1 from libraries" "that error is counted as a library one"
+
+# The stack under a prelude line is where the block was allocated. If an error
+# ends without a frame to blame - every frame a valgrind wrapper, or one with
+# no location at all - that allocation stack must not be read as a
+# continuation of it, or the code that allocated the block answers for a bug
+# in the code that touched it.
+run_case wrapper_only_then_prelude_n <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid read of size 4
+==1==    at 0x1111: memcpy (vg_replace_strmem.c:1123)
+==1==  Address 0x5204040 is 0 bytes after a block of size 8 alloc'd
+==1==    at 0x2222: malloc (vg_replace_malloc.c:381)
+==1==    by 0x3333: my_element_init (myelement.c:11)
+==1==
+EOF
+expect_status 0 "an error with no frame to blame does not fall through to the next stack"
+expect_not_in "myelement.c:11" "the allocating frame is not blamed for it"
+
+run_case unlocatable_then_prelude_n <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Use of uninitialised value of size 8
+==1==    at 0x1111: ???
+==1==  Uninitialised value was created by a heap allocation
+==1==    at 0x2222: malloc (vg_replace_malloc.c:381)
+==1==    by 0x3333: my_element_init (myelement.c:11)
+==1==
+EOF
+expect_status 0 "a frame with no location does not carry the error into the origin stack"
+expect_not_in "myelement.c:11" "the allocating frame is not blamed for it either"
+
+run_case build_elsewhere_n <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid read of size 4
+==1==    at 0x7777: some_symbol (in /opt/vendor/build/lib/libvendor.so)
+==1==
+EOF
+expect_status 0 "an object merely built somewhere is not ours"
+expect_in "1 from libraries" "that error is counted as a library one"
+
+run_case unknown_kind <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invented error nobody has seen before
+==1==    at 0x1111: my_element_chain (myelement.c:42)
+==1==
+EOF
+expect_status 0 "a report of a kind this checker does not know does not fail the check"
+expect_in "::warning::" "but it is called out rather than passed over"
+expect_in "Invented error" "and the report is quoted"
+
+run_case known_prelude_n <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid read of size 4
+==1==    at 0x1111: g_str_equal (in /usr/lib/libglib-2.0.so.0)
+==1==  Address 0x5204040 is 0 bytes after a block of size 8 alloc'd
+==1==    at 0x2222: malloc (vg_replace_malloc.c:381)
+==1==    by 0x3333: my_element_init (myelement.c:11)
+==1==
+==1== Process terminating with default action of signal 6 (SIGABRT)
+==1==    at 0x4444: raise (raise.c:51)
+==1==
+EOF
+expect_not_in "::warning::" "the lines memcheck writes above a stack of their own are not reports"
+
+run_case quiet_required --require-output <<'EOF'
+[  PASSED  ] 12 tests.
+EOF
+expect_status 1 "--require-output rejects a log that lost its memcheck output"
+expect_in "no memcheck output" "and says why"
+
+run_case examined_required --require-output <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid read of size 8
+==1==    at 0x3333: strncmp (strcmp.S:172)
+==1==
+EOF
+expect_status 0 "--require-output passes a log that has memcheck output and no error of ours"
+expect_in "1 binaries examined" "the binary count is reported"
+
+output=$(bash "${CHECKER}" --repo-root "${repo}" "${workdir}/does-not-exist.log" 2>&1)
+status=$?
+expect_status 2 "a missing log file is a usage error, not a pass"
+
+output=$(bash "${CHECKER}" --repo-root "${repo}" 2>&1)
+status=$?
+expect_status 2 "no log file at all is a usage error, not a pass"
+
+# A root with no source in it leaves every frame looking like a library's, so
+# the check would pass anything. It has to say so instead.
+empty="${workdir}/empty-root"
+mkdir -p "${empty}"
+cat > "${workdir}/for-empty-root.log" <<'EOF'
+==1== Command: ./tests/unittest_demo
+==1== Invalid read of size 4
+==1==    at 0x1111: my_element_chain (myelement.c:42)
+==1==
+EOF
+output=$(bash "${CHECKER}" --repo-root "${empty}" "${workdir}/for-empty-root.log" 2>&1)
+status=$?
+expect_status 2 "a repository root holding no source is a usage error, not a pass"
+expect_in "no source file found" "and says why"
+
+if [ ${failed} -ne 0 ]; then
+  echo "check_valgrind_log.sh self-test failed."
+  exit 1
+fi
+
+echo "check_valgrind_log.sh self-test passed."
+exit 0


### PR DESCRIPTION
The memcheck pass has never been able to fail a build. Both invocations end in `|| echo`, and valgrind runs without `--error-exitcode`, so a finding never reaches the step's exit status in the first place. This makes it fail on a memcheck error that is ours, and only on that.

Follows #4921, which brought the step to 7-12 min over 22 binaries, and #4929, which removed the last memcheck errors this repository was responsible for.

## Why not suppressions

The reason the pass was advisory is real and is not going away: a run reports errors from GLib, from ld.so and from the inference runtimes, and those belong to other projects.

Suppressions cannot separate them, because they match a stack. The stack of a block GLib allocated and *we* failed to free looks like the stack of one GLib allocated and leaked itself; a suppression written against our own frames would hide our bugs along with the noise. The repository's own file shows the same problem from the other side — `tools/debugging/valgrind_suppression` has 28 entries and suppressed **2** errors across a whole run, because it was written for `gst-launch` and python, not for these binaries. Growing it is not the path.

## What this does instead

`tools/debugging/check_valgrind_log.sh` attributes each error to the frame memcheck blames for it — the first one that is not valgrind's own allocator wrapper — and calls that frame ours when it names a source file this repository holds or an object under the build directory. Only a non-leak error attributed to us fails.

Measured on real logs:

| | errors of ours | library errors | leak reports | binaries |
|---|---|---|---|---|
| [34094878222](https://github.com/nnstreamer/nnstreamer/actions/runs/34094878222), current main | **0** | 14 | 167 | 23 |
| [33853964542](https://github.com/nnstreamer/nnstreamer/actions/runs/33853964542), before #4929 | **8** | 13 | 158 | 22 |

The 8 are exactly the uninitialised reads `gst_tensor_meta_info_parse_header` and `gst_tensor_meta_info_validate` were making on tensor_transform's unfilled output memory, which #4929 fixed. So the gate goes in with **no baseline file**: there is nothing to forgive today, and anything that appears afterwards is new.

And in this branch's own CI ([34099915322](https://github.com/nnstreamer/nnstreamer/actions/runs/34099915322)) the gate runs for real and says the same thing:

```
valgrind log check: 0 error contexts from this repository, 14 from libraries, 162 leak reports, 23 binaries examined
```

I also checked the rule cannot misfire on a name collision. Of the 67 source file names that appear in frames across both logs, the 39 the repository also holds are all genuinely ours (nnstreamer sources and test sources); the other 28 — `dl-load.c`, `strcmp.S`, `rtld-malloc.h`, `pthread_create.c`, `gtest.h` and so on — exist in no file of ours.

## What stays out

**Leaks.** A leak is reported at its allocation, which for most of ours is inside GLib, so the frame that would decide responsibility is further down the stack than this rule looks. In that same run, 77 of 89 leak contexts have a frame of ours somewhere — 56 of them in test code. Gating on that rule would be wrong in both directions. They are counted and printed, and left for their own change.

**Test failures.** The two runs are piped through `tee`, so the runner's exit status is the pipeline's last command and a failing test binary still does not fail the step, exactly as `|| echo` did. What replaces `|| echo` is the checker's own verdict.

`--require-output` covers the one case that arrangement would otherwise hide: a log that lost its memcheck output entirely — a runner that died early, a flag that stopped matching — is indistinguishable from a clean one, so the step asks for it explicitly. The two runs write separate logs and are checked separately, so neither can satisfy that on the other's behalf, and both logs are kept as an artifact when the job fails.

**Reports of a kind the checker does not know.** Printed as a `::warning::` naming the line rather than silently counted as nothing, so a new or renamed memcheck message surfaces instead of quietly leaving the gate. It does not fail: a new announcement turning every job red is the worse failure. Both reference logs produce no warnings — the only unclassified lines in them were `Process terminating with default action of signal 6` and a `Thread N ...` header, which are recognised as the announcements they are.

## Blast radius

`packaging/run_unittests_binaries.sh` is untouched. It has five callers and only this step passes `--valgrind`, so `debian/rules`, `nnstreamer.spec`, `risc-v.yml` and the docker image see no change at all. The two new files live under `tools/`, which no packaging file ships. The step is already x86-only.

Worth knowing: `unittest_*.cc` are sources of ours, so a memory error in test code would gate too. There are none today, and an invalid read in a test is a bug worth stopping for.

## Testing

`tools/debugging/test_check_valgrind_log.sh` pins the rule against hand-written logs, wired into *Static checks* with the same merge-ref guard as the other self-tests: an error in a source of ours fails; the same error in `strcmp.S` or in a system object does not; valgrind's wrapper is skipped so the frame under it decides; skipping the wrapper does not by itself make an error ours; a leak allocated by us does not gate; a build-directory object does gate; the CI timestamp prefix is tolerated; a repeat is counted once and the same error in two binaries twice; a missing file and a missing argument are usage errors rather than passes; and `--require-output` rejects an empty log while accepting one that merely has no error of ours.

Every case that expects a pass also asserts the counts in the summary line, so a checker that silently parsed nothing could not satisfy them.

Verified locally with shellcheck clean, the self-test green, and both CI logs above run through the checker end to end. The pipeline semantics were checked separately under `bash -e` without `pipefail`, which is what GitHub gives this step: a failing runner does not abort it, and the checker does.

## Not in this change

- The SSAT valgrind step on decoder-bounding-box. Its output is not captured, and SSAT's own verdict does not see memcheck findings either.
- The leak gate, and the 21 leak contexts in shipped code that would have to be dealt with first.
- `tools/debugging/valgrind_suppression`. It is nearly inert, but nothing here depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
