### PR TITLE
[Element/Decoder] Validate the incoming buffer before decoding

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_decoder.c
+++ b/gst/nnstreamer/elements/gsttensor_decoder.c
@@ -683,6 +683,82 @@ gst_tensordec_configure (GstTensorDecoder * self, const GstCaps * in_caps,
 }
 
 /**
+ * @brief Release the mapped memories of the incoming buffer.
+ * @param mem the memories acquired from the incoming buffer
+ * @param info the map info of each memory
+ * @param num the number of the memories to release
+ */
+static void
+gst_tensordec_release_input (GstMemory * mem[], GstMapInfo info[], guint num)
+{
+  guint i;
+
+  for (i = 0; i < num; i++) {
+    gst_memory_unmap (mem[i], &info[i]);
+    gst_memory_unref (mem[i]);
+  }
+}
+
+/**
+ * @brief Validate the memory of the incoming buffer with the negotiated config.
+ * @param self this pointer of tensor_decoder
+ * @param index the index of the tensor in the incoming buffer
+ * @param data the mapped memory of the tensor
+ * @param size the mapped size of @a data
+ * @return TRUE if the memory holds the tensor the decoder sub-plugin will read
+ */
+static gboolean
+gst_tensordec_check_input_size (GstTensorDecoder * self, guint index,
+    gpointer data, gsize size)
+{
+  gsize expected;
+
+  if (gst_tensors_config_is_flexible (&self->tensor_config)) {
+    GstTensorMetaInfo meta;
+    gsize hsize;
+
+    gst_tensor_meta_info_init (&meta);
+
+    if (size < gst_tensor_meta_info_get_header_size (&meta) ||
+        !gst_tensor_meta_info_parse_header (&meta, data)) {
+      GST_ERROR_OBJECT (self,
+          "Failed to parse the meta info of the %u'th tensor in the incoming buffer.",
+          index);
+      return FALSE;
+    }
+
+    /* a meta version this build cannot size gives no offset to the data */
+    hsize = gst_tensor_meta_info_get_header_size (&meta);
+    if (hsize == 0) {
+      GST_ERROR_OBJECT (self,
+          "The meta info of the %u'th tensor in the incoming buffer declares a version of which the header layout is unknown.",
+          index);
+      return FALSE;
+    }
+
+    expected = hsize + gst_tensor_meta_info_get_data_size (&meta);
+
+    if (size < expected) {
+      GST_ERROR_OBJECT (self,
+          "The %u'th tensor of the incoming buffer is %zd bytes, which is smaller than %zd bytes described by its own meta info.",
+          index, size, expected);
+      return FALSE;
+    }
+  } else {
+    expected = gst_tensors_info_get_size (&self->tensor_config.info, index);
+
+    if (size != expected) {
+      GST_ERROR_OBJECT (self,
+          "The %u'th tensor of the incoming buffer is %zd bytes, which is expected to be %zd bytes by the negotiated caps. Check whether the incoming stream is consistent with the caps of the sink pad.",
+          index, size, expected);
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
  * @brief non-ip transform. required vmethod for BaseTransform class.
  */
 static GstFlowReturn
@@ -710,20 +786,26 @@ gst_tensordec_transform (GstBaseTransform * trans,
       self->tensor_config.info.num_tensors = num_mems;
     }
     num_tensors = self->tensor_config.info.num_tensors;
-    /** Internal logic error. Negotiation process should prevent this! */
-    g_assert (num_mems == num_tensors);
+    if (num_mems != num_tensors) {
+      GST_ERROR_OBJECT (self,
+          "The incoming buffer has %u memory chunks, which is expected to be %u, the number of tensors of the negotiated caps.",
+          num_mems, num_tensors);
+      return GST_FLOW_ERROR;
+    }
 
     for (i = 0; i < num_tensors; i++) {
       in_mem[i] = gst_tensor_buffer_get_nth_memory (inbuf, i);
       if (!gst_memory_map (in_mem[i], &in_info[i], GST_MAP_READ)) {
-        guint j;
         ml_logf ("Failed to map in_mem[%u].\n", i);
 
-        for (j = 0; j < i; j++) {
-          gst_memory_unmap (in_mem[j], &in_info[j]);
-          gst_memory_unref (in_mem[j]);
-        }
+        gst_tensordec_release_input (in_mem, in_info, i);
         gst_memory_unref (in_mem[i]);
+        return GST_FLOW_ERROR;
+      }
+
+      if (!gst_tensordec_check_input_size (self, i, in_info[i].data,
+              in_info[i].size)) {
+        gst_tensordec_release_input (in_mem, in_info, i + 1);
         return GST_FLOW_ERROR;
       }
 
@@ -741,10 +823,7 @@ gst_tensordec_transform (GstBaseTransform * trans,
       res = GST_FLOW_ERROR;
     }
 
-    for (i = 0; i < num_tensors; i++) {
-      gst_memory_unmap (in_mem[i], &in_info[i]);
-      gst_memory_unref (in_mem[i]);
-    }
+    gst_tensordec_release_input (in_mem, in_info, num_tensors);
   } else {
     GST_ERROR_OBJECT (self, "Decoder plugin not yet configured.");
     goto unknown_type;

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -22,6 +22,7 @@
 #include <nnstreamer_util.h>
 #include <string.h>
 #include <tensor_common.h>
+#include <tensor_decoder_custom.h>
 #include <tensor_meta.h>
 #include <unistd.h>
 
@@ -10357,6 +10358,496 @@ TEST (testTensorSplit, finalizeWithoutTensorseg)
   g_log_set_default_handler (old_handler, NULL);
 
   EXPECT_FALSE (tensor_split_logged_critical);
+}
+
+/**
+ * @brief The dimension of the tensor the decoder input cases negotiate
+ */
+#define TEST_DECODER_DIM "3:16:16"
+
+/* how many times the custom decoder below was called, and with what size */
+static guint decoder_custom_invoked;
+static gsize decoder_custom_size;
+
+/**
+ * @brief Custom decoder recording what the element handed over
+ */
+static int
+_decoder_custom_cb (const GstTensorMemory *input,
+    const GstTensorsConfig *config, void *data, GstBuffer *out_buf)
+{
+  UNUSED (config);
+  UNUSED (data);
+
+  decoder_custom_invoked++;
+  decoder_custom_size = input[0].size;
+
+  gst_buffer_append_memory (out_buf, gst_allocator_alloc (NULL, 4, NULL));
+
+  return GST_FLOW_OK;
+}
+
+/**
+ * @brief Get a harness of a tensor_decoder negotiated with the given config
+ */
+static GstHarness *
+_get_decoder_harness (const gchar *mode, const gchar *option1, GstTensorsConfig *config)
+{
+  GstElement *dec = gst_element_factory_make ("tensor_decoder", NULL);
+  GstHarness *h;
+
+  if (!dec)
+    return NULL;
+  gst_object_ref_sink (dec);
+
+  /* the mode should be selected before the caps are negotiated */
+  g_object_set (dec, "mode", mode, NULL);
+  if (option1)
+    g_object_set (dec, "option1", option1, NULL);
+
+  h = gst_harness_new_with_element (dec, "sink", "src");
+  gst_object_unref (dec);
+
+  if (h)
+    gst_harness_set_src_caps (h, gst_tensors_caps_from_config (config));
+
+  return h;
+}
+
+/**
+ * @brief Get a static tensors config of a single uint8 tensor
+ */
+static void
+_get_decoder_config (GstTensorsConfig *config)
+{
+  gst_tensors_config_init (config);
+  config->info.num_tensors = 1;
+  config->info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension (TEST_DECODER_DIM, config->info.info[0].dimension);
+  config->rate_n = 0;
+  config->rate_d = 1;
+}
+
+/**
+ * @brief Get a flexible tensor buffer, of which the meta info describes
+ *        @a data_size bytes while the memory holds @a mem_size bytes
+ */
+static GstBuffer *
+_get_flex_decoder_buffer (GstHarness *h, gsize data_size, gsize mem_size)
+{
+  GstTensorMetaInfo meta;
+  GstBuffer *buf;
+  GstMapInfo map;
+
+  gst_tensor_meta_info_init (&meta);
+  meta.type = _NNS_UINT8;
+  meta.dimension[0] = (uint32_t) data_size;
+  meta.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+
+  buf = gst_harness_create_buffer (h, mem_size);
+
+  if (mem_size >= gst_tensor_meta_info_get_header_size (&meta)) {
+    if (!gst_buffer_map (buf, &map, GST_MAP_WRITE)) {
+      gst_buffer_unref (buf);
+      return NULL;
+    }
+    gst_tensor_meta_info_update_header (&meta, map.data);
+    gst_buffer_unmap (buf, &map);
+  }
+
+  return buf;
+}
+
+/**
+ * @brief The negotiated tensor is handed to the decoder sub-plugin as it is.
+ */
+TEST (testTensorDecoder, pushInputSize)
+{
+  GstTensorsConfig config;
+  GstHarness *h;
+  gsize data_size;
+
+  ASSERT_EQ (0, nnstreamer_decoder_custom_register ("tdec_size", _decoder_custom_cb, NULL));
+
+  _get_decoder_config (&config);
+  h = _get_decoder_harness ("custom-code", "tdec_size", &config);
+  ASSERT_TRUE (h != NULL);
+
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+  decoder_custom_invoked = 0;
+
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_OK);
+  EXPECT_EQ (decoder_custom_invoked, 1U);
+  EXPECT_EQ (decoder_custom_size, data_size);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  EXPECT_EQ (0, nnstreamer_decoder_custom_unregister ("tdec_size"));
+}
+
+/**
+ * @brief A buffer larger than the negotiated tensor is refused.
+ * @details The sub-plugin sizes its output from the caps while it reads as
+ *          many bytes as the incoming memory holds, so the surplus of an
+ *          oversized buffer is written past the end of that output.
+ */
+TEST (testTensorDecoder, pushInputSizeTooLarge_n)
+{
+  GstTensorsConfig config;
+  GstHarness *h;
+  gsize data_size;
+
+  ASSERT_EQ (0, nnstreamer_decoder_custom_register ("tdec_size", _decoder_custom_cb, NULL));
+
+  _get_decoder_config (&config);
+  h = _get_decoder_harness ("custom-code", "tdec_size", &config);
+  ASSERT_TRUE (h != NULL);
+
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+  decoder_custom_invoked = 0;
+
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size + 1)), GST_FLOW_ERROR);
+  EXPECT_EQ (decoder_custom_invoked, 0U);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  EXPECT_EQ (0, nnstreamer_decoder_custom_unregister ("tdec_size"));
+}
+
+/**
+ * @brief A buffer smaller than the negotiated tensor is refused.
+ */
+TEST (testTensorDecoder, pushInputSizeTooSmall_n)
+{
+  GstTensorsConfig config;
+  GstHarness *h;
+  gsize data_size;
+
+  ASSERT_EQ (0, nnstreamer_decoder_custom_register ("tdec_size", _decoder_custom_cb, NULL));
+
+  _get_decoder_config (&config);
+  h = _get_decoder_harness ("custom-code", "tdec_size", &config);
+  ASSERT_TRUE (h != NULL);
+
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+  decoder_custom_invoked = 0;
+
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size / 2)), GST_FLOW_ERROR);
+  EXPECT_EQ (decoder_custom_invoked, 0U);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  EXPECT_EQ (0, nnstreamer_decoder_custom_unregister ("tdec_size"));
+}
+
+/**
+ * @brief A buffer holding more memory chunks than the caps have tensors is refused.
+ * @details The element used to assert on this, which aborts the process for a
+ *          buffer an application or a remote peer has built.
+ */
+TEST (testTensorDecoder, pushInputMemoryCount_n)
+{
+  GstTensorsConfig config;
+  GstHarness *h;
+  GstBuffer *buf;
+  gsize data_size;
+
+  ASSERT_EQ (0, nnstreamer_decoder_custom_register ("tdec_size", _decoder_custom_cb, NULL));
+
+  _get_decoder_config (&config);
+  h = _get_decoder_harness ("custom-code", "tdec_size", &config);
+  ASSERT_TRUE (h != NULL);
+
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+  decoder_custom_invoked = 0;
+
+  buf = gst_harness_create_buffer (h, data_size / 2);
+  gst_buffer_append_memory (buf, gst_allocator_alloc (NULL, data_size / 2, NULL));
+
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_ERROR);
+  EXPECT_EQ (decoder_custom_invoked, 0U);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  EXPECT_EQ (0, nnstreamer_decoder_custom_unregister ("tdec_size"));
+}
+
+/**
+ * @brief A buffer holding fewer memory chunks than the caps have tensors is refused.
+ */
+TEST (testTensorDecoder, pushInputMemoryCountShort_n)
+{
+  GstTensorsConfig config;
+  GstHarness *h;
+  gsize data_size;
+
+  ASSERT_EQ (0, nnstreamer_decoder_custom_register ("tdec_size", _decoder_custom_cb, NULL));
+
+  _get_decoder_config (&config);
+  config.info.num_tensors = 2;
+  gst_tensor_parse_dimension (TEST_DECODER_DIM, config.info.info[1].dimension);
+  config.info.info[1].type = _NNS_UINT8;
+
+  h = _get_decoder_harness ("custom-code", "tdec_size", &config);
+  ASSERT_TRUE (h != NULL);
+
+  data_size = gst_tensors_info_get_size (&config.info, -1);
+  decoder_custom_invoked = 0;
+
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_ERROR);
+  EXPECT_EQ (decoder_custom_invoked, 0U);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  EXPECT_EQ (0, nnstreamer_decoder_custom_unregister ("tdec_size"));
+}
+
+/**
+ * @brief A flexible tensor is handed over with its meta header.
+ */
+TEST (testTensorDecoder, pushFlexibleInput)
+{
+  GstTensorsConfig config;
+  GstTensorMetaInfo meta;
+  GstHarness *h;
+  gsize hsize;
+
+  ASSERT_EQ (0, nnstreamer_decoder_custom_register ("tdec_size", _decoder_custom_cb, NULL));
+
+  gst_tensors_config_init (&config);
+  config.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  h = _get_decoder_harness ("custom-code", "tdec_size", &config);
+  ASSERT_TRUE (h != NULL);
+
+  gst_tensor_meta_info_init (&meta);
+  hsize = gst_tensor_meta_info_get_header_size (&meta);
+  decoder_custom_invoked = 0;
+
+  EXPECT_EQ (gst_harness_push (h, _get_flex_decoder_buffer (h, 64, hsize + 64)), GST_FLOW_OK);
+  EXPECT_EQ (decoder_custom_invoked, 1U);
+  EXPECT_EQ (decoder_custom_size, hsize + 64);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  EXPECT_EQ (0, nnstreamer_decoder_custom_unregister ("tdec_size"));
+}
+
+/**
+ * @brief A flexible tensor longer than its own meta info is accepted.
+ * @details A tensor that describes itself is allowed to carry slack, so the
+ *          header and the data have to fit in the memory, not to fill it.
+ */
+TEST (testTensorDecoder, pushFlexibleInputOversized)
+{
+  GstTensorsConfig config;
+  GstTensorMetaInfo meta;
+  GstHarness *h;
+  gsize hsize;
+
+  ASSERT_EQ (0, nnstreamer_decoder_custom_register ("tdec_size", _decoder_custom_cb, NULL));
+
+  gst_tensors_config_init (&config);
+  config.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  h = _get_decoder_harness ("custom-code", "tdec_size", &config);
+  ASSERT_TRUE (h != NULL);
+
+  gst_tensor_meta_info_init (&meta);
+  hsize = gst_tensor_meta_info_get_header_size (&meta);
+  decoder_custom_invoked = 0;
+
+  EXPECT_EQ (gst_harness_push (h, _get_flex_decoder_buffer (h, 64, hsize + 128)), GST_FLOW_OK);
+  EXPECT_EQ (decoder_custom_invoked, 1U);
+  EXPECT_EQ (decoder_custom_size, hsize + 128);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  EXPECT_EQ (0, nnstreamer_decoder_custom_unregister ("tdec_size"));
+}
+
+/**
+ * @brief A flexible tensor shorter than its own meta info is refused.
+ * @details The sub-plugins take the data size out of the meta header without
+ *          knowing how long the memory holding it is.
+ */
+TEST (testTensorDecoder, pushFlexibleInputTruncated_n)
+{
+  GstTensorsConfig config;
+  GstTensorMetaInfo meta;
+  GstHarness *h;
+  gsize hsize;
+
+  ASSERT_EQ (0, nnstreamer_decoder_custom_register ("tdec_size", _decoder_custom_cb, NULL));
+
+  gst_tensors_config_init (&config);
+  config.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  h = _get_decoder_harness ("custom-code", "tdec_size", &config);
+  ASSERT_TRUE (h != NULL);
+
+  gst_tensor_meta_info_init (&meta);
+  hsize = gst_tensor_meta_info_get_header_size (&meta);
+  decoder_custom_invoked = 0;
+
+  EXPECT_EQ (gst_harness_push (h, _get_flex_decoder_buffer (h, 64, hsize + 32)), GST_FLOW_ERROR);
+  EXPECT_EQ (decoder_custom_invoked, 0U);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  EXPECT_EQ (0, nnstreamer_decoder_custom_unregister ("tdec_size"));
+}
+
+/**
+ * @brief A flexible tensor long enough for a meta header but not holding one is refused.
+ * @details The memory passes the length guard, so this is the branch where the
+ *          content of the header itself decides.
+ */
+TEST (testTensorDecoder, pushFlexibleInputBrokenHeader_n)
+{
+  GstTensorsConfig config;
+  GstTensorMetaInfo meta;
+  GstHarness *h;
+  GstBuffer *buf;
+  gsize hsize;
+
+  ASSERT_EQ (0, nnstreamer_decoder_custom_register ("tdec_size", _decoder_custom_cb, NULL));
+
+  gst_tensors_config_init (&config);
+  config.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  h = _get_decoder_harness ("custom-code", "tdec_size", &config);
+  ASSERT_TRUE (h != NULL);
+
+  gst_tensor_meta_info_init (&meta);
+  hsize = gst_tensor_meta_info_get_header_size (&meta);
+  decoder_custom_invoked = 0;
+
+  buf = gst_harness_create_buffer (h, hsize + 64);
+  gst_buffer_memset (buf, 0, 0x11, hsize + 64);
+
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_ERROR);
+  EXPECT_EQ (decoder_custom_invoked, 0U);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  EXPECT_EQ (0, nnstreamer_decoder_custom_unregister ("tdec_size"));
+}
+
+/**
+ * @brief A flexible tensor declaring an unknown meta version is refused.
+ * @details The magic and the fields still validate, but the header layout of
+ *          another major version is unknown, so the data cannot be located.
+ */
+TEST (testTensorDecoder, pushFlexibleInputUnknownVersion_n)
+{
+  GstTensorsConfig config;
+  GstTensorMetaInfo meta;
+  GstHarness *h;
+  GstBuffer *buf;
+  GstMapInfo map;
+  gsize hsize;
+  guint major = 0;
+
+  ASSERT_EQ (0, nnstreamer_decoder_custom_register ("tdec_size", _decoder_custom_cb, NULL));
+
+  gst_tensors_config_init (&config);
+  config.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  h = _get_decoder_harness ("custom-code", "tdec_size", &config);
+  ASSERT_TRUE (h != NULL);
+
+  gst_tensor_meta_info_init (&meta);
+  hsize = gst_tensor_meta_info_get_header_size (&meta);
+  decoder_custom_invoked = 0;
+
+  buf = _get_flex_decoder_buffer (h, 64, hsize + 64);
+  ASSERT_TRUE (buf != NULL);
+
+  /**
+   * Keep the magic and raise the major of the version. The version marker and
+   * the major live in the second word of the header; both encodings are
+   * private to nnstreamer_plugin_api_util_impl.c, so the assertions below pin
+   * what this literal has to mean: a header that still validates, of a version
+   * whose layout cannot be sized. Without them a changed encoding would leave
+   * the case passing on the parse failure before the branch under test.
+   */
+  ASSERT_TRUE (gst_buffer_map (buf, &map, GST_MAP_WRITE));
+  ((uint32_t *) map.data)[1] = 0xDE002000U;
+
+  EXPECT_TRUE (gst_tensor_meta_info_parse_header (&meta, map.data));
+  EXPECT_TRUE (gst_tensor_meta_info_get_version (&meta, &major, NULL));
+  EXPECT_NE (major, 1U);
+  EXPECT_EQ (gst_tensor_meta_info_get_header_size (&meta), 0U);
+  gst_buffer_unmap (buf, &map);
+
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_ERROR);
+  EXPECT_EQ (decoder_custom_invoked, 0U);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  EXPECT_EQ (0, nnstreamer_decoder_custom_unregister ("tdec_size"));
+}
+
+/**
+ * @brief A flexible tensor too short to hold a meta header is refused.
+ */
+TEST (testTensorDecoder, pushFlexibleInputNoHeader_n)
+{
+  GstTensorsConfig config;
+  GstHarness *h;
+
+  ASSERT_EQ (0, nnstreamer_decoder_custom_register ("tdec_size", _decoder_custom_cb, NULL));
+
+  gst_tensors_config_init (&config);
+  config.info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  h = _get_decoder_harness ("custom-code", "tdec_size", &config);
+  ASSERT_TRUE (h != NULL);
+
+  decoder_custom_invoked = 0;
+
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, 16)), GST_FLOW_ERROR);
+  EXPECT_EQ (decoder_custom_invoked, 0U);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  EXPECT_EQ (0, nnstreamer_decoder_custom_unregister ("tdec_size"));
+}
+
+/**
+ * @brief An oversized buffer does not overrun the video frame of direct_video.
+ * @details direct_video copies as many bytes as the incoming memory holds into
+ *          an output frame sized from the negotiated dimensions.
+ */
+TEST (testTensorDecoder, pushDirectVideoInputSizeTooLarge_n)
+{
+  GstTensorsConfig config;
+  GstHarness *h;
+  gsize data_size;
+
+  _get_decoder_config (&config);
+  h = _get_decoder_harness ("direct_video", NULL, &config);
+  ASSERT_TRUE (h != NULL);
+
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size * 64)), GST_FLOW_ERROR);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
 }
 
 /**


### PR DESCRIPTION
This is item **C24** of the memory-safety audit tracking issue #4920.

## The defect

`gst_tensordec_transform()` maps every memory of the incoming buffer and hands it to the decoder sub-plugin without ever comparing it with the negotiated caps:

- `tensordec-directvideo.c` copies `input->size` bytes into an output frame sized from the negotiated dimensions, so an oversized buffer overflows that frame (item G14) and an undersized one is read past its end in the padding branch.
- The sub-plugins that accept flexible tensors (`octet_stream`, `flatbuf`, `flexbuf`, protobuf) parse the meta header of the memory and then use the data size it declares, without knowing how long the memory actually is (item G15).
- The number of memory chunks was checked with `g_assert (num_mems == num_tensors)`, which aborts the process for a buffer an application (`appsrc`) or a remote peer (`tensor_query`, `edge`) has built.

## The fix

Validate each memory in the element, before the sub-plugin sees it:

- a **static** tensor is fully described by the caps, so its size has to match exactly — the same rule `tensor_filter` has always applied to its input;
- a **flexible** tensor describes itself, so the memory has to be long enough for a meta header, the header has to parse into a version this build can size, and header + data have to fit in the memory. The header is parsed in place with `gst_tensor_meta_info_parse_header()` on the mapping the element already holds, the way the sub-plugins read it, with the length guard kept explicit and evaluated first;
- a chunk-count mismatch returns `GST_FLOW_ERROR` instead of aborting.

The two duplicated release loops are folded into one helper so the new error path does not add a third copy.

## Tests

`tests/nnstreamer_plugins/unittest_plugins.cc` gains 12 cases driving a `tensor_decoder` harness (`testTensorDecoder.*`). Verified against the pre-fix element, they fail as follows without this PR:

| case | without the fix |
| --- | --- |
| `pushInputSizeTooLarge_n` | FAILED (sub-plugin invoked with a surplus) |
| `pushInputSizeTooSmall_n` | FAILED |
| `pushInputMemoryCount_n`, `pushInputMemoryCountShort_n` | **abort** (`assertion failed: (num_mems == num_tensors)`) |
| `pushFlexibleInputTruncated_n` | FAILED |
| `pushFlexibleInputBrokenHeader_n` | FAILED |
| `pushFlexibleInputUnknownVersion_n` | FAILED |
| `pushFlexibleInputNoHeader_n` | FAILED |
| `pushDirectVideoInputSizeTooLarge_n` | **SIGSEGV** (the overflowed video frame) |
| `pushInputSize`, `pushFlexibleInput`, `pushFlexibleInputOversized` | pass (they pin the unchanged hand-over, header included, and the tolerated slack) |

Local verification on Ubuntu 22.04: `meson test` 22/23 (`unittest_filter_python3` fails identically on the unpatched tree — a numpy 1.x/2.x mismatch in this environment), SSAT 784 passed with the three python3 groups failing identically before and after the change. Every decoder group is green: `nnstreamer_decoder` 60/60, `nnstreamer_decoder_boundingbox` 51/51, `nnstreamer_octet_stream` 16/16, `nnstreamer_decoder_pose` 5/5, `nnstreamer_decoder_tensor_region` 2/2.

## Notes

- For a flexible stream with more than 16 tensors, the extra-tensor bookkeeping records the data size without the meta header (issue #4934), so the memory handed back for the 17th tensor is already one header short of what its own meta declares. This PR turns that into a clean `GST_FLOW_ERROR` instead of a truncated tensor handed to a sub-plugin; the underlying accounting is fixed separately in #4934.
- `gst_tensor_meta_info_validate()` accepts any version carrying the version marker, while `gst_tensor_meta_info_get_header_size()` can only size version 1. This element now refuses such a header rather than assuming a zero-length one; the same gap in the shared helpers is listed as item A7 of #4920.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
