### PR TITLE
[Common] Do not parse a tensor meta header past the buffer

### DIFF
--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -533,6 +533,7 @@ gst_tensor_time_sync_buffer_from_collectpad (GstCollectPads * collect,
  * @brief Configure gst-buffer with tensors information.
  * NNStreamer handles single memory chunk as single tensor.
  * If incoming buffer has invalid memories, separate it and generate new gst-buffer using tensors information.
+ * Bytes of a flexible buffer that do not describe a tensor are handed over as the last memory of the result.
  * Note that this function always takes the ownership of input buffer.
  * @param in input buffer
  * @param config tensors config structure
@@ -582,6 +583,9 @@ gst_tensor_buffer_from_config (GstBuffer * in, GstTensorsConfig * config)
         mem_size[num - 1] += gst_tensors_info_get_size (&config->info, i);
     }
   } else {
+    GstTensorMetaInfo meta;
+    gsize hsize;
+
     if (num > 1) {
       /* Suppose it is already configured. */
       out = gst_buffer_ref (in);
@@ -593,20 +597,27 @@ gst_tensor_buffer_from_config (GstBuffer * in, GstTensorsConfig * config)
       goto error;
     }
 
+    gst_tensor_meta_info_init (&meta);
+    hsize = gst_tensor_meta_info_get_header_size (&meta);
+
     num = 0;
     offset = 0;
     while (offset < total) {
-      GstTensorMetaInfo meta;
-      gpointer h = map.data + offset;
-
-      if (num >= NNS_TENSOR_MEMORY_MAX - 1) {
+      if (num >= NNS_TENSOR_MEMORY_MAX - 1 || (total - offset) < hsize ||
+          !gst_tensor_meta_info_parse_header (&meta, map.data + offset)) {
         /* Suppose remained memory may include extra tensors. */
         mem_size[num++] = total - offset;
         break;
       }
 
-      gst_tensor_meta_info_parse_header (&meta, h);
       mem_size[num] = gst_tensor_meta_info_get_header_size (&meta);
+
+      if (mem_size[num] == 0) {
+        /* Parsed header of an unknown version, cannot tell the tensors apart. */
+        mem_size[num++] = total - offset;
+        break;
+      }
+
       mem_size[num] += gst_tensor_meta_info_get_data_size (&meta);
 
       offset += mem_size[num];

--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -184,6 +184,7 @@ gst_tensor_time_sync_buffer_from_collectpad (GstCollectPads * collect, tensor_ti
  * @brief Configure gst-buffer with tensors information.
  * NNStreamer handles single memory chunk as single tensor.
  * If incoming buffer has invalid memories, separate it and generate new gst-buffer using tensors information.
+ * Bytes of a flexible buffer that do not describe a tensor are handed over as the last memory of the result.
  * Note that this function always takes the ownership of input buffer.
  * @param in input buffer
  * @param config tensors config structure

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -2455,6 +2455,301 @@ TEST (commonUtil, createFlexTensorBuffer)
 }
 
 /**
+ * @brief Internal util function to build a flexible tensor stream of @a num
+ *        tensors, each carrying @a dsize bytes filled with its own index.
+ *        The size of the whole block is stored in @a total and the size of a
+ *        single tensor, its header included, in @a each. The caller owns the
+ *        returned block.
+ */
+static guint8 *
+build_flex_tensor_data (guint num, gsize dsize, gsize *total, gsize *each)
+{
+  GstTensorInfo info;
+  GstTensorMetaInfo meta;
+  guint8 *data;
+  gsize hsize, offset = 0;
+  guint i;
+
+  gst_tensor_info_init (&info);
+  info.type = _NNS_UINT8;
+  info.dimension[0] = (uint32_t) dsize;
+
+  gst_tensor_info_convert_to_meta (&info, &meta);
+  hsize = gst_tensor_meta_info_get_header_size (&meta);
+
+  *each = hsize + dsize;
+  *total = *each * num;
+  data = (guint8 *) g_malloc (*total);
+
+  for (i = 0; i < num; i++) {
+    gst_tensor_meta_info_update_header (&meta, data + offset);
+    memset (data + offset + hsize, (int) i, dsize);
+    offset += *each;
+  }
+
+  gst_tensor_info_free (&info);
+  return data;
+}
+
+/**
+ * @brief Internal util function to run gst_tensor_buffer_from_config () on a
+ *        flexible config with @a data of @a size bytes, which it takes over.
+ */
+static GstBuffer *
+flex_buffer_from_config (guint8 *data, gsize size)
+{
+  GstTensorsConfig config;
+  GstBuffer *out;
+
+  gst_tensors_config_init (&config);
+  config.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  config.rate_n = config.rate_d = 1;
+
+  out = gst_tensor_buffer_from_config (gst_buffer_new_wrapped (data, size), &config);
+
+  gst_tensors_config_free (&config);
+  return out;
+}
+
+/**
+ * @brief Internal util function to get the size of the nth memory of @a buf.
+ */
+static gsize
+peek_memory_size (GstBuffer *buf, guint nth)
+{
+  return gst_memory_get_sizes (gst_buffer_peek_memory (buf, nth), NULL, NULL);
+}
+
+/**
+ * @brief Test tensor buffer util (more flexible tensors than the memory limit)
+ */
+TEST (commonUtil, createFlexTensorBufferOverMemoryMax)
+{
+  GstBuffer *out;
+  guint8 *data;
+  gsize total, each;
+  guint i;
+
+  data = build_flex_tensor_data (20U, 16U, &total, &each);
+  out = flex_buffer_from_config (data, total);
+  ASSERT_TRUE (out != NULL);
+
+  EXPECT_EQ (gst_buffer_n_memory (out), (guint) NNS_TENSOR_MEMORY_MAX);
+  for (i = 0; i < NNS_TENSOR_MEMORY_MAX - 1U; i++)
+    EXPECT_EQ (peek_memory_size (out, i), each);
+
+  /* the tensors that do not fit are left in the last memory */
+  EXPECT_EQ (peek_memory_size (out, NNS_TENSOR_MEMORY_MAX - 1U),
+      each * (20U - (NNS_TENSOR_MEMORY_MAX - 1U)));
+  EXPECT_EQ (gst_buffer_get_size (out), total);
+
+  gst_buffer_unref (out);
+}
+
+/**
+ * @brief Test tensor buffer util (flexible buffer shorter than a meta header)
+ */
+TEST (commonUtil, createFlexTensorBufferShortHeader_n)
+{
+  GstBuffer *out;
+
+  out = flex_buffer_from_config ((guint8 *) g_malloc0 (4), 4);
+  ASSERT_TRUE (out != NULL);
+
+  EXPECT_EQ (gst_buffer_n_memory (out), 1U);
+  EXPECT_EQ (gst_buffer_get_size (out), (gsize) 4);
+
+  gst_buffer_unref (out);
+}
+
+/**
+ * @brief Test tensor buffer util (trailing bytes shorter than a meta header)
+ */
+TEST (commonUtil, createFlexTensorBufferShortTrailing_n)
+{
+  GstBuffer *out;
+  guint8 *data;
+  gsize total, each;
+
+  data = build_flex_tensor_data (1U, 16U, &total, &each);
+  data = (guint8 *) g_realloc (data, total + 4);
+  memset (data + total, 0, 4);
+
+  out = flex_buffer_from_config (data, total + 4);
+  ASSERT_TRUE (out != NULL);
+
+  EXPECT_EQ (gst_buffer_n_memory (out), 2U);
+  EXPECT_EQ (peek_memory_size (out, 0), each);
+  EXPECT_EQ (peek_memory_size (out, 1), (gsize) 4);
+
+  gst_buffer_unref (out);
+}
+
+/**
+ * @brief Test tensor buffer util (flexible buffer without a valid meta header)
+ */
+TEST (commonUtil, createFlexTensorBufferInvalidHeader_n)
+{
+  GstBuffer *out;
+
+  out = flex_buffer_from_config ((guint8 *) g_malloc0 (256), 256);
+  ASSERT_TRUE (out != NULL);
+
+  EXPECT_EQ (gst_buffer_n_memory (out), 1U);
+  EXPECT_EQ (gst_buffer_get_size (out), (gsize) 256);
+
+  gst_buffer_unref (out);
+}
+
+/**
+ * @brief Test tensor buffer util (trailing bytes without a valid meta header)
+ */
+TEST (commonUtil, createFlexTensorBufferInvalidTrailing_n)
+{
+  GstBuffer *out;
+  guint8 *data;
+  gsize total, each;
+
+  data = build_flex_tensor_data (1U, 16U, &total, &each);
+  data = (guint8 *) g_realloc (data, total + 256);
+  memset (data + total, 0, 256);
+
+  out = flex_buffer_from_config (data, total + 256);
+  ASSERT_TRUE (out != NULL);
+
+  EXPECT_EQ (gst_buffer_n_memory (out), 2U);
+  EXPECT_EQ (peek_memory_size (out, 0), each);
+  EXPECT_EQ (peek_memory_size (out, 1), (gsize) 256);
+
+  gst_buffer_unref (out);
+}
+
+/**
+ * @brief Internal util function to build a block of @a size bytes that starts
+ *        with a meta header of @a format and a version that passes the
+ *        validation of the meta but is not V1, so that the header size of the
+ *        tensor it describes is 0. The caller owns the returned block.
+ */
+static guint8 *
+build_unknown_version_data (gsize size, tensor_format format)
+{
+  guint8 *data = (guint8 *) g_malloc0 (size);
+  uint32_t *header = (uint32_t *) data;
+
+  header[0] = 0xfeedcced; /* magic */
+  header[1] = 0xDE002000; /* version */
+  header[2] = (uint32_t) _NNS_UINT8; /* type */
+  header[3] = 1U; /* dimension */
+  header[19] = (uint32_t) format;
+  header[20] = (uint32_t) _NNS_TENSOR; /* media type */
+
+  return data;
+}
+
+/**
+ * @brief Test tensor buffer util (meta header that describes no bytes)
+ */
+TEST (commonUtil, createFlexTensorBufferZeroSizeHeader_n)
+{
+  GstBuffer *out;
+
+  /* a sparse format without a non-zero element has a data size of 0 as well */
+  out = flex_buffer_from_config (
+      build_unknown_version_data (300, _NNS_TENSOR_FORMAT_SPARSE), 300);
+  ASSERT_TRUE (out != NULL);
+
+  EXPECT_EQ (gst_buffer_n_memory (out), 1U);
+  EXPECT_EQ (gst_buffer_get_size (out), (gsize) 300);
+
+  gst_buffer_unref (out);
+}
+
+/**
+ * @brief Test tensor buffer util (meta header of an unknown version)
+ */
+TEST (commonUtil, createFlexTensorBufferUnknownVersionHeader_n)
+{
+  GstBuffer *out;
+
+  /* the data size is known, but without a header size the tensors cannot be told apart */
+  out = flex_buffer_from_config (
+      build_unknown_version_data (300, _NNS_TENSOR_FORMAT_STATIC), 300);
+  ASSERT_TRUE (out != NULL);
+
+  EXPECT_EQ (gst_buffer_n_memory (out), 1U);
+  EXPECT_EQ (gst_buffer_get_size (out), (gsize) 300);
+
+  gst_buffer_unref (out);
+}
+
+/**
+ * @brief Callback for the new-data signal, keeping the size of the buffer.
+ */
+static void
+flex_trailing_new_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  gsize *size = (gsize *) user_data;
+
+  (void) element;
+
+  EXPECT_EQ (gst_tensor_buffer_get_count (buffer), 1U);
+  *size = gst_buffer_get_size (buffer);
+}
+
+/**
+ * @brief Test tensor buffer util (trailing bytes of a flexible buffer in a pipeline)
+ */
+TEST (commonUtil, createFlexTensorBufferShortTrailingPipeline_n)
+{
+  GstElement *pipeline, *appsrc, *sinkx;
+  GstBuffer *buf;
+  guint8 *data;
+  gsize total, each;
+  guint received = 0U;
+  gsize received_size = 0;
+  GstFlowReturn flow_ret;
+
+  pipeline = gst_parse_launch ("appsrc name=appsrc caps=other/tensors,format=flexible,framerate=(fraction)0/1 ! "
+                               "tensor_demux ! tensor_sink name=sinkx async=false sync=false",
+      NULL);
+  ASSERT_TRUE (pipeline != nullptr);
+
+  appsrc = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc");
+  ASSERT_TRUE (appsrc != nullptr);
+  sinkx = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  ASSERT_TRUE (sinkx != nullptr);
+
+  g_signal_connect (sinkx, "new-data", (GCallback) flex_trailing_new_data_cb, &received_size);
+  g_signal_connect (sinkx, "new-data", (GCallback) count_output, &received);
+
+  data = build_flex_tensor_data (1U, 16U, &total, &each);
+  data = (guint8 *) g_realloc (data, total + 4);
+  memset (data + total, 0, 4);
+  buf = gst_buffer_new_wrapped (data, total + 4);
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  /* gst_app_src_push_buffer () takes ownership of buf */
+  flow_ret = gst_app_src_push_buffer (GST_APP_SRC (appsrc), buf);
+  EXPECT_EQ (flow_ret, GST_FLOW_OK);
+  EXPECT_TRUE (wait_pipeline_process_buffers (&received, 1U, TEST_TIMEOUT_LIMIT_MS));
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  /**
+   * The trailing bytes are not a tensor, so the demux ends the flow with an
+   * error once it reaches them. The valid tensor is pushed before that, which
+   * is what this case asserts.
+   */
+  EXPECT_EQ (received, 1U);
+  EXPECT_EQ (received_size, each);
+
+  gst_object_unref (appsrc);
+  gst_object_unref (sinkx);
+  gst_object_unref (pipeline);
+}
+
+/**
  * @brief Test tensor buffer util (invalid config)
  */
 TEST (commonUtil, createTensorBufferInvalidConfig_n)


### PR DESCRIPTION
## What

`gst_tensor_buffer_from_config()` splits a single-memory flexible buffer by walking the meta header of each tensor. The loop parsed a header at every offset without checking that the remaining bytes can hold one:

```c
while (offset < total) {
  gst_tensor_meta_info_parse_header (&meta, map.data + offset);   /* reads up to 88 bytes, always */
  mem_size[num] = gst_tensor_meta_info_get_header_size (&meta);   /* 0 when the parse failed */
  mem_size[num] += gst_tensor_meta_info_get_data_size (&meta);    /* 0 as well */
  offset += mem_size[num];                                        /* offset does not advance */
  num++;
}
```

* A remainder shorter than the 128-byte v1 header is read past the end of the mapped memory. `parse_header()` takes no size: it reads `val[0..20]` (84 bytes, and `val[21]` too for a sparse format) before it validates anything.
* When the parse fails the sizes are 0, so `offset` stays put and the same out-of-bounds bytes are re-read until `num` reaches the memory limit. The buffer then comes back split into 15 zero-length memories plus the remainder.

Reachable from any flexible stream with a single memory that carries trailing bytes or a short payload, through `tensor_transform`, `tensor_demux`, `tensor_crop`, `tensor_sparse{enc,dec}`, `tensor_converter` and the collect-pad sync helper.

This is item **A2** of #4920.

## How

Check the remainder against the header size, and treat a header that does not parse the same way the loop already treats the memory limit: the remaining bytes become the last memory.

A header can also parse and still describe no bytes — `GST_TENSOR_META_IS_VALID()` accepts any version whose top bits match, while `gst_tensor_meta_info_get_header_size()` returns 0 for a version that is not V1, and a sparse format with `nnz == 0` has a data size of 0. That stalls the offset the same way, so the loop takes the same exit whenever the size comes out 0.

**A deliberate deviation from the issue text**, which suggested failing on an invalid header: `gst_tensor_buffer_from_config()` returning NULL more often would turn this over-read into a NULL dereference in the callers that do not check the return value — `tensor_crop` dereferences it immediately (`GST_BUFFER_TIMESTAMP`), and `tensor_demux` / `tensor_sparse*` pass it straight to `gst_tensor_buffer_get_count()`. Those are tracked as items C12/C15 of #4920, so this PR keeps the "hand the undecodable bytes on as one memory" contract the loop already had for the overflow case — now written down in the function's Doxygen — and leaves the stricter rejection to the items that fix the callers.

## Verification

* `unittest_common`: 159/159 pass; the 5 negative cases fail without the fix (the buffer comes back with 16 memories instead of 1 or 2).
* Valgrind (memcheck) over the new cases: **688 errors from 25 contexts** without the fix, all `Invalid read` in `gst_tensor_meta_info_parse_header()` called from `gst_tensor_buffer_from_config()`, and **0 errors** with it. The CI Valgrind GTEST step runs `unittest_common`, so a regression is caught there as well as by the counts.
* Full local suite: 22/23 meson tests pass; `unittest_filter_python3` fails on this box for the known NumPy 1.x/2.x mismatch, unrelated to the change.
* `gst-indent` leaves the changed hunks untouched, `clang-format` (16, the version CPP-Linter pins) is clean on the test file, and `doxygen-tag.sh` (advanced mode, with a negative control) passes.

## Other modules

The helper is shared, so the behaviour change was checked against every caller: for a well-formed flexible buffer nothing changes (the same headers parse to the same memories), and for a malformed one each caller now sees the undecodable bytes as a single memory instead of 15 empty ones plus a remainder — its own parse rejects them exactly as before. The pipeline test pins that on the real element path (`appsrc ! tensor_demux ! tensor_sink`): the valid tensor still reaches the sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
