### PR TITLE
[Filter] Do not open a sub-plugin that needs a model without one

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_mxnet.cc
@@ -358,7 +358,8 @@ TensorFilterMXNet::getFrameworkInfo (GstTensorFilterFrameworkInfo &info)
   info.allow_in_place = FALSE;
   info.allocate_in_invoke = FALSE;
   info.run_without_model = FALSE;
-  info.verify_model_path = TRUE;
+  /* The model property is a base path this sub-plugin appends extensions to. */
+  info.verify_model_path = FALSE;
   info.hw_list = hw_list;
   info.num_hw = num_hw;
   info.accl_auto = ACCL_CPU;

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -164,8 +164,8 @@ typedef struct _GstTensorFilterFrameworkInfo
   const char *name; /**< Name of the neural network framework, searchable by FRAMEWORK property. Subplugin is supposed to allocate/deallocate. */
   int allow_in_place; /**< TRUE(nonzero) if in-place transfer of input-to-output is allowed. Not supported in main, yet. */
   int allocate_in_invoke; /**< TRUE(nonzero) if invoke_NN is going to allocate output ptr by itself and return the address via output ptr. Do not change this value after cap negotiation is complete (or the stream has been started). */
-  int run_without_model; /**< TRUE(nonzero) when the neural network framework does not need a model file. Tensor-filter will run invoke_NN without model. */
-  int verify_model_path; /**< TRUE(nonzero) when the NNS framework, not the sub-plugin, should verify the path of model files. */
+  int run_without_model; /**< TRUE(nonzero) when the neural network framework does not need a model file. Tensor-filter will run invoke_NN without model. When this is FALSE, tensor-filter refuses to call open() unless the model property holds at least one entry, whatever verify_model_path says; a sub-plugin that defines no open callback is started without that check. */
+  int verify_model_path; /**< TRUE(nonzero) when the NNS framework, not the sub-plugin, should verify the path of model files. Consulted only when run_without_model is FALSE, and only to choose who tests that each given entry is a regular file. Declare FALSE if a model entry is not a path, or is a path the sub-plugin derives other paths from. */
   const accl_hw *hw_list; /**< List of supported hardware accelerators by the framework. Positive response of this check does not guarantee successful running of model with this accelerator. Subplugin is supposed to allocate/deallocate. */
   int num_hw; /**< number of hardware accelerators in the hw_list supported by the framework. */
   accl_hw accl_auto;  /**< accelerator to be used in auto mode (acceleration to be used but accelerator is not specified for the filter) - default -1 implies use first entry from hw_list. */
@@ -290,8 +290,8 @@ struct _GstTensorFilterFramework
       char *name; /**< Name of the neural network framework, searchable by FRAMEWORK property */
       int allow_in_place; /**< TRUE(nonzero) if in-place transfer of input-to-output is allowed. Not supported in main, yet */
       int allocate_in_invoke; /**< TRUE(nonzero) if invoke_NN is going to allocate output ptr by itself and return the address via output ptr. Do not change this value after cap negotiation is complete (or the stream has been started). */
-      int run_without_model; /**< TRUE(nonzero) when the neural network framework does not need a model file. Tensor-filter will run invoke_NN without model. */
-      int verify_model_path; /**< TRUE(nonzero) when the NNS framework, not the sub-plugin, should verify the path of model files. */
+      int run_without_model; /**< TRUE(nonzero) when the neural network framework does not need a model file. Tensor-filter will run invoke_NN without model. When this is FALSE, tensor-filter refuses to call open() unless the model property holds at least one entry, whatever verify_model_path says; a sub-plugin that defines no open callback is started without that check. */
+      int verify_model_path; /**< TRUE(nonzero) when the NNS framework, not the sub-plugin, should verify the path of model files. Consulted only when run_without_model is FALSE, and only to choose who tests that each given entry is a regular file. Declare FALSE if a model entry is not a path, or is a path the sub-plugin derives other paths from. */
 
       const GstTensorFilterFrameworkStatistics *statistics;  /**< usage statistics by the framework. This is shared across all opened instances of this framework. */
 
@@ -421,6 +421,7 @@ struct _GstTensorFilterFramework
        * @return 0 if OK. non-zero if error.
        *
        * @note CAUTION: private_data can be NULL if the framework is not yet opened by the caller.
