### PR TITLE
[Element/Decoder] Fix the bounding box model size and label sprite crashes

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
@@ -267,7 +267,8 @@ init_bb (void)
         "\t\t option3=0.5:4:0.2:0.8\n"
         "\t\t option3=0.5:4:1.0:1.0:0.5:0.5:8:16:16:16",
         "option4", "Video Output Dimension (WIDTH:HEIGHT). This is independent from option1.",
-        "option5", "Input Dimension (WIDTH:HEIGHT). This is independent from option1.", "option6",
+        "option5", "Input Dimension (WIDTH:HEIGHT). Mandatory; the decoded boxes are scaled by this size. This is independent from option1.",
+        "option6",
         "Whether to track result bounding boxes or not\n"
         "\t\t 0 (default, do not track)\n"
         "\t\t 1 (track result bounding boxes, with naive centroid based algorithm)",
@@ -982,17 +983,20 @@ BoundingBox::setInputModelSize (const char *param)
     return TRUE;
 
   rank = gst_tensor_parse_dimension (param, dim);
-  bdata->setInputWidth (0);
-  bdata->setInputHeight (0);
 
   if (rank < 2) {
-    GST_ERROR ("mode-option-3 of boundingbox is input video dimension (WIDTH:HEIGHT). The given parameter, \"%s\", is not acceptable.",
+    GST_ERROR ("option5 of boundingbox is input video dimension (WIDTH:HEIGHT). The given parameter, \"%s\", is not acceptable.",
         param);
-    return TRUE; /* Ignore this param */
+    return FALSE;
   }
   if (rank > 2) {
-    GST_WARNING ("mode-option-3 of boundingbox is input video dimension (WIDTH:HEIGHT). The third and later elements of the given parameter, \"%s\", are ignored.",
+    GST_WARNING ("option5 of boundingbox is input video dimension (WIDTH:HEIGHT). The third and later elements of the given parameter, \"%s\", are ignored.",
         param);
+  }
+  if (dim[0] == 0 || dim[1] == 0) {
+    GST_ERROR ("option5 of boundingbox is input video dimension (WIDTH:HEIGHT). The given parameter, \"%s\", has a zero dimension.",
+        param);
+    return FALSE;
   }
   bdata->setInputWidth (dim[0]);
   bdata->setInputHeight (dim[1]);
@@ -1044,6 +1048,11 @@ BoundingBox::getOutCaps (const GstTensorsConfig *config)
   if (!ret)
     return NULL;
 
+  if (bdata->getInputWidth () == 0 || bdata->getInputHeight () == 0) {
+    GST_ERROR ("The input video dimension of the model is not configured. Set option5 of boundingbox to the WIDTH:HEIGHT the model takes, which the decoder scales the decoded boxes by.");
+    return NULL;
+  }
+
   str = g_strdup_printf ("video/x-raw, format = RGBA, " /* Use alpha channel to make the background transparent */
                          "width = %u, height = %u",
       width, height);
@@ -1071,6 +1080,13 @@ BoundingBox::decode (const GstTensorsConfig *config,
   gboolean need_output_alloc;
 
   g_assert (outbuf);
+
+  /* option1 may have swapped bdata since getOutCaps () approved the stream */
+  if (bdata->getInputWidth () == 0 || bdata->getInputHeight () == 0) {
+    GST_ERROR ("The input video dimension of the model is zero. Set option5 of boundingbox to the WIDTH:HEIGHT the model takes.");
+    return GST_FLOW_ERROR;
+  }
+
   need_output_alloc = gst_buffer_get_size (outbuf) == 0;
 
   if (checkLabelProps ())

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
@@ -827,7 +827,7 @@ BoundingBox::draw (GstMapInfo *out_info, GArray *results)
         y1 = MAX (0, (y1 - 14));
         pos1 = &frame[y1 * width + x1];
         for (k = 0; k < label_len; k++) {
-          unsigned int char_index = label[k];
+          unsigned int char_index = (unsigned char) label[k];
           if ((x1 + 8) > (int) width)
             break; /* Stop drawing if it may overfill */
           pos2 = pos1;

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.h
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.h
@@ -90,6 +90,7 @@
  *          This is independent from option1
  * option5: Input Dimension (WIDTH:HEIGHT)
  *          This is independent from option1
+ *          Mandatory: the decoded boxes are scaled by this size
  * option6: Whether to track result bounding boxes or not
  *          0 (default, do not track)
  *          1 (track result bounding boxes, with naive centroid based algorithm)
@@ -272,14 +273,14 @@ class BoxProperties
   {
     return i_height;
   }
-  gchar *name;
+  gchar *name = nullptr;
 
   protected:
-  guint i_width; /**< Input Video Width */
-  guint i_height; /**< Input Video Height */
+  guint i_width = 0; /**< Input Video Width */
+  guint i_height = 0; /**< Input Video Height */
 
-  guint max_detection;
-  guint total_labels;
+  guint max_detection = 0;
+  guint total_labels = 0;
 };
 
 /**

--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -663,7 +663,7 @@ draw_label (uint32_t * frame, pose_data * data, pose * xydata)
         if ((x1 + 8) > (int) data->width)
           break;
         pos2 = pos1;
-        for (y2 = 0; y2 < 13; y2++) {
+        for (y2 = 0; y2 < 13 && (y1 + y2) < (int) data->height; y2++) {
           for (x2 = 0; x2 < 8; x2++) {
             *(pos2 + x2) = singleLineSprite[char_index][y2][x2];
           }

--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -659,7 +659,7 @@ draw_label (uint32_t * frame, pose_data * data, pose * xydata)
       y1 = MAX (0, (y1 - 14));
       pos1 = &frame[y1 * data->width + x1];
       for (j = 0; j < label_len; j++) {
-        unsigned int char_index = label[j];
+        unsigned int char_index = (unsigned char) label[j];
         if ((x1 + 8) > (int) data->width)
           break;
         pos2 = pos1;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -106,7 +106,7 @@ if gtest_dep.found()
     # RUN unittest_decoder_boundingbox
     unittest_decoder_boundingbox = executable('unittest_decoder_boundingbox',
       join_paths('nnstreamer_decoder_boundingbox', 'unittest_decoder_boundingbox.cc'),
-      dependencies: [nnstreamer_unittest_deps],
+      dependencies: [nnstreamer_unittest_deps, nnstreamer_internal_deps],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
     )

--- a/tests/nnstreamer_decoder_boundingbox/runTest.sh
+++ b/tests/nnstreamer_decoder_boundingbox/runTest.sh
@@ -172,4 +172,43 @@ rm mobilenetssd_short_output.log
 
 rm yolov*.log
 
+# The decoder scales the decoded boxes by the model input dimension of option5,
+# so a missing or unparsable one used to divide by zero on the first box. These
+# cases need a process of their own: the box properties are shared per process,
+# so within one process an earlier pipeline's option5 is still in place.
+MODELSIZE_SRC="multifilesrc name=fs1 location=mobilenetssd_tensors.0.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=4:1:1917:1 input-type=float32 ! mux.sink_0  multifilesrc name=fs2 location=mobilenetssd_tensors.1.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=91:1917:1 input-type=float32 ! mux.sink_1"
+MODELSIZE_DEC="tensor_mux name=mux ! tensor_decoder mode=bounding_boxes option1=mobilenet-ssd option2=coco_labels_list.txt option3=box_priors.txt option4=160:120"
+
+
+## @brief Run a pipeline the decoder must refuse, failing if it does anything else
+## @details gstTest cannot tell a refusal from a crash: it only asks for a non-zero
+##          exit, which a SIGFPE gives just as a refusal does. gst-launch-1.0
+##          reports a refusal as 1 or as 255 (its -1), and everything else here is
+##          a failure: 0 is a pipeline that ran, 128 + n is a signal, and 126/127
+##          is a launcher that could not be started at all.
+## @param $1 gst-launch-1.0 arguments
+## @param $2 test case ID
+function refusedTest() {
+    local prefix=""
+    if [[ "$VALGRIND" -eq "1" ]]; then
+        prefix="valgrind --track-origins=yes ${VALGRIND_SUPPRESSION}"
+    fi
+    eval $prefix gst-launch-1.0 -f -q "$1" &> /dev/null
+    retcode=$?
+    if [[ "${retcode}" -eq "1" || "${retcode}" -eq "255" ]]; then
+        testResult 1 "$2" "gst-launch of case $2, ret(${retcode})"
+    else
+        testResult 0 "$2" "gst-launch of case $2, ret(${retcode})"
+    fi
+}
+
+refusedTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${MODELSIZE_DEC} ! fakesink ${MODELSIZE_SRC}" 13_n
+
+refusedTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${MODELSIZE_DEC} option5=300 ! fakesink ${MODELSIZE_SRC}" 14_n
+
+refusedTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${MODELSIZE_DEC} option5=0:0 ! fakesink ${MODELSIZE_SRC}" 15_n
+
+# A third element is warned about and ignored, not refused.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${MODELSIZE_DEC} option5=300:300:3 ! fakesink ${MODELSIZE_SRC}" 16 0 0 $PERFORMANCE
+
 report

--- a/tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc
+++ b/tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc
@@ -32,6 +32,10 @@
 #define LABEL_HEIGHT (12U)
 #define LABEL_PIXELS (OUT_WIDTH * LABEL_HEIGHT)
 #define LABEL_TEXT "X\n"
+/* A two-byte UTF-8 character; both bytes are negative as a signed char */
+#define LABEL_TEXT_NON_ASCII "\xc3\xa9\n"
+/* What the sprite table holds for every byte that is not printable ASCII */
+#define LABEL_TEXT_FALLBACK "**\n"
 
 #define BOX_PIXEL (0xFF0000FFU)
 
@@ -150,10 +154,11 @@ decodeBoundingBoxes (const float *tensor, uint32_t *frame)
  *          low enough that the label is written from row 0, and the output frame is
  *          shorter than the 13 rows of a character, which is what the sprite loop has
  *          to be clipped against.
+ * @param[in] label_text the content of the label file, one label per line
  * @param[out] frame LABEL_PIXELS RGBA pixels drawn by the decoder
  */
 static gboolean
-decodeLabelledBox (uint32_t *frame)
+decodeLabelledBox (const gchar *label_text, uint32_t *frame)
 {
   const float num[] = { 1.0f };
   const float classes[] = { 0.0f };
@@ -170,7 +175,7 @@ decodeLabelledBox (uint32_t *frame)
 
   if (num_file != NULL && class_file != NULL && score_file != NULL
       && box_file != NULL && label_file != NULL && out_file != NULL
-      && g_file_set_contents (label_file, LABEL_TEXT, -1, NULL)) {
+      && g_file_set_contents (label_file, label_text, -1, NULL)) {
     pipeline_str = g_strdup_printf (
         "tensor_mux name=mux ! tensor_decoder mode=bounding_boxes "
         "option1=mobilenet-ssd-postprocess option2=%s option4=%u:%u option5=%u:%u ! "
@@ -361,7 +366,7 @@ TEST (tensorDecoderBoundingBox, drawLabelInShortFrame)
   uint32_t frame[LABEL_PIXELS] = { 0U };
   guint i, label_pixels = 0;
 
-  ASSERT_TRUE (decodeLabelledBox (frame));
+  ASSERT_TRUE (decodeLabelledBox (LABEL_TEXT, frame));
 
   /* The box covers x 16 to 32 and y 6 to 9; its left columns are behind the label */
   EXPECT_EQ (frame[6 * OUT_WIDTH + 32], BOX_PIXEL);
@@ -373,6 +378,24 @@ TEST (tensorDecoderBoundingBox, drawLabelInShortFrame)
       label_pixels++;
   }
   EXPECT_GT (label_pixels, 0U);
+}
+
+/**
+ * @brief A label outside ASCII is drawn as the fallback glyph.
+ * @details The sprite table has an entry for every byte value, but a label byte
+ *          above 0x7f is negative as a signed char and used to index that table
+ *          several gigabytes past its end.
+ */
+TEST (tensorDecoderBoundingBox, drawNonAsciiLabel)
+{
+  uint32_t frame[LABEL_PIXELS] = { 0U };
+  uint32_t fallback[LABEL_PIXELS] = { 0U };
+
+  ASSERT_TRUE (decodeLabelledBox (LABEL_TEXT_NON_ASCII, frame));
+  ASSERT_TRUE (decodeLabelledBox (LABEL_TEXT_FALLBACK, fallback));
+
+  EXPECT_GT (countDrawnPixels (fallback, LABEL_PIXELS), 0U);
+  EXPECT_EQ (memcmp (frame, fallback, sizeof (frame)), 0);
 }
 
 /**

--- a/tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc
+++ b/tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc
@@ -15,6 +15,9 @@
 #include <string.h>
 #include <unittest_util.h>
 
+#include <nnstreamer_plugin_api_decoder.h>
+#include <nnstreamer_plugin_api_util.h>
+
 #define OV_DESC_SIZE (7U)
 #define OV_DETECTION_MAX (200U)
 #define OV_TENSOR_ELEMENTS (OV_DESC_SIZE * OV_DETECTION_MAX)
@@ -370,6 +373,42 @@ TEST (tensorDecoderBoundingBox, drawLabelInShortFrame)
       label_pixels++;
   }
   EXPECT_GT (label_pixels, 0U);
+}
+
+/**
+ * @brief Swapping the mode of a configured decoder is refused, not divided by.
+ * @details option1 takes the box properties from a table shared by the whole
+ *          process and does not renegotiate, so a decoder that was configured
+ *          with one mode's model input size reaches decode () holding another
+ *          mode's, which may never have been given one. The mode swapped to
+ *          here is one no other case in this binary configures, so its size is
+ *          still the zero it was initialised with.
+ */
+TEST (tensorDecoderBoundingBox, swapModeOfConfiguredDecoder_n)
+{
+  const GstTensorDecoderDef *decoder = nnstreamer_decoder_find ("bounding_boxes");
+  GstTensorsConfig config;
+  GstTensorMemory input;
+  GstBuffer *outbuf;
+  void *pdata = NULL;
+
+  ASSERT_TRUE (decoder != NULL);
+  ASSERT_TRUE (decoder->init (&pdata));
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 0, "ov-person-detection"));
+  EXPECT_TRUE (decoder->setOption (&pdata, 3, "64:48"));
+  EXPECT_TRUE (decoder->setOption (&pdata, 4, "640:480"));
+  EXPECT_TRUE (decoder->setOption (&pdata, 0, "mobilenet-ssd"));
+
+  gst_tensors_config_init (&config);
+  memset (&input, 0, sizeof (input));
+  outbuf = gst_buffer_new ();
+
+  EXPECT_EQ (decoder->decode (&pdata, &config, &input, outbuf), GST_FLOW_ERROR);
+
+  gst_buffer_unref (outbuf);
+  gst_tensors_config_free (&config);
+  decoder->exit (&pdata);
 }
 
 /**

--- a/tests/nnstreamer_decoder_pose/runTest.sh
+++ b/tests/nnstreamer_decoder_pose/runTest.sh
@@ -53,10 +53,19 @@ rightAnkle 14" > pose_label.txt
 # TEST OPTION3 and OPTION4
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=20 ! videoconvert ! videoscale ! video/x-raw,width=17,height=17,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:128,div:255 ! tensor_split name=a tensorseg=1:17:17:1,2:17:17:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=17:17 option3=pose_label.txt option4=heatmap-only option5=ignored ! fakesink" 3 0 0 $PERFORMANCE
 
-rm pose_label.txt
-
 # TEST WITH ALL-NEGATIVE HEATMAP VALUES (path exercise only: the output is
 # not verified since keypoints with prob < 0.5 are never drawn)
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:-256,div:255 ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 4 0 0 $PERFORMANCE
+
+# TEST A LABEL CARRYING A NON-ASCII CHARACTER
+# The label bytes index the font sprite table, and a byte above 0x7f is negative
+# as a signed char. This is a path exercise: it shows the pipeline survives the
+# label, not what was drawn. The bounding box gtest checks the glyph itself.
+printf 'nos\xc3\xa9 1 2 3 4\n' > pose_label_utf8.txt
+tail -n +2 pose_label.txt >> pose_label_utf8.txt
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,width=17,height=17,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:128,div:255 ! tensor_split name=a tensorseg=1:17:17:1,2:17:17:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=17:17 option3=pose_label_utf8.txt option4=heatmap-only ! fakesink" 5 0 0 $PERFORMANCE
+
+rm pose_label.txt pose_label_utf8.txt
 
 report

--- a/tests/nnstreamer_decoder_pose/runTest.sh
+++ b/tests/nnstreamer_decoder_pose/runTest.sh
@@ -66,6 +66,16 @@ tail -n +2 pose_label.txt >> pose_label_utf8.txt
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,width=17,height=17,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:128,div:255 ! tensor_split name=a tensorseg=1:17:17:1,2:17:17:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=17:17 option3=pose_label_utf8.txt option4=heatmap-only ! fakesink" 5 0 0 $PERFORMANCE
 
+# TEST A LABEL DRAWN INTO A FRAME SHORTER THAN A CHARACTER CELL
+# The sprite is 13 rows tall and the output frame is one row, so the rows that
+# do not fit are written past the end of it. The width is what makes that fatal
+# rather than silent: at one row of 65536 pixels the twelve rows that do not fit
+# are three megabytes past a frame of 256 KB, far enough out to fault. A narrow
+# frame overruns by too little to leave the heap and the case would pass either
+# way. That makes this a heuristic detector rather than a deterministic one: an
+# allocator that hands out enough slack could absorb the overrun.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,width=17,height=17,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:128,div:255 ! tensor_split name=a tensorseg=1:17:17:1,2:17:17:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=65536:1 option2=17:17 option3=pose_label.txt option4=heatmap-only ! fakesink" 6 0 0 $PERFORMANCE
+
 rm pose_label.txt pose_label_utf8.txt
 
 report


### PR DESCRIPTION
## Summary

Memory-safety items **G19** and **G2** of #4920, both in the drawing path of the
`bounding_boxes` decoder (and, for G2, of `pose_estimation`), plus one adjacent
out-of-bounds write found while reviewing them. Three commits, one per topic,
each carrying the test that pins it.

### G19 — a model input size of zero divides by zero

`BoundingBox::draw()` scales every decoded box by the model input size that
`option5` carries, dividing by `getInputWidth()` / `getInputHeight()`.

- `BoxProperties` declared `i_width` / `i_height` with no initialiser and none of
  the eight sub-classes set them, so a decoder never given `option5` read them
  uninitialised.
- `BoundingBox::setInputModelSize()` zeroed both *before* parsing and returned
  `TRUE` on a rank &lt; 2 parameter with the comment "Ignore this param".
- No mode's `checkCompatible()` requires a nonzero model size, so negotiation
  succeeded and the first detected box raised `SIGFPE`.

Reproduced on main with the in-tree fixtures — `option5=300`, or no `option5` at
all, gives `Floating point exception (core dumped)`.

The fix initialises the members, parses into locals and assigns only on success
(so a bad value can no longer zero the size of a running pipeline, nor of another
element sharing the same box-properties object), refuses to negotiate in
`getOutCaps()` while the size is unset, and fails `decode()` with `GST_FLOW_ERROR`
rather than divide should a zero arrive anyway — which is what an `option1` mode
switch can still do, since it swaps the box properties without a renegotiation.
`box_properties/mppalmdetection.cc` divides by the same two values inside its own
`decode()`, which is why that guard is at the top of `BoundingBox::decode()` and
not in `draw()`. `max_detection`, `total_labels` and `name` in the same block had
the same missing initialiser — `YoloV5`, `YoloV8` and `YoloV8_OBB` read
`total_labels` in `checkCompatible()` and only `setLabelPath()` ever writes it.

### G2 — a non-ASCII label byte indexes the font sprite ~1.8 TB out of bounds

Both decoders draw a label with `unsigned int char_index = label[k]` and read
`singleLineSprite[char_index][y][x]`, where the table is `uint32_t[256][13][8]`.
`char` is signed on x86 and arm32, so a byte above `0x7f` — every byte of a
non-ASCII UTF-8 character — sign-extends to an index of about 4G, i.e. roughly
1.8 TB past the array. `initSingleLineSprite()` already fills an entry for all 256
byte values (the `'*'` fallback for anything not printable ASCII), so the cast is
the whole fix. The label comes from a user-supplied file, so any label file that
is not pure ASCII crashes the pipeline on the first frame that draws a label.

### Adjacent: the pose label sprite is not clipped vertically

`draw_label()` in `tensordec-pose.c` writes the 13 rows of a character cell
unconditionally, while the bounding-box twin stops at the last row of the frame.
An `option1` height below 13 writes the rows that do not fit past the end of the
output memory — an OOB **write**, in the same loop as the G2 fix. Not one of the
items listed in #4920.

## Test cases

**gtest** — `tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc`

| case | |
|---|---|
| `drawNonAsciiLabel` | a two-byte UTF-8 label draws exactly the frame `"**"` draws, so the fallback glyph is checked rather than mere survival |
| `swapModeOfConfiguredDecoder_n` | `option1` swapped after the decoder is configured makes `decode()` return `GST_FLOW_ERROR` instead of dividing |

**SSAT** — `tests/nnstreamer_decoder_boundingbox/runTest.sh`

| case | |
|---|---|
| `13_n` | no `option5` at all — the spelling #4920 names |
| `14_n` | `option5=300` (rank 1) |
| `15_n` | `option5=0:0` |
| `16` | `option5=300:300:3` is warned about and accepted, not refused |

These live in SSAT rather than the gtest because it forks per case: the
box-properties objects are process-wide singletons (item **G10** of #4920), so
inside one gtest binary an earlier pipeline's `option5` is still in place. They use
a local `refusedTest` helper instead of `gstTest`, because a plain "expect non-zero
exit" passes on the `SIGFPE` too — the helper passes only on the 1 and 255
`gst-launch-1.0` reports for a refusal.

**SSAT** — `tests/nnstreamer_decoder_pose/runTest.sh`: case `5` (a label file whose
first key point carries a non-ASCII character) and case `6` (a one-row output frame,
so the unclipped sprite writes megabytes past a 256 KB buffer).

Negative control, measured against the pre-fix decoders:

```
gtest    drawNonAsciiLabel                 exit=139 (SIGSEGV)
gtest    swapModeOfConfiguredDecoder_n     exit=134 with the decode() guard deleted
SSAT     boundingbox 13_n / 14_n / 15_n    FAILED, ret(136) = SIGFPE
SSAT     pose 5, pose 6                    FAILED   (pose 3, ASCII labels, passes)
```

With the change: 11/11 gtest cases, SSAT `nnstreamer_decoder_boundingbox` 55/55,
SSAT `nnstreamer_decoder_pose` 7/7. Each of the three commits builds and passes
its own tests.

## Notes

- The `_n` cases log a run of `GStreamer-CRITICAL` assertions while the pipeline
  fails to negotiate. That is item **C22** of #4920 — `getOutCaps()` returning NULL
  reaches `gst_caps_intersect()` unchecked — and is the pre-existing behaviour of
  every rejected config. It lives in `gst/nnstreamer/elements/gsttensor_decoder.c`,
  which #4939 is editing, so it is left alone here. No workflow sets
  `G_DEBUG=fatal_warnings`, so it does not gate.
- The new gtest needs `nnstreamer_internal_deps` on its meson target to reach
  `nnstreamer_decoder_find()`. It is deliberately not in `unittest_plugins.cc`,
  which #4939 is also editing.
- Locally `meson test` is 19/21 with and without this change:
  `unittest_filter_python3` (numpy ABI, `_ARRAY_API not found`) and
  `unittest_trainer` (timeout) fail on this machine and touch neither decoder.

Addresses items G19 and G2 of #4920.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