+       * @note Tensor-filter issues this query before open() as well, to read run_without_model and verify_model_path. A sub-plugin that cannot report those two without an opened model is refused an open.
        */
 
       int (*getModelInfo) (const GstTensorFilterFramework * self,

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -86,6 +86,8 @@ static gint _gtfc_setprop_IS_UPDATABLE (GstTensorFilterPrivate * priv,
     GstTensorFilterProperties * prop, const GValue * value);
 static gint _gtfc_setprop_ACCELERATOR (GstTensorFilterPrivate * priv,
     GstTensorFilterProperties * prop, const GValue * value);
+static void gst_tensor_filter_framework_info_init (GstTensorFilterFrameworkInfo
+    * info);
 
 /**
  * @brief mutex for shared model table.
@@ -459,7 +461,10 @@ create_regex (const gchar ** enum_list, const gchar ** regex_utils)
 }
 
 /**
- * @brief Verify validity of path for given model file if verify_model_path is set
+ * @brief Verify that the sub-plugin may be opened with the given model property
+ * @details A sub-plugin that does not declare run_without_model requires at least
+ *          one model entry; on top of that, each entry is checked to be a regular
+ *          file only if the sub-plugin declares verify_model_path.
  * @param[in] priv Struct containing the common tensor-filter properties of the object
  * @return TRUE if there is no error
  */
@@ -474,33 +479,41 @@ verify_model_path (const GstTensorFilterPrivate * priv)
 
   prop = &(priv->prop);
 
-  if (g_strcmp0 (prop->fwname, "custom-easy") == 0)
-    return TRUE;
-
   run_without_model = verify_model_path = 0;
 
   if (GST_TF_FW_V0 (priv->fw)) {
     run_without_model = priv->fw->run_without_model;
     verify_model_path = priv->fw->verify_model_path;
   } else if (GST_TF_FW_V1 (priv->fw)) {
-    run_without_model = priv->info.run_without_model;
-    verify_model_path = priv->info.verify_model_path;
+    GstTensorFilterFrameworkInfo info;
+
+    /* priv->info is filled after open(), so ask the sub-plugin directly. */
+    gst_tensor_filter_framework_info_init (&info);
+    if (priv->fw->getFrameworkInfo (priv->fw, prop, NULL, &info) != 0) {
+      ml_loge ("Cannot get the framework info of filter %s.", prop->fwname);
+      return FALSE;
+    }
+
+    run_without_model = info.run_without_model;
+    verify_model_path = info.verify_model_path;
   } else {
     /* Invalid version, internal error? */
     return FALSE;
   }
 
-  if (!run_without_model && verify_model_path) {
+  if (!run_without_model) {
     /* At least one model should be configured before opening fw. */
-    if (prop->num_models <= 0) {
+    if (prop->num_models <= 0 || prop->model_files == NULL) {
       ml_loge ("Set proper model file for filter %s.", prop->fwname);
       return FALSE;
     }
 
-    for (i = 0; i < prop->num_models; i++) {
-      if (!g_file_test (prop->model_files[i], G_FILE_TEST_IS_REGULAR)) {
-        ml_loge ("Cannot find the model file[%d] %s", i, prop->model_files[i]);
-        return FALSE;
+    if (verify_model_path) {
+      for (i = 0; i < prop->num_models; i++) {
+        if (!g_file_test (prop->model_files[i], G_FILE_TEST_IS_REGULAR)) {
+          ml_loge ("Cannot find the model file[%d] %s", i, prop->model_files[i]);
+          return FALSE;
+        }
       }
     }
   }

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
@@ -166,6 +166,13 @@ custom_open (const GstTensorFilterProperties * prop, void **private_data)
 {
   runtime_data *rd;
 
+  if (!prop->model_files || prop->num_models < 1 || !prop->model_files[0]
+      || prop->model_files[0][0] == '\0') {
+    ml_loge ("The easy-custom filter requires a registered model name. "
+        "Set the 'model' property of tensor_filter.");
+    return -EINVAL;
+  }
+
   rd = g_new (runtime_data, 1);
   if (!rd)
     return -ENOMEM;

--- a/tests/nnstreamer_filter_custom/unittest_filter_custom.cc
+++ b/tests/nnstreamer_filter_custom/unittest_filter_custom.cc
@@ -409,6 +409,49 @@ TEST (tensorFilterCustom, notRegisterFlexibleInvoke_n)
 }
 
 /**
+ * @brief Test custom-easy filter without the model property.
+ */
+TEST (tensorFilterCustom, easyOpenWithoutModel_n)
+{
+  GstElement *gstpipe;
+  GError *err = NULL;
+  const gchar *pipeline
+      = "videotestsrc num-buffers=3 ! videoconvert ! "
+        "video/x-raw,width=160,height=120,format=RGB,framerate=10/1 ! tensor_converter ! "
+        "tensor_filter framework=custom-easy ! tensor_sink sync=true";
+
+  gstpipe = gst_parse_launch (pipeline, &err);
+  ASSERT_TRUE (gstpipe != nullptr);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT),
+      -ESTRPIPE);
+
+  gst_object_unref (gstpipe);
+}
+
+/**
+ * @brief Test custom-easy filter with an empty model name.
+ * @details "," splits into two empty names, unlike "" which yields no name at all.
+ */
+TEST (tensorFilterCustom, easyOpenEmptyModel_n)
+{
+  GstElement *gstpipe;
+  GError *err = NULL;
+  const gchar *pipeline
+      = "videotestsrc num-buffers=3 ! videoconvert ! "
+        "video/x-raw,width=160,height=120,format=RGB,framerate=10/1 ! tensor_converter ! "
+        "tensor_filter framework=custom-easy model=\",\" ! tensor_sink sync=true";
+
+  gstpipe = gst_parse_launch (pipeline, &err);
+  ASSERT_TRUE (gstpipe != nullptr);
+
+  EXPECT_EQ (setPipelineStateSync (gstpipe, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT),
+      -ESTRPIPE);
+
+  gst_object_unref (gstpipe);
+}
+
+/**
  * @brief Test dynamic invoke with invalid param.
  * @todo Enable the test after development is done.
  */

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -7137,6 +7137,26 @@ class testTensorFilterCppSubplugin : public ::testing::Test
 };
 
 /**
+ * @brief Test that a C++ sub-plugin declaring run_without_model is opened by
+ *        the element without a model property.
+ * @details This drives cpp_getFrameworkInfo() with no private data, the path
+ *          every C++ sub-plugin takes while tensor_filter verifies the model.
+ */
+TEST_F (testTensorFilterCppSubplugin, elementOpenWithoutModel)
+{
+  GstElement *filter = gst_element_factory_make ("tensor_filter", NULL);
+
+  ASSERT_TRUE (filter != NULL);
+  g_object_set (filter, "framework", cpp_mock_subplugin::mock_name, NULL);
+
+  EXPECT_EQ (gst_element_set_state (filter, GST_STATE_PAUSED), GST_STATE_CHANGE_SUCCESS);
+  EXPECT_EQ (cpp_mock_subplugin::resources_alive, 1U);
+
+  gst_element_set_state (filter, GST_STATE_NULL);
+  gst_object_unref (filter);
+}
+
+/**
  * @brief Test C++ subplugin open: when configure_instance() throws at any
  *        point, repeated open attempts must neither crash nor leak the
  *        spawned instance and the resources it acquired before throwing.

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -4414,6 +4414,21 @@ test_custom_v0_setdim (const GstTensorFilterProperties *prop,
 }
 
 /**
+ * @brief Whether the open callback of the test sub-plugin has been called.
+ */
+static gboolean test_custom_v0_opened;
+
+/**
+ * @brief The optional callback for GstTensorFilterFramework.
+ */
+static int
+test_custom_v0_open (const GstTensorFilterProperties *prop, void **private_data)
+{
+  test_custom_v0_opened = TRUE;
+  return 0;
+}
+
+/**
  * @brief The optional callback for GstTensorFilterFramework.
  */
 static int
@@ -4605,6 +4620,343 @@ TEST (tensorStreamTest, subpluginV0Run)
   test_custom_run_pipeline ();
 
   /* unregister custom filter */
+  nnstreamer_filter_exit (test_fw_custom_name);
+  g_free (fw);
+}
+
+/**
+ * @brief Register the test sub-plugin that requires a model file.
+ * @return The allocated framework, to be freed after nnstreamer_filter_exit().
+ */
+static GstTensorFilterFramework *
+test_custom_v0_probe_with_model (void)
+{
+  GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
+
+  if (fw == NULL)
+    return NULL;
+
+  fw->version = GST_TENSOR_FILTER_FRAMEWORK_V0;
+  fw->name = (char *) test_fw_custom_name;
+  fw->run_without_model = FALSE;
+  fw->open = test_custom_v0_open;
+  fw->invoke_NN = test_custom_v0_invoke;
+  fw->setInputDimension = test_custom_v0_setdim;
+
+  test_custom_v0_opened = FALSE;
+  return fw;
+}
+
+/**
+ * @brief Test that a sub-plugin requiring a model is opened with one.
+ */
+TEST (tensorStreamTest, subpluginV0OpenWithModel)
+{
+  GstTensorFilterFramework *fw = test_custom_v0_probe_with_model ();
+  GstElement *filter;
+
+  ASSERT_TRUE (fw != NULL);
+  ASSERT_TRUE (nnstreamer_filter_probe (fw));
+
+  filter = gst_element_factory_make ("tensor_filter", NULL);
+  ASSERT_TRUE (filter != NULL);
+  g_object_set (filter, "framework", test_fw_custom_name, "model", "test-model", NULL);
+
+  EXPECT_EQ (gst_element_set_state (filter, GST_STATE_PAUSED), GST_STATE_CHANGE_SUCCESS);
+  EXPECT_TRUE (test_custom_v0_opened);
+
+  gst_element_set_state (filter, GST_STATE_NULL);
+  gst_object_unref (filter);
+
+  nnstreamer_filter_exit (test_fw_custom_name);
+  g_free (fw);
+}
+
+/**
+ * @brief Test that a sub-plugin requiring a model is not opened without one.
+ */
+TEST (tensorStreamTest, subpluginV0OpenWithoutModel_n)
+{
+  GstTensorFilterFramework *fw = test_custom_v0_probe_with_model ();
+  GstElement *filter;
+
+  ASSERT_TRUE (fw != NULL);
+  ASSERT_TRUE (nnstreamer_filter_probe (fw));
+
+  filter = gst_element_factory_make ("tensor_filter", NULL);
+  ASSERT_TRUE (filter != NULL);
+  g_object_set (filter, "framework", test_fw_custom_name, NULL);
+
+  EXPECT_EQ (gst_element_set_state (filter, GST_STATE_PAUSED), GST_STATE_CHANGE_FAILURE);
+  EXPECT_FALSE (test_custom_v0_opened);
+
+  gst_element_set_state (filter, GST_STATE_NULL);
+  gst_object_unref (filter);
+
+  nnstreamer_filter_exit (test_fw_custom_name);
+  g_free (fw);
+}
+
+/**
+ * @brief The flags the test V1 sub-plugin declares to the framework.
+ */
+static int test_custom_v1_run_without_model;
+static int test_custom_v1_verify_model_path;
+
+/**
+ * @brief Whether the test V1 sub-plugin fails to report its framework info.
+ */
+static gboolean test_custom_v1_fwinfo_fails;
+
+/**
+ * @brief The mandatory callback for GstTensorFilterFramework (v1).
+ * @details Unlike test_custom_v1_getFWInfo(), this one declares the model flags
+ *          the test asked for.
+ */
+static int
+test_custom_v1_getFWInfo_model (const GstTensorFilterFramework *self,
+    const GstTensorFilterProperties *prop, void *private_data,
+    GstTensorFilterFrameworkInfo *fw_info)
+{
+  if (test_custom_v1_fwinfo_fails)
+    return -EINVAL;
+
+  test_custom_v1_getFWInfo (self, prop, private_data, fw_info);
+  fw_info->run_without_model = test_custom_v1_run_without_model;
+  fw_info->verify_model_path = test_custom_v1_verify_model_path;
+  return 0;
+}
+
+/**
+ * @brief Register a V1 test sub-plugin that has an open callback.
+ * @param[in] run_without_model Whether the sub-plugin declares that it needs no model.
+ * @param[in] verify_model_path Whether the sub-plugin lets the framework test the paths.
+ * @return The allocated framework, to be freed after nnstreamer_filter_exit().
+ */
+static GstTensorFilterFramework *
+test_custom_v1_probe_open (int run_without_model, int verify_model_path)
+{
+  GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
+
+  if (fw == NULL)
+    return NULL;
+
+  fw->version = GST_TENSOR_FILTER_FRAMEWORK_V1;
+  fw->open = test_custom_v0_open;
+  fw->invoke = test_custom_v1_invoke;
+  fw->getFrameworkInfo = test_custom_v1_getFWInfo_model;
+  fw->getModelInfo = test_custom_v1_getModelInfo;
+  fw->eventHandler = test_custom_v1_eventHandler;
+
+  test_custom_v1_run_without_model = run_without_model;
+  test_custom_v1_verify_model_path = verify_model_path;
+  test_custom_v1_fwinfo_fails = FALSE;
+  test_custom_v0_opened = FALSE;
+  return fw;
+}
+
+/**
+ * @brief Test that a V1 sub-plugin declaring run_without_model is opened without a model.
+ */
+TEST (tensorStreamTest, subpluginV1OpenWithoutModel)
+{
+  GstTensorFilterFramework *fw = test_custom_v1_probe_open (1, 0);
+  GstElement *filter;
+
+  ASSERT_TRUE (fw != NULL);
+  ASSERT_TRUE (nnstreamer_filter_probe (fw));
+
+  filter = gst_element_factory_make ("tensor_filter", NULL);
+  ASSERT_TRUE (filter != NULL);
+  g_object_set (filter, "framework", test_fw_custom_name, NULL);
+
+  EXPECT_EQ (gst_element_set_state (filter, GST_STATE_PAUSED), GST_STATE_CHANGE_SUCCESS);
+  EXPECT_TRUE (test_custom_v0_opened);
+
+  gst_element_set_state (filter, GST_STATE_NULL);
+  gst_object_unref (filter);
+
+  nnstreamer_filter_exit (test_fw_custom_name);
+  g_free (fw);
+}
+
+/**
+ * @brief Test that a V1 sub-plugin requiring a model is opened with an existing file.
+ */
+TEST (tensorStreamTest, subpluginV1OpenWithModel)
+{
+  GstTensorFilterFramework *fw = test_custom_v1_probe_open (0, 1);
+  GstElement *filter;
+  gchar *model_file = getTempFilename ();
+
+  ASSERT_TRUE (fw != NULL);
+  ASSERT_TRUE (model_file != NULL);
+  ASSERT_TRUE (nnstreamer_filter_probe (fw));
+
+  filter = gst_element_factory_make ("tensor_filter", NULL);
+  ASSERT_TRUE (filter != NULL);
+  g_object_set (filter, "framework", test_fw_custom_name, "model", model_file, NULL);
+
+  EXPECT_EQ (gst_element_set_state (filter, GST_STATE_PAUSED), GST_STATE_CHANGE_SUCCESS);
+  EXPECT_TRUE (test_custom_v0_opened);
+
+  gst_element_set_state (filter, GST_STATE_NULL);
+  gst_object_unref (filter);
+
+  removeTempFile (&model_file);
+  nnstreamer_filter_exit (test_fw_custom_name);
+  g_free (fw);
+}
+
+/**
+ * @brief Test that a V1 sub-plugin requiring a model is not opened without one.
+ */
+TEST (tensorStreamTest, subpluginV1OpenWithoutModel_n)
+{
+  GstTensorFilterFramework *fw = test_custom_v1_probe_open (0, 1);
+  GstElement *filter;
+
+  ASSERT_TRUE (fw != NULL);
+  ASSERT_TRUE (nnstreamer_filter_probe (fw));
+
+  filter = gst_element_factory_make ("tensor_filter", NULL);
+  ASSERT_TRUE (filter != NULL);
+  g_object_set (filter, "framework", test_fw_custom_name, NULL);
+
+  EXPECT_EQ (gst_element_set_state (filter, GST_STATE_PAUSED), GST_STATE_CHANGE_FAILURE);
+  EXPECT_FALSE (test_custom_v0_opened);
+
+  gst_element_set_state (filter, GST_STATE_NULL);
+  gst_object_unref (filter);
+
+  nnstreamer_filter_exit (test_fw_custom_name);
+  g_free (fw);
+}
+
+/**
+ * @brief Test that a model file the sub-plugin declared to be verified must exist.
+ */
+TEST (tensorStreamTest, subpluginV1OpenMissingModel_n)
+{
+  GstTensorFilterFramework *fw = test_custom_v1_probe_open (0, 1);
+  GstElement *filter;
+  gchar *model_file = getTempFilename ();
+
+  ASSERT_TRUE (fw != NULL);
+  ASSERT_TRUE (model_file != NULL);
+  ASSERT_TRUE (nnstreamer_filter_probe (fw));
+
+  g_remove (model_file);
+  ASSERT_FALSE (g_file_test (model_file, G_FILE_TEST_EXISTS));
+
+  filter = gst_element_factory_make ("tensor_filter", NULL);
+  ASSERT_TRUE (filter != NULL);
+  g_object_set (filter, "framework", test_fw_custom_name, "model", model_file, NULL);
+
+  EXPECT_EQ (gst_element_set_state (filter, GST_STATE_PAUSED), GST_STATE_CHANGE_FAILURE);
+  EXPECT_FALSE (test_custom_v0_opened);
+
+  gst_element_set_state (filter, GST_STATE_NULL);
+  gst_object_unref (filter);
+
+  g_free (model_file);
+  nnstreamer_filter_exit (test_fw_custom_name);
+  g_free (fw);
+}
+
+/**
+ * @brief Test that a model entry the sub-plugin verifies itself is not tested as a file.
+ * @details mxnet takes a base path it derives file names from, and lua may carry a
+ *          script body; both declare verify_model_path = 0 to keep it unchecked.
+ */
+TEST (tensorStreamTest, subpluginV1OpenUnverifiedModel)
+{
+  GstTensorFilterFramework *fw = test_custom_v1_probe_open (0, 0);
+  GstElement *filter;
+
+  ASSERT_TRUE (fw != NULL);
+  ASSERT_TRUE (nnstreamer_filter_probe (fw));
+
+  filter = gst_element_factory_make ("tensor_filter", NULL);
+  ASSERT_TRUE (filter != NULL);
+  g_object_set (filter, "framework", test_fw_custom_name, "model", "not-a-file", NULL);
+
+  EXPECT_EQ (gst_element_set_state (filter, GST_STATE_PAUSED), GST_STATE_CHANGE_SUCCESS);
+  EXPECT_TRUE (test_custom_v0_opened);
+
+  gst_element_set_state (filter, GST_STATE_NULL);
+  gst_object_unref (filter);
+
+  nnstreamer_filter_exit (test_fw_custom_name);
+  g_free (fw);
+}
+
+/**
+ * @brief Test that every model entry is verified, not only the first one.
+ */
+TEST (tensorStreamTest, subpluginV1OpenSecondModelMissing_n)
+{
+  GstTensorFilterFramework *fw = test_custom_v1_probe_open (0, 1);
+  GstElement *filter;
+  gchar *model_file = getTempFilename ();
+  gchar *missing_file = getTempFilename ();
+  gchar *models;
+
+  ASSERT_TRUE (fw != NULL);
+  ASSERT_TRUE (model_file != NULL && missing_file != NULL);
+  ASSERT_TRUE (nnstreamer_filter_probe (fw));
+
+  g_remove (missing_file);
+  models = g_strdup_printf ("%s,%s", model_file, missing_file);
+
+  filter = gst_element_factory_make ("tensor_filter", NULL);
+  ASSERT_TRUE (filter != NULL);
+  g_object_set (filter, "framework", test_fw_custom_name, "model", models, NULL);
+
+  EXPECT_EQ (gst_element_set_state (filter, GST_STATE_PAUSED), GST_STATE_CHANGE_FAILURE);
+  EXPECT_FALSE (test_custom_v0_opened);
+
+  gst_element_set_state (filter, GST_STATE_NULL);
+  gst_object_unref (filter);
+
+  removeTempFile (&model_file);
+  g_free (missing_file);
+  g_free (models);
+  nnstreamer_filter_exit (test_fw_custom_name);
+  g_free (fw);
+}
+
+/**
+ * @brief Test that a sub-plugin which cannot report its framework info is not opened.
+ * @details Registration rejects such a sub-plugin, so the failure is made to start
+ *          only afterwards, the way a HAL backend that stops answering would. The
+ *          model property is set so that the refusal can only come from the failed
+ *          query: an unreported flag reads as "a model is needed", which a missing
+ *          model would satisfy on its own.
+ */
+TEST (tensorStreamTest, subpluginV1OpenNoFrameworkInfo_n)
+{
+  GstTensorFilterFramework *fw = test_custom_v1_probe_open (1, 0);
+  GstElement *filter;
+  gchar *model_file = getTempFilename ();
+
+  ASSERT_TRUE (fw != NULL);
+  ASSERT_TRUE (model_file != NULL);
+  ASSERT_TRUE (nnstreamer_filter_probe (fw));
+
+  filter = gst_element_factory_make ("tensor_filter", NULL);
+  ASSERT_TRUE (filter != NULL);
+  g_object_set (filter, "framework", test_fw_custom_name, "model", model_file, NULL);
+
+  test_custom_v1_fwinfo_fails = TRUE;
+  EXPECT_EQ (gst_element_set_state (filter, GST_STATE_PAUSED), GST_STATE_CHANGE_FAILURE);
+  EXPECT_FALSE (test_custom_v0_opened);
+  test_custom_v1_fwinfo_fails = FALSE;
+
+  gst_element_set_state (filter, GST_STATE_NULL);
+  gst_object_unref (filter);
+
+  removeTempFile (&model_file);
   nnstreamer_filter_exit (test_fw_custom_name);
   g_free (fw);
 }


### PR DESCRIPTION
Fixes items **B1** and **B2** of #4920: a `tensor_filter` sub-plugin that needs a model file was reached with `prop->model_files == NULL` and dereferenced `model_files[0]`, so a pipeline built without the `model` property crashed on its way to `PAUSED`.

### The framework never enforced "a model is required"

`verify_model_path()` gated the model-count check on `!run_without_model && verify_model_path`, but the two flags are documented to mean different things:

- `run_without_model` — "TRUE when the neural network framework does not need a model file"
- `verify_model_path` — "TRUE when the NNS framework, not the sub-plugin, should verify the path of model files"

They are now split, so a missing model is refused before `open()` is called while the per-file `g_file_test()` stays under `verify_model_path`.

**V0 sub-plugins** that need a model but check the path themselves had the count check skipped entirely: `cpp`, `nnfw`, `openvino`, `movidius-ncsdk2`, `vivante`, `armnn`, `caffe2`. (`custom` and `tensorrt` carry their own guard and were already safe.)

**V1 sub-plugins had no check at all.** `verify_model_path()` read the flags from `priv->info`, which is zeroed at init (`tensor_filter_common.c:994`) and only filled from `getFrameworkInfo()` *after* a successful `open()` (`:2573`); the one pre-open call writes into a discarded local. Both flags therefore always read 0 there, so `lua` and `executorch-llama` crashed the same way, and `onnxruntime`, `litert`, `tvm`, `ncnn`, `python3`, `snpe` and the rest never had their declared `verify_model_path` honoured. Splitting the condition without fixing this would have applied the model requirement to every V1 sub-plugin regardless of its declaration, wrongly refusing one that declares `run_without_model` — the whole C++ sub-plugin class, since `tensor_filter_subplugin` always installs `cpp_open()`.

So the flags are now read from the sub-plugin. That is safe by construction: `nnstreamer_filter_probe()` refuses to register a V1 sub-plugin whose `getFrameworkInfo()` cannot answer a query carrying no private data (`:606`, `:642`), and `cpp_getFrameworkInfo()` handles `private_data == nullptr` explicitly by querying the empty instance (`tensor_filter_support_cc.cc:208-218`).

The `custom-easy` special case in `verify_model_path()` is removed with it: reading the declaration now covers what the fwname comparison used to.

### Behaviour change: the `g_file_test()` loop becomes live for V1

Honouring `verify_model_path` for V1 activates a loop that has never run for those ~20 sub-plugins. All in-tree V1 sub-plugins declaring it were audited; every one uses `model_files[i]` as a path that must exist, **except `mxnet`**, which takes a base path and appends `-symbol.json` / `.params` itself (`tensor_filter_mxnet.cc:222-247`). Its `verify_model_path = TRUE` was simply wrong and is corrected in the first commit, ordered before the framework change so no commit in this branch leaves `mxnet` broken.

### custom-easy

`custom-easy` needs a model *name*, not a model *file*, so it correctly declares `run_without_model` and the framework guard cannot cover it. `custom_open()` now returns `-EINVAL` when the name is missing or empty — the same predicate `tensor_filter_custom.c:75-76` already uses, and the same outcome as a name that was never registered.

### Tests

`unittest_sink` — V0: `subpluginV0OpenWithModel`, `subpluginV0OpenWithoutModel_n`. V1: `subpluginV1OpenWithoutModel` (a sub-plugin declaring `run_without_model` must still open), `subpluginV1OpenWithModel`, `subpluginV1OpenWithoutModel_n`, `subpluginV1OpenMissingModel_n` and `subpluginV1OpenSecondModelMissing_n` (the `g_file_test()` loop, including that it checks every entry rather than the first), and `subpluginV1OpenUnverifiedModel` for the opposite contract `mxnet` and `lua` rely on — a model entry the sub-plugin resolves itself must not be tested as a file. All register a sub-plugin with an `open` callback that records whether it ran — the pre-existing V1 harness installs none, so `verify_model_path()` was never reached for V1 by any test.

`unittest_plugins` — `testTensorFilterCppSubplugin.elementOpenWithoutModel` drives the real C++ path, `cpp_getFrameworkInfo()` with no private data, through an element state change.

`unittest_filter_custom` — `easyOpenWithoutModel_n`, `easyOpenEmptyModel_n`.

Negative controls, measured:

| test | `main` | split without the V1 read | this PR |
|---|---|---|---|
| `subpluginV0OpenWithoutModel_n` | FAIL | OK | OK |
| `subpluginV1OpenWithoutModel` | OK | **FAIL** | OK |
| `subpluginV1OpenWithoutModel_n` | FAIL | OK | OK |
| `subpluginV1OpenMissingModel_n` | FAIL | **FAIL** | OK |
| `elementOpenWithoutModel` | OK | **FAIL** | OK |
| `easyOpenWithoutModel_n` | **SIGSEGV** | OK | OK |

`easyOpenEmptyModel_n` passes on `main` as well: an empty model name was never a crash, only an unchecked string. It is there so the branch is executed rather than left to rot.

Local `meson test`: 22/23 OK. The one failure, `unittest_filter_python3`, is a NumPy 1.x/2.x ABI mismatch in the local box and reproduces on other trees at `main`.

### tizen-hal

`tizen_hal_subplugin` creates its `hal_handle` in `configure_instance()`, so the registered representation still has none when `getFrameworkInfo()` is queried before `open()`; it returns early after setting `info.name` (`tensor_filter_tizen_hal.cc:193-200`). The flags therefore stay 0/0 for `framework=tizen-hal`: it gains the "a model entry is required" rule, which it wants, gets no file test, and the query costs no HAL round trip.

The other two HAL sub-plugins differ. `snpe_tizen_hal_subplugin` and `vivante_tizen_hal_subplugin` call `hal_ml_create()` in their **constructors** (`tensor_filter_tizen_hal_snpe.cc:64-75`, `..._vivante.cc:65-73`), so the representation holds a live handle and their `getFrameworkInfo()` has no `!hal_handle` guard: on Tizen, `framework=snpe` and `framework=vivante` do one extra HAL round trip per open, and the flags the backend declares are enforced for the first time. The round trip already happens at registration and whenever `framework=` is set, and a throw is caught by `cpp_getFrameworkInfo()` and turned into `-EINVAL`, so this is a behaviour change rather than a new failure mode — but it is not exercised by this repository's CI and is worth a Tizen maintainer's eye.

### Deliberately out of scope

- `tensor_filter.c:621` reads `priv->fw->run_without_model`, the v0 union member, unconditionally; for a V1 sub-plugin that is a meaningless read. Pre-existing, and with this PR in place that check is no longer the one that catches a missing model.
- `tensor_filter_executorch_llama.cc:106,114` dereferences `model_files[1]` without checking `num_models >= 2`. This PR only guarantees `model_files[0]`.
- `verify_model_path()` is consulted only when the sub-plugin defines an `open` callback (`:2560`). A sub-plugin without one has nothing to crash, so the header now says so rather than the check moving.
- The model properties are replaced without a lock while the open path walks them, and `SUSPEND`/`RESUME` hand a NULL event data to `cpp_eventHandler()`, which binds a reference to it. Both were found while reviewing this PR and are filed as items **B14** and **B13** on #4920.

The first two are candidates for further items there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
