### PR TITLE
[Element/Crop] Bound the crop region and the incoming buffers

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_crop.c
+++ b/gst/nnstreamer/elements/gsttensor_crop.c
@@ -509,8 +509,13 @@ gst_tensor_crop_prepare_out_meta (GstTensorCrop * self, gpointer buffer,
 
   gst_tensor_meta_info_init (meta);
   gst_tensor_info_init (info);
+  gst_tensors_config_init (&config);
 
   caps = gst_pad_get_current_caps (self->sinkpad_raw);
+  if (!caps) {
+    GST_ERROR_OBJECT (self, "The raw pad is not negotiated.");
+    goto done;
+  }
 
   if (!gst_tensors_config_from_caps (&config, caps, TRUE)) {
     GST_ERROR_OBJECT (self, "Failed to get the config from caps.");
@@ -545,7 +550,8 @@ gst_tensor_crop_prepare_out_meta (GstTensorCrop * self, gpointer buffer,
   meta->format = _NNS_TENSOR_FORMAT_FLEXIBLE;
 
 done:
-  gst_caps_unref (caps);
+  if (caps)
+    gst_caps_unref (caps);
   gst_tensors_config_free (&config);
   return ret;
 }
@@ -659,7 +665,7 @@ gst_tensor_crop_do_cropping (GstTensorCrop * self, GstBuffer * raw,
   GstTensorMetaInfo meta;
   GstTensorInfo info;
   gboolean flexible;
-  gsize hsize, esize, dsize;
+  gsize hsize, esize, dsize, fsize;
   guint8 *cropped, *dpos, *desc, *src;
   guint i, j, ch, mw, mh, _x, _y, _w, _h;
 
@@ -695,17 +701,35 @@ gst_tensor_crop_do_cropping (GstTensorCrop * self, GstBuffer * raw,
   if ((hsize + dsize) != map.size) {
     GST_ERROR_OBJECT (self,
         "Raw buffer has invalid data size (received %zd, expected %zd).",
-        map.size, dsize);
+        map.size, hsize + dsize);
     goto done;
   }
-
-  result = gst_buffer_new ();
 
   /** @todo Add various mode to crop tensor. */
   ch = info.dimension[0];
   mw = info.dimension[1];
   mh = info.dimension[2];
   esize = gst_tensor_get_element_size (info.type);
+
+  /**
+   * The frame is read as ch * mw * mh elements. dsize above cannot bound it: it
+   * comes from gst_tensor_meta_info_get_data_size(), whose element count is an
+   * unchecked product of the dimensions, so a flexible header can declare a
+   * frame whose byte size wraps below map.size. Recompute the frame with
+   * overflow-checked arithmetic and require it to fit the mapped payload.
+   */
+  if (!g_size_checked_mul (&fsize, esize, ch) ||
+      !g_size_checked_mul (&fsize, fsize, mw) ||
+      !g_size_checked_mul (&fsize, fsize, mh) ||
+      fsize > map.size - hsize) {
+    GST_ERROR_OBJECT (self,
+        "Raw tensor dimension %u:%u:%u does not fit the buffer (%zd bytes).",
+        ch, mw, mh, map.size - hsize);
+    goto done;
+  }
+
+  result = gst_buffer_new ();
+
   hsize = gst_tensor_meta_info_get_header_size (&meta);
 
   for (i = 0; i < cinfo->num; i++) {
@@ -802,8 +826,8 @@ gst_tensor_crop_chain (GstTensorCrop * self,
   buf_info = gst_tensor_buffer_from_config (buf_info, &cpad->config);
 
   if (!buf_raw || !buf_info) {
-    GST_ERROR_OBJECT (self,
-        "Incoming buffer does not match the negotiated caps.");
+    GST_ELEMENT_ERROR (self, STREAM, FORMAT, (NULL),
+        ("Incoming buffer does not match the negotiated caps."));
     ret = GST_FLOW_ERROR;
     goto done;
   }
@@ -843,12 +867,16 @@ gst_tensor_crop_chain (GstTensorCrop * self,
   }
 
   if (!gst_tensor_crop_get_crop_info (self, buf_info, &cinfo)) {
+    GST_ELEMENT_ERROR (self, STREAM, FORMAT, (NULL),
+        ("Failed to parse the crop info buffer."));
     ret = GST_FLOW_ERROR;
     goto done;
   }
 
   result = gst_tensor_crop_do_cropping (self, buf_raw, &cinfo);
   if (!result) {
+    GST_ELEMENT_ERROR (self, STREAM, FORMAT, (NULL),
+        ("Failed to crop the raw buffer."));
     ret = GST_FLOW_ERROR;
     goto done;
   }

--- a/gst/nnstreamer/elements/gsttensor_crop.c
+++ b/gst/nnstreamer/elements/gsttensor_crop.c
@@ -577,6 +577,8 @@ gst_tensor_crop_get_crop_info (GstTensorCrop * self, GstBuffer * info,
   mem = gst_tensor_buffer_get_nth_memory (info, 0);
   if (!gst_memory_map (mem, &map, GST_MAP_READ)) {
     GST_ERROR_OBJECT (self, "Failed to map the info buffer.");
+    gst_memory_unref (mem);
+    mem = NULL;
     goto done;
   }
 
@@ -671,6 +673,8 @@ gst_tensor_crop_do_cropping (GstTensorCrop * self, GstBuffer * raw,
   mem = gst_tensor_buffer_get_nth_memory (raw, 0);
   if (!gst_memory_map (mem, &map, GST_MAP_READ)) {
     GST_ERROR_OBJECT (self, "Failed to map the raw buffer.");
+    gst_memory_unref (mem);
+    mem = NULL;
     goto done;
   }
 
@@ -703,12 +707,22 @@ gst_tensor_crop_do_cropping (GstTensorCrop * self, GstBuffer * raw,
     GstTensorInfo crop_info;
     GstMemory *crop_mem;
 
-    _x = (cinfo->region[i].x < mw) ? cinfo->region[i].x : mw;
-    _y = (cinfo->region[i].y < mh) ? cinfo->region[i].y : mh;
-    _w = (_x + cinfo->region[i].w - 1 < mw) ? cinfo->region[i].w : (mw - _x);
-    _h = (_y + cinfo->region[i].h - 1 < mh) ? cinfo->region[i].h : (mh - _y);
+    /* a zero size means the rest of the frame, as it always has */
+    _x = MIN (cinfo->region[i].x, mw);
+    _y = MIN (cinfo->region[i].y, mh);
+    _w = (cinfo->region[i].w > 0) ?
+        MIN (cinfo->region[i].w, mw - _x) : (mw - _x);
+    _h = (cinfo->region[i].h > 0) ?
+        MIN (cinfo->region[i].h, mh - _y) : (mh - _y);
 
-    g_assert (_w > 0 && _h > 0);
+    if (_w == 0 || _h == 0) {
+      GST_WARNING_OBJECT (self,
+          "Skip the crop region %u [%u, %u, %u, %u], the raw data is %u:%u.", i,
+          cinfo->region[i].x, cinfo->region[i].y, cinfo->region[i].w,
+          cinfo->region[i].h, mw, mh);
+      continue;
+    }
+
     dsize = hsize + (esize * ch * _w * _h);
     cropped = (guint8 *) g_malloc0 (dsize);
 
@@ -731,6 +745,12 @@ gst_tensor_crop_do_cropping (GstTensorCrop * self, GstBuffer * raw,
 
     gst_tensor_buffer_append_memory (result, crop_mem, &crop_info);
     gst_tensor_info_free (&crop_info);
+  }
+
+  if (gst_buffer_n_memory (result) == 0) {
+    GST_ERROR_OBJECT (self, "No crop region of the info buffer is usable.");
+    gst_buffer_replace (&result, NULL);
+    goto done;
   }
 
   /* set timestamp from raw buffer */

--- a/gst/nnstreamer/elements/gsttensor_crop.c
+++ b/gst/nnstreamer/elements/gsttensor_crop.c
@@ -23,6 +23,9 @@
  * So, when incoming buffer on info pad has more than NNS_TENSOR_SIZE_LIMIT crop-info array, tensor_crop will ignore the data.
  *
  * The output is always in the format of other/tensors-flexible.
+ * A crop region of zero width or height means the rest of the frame, and a
+ * region that has nothing left to crop after clamping is skipped, so the output
+ * may hold fewer tensors than the info buffer describes.
  *
  * <refsect2>
  * <title>Example launch line</title>
@@ -660,6 +663,8 @@ gst_tensor_crop_do_cropping (GstTensorCrop * self, GstBuffer * raw,
   guint8 *cropped, *dpos, *desc, *src;
   guint i, j, ch, mw, mh, _x, _y, _w, _h;
 
+  gst_tensor_info_init (&info);
+
   i = gst_tensor_buffer_get_count (raw);
   if (i == 0) {
     GST_ERROR_OBJECT (self, "Raw data buffer has no memory.");
@@ -761,6 +766,7 @@ done:
     gst_memory_unmap (mem, &map);
     gst_memory_unref (mem);
   }
+  gst_tensor_info_free (&info);
 
   return result;
 }

--- a/gst/nnstreamer/elements/gsttensor_crop.c
+++ b/gst/nnstreamer/elements/gsttensor_crop.c
@@ -491,10 +491,13 @@ gst_tensor_crop_negotiate (GstTensorCrop * self)
 
 /**
  * @brief Internal function to prepare output meta info.
+ * @param[in] buffer mapped data of the first memory in the raw buffer
+ * @param[in] size mapped size of @a buffer
  */
 static gboolean
 gst_tensor_crop_prepare_out_meta (GstTensorCrop * self, gpointer buffer,
-    GstTensorMetaInfo * meta, GstTensorInfo * info, gboolean * is_flexible)
+    gsize size, GstTensorMetaInfo * meta, GstTensorInfo * info,
+    gboolean * is_flexible)
 {
   GstCaps *caps;
   GstTensorsConfig config;
@@ -519,6 +522,13 @@ gst_tensor_crop_prepare_out_meta (GstTensorCrop * self, gpointer buffer,
 
   if (*is_flexible) {
     /* meta from buffer */
+    if (size < gst_tensor_meta_info_get_header_size (meta)) {
+      GST_ERROR_OBJECT (self,
+          "Raw buffer is too small to have the meta header (received %zd).",
+          size);
+      goto done;
+    }
+
     if (gst_tensor_meta_info_parse_header (meta, buffer)) {
       ret = gst_tensor_meta_info_convert (meta, info);
     }
@@ -544,7 +554,7 @@ static gboolean
 gst_tensor_crop_get_crop_info (GstTensorCrop * self, GstBuffer * info,
     tensor_crop_info_s * cinfo)
 {
-  GstMemory *mem;
+  GstMemory *mem = NULL;
   GstMapInfo map;
   GstTensorMetaInfo meta;
   gsize hsize, dsize, esize;
@@ -552,8 +562,13 @@ gst_tensor_crop_get_crop_info (GstTensorCrop * self, GstBuffer * info,
   guint8 *pos, *src, *desc;
   gboolean ret = FALSE;
 
+  gst_tensor_meta_info_init (&meta);
+
   i = gst_tensor_buffer_get_count (info);
-  g_assert (i > 0);
+  if (i == 0) {
+    GST_ERROR_OBJECT (self, "Info buffer has no memory.");
+    goto done;
+  }
   if (i > 1) {
     GST_WARNING_OBJECT (self,
         "Info buffer has %u memories, parse first one.", i);
@@ -566,6 +581,13 @@ gst_tensor_crop_get_crop_info (GstTensorCrop * self, GstBuffer * info,
   }
 
   /* parse crop-info from flex tensor */
+  if (map.size < gst_tensor_meta_info_get_header_size (&meta)) {
+    GST_ERROR_OBJECT (self,
+        "Info buffer is too small to have the meta header (received %zd).",
+        map.size);
+    goto done;
+  }
+
   if (!gst_tensor_meta_info_parse_header (&meta, map.data)) {
     GST_ERROR_OBJECT (self, "Failed to get the meta from info buffer.");
     goto done;
@@ -586,7 +608,12 @@ gst_tensor_crop_get_crop_info (GstTensorCrop * self, GstBuffer * info,
    * @todo Add various mode to crop tensor.
    * Now tensor-crop handles NHWC data format only.
    */
-  g_assert ((dsize % (esize * 4)) == 0);
+  if (dsize == 0 || (dsize % (esize * 4)) != 0) {
+    GST_ERROR_OBJECT (self,
+        "Info buffer does not have a multiple of 4 elements (received %zd bytes of %zd-byte elements).",
+        dsize, esize);
+    goto done;
+  }
 
   memset (cinfo, 0, sizeof (tensor_crop_info_s));
 
@@ -622,7 +649,7 @@ gst_tensor_crop_do_cropping (GstTensorCrop * self, GstBuffer * raw,
     tensor_crop_info_s * cinfo)
 {
   GstBuffer *result = NULL;
-  GstMemory *mem;
+  GstMemory *mem = NULL;
   GstMapInfo map;
   GstTensorMetaInfo meta;
   GstTensorInfo info;
@@ -632,7 +659,10 @@ gst_tensor_crop_do_cropping (GstTensorCrop * self, GstBuffer * raw,
   guint i, j, ch, mw, mh, _x, _y, _w, _h;
 
   i = gst_tensor_buffer_get_count (raw);
-  g_assert (i > 0);
+  if (i == 0) {
+    GST_ERROR_OBJECT (self, "Raw data buffer has no memory.");
+    goto done;
+  }
   if (i > 1) {
     GST_WARNING_OBJECT (self,
         "Raw data buffer has %u memories, parse first one.", i);
@@ -644,7 +674,7 @@ gst_tensor_crop_do_cropping (GstTensorCrop * self, GstBuffer * raw,
     goto done;
   }
 
-  if (!gst_tensor_crop_prepare_out_meta (self, map.data, &meta,
+  if (!gst_tensor_crop_prepare_out_meta (self, map.data, map.size, &meta,
           &info, &flexible)) {
     GST_ERROR_OBJECT (self, "Failed to get the output meta.");
     goto done;
@@ -745,6 +775,13 @@ gst_tensor_crop_chain (GstTensorCrop * self,
   cpad = (GstTensorCropPadData *) data_info;
   buf_info = gst_tensor_buffer_from_config (buf_info, &cpad->config);
 
+  if (!buf_raw || !buf_info) {
+    GST_ERROR_OBJECT (self,
+        "Incoming buffer does not match the negotiated caps.");
+    ret = GST_FLOW_ERROR;
+    goto done;
+  }
+
   /**
    * The case when raw and info have different timestamp.
    * Compare timestamp and if time diff is less than lateness, crop raw buffer.
@@ -785,6 +822,11 @@ gst_tensor_crop_chain (GstTensorCrop * self,
   }
 
   result = gst_tensor_crop_do_cropping (self, buf_raw, &cinfo);
+  if (!result) {
+    ret = GST_FLOW_ERROR;
+    goto done;
+  }
+
   ret = gst_pad_push (self->srcpad, result);
 
 done:

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -120,7 +120,7 @@ if gtest_dep.found()
       install_dir: unittest_install_dir
     )
 
-    test('unittest_plugins', unittest_plugins, env: testenv)
+    test('unittest_plugins', unittest_plugins, timeout: 120, env: testenv)
 
     # Run unittest_watchdog
     unittest_watchdog = executable('unittest_watchdog',

--- a/tests/nnstreamer_decoder_tensor_region/runTest.sh
+++ b/tests/nnstreamer_decoder_tensor_region/runTest.sh
@@ -24,7 +24,7 @@ PATH_TO_LABELS="../nnstreamer_decoder_boundingbox/coco_labels_list.txt"
 PATH_TO_BOX_PRIORS="../nnstreamer_decoder_boundingbox/box_priors.txt"
 PATH_TO_MODEL="../test_models/models/ssd_mobilenet_v2_coco.tflite"
 CASESTART=0
-CASEEND=3
+CASEEND=1
 
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
@@ -51,7 +51,7 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
 # them the file cannot reach this size.
 WHOLE_FRAME=$(( 128 + 300 * 300 * 3 ))
 [[ -f tensor_region_output_zero.dat ]] && [[ $(wc -c < tensor_region_output_zero.dat) -ge $(( WHOLE_FRAME * 2 )) ]]
-testResult $? 2 "mobilenet-ssd crop of the regions without a detection" 0 1
+testResult $? 1 "mobilenet-ssd crop of the regions without a detection" 0 1
 
 rm tensor_region_output_*
 report

--- a/tests/nnstreamer_decoder_tensor_region/runTest.sh
+++ b/tests/nnstreamer_decoder_tensor_region/runTest.sh
@@ -24,7 +24,7 @@ PATH_TO_LABELS="../nnstreamer_decoder_boundingbox/coco_labels_list.txt"
 PATH_TO_BOX_PRIORS="../nnstreamer_decoder_boundingbox/box_priors.txt"
 PATH_TO_MODEL="../test_models/models/ssd_mobilenet_v2_coco.tflite"
 CASESTART=0
-CASEEND=2
+CASEEND=3
 
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
@@ -44,7 +44,14 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
     filesrc  location=mobilenet_ssd_tensor.0 blocksize=-1 ! application/octet-stream ! tensor_converter name=el1 input-dim=4:1:1917:1 input-type=float32 ! mux.sink_0 \
     filesrc  location=mobilenet_ssd_tensor.1 blocksize=-1 ! application/octet-stream ! tensor_converter name=el2 input-dim=91:1917:1 input-type=float32 ! mux.sink_1 \
     tensor_mux name=mux ! other/tensors,format=static ! tensor_decoder mode=tensor_region option1=3 option2=${PATH_TO_LABELS} option3=${PATH_TO_BOX_PRIORS} ! crop.info\
-    tensor_crop name=crop ! other/tensors,format=flexible ! fakesink   " 1 0 0 $PERFORMANCE
+    tensor_crop name=crop ! other/tensors,format=flexible ! filesink location=tensor_region_output_zero.dat   " 1 0 0 $PERFORMANCE
+
+# A whole-frame crop is a 128-byte flex header plus the 300x300 RGB frame. Two of
+# the three regions are the empty ones, so both have to be in the output; without
+# them the file cannot reach this size.
+WHOLE_FRAME=$(( 128 + 300 * 300 * 3 ))
+[[ -f tensor_region_output_zero.dat ]] && [[ $(wc -c < tensor_region_output_zero.dat) -ge $(( WHOLE_FRAME * 2 )) ]]
+testResult $? 2 "mobilenet-ssd crop of the regions without a detection" 0 1
 
 rm tensor_region_output_*
 report

--- a/tests/nnstreamer_decoder_tensor_region/runTest.sh
+++ b/tests/nnstreamer_decoder_tensor_region/runTest.sh
@@ -24,7 +24,7 @@ PATH_TO_LABELS="../nnstreamer_decoder_boundingbox/coco_labels_list.txt"
 PATH_TO_BOX_PRIORS="../nnstreamer_decoder_boundingbox/box_priors.txt"
 PATH_TO_MODEL="../test_models/models/ssd_mobilenet_v2_coco.tflite"
 CASESTART=0
-CASEEND=1
+CASEEND=2
 
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
@@ -35,5 +35,16 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
     tensor_crop name=crop ! other/tensors,format=flexible ! tensor_converter ! tensor_decoder mode=direct_video ! videoconvert ! video/x-raw,format=RGBx  !  filesink location=tensor_region_output_orange.txt   " 0 0 0 $PERFORMANCE
 
 callCompareTest tensor_region_orange.txt tensor_region_output_orange.txt 0 "mobilenet-ssd Decode 1" 0
+
+# The decoder zero-fills the crop-info slots it has no detection for, so asking
+# for more regions than the image has is the case that hands tensor_crop a
+# region of size zero. It should crop the whole frame for those, not fail.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} \
+    filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoconvert ! videoscale ! video/x-raw,width=300,height=300,format=RGB,framerate=0/1 ! tensor_converter ! crop.raw \
+    filesrc  location=mobilenet_ssd_tensor.0 blocksize=-1 ! application/octet-stream ! tensor_converter name=el1 input-dim=4:1:1917:1 input-type=float32 ! mux.sink_0 \
+    filesrc  location=mobilenet_ssd_tensor.1 blocksize=-1 ! application/octet-stream ! tensor_converter name=el2 input-dim=91:1917:1 input-type=float32 ! mux.sink_1 \
+    tensor_mux name=mux ! other/tensors,format=static ! tensor_decoder mode=tensor_region option1=3 option2=${PATH_TO_LABELS} option3=${PATH_TO_BOX_PRIORS} ! crop.info\
+    tensor_crop name=crop ! other/tensors,format=flexible ! fakesink   " 1 0 0 $PERFORMANCE
+
 rm tensor_region_output_*
 report

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -21,6 +21,7 @@
 #include <nnstreamer_subplugin.h>
 #include <nnstreamer_util.h>
 #include <string.h>
+#include <sys/mman.h>
 #include <tensor_common.h>
 #include <tensor_decoder_custom.h>
 #include <tensor_meta.h>
@@ -9864,14 +9865,13 @@ _crop_test_free (crop_test_data_s *crop_test)
   } while (0)
 
 /**
- * @brief Push raw and info buffer to tensor_crop.
+ * @brief Set the raw-pad caps of tensor_crop.
  */
 static void
-_crop_test_push_buffer (crop_test_data_s *crop_test)
+_crop_test_set_raw_caps (crop_test_data_s *crop_test)
 {
   GstTensorsConfig config;
 
-  /* caps for raw data */
   gst_tensors_config_init (&config);
   config.info.num_tensors = 1;
   config.info.info[0] = crop_test->raw_info;
@@ -9880,6 +9880,112 @@ _crop_test_push_buffer (crop_test_data_s *crop_test)
   config.rate_d = 1;
 
   gst_harness_set_src_caps (crop_test->raw_q, gst_tensors_caps_from_config (&config));
+}
+
+/**
+ * @brief Push a buffer of two memories to the given pad.
+ * @details gst_tensor_buffer_from_config() passes a multi-memory buffer through
+ *          as it is, so the element receives the given memories unchanged.
+ */
+static void
+_crop_test_push_two_memories (GstHarness *h, gsize first, gsize second)
+{
+  GstBuffer *buf = gst_buffer_new ();
+
+  gst_buffer_append_memory (buf, gst_allocator_alloc (NULL, first, NULL));
+  gst_buffer_append_memory (buf, gst_allocator_alloc (NULL, second, NULL));
+
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_OK);
+}
+
+/**
+ * @brief Release the mapping of a memory from _crop_test_new_guarded_memory().
+ */
+static void
+_crop_test_unmap_guarded (gpointer base)
+{
+  munmap (base, 2 * (gsize) sysconf (_SC_PAGESIZE));
+}
+
+/**
+ * @brief Create a memory of @a size bytes that is followed by an unreadable page.
+ * @details Reading a single byte past the memory faults, which turns an
+ *          out-of-bounds read into a deterministic failure without valgrind.
+ * @return The memory, or NULL when the guarded mapping is not available.
+ */
+static GstMemory *
+_crop_test_new_guarded_memory (gsize size)
+{
+  const gsize page = (gsize) sysconf (_SC_PAGESIZE);
+  guint8 *base;
+
+  if (size > page)
+    return NULL;
+
+  base = (guint8 *) mmap (NULL, 2 * page, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (base == MAP_FAILED)
+    return NULL;
+
+  if (mprotect (base + page, page, PROT_NONE) != 0) {
+    munmap (base, 2 * page);
+    return NULL;
+  }
+
+  return gst_memory_new_wrapped (GST_MEMORY_FLAG_READONLY, base + page - size,
+      size, 0, size, base, _crop_test_unmap_guarded);
+}
+
+/**
+ * @brief Push a buffer whose first memory is followed by an unreadable page.
+ */
+static void
+_crop_test_push_guarded_memory (GstHarness *h, gsize size)
+{
+  GstBuffer *buf;
+  GstMemory *mem = _crop_test_new_guarded_memory (size);
+
+  ASSERT_TRUE (mem != NULL);
+
+  buf = gst_buffer_new ();
+  gst_buffer_append_memory (buf, mem);
+  /* the second memory keeps gst_tensor_buffer_from_config() from re-splitting */
+  gst_buffer_append_memory (buf, gst_allocator_alloc (NULL, size, NULL));
+
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_OK);
+}
+
+/**
+ * @brief Push an info buffer carrying a flex tensor of the given dimension.
+ */
+static void
+_crop_test_push_info_dimension (crop_test_data_s *crop_test, guint d0, guint d1)
+{
+  GstBuffer *buf = gst_buffer_new ();
+  GstMemory *mem;
+  GstTensorMetaInfo meta;
+
+  gst_tensor_meta_info_init (&meta);
+  meta.type = crop_test->info_type;
+  meta.dimension[0] = d0;
+  meta.dimension[1] = d1;
+  meta.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+
+  mem = gst_memory_new_wrapped (GST_MEMORY_FLAG_READONLY, crop_test->info_data,
+      crop_test->info_size, 0, crop_test->info_size, NULL, NULL);
+  gst_buffer_append_memory (buf, gst_tensor_meta_info_append_header (&meta, mem));
+  gst_memory_unref (mem);
+
+  EXPECT_EQ (gst_harness_push (crop_test->info_q, buf), GST_FLOW_OK);
+}
+
+/**
+ * @brief Push raw and info buffer to tensor_crop.
+ */
+static void
+_crop_test_push_buffer (crop_test_data_s *crop_test)
+{
+  _crop_test_set_raw_caps (crop_test);
 
   /* push raw buffer */
   _crop_test_push_raw_buffer (crop_test, crop_test->ts_raw);
@@ -10309,6 +10415,217 @@ TEST (testTensorCrop, infoDelayed_n)
 
   if (crop_test.received > 0)
     _crop_test_compare_res2 (&crop_test);
+
+  _crop_test_free (&crop_test);
+}
+
+/**
+ * @brief Prepare the raw data (uint32 1:10:4:1, [1, 2, ..., 40]) and one region.
+ */
+static void
+_crop_test_prepare_single_region (crop_test_data_s *crop_test)
+{
+  guint i;
+  guint *_data;
+
+  crop_test->raw_info.type = _NNS_UINT32;
+  gst_tensor_parse_dimension ("1:10:4:1", crop_test->raw_info.dimension);
+
+  crop_test->raw_size = sizeof (guint) * 40U;
+  crop_test->raw_data = g_malloc0 (crop_test->raw_size);
+  _data = (guint *) crop_test->raw_data;
+
+  for (i = 0; i < 40; i++)
+    _data[i] = i + 1;
+
+  crop_test->info_type = _NNS_UINT32;
+  crop_test->info_size = sizeof (guint) * 4U;
+  crop_test->info_num = 1U;
+  crop_test->info_data = g_malloc0 (crop_test->info_size);
+}
+
+/**
+ * @brief Set the single crop region [x, y, w, h].
+ */
+static void
+_crop_test_set_region (crop_test_data_s *crop_test, guint x, guint y, guint w, guint h)
+{
+  guint *_info = (guint *) crop_test->info_data;
+
+  _info[0] = x;
+  _info[1] = y;
+  _info[2] = w;
+  _info[3] = h;
+}
+
+/**
+ * @brief Wait for tensor_crop to handle the pushed buffers, expecting no output.
+ * @details The element decides in its chain function, so a short budget is
+ *          enough; a case that regresses crashes there instead of timing out.
+ */
+static guint
+_crop_test_wait_for_no_output (crop_test_data_s *crop_test)
+{
+  guint count;
+
+  for (count = 0; count < 5; count++) {
+    g_usleep (100000);
+    if (gst_harness_buffers_received (crop_test->crop) > 0)
+      break;
+  }
+
+  return gst_harness_buffers_received (crop_test->crop);
+}
+
+/**
+ * @brief Test for tensor_crop, an info tensor that does not hold whole regions.
+ * @details Without the fix the element aborts on the element-count assertion.
+ */
+TEST (testTensorCrop, cropInfoElementCount_n)
+{
+  crop_test_data_s crop_test;
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+
+  crop_test.info_size = sizeof (guint) * 3U;
+
+  _crop_test_set_raw_caps (&crop_test);
+  _crop_test_push_raw_buffer (&crop_test, crop_test.ts_raw);
+  _crop_test_push_info_dimension (&crop_test, 3U, 1U);
+
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test);
+  EXPECT_EQ (crop_test.received, 0U);
+
+  _crop_test_free (&crop_test);
+}
+
+/**
+ * @brief Test for tensor_crop, an info memory smaller than the meta header.
+ * @details Without the fix the header is parsed past the end of the memory.
+ */
+TEST (testTensorCrop, cropInfoShortHeader_n)
+{
+  crop_test_data_s crop_test;
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+
+  _crop_test_set_raw_caps (&crop_test);
+  _crop_test_push_raw_buffer (&crop_test, crop_test.ts_raw);
+  _crop_test_push_guarded_memory (crop_test.info_q, 16U);
+
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test);
+  EXPECT_EQ (crop_test.received, 0U);
+
+  _crop_test_free (&crop_test);
+}
+
+/**
+ * @brief Test for tensor_crop, a raw memory smaller than the meta header.
+ * @details Without the fix the header is parsed past the end of the memory.
+ */
+TEST (testTensorCrop, cropRawShortHeader_n)
+{
+  crop_test_data_s crop_test;
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+  _crop_test_set_region (&crop_test, 0U, 0U, 1U, 1U);
+
+  crop_test.raw_format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+
+  _crop_test_set_raw_caps (&crop_test);
+  _crop_test_push_guarded_memory (crop_test.raw_q, 16U);
+  _crop_test_push_info_buffer (&crop_test, crop_test.ts_info);
+
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test);
+  EXPECT_EQ (crop_test.received, 0U);
+
+  _crop_test_free (&crop_test);
+}
+
+/**
+ * @brief Test for tensor_crop, a raw buffer that does not match the caps.
+ * @details gst_tensor_buffer_from_config() returns NULL for it; without the fix
+ *          the element reads the timestamp of that NULL buffer.
+ */
+TEST (testTensorCrop, cropRawConfigMismatch_n)
+{
+  crop_test_data_s crop_test;
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+  _crop_test_set_region (&crop_test, 0U, 0U, 1U, 1U);
+
+  /* the timestamp of the buffer is read only while lateness is set */
+  g_object_set (crop_test.crop->element, "lateness", 100, NULL);
+
+  _crop_test_set_raw_caps (&crop_test);
+  _crop_test_push_two_memories (crop_test.raw_q, 16U, 16U);
+  _crop_test_push_info_buffer (&crop_test, crop_test.ts_info);
+
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test);
+  EXPECT_EQ (crop_test.received, 0U);
+
+  _crop_test_free (&crop_test);
+}
+
+/* set by _record_critical() when a critical is logged */
+static gboolean tensor_crop_logged_critical;
+
+/**
+ * @brief Log handler that records whether a critical was issued.
+ */
+static void
+_crop_record_critical (const gchar *domain, GLogLevelFlags level,
+    const gchar *message, gpointer user_data)
+{
+  UNUSED (domain);
+  UNUSED (message);
+  UNUSED (user_data);
+
+  if (level & G_LOG_LEVEL_CRITICAL)
+    tensor_crop_logged_critical = TRUE;
+}
+
+/**
+ * @brief Test for tensor_crop, a buffer that cannot be cropped is not pushed.
+ * @details Without the fix the NULL result of the cropping is handed to
+ *          gst_pad_push(), which rejects it with a critical.
+ */
+TEST (testTensorCrop, cropNoResultBuffer_n)
+{
+  crop_test_data_s crop_test;
+  guint handler_id;
+
+  _crop_test_init (&crop_test);
+
+  crop_test.raw_info.type = _NNS_UINT32;
+  gst_tensor_parse_dimension ("20:1:1:1", crop_test.raw_info.dimension);
+
+  /* the raw buffer is smaller than the caps describe */
+  crop_test.raw_size = sizeof (guint) * 10U;
+  crop_test.raw_data = g_malloc0 (crop_test.raw_size);
+
+  crop_test.info_type = _NNS_UINT32;
+  crop_test.info_size = sizeof (guint) * 4U;
+  crop_test.info_num = 1U;
+  crop_test.info_data = g_malloc0 (crop_test.info_size);
+  _crop_test_set_region (&crop_test, 0U, 0U, 1U, 1U);
+
+  tensor_crop_logged_critical = FALSE;
+  handler_id = g_log_set_handler ("GStreamer",
+      (GLogLevelFlags) (G_LOG_LEVEL_CRITICAL | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION),
+      _crop_record_critical, NULL);
+  _crop_test_set_raw_caps (&crop_test);
+  _crop_test_push_raw_buffer (&crop_test, crop_test.ts_raw);
+  _crop_test_push_info_buffer (&crop_test, crop_test.ts_info);
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test);
+  g_log_remove_handler ("GStreamer", handler_id);
+
+  EXPECT_EQ (crop_test.received, 0U);
+  EXPECT_FALSE (tensor_crop_logged_critical);
 
   _crop_test_free (&crop_test);
 }

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -10624,11 +10624,24 @@ TEST (testTensorCrop, cropRegionZeroIsWholeFrame)
     GstMemory *mem = gst_buffer_peek_memory (out_buf, i);
     GstMapInfo map;
     GstTensorMetaInfo meta;
+    gsize hsize;
+    guint j, elements;
+    guint *cropped;
 
     ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));
     ASSERT_TRUE (gst_tensor_meta_info_parse_header (&meta, map.data));
     EXPECT_EQ (meta.dimension[1], (i == 0) ? 3U : 10U);
     EXPECT_EQ (meta.dimension[2], (i == 0) ? 1U : 4U);
+
+    hsize = gst_tensor_meta_info_get_header_size (&meta);
+    cropped = (guint *) (map.data + hsize);
+    elements = (i == 0) ? 3U : 40U;
+    EXPECT_EQ (map.size - hsize, sizeof (guint) * elements);
+
+    /* [4, 5, 6] for the detected region, the whole [1, 2, ..., 40] for the empty one */
+    for (j = 0; j < elements; j++)
+      EXPECT_EQ (cropped[j], (i == 0) ? j + 4U : j + 1U);
+
     gst_memory_unmap (mem, &map);
   }
 

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -9884,8 +9884,6 @@ _crop_test_set_raw_caps (crop_test_data_s *crop_test)
 
 /**
  * @brief Push a buffer of two memories to the given pad.
- * @details gst_tensor_buffer_from_config() passes a multi-memory buffer through
- *          as it is, so the element receives the given memories unchanged.
  */
 static void
 _crop_test_push_two_memories (GstHarness *h, gsize first, gsize second)
@@ -9911,6 +9909,7 @@ _crop_test_unmap_guarded (gpointer base)
  * @brief Create a memory of @a size bytes that is followed by an unreadable page.
  * @details Reading a single byte past the memory faults, which turns an
  *          out-of-bounds read into a deterministic failure without valgrind.
+ * @note @a size cannot exceed the page size, the memory ends on a page boundary.
  * @return The memory, or NULL when the guarded mapping is not available.
  */
 static GstMemory *
@@ -10459,6 +10458,43 @@ _crop_test_set_region (crop_test_data_s *crop_test, guint x, guint y, guint w, g
 }
 
 /**
+ * @brief Check the single cropped tensor against the expected elements.
+ */
+static void
+_crop_test_compare_single (crop_test_data_s *crop_test, guint width,
+    guint height, const guint *expected)
+{
+  GstBuffer *out_buf;
+  GstMemory *mem;
+  GstMapInfo map;
+  GstTensorMetaInfo meta;
+  gsize hsize;
+  guint i;
+  guint *cropped;
+
+  out_buf = gst_harness_pull (crop_test->crop);
+  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
+
+  mem = gst_buffer_peek_memory (out_buf, 0);
+  ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));
+
+  gst_tensor_meta_info_parse_header (&meta, map.data);
+  EXPECT_EQ (meta.dimension[0], 1U);
+  EXPECT_EQ (meta.dimension[1], width);
+  EXPECT_EQ (meta.dimension[2], height);
+
+  hsize = gst_tensor_meta_info_get_header_size (&meta);
+  cropped = (guint *) (map.data + hsize);
+  EXPECT_EQ (map.size - hsize, sizeof (guint) * width * height);
+
+  for (i = 0; i < width * height; i++)
+    EXPECT_EQ (cropped[i], expected[i]);
+
+  gst_memory_unmap (mem, &map);
+  gst_buffer_unref (out_buf);
+}
+
+/**
  * @brief Wait for tensor_crop to handle the pushed buffers, expecting no output.
  * @details The element decides in its chain function, so a short budget is
  *          enough; a case that regresses crashes there instead of timing out.
@@ -10475,6 +10511,153 @@ _crop_test_wait_for_no_output (crop_test_data_s *crop_test)
   }
 
   return gst_harness_buffers_received (crop_test->crop);
+}
+
+/**
+ * @brief Test for tensor_crop, a region wider than the frame is clamped.
+ * @details Without the fix the width is kept as it is, because the bounds test
+ *          'x + w - 1 < width' wraps around in 32-bit arithmetic.
+ */
+TEST (testTensorCrop, cropRegionWidthOverflow)
+{
+  crop_test_data_s crop_test;
+  const guint expected[] = { 3U, 4U, 5U, 6U, 7U, 8U, 9U, 10U };
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+
+  /* the width wraps 'x + w - 1' to 0 */
+  _crop_test_set_region (&crop_test, 2U, 0U, G_MAXUINT32, 1U);
+
+  _crop_test_push_buffer (&crop_test);
+  EXPECT_EQ (crop_test.received, 1U);
+
+  if (crop_test.received > 0)
+    _crop_test_compare_single (&crop_test, 8U, 1U, expected);
+
+  _crop_test_free (&crop_test);
+}
+
+/**
+ * @brief Test for tensor_crop, a region taller than the frame is clamped.
+ * @details Without the fix the height is kept as it is, because the bounds test
+ *          'y + h - 1 < height' wraps around in 32-bit arithmetic.
+ */
+TEST (testTensorCrop, cropRegionHeightOverflow)
+{
+  crop_test_data_s crop_test;
+  const guint expected[] = { 21U, 31U };
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+
+  /* the height wraps 'y + h - 1' to 0 */
+  _crop_test_set_region (&crop_test, 0U, 2U, 1U, G_MAXUINT32);
+
+  _crop_test_push_buffer (&crop_test);
+  EXPECT_EQ (crop_test.received, 1U);
+
+  if (crop_test.received > 0)
+    _crop_test_compare_single (&crop_test, 1U, 2U, expected);
+
+  _crop_test_free (&crop_test);
+}
+
+/**
+ * @brief Test for tensor_crop, a region of zero width crops the rest of the row.
+ * @details Without the fix the clamped width is 0 and the element aborts, unless
+ *          the region also starts at 0, which the tensor_region decoder relies on.
+ */
+TEST (testTensorCrop, cropRegionZeroWidth)
+{
+  crop_test_data_s crop_test;
+  const guint expected[] = { 4U, 5U, 6U, 7U, 8U, 9U, 10U };
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+
+  _crop_test_set_region (&crop_test, 3U, 0U, 0U, 1U);
+
+  _crop_test_push_buffer (&crop_test);
+  EXPECT_EQ (crop_test.received, 1U);
+
+  if (crop_test.received > 0)
+    _crop_test_compare_single (&crop_test, 7U, 1U, expected);
+
+  _crop_test_free (&crop_test);
+}
+
+/**
+ * @brief Test for tensor_crop, an all-zero region crops the whole frame.
+ * @details The tensor_region decoder zero-fills the crop-info slots it has no
+ *          detection for, so this is what a pipeline of it emits every time
+ *          there are fewer detections than 'option1' asks for.
+ */
+TEST (testTensorCrop, cropRegionZeroIsWholeFrame)
+{
+  crop_test_data_s crop_test;
+  GstBuffer *out_buf;
+  guint i;
+  guint *_info;
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+
+  /* one detected region and one the decoder left empty */
+  crop_test.info_size = sizeof (guint) * 8U;
+  crop_test.info_num = 2U;
+  g_free (crop_test.info_data);
+  crop_test.info_data = g_malloc0 (crop_test.info_size);
+  _info = (guint *) crop_test.info_data;
+  _info[0] = 3U;
+  _info[1] = 0U;
+  _info[2] = 3U;
+  _info[3] = 1U;
+
+  _crop_test_push_buffer (&crop_test);
+  ASSERT_EQ (crop_test.received, 1U);
+
+  out_buf = gst_harness_pull (crop_test.crop);
+  ASSERT_EQ (gst_buffer_n_memory (out_buf), 2U);
+
+  for (i = 0; i < 2U; i++) {
+    GstMemory *mem = gst_buffer_peek_memory (out_buf, i);
+    GstMapInfo map;
+    GstTensorMetaInfo meta;
+
+    ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));
+    ASSERT_TRUE (gst_tensor_meta_info_parse_header (&meta, map.data));
+    EXPECT_EQ (meta.dimension[1], (i == 0) ? 3U : 10U);
+    EXPECT_EQ (meta.dimension[2], (i == 0) ? 1U : 4U);
+    gst_memory_unmap (mem, &map);
+  }
+
+  gst_buffer_unref (out_buf);
+  _crop_test_free (&crop_test);
+}
+
+/**
+ * @brief Test for tensor_crop, a region starting outside the frame is skipped.
+ * @details Without the fix the clamped width is 0 and the element aborts; here
+ *          it is the only region, so the buffer as a whole has nothing to crop.
+ */
+TEST (testTensorCrop, cropRegionOutOfFrame_n)
+{
+  crop_test_data_s crop_test;
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+
+  /* the raw data is 10 wide */
+  _crop_test_set_region (&crop_test, 10U, 0U, 2U, 1U);
+
+  _crop_test_set_raw_caps (&crop_test);
+  _crop_test_push_raw_buffer (&crop_test, crop_test.ts_raw);
+  _crop_test_push_info_buffer (&crop_test, crop_test.ts_info);
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test);
+  EXPECT_EQ (crop_test.received, 0U);
+
+  _crop_test_free (&crop_test);
 }
 
 /**
@@ -10571,7 +10754,7 @@ TEST (testTensorCrop, cropRawConfigMismatch_n)
   _crop_test_free (&crop_test);
 }
 
-/* set by _record_critical() when a critical is logged */
+/* set by _crop_record_critical() when a critical is logged */
 static gboolean tensor_crop_logged_critical;
 
 /**

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -9892,6 +9892,8 @@ _crop_test_push_two_memories (GstHarness *h, gsize first, gsize second)
 
   gst_buffer_append_memory (buf, gst_allocator_alloc (NULL, first, NULL));
   gst_buffer_append_memory (buf, gst_allocator_alloc (NULL, second, NULL));
+  /* an element that sniffs a header must not branch on uninitialised bytes */
+  gst_buffer_memset (buf, 0, 0, gst_buffer_get_size (buf));
 
   EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_OK);
 }
@@ -9909,11 +9911,12 @@ _crop_test_unmap_guarded (gpointer base)
  * @brief Create a memory of @a size bytes that is followed by an unreadable page.
  * @details Reading a single byte past the memory faults, which turns an
  *          out-of-bounds read into a deterministic failure without valgrind.
+ *          When @a src is not NULL, @a size bytes are copied into the memory.
  * @note @a size cannot exceed the page size, the memory ends on a page boundary.
  * @return The memory, or NULL when the guarded mapping is not available.
  */
 static GstMemory *
-_crop_test_new_guarded_memory (gsize size)
+_crop_test_new_guarded_memory (gsize size, const void *src)
 {
   const gsize page = (gsize) sysconf (_SC_PAGESIZE);
   guint8 *base;
@@ -9926,6 +9929,9 @@ _crop_test_new_guarded_memory (gsize size)
   if (base == MAP_FAILED)
     return NULL;
 
+  if (src != NULL)
+    memcpy (base + page - size, src, size);
+
   if (mprotect (base + page, page, PROT_NONE) != 0) {
     munmap (base, 2 * page);
     return NULL;
@@ -9937,21 +9943,35 @@ _crop_test_new_guarded_memory (gsize size)
 
 /**
  * @brief Push a buffer whose first memory is followed by an unreadable page.
+ * @return TRUE if the guarded memory could be built; a push that is refused is
+ *         reported by the expectation below, which names the flow return.
  */
-static void
+static gboolean
 _crop_test_push_guarded_memory (GstHarness *h, gsize size)
 {
   GstBuffer *buf;
-  GstMemory *mem = _crop_test_new_guarded_memory (size);
+  GstFlowReturn ret;
+  gpointer filler;
+  GstMemory *mem = _crop_test_new_guarded_memory (size, NULL);
 
-  ASSERT_TRUE (mem != NULL);
+  if (!mem)
+    return FALSE;
 
   buf = gst_buffer_new ();
   gst_buffer_append_memory (buf, mem);
-  /* the second memory keeps gst_tensor_buffer_from_config() from re-splitting */
-  gst_buffer_append_memory (buf, gst_allocator_alloc (NULL, size, NULL));
+  /**
+   * The second memory keeps gst_tensor_buffer_from_config() from re-splitting.
+   * It is zeroed because an element that sniffs a header must not branch on
+   * uninitialised bytes; the guarded one is an anonymous mapping, so the kernel
+   * has already zeroed it, and it is read-only anyway.
+   */
+  filler = g_malloc0 (size);
+  gst_buffer_append_memory (buf, gst_memory_new_wrapped ((GstMemoryFlags) 0,
+                                     filler, size, 0, size, filler, g_free));
 
-  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_OK);
+  ret = gst_harness_push (h, buf);
+  EXPECT_EQ (ret, GST_FLOW_OK) << gst_flow_get_name (ret);
+  return TRUE;
 }
 
 /**
@@ -10478,7 +10498,7 @@ _crop_test_compare_single (crop_test_data_s *crop_test, guint width,
   mem = gst_buffer_peek_memory (out_buf, 0);
   ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));
 
-  gst_tensor_meta_info_parse_header (&meta, map.data);
+  ASSERT_TRUE (gst_tensor_meta_info_parse_header (&meta, map.data));
   EXPECT_EQ (meta.dimension[0], 1U);
   EXPECT_EQ (meta.dimension[1], width);
   EXPECT_EQ (meta.dimension[2], height);
@@ -10495,18 +10515,24 @@ _crop_test_compare_single (crop_test_data_s *crop_test, guint width,
 }
 
 /**
- * @brief Wait for tensor_crop to handle the pushed buffers, expecting no output.
- * @details The element decides in its chain function, so a short budget is
- *          enough; a case that regresses crashes there instead of timing out.
+ * @brief Wait for tensor_crop to handle the pushed buffers, expecting no more
+ *        output than @a baseline buffers.
+ * @details The harness pushes into a queue, so the element runs on the queue's
+ *          streaming thread and the count is not final when the push returns;
+ *          checking it once would report "has not run yet" as "produced
+ *          nothing". There is nothing to wait for in a case that expects no
+ *          new buffer, so the budget is a short one - a regressed element
+ *          crashes in its chain function rather than producing a late buffer.
+ *          @a baseline is the number of buffers cropped before this wait.
  */
 static guint
-_crop_test_wait_for_no_output (crop_test_data_s *crop_test)
+_crop_test_wait_for_no_output (crop_test_data_s *crop_test, guint baseline)
 {
   guint count;
 
   for (count = 0; count < 5; count++) {
     g_usleep (100000);
-    if (gst_harness_buffers_received (crop_test->crop) > 0)
+    if (gst_harness_buffers_received (crop_test->crop) > baseline)
       break;
   }
 
@@ -10650,6 +10676,68 @@ TEST (testTensorCrop, cropRegionZeroIsWholeFrame)
 }
 
 /**
+ * @brief Test for tensor_crop, one unusable region does not drop the others.
+ * @details The unusable region sits between two usable ones, so the case pins
+ *          that the loop goes on past a skip, that what came before the skip is
+ *          kept, and that the survivors keep their order.
+ */
+TEST (testTensorCrop, cropRegionPartiallyOutOfFrame)
+{
+  crop_test_data_s crop_test;
+  const guint expected0[] = { 4U, 5U, 6U };
+  const guint expected1[] = { 22U, 23U, 32U, 33U };
+  const guint regions[] = {
+    3U, 0U, 3U, 1U, /* usable */
+    10U, 0U, 2U, 1U, /* starts past the right edge of the 10-wide frame */
+    1U, 2U, 2U, 2U, /* usable */
+  };
+  GstBuffer *out_buf;
+  guint i, j;
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+
+  crop_test.info_size = sizeof (regions);
+  crop_test.info_num = 3U;
+  g_free (crop_test.info_data);
+  crop_test.info_data = _g_memdup (regions, sizeof (regions));
+
+  _crop_test_push_buffer (&crop_test);
+  ASSERT_EQ (crop_test.received, 1U);
+
+  out_buf = gst_harness_pull (crop_test.crop);
+  ASSERT_EQ (gst_buffer_n_memory (out_buf), 2U);
+
+  for (i = 0; i < 2U; i++) {
+    GstMemory *mem = gst_buffer_peek_memory (out_buf, i);
+    const guint *expected = (i == 0) ? expected0 : expected1;
+    const guint width = (i == 0) ? 3U : 2U;
+    const guint height = (i == 0) ? 1U : 2U;
+    GstMapInfo map;
+    GstTensorMetaInfo meta;
+    gsize hsize;
+    guint *cropped;
+
+    ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));
+    ASSERT_TRUE (gst_tensor_meta_info_parse_header (&meta, map.data));
+    EXPECT_EQ (meta.dimension[1], width);
+    EXPECT_EQ (meta.dimension[2], height);
+
+    hsize = gst_tensor_meta_info_get_header_size (&meta);
+    cropped = (guint *) (map.data + hsize);
+    EXPECT_EQ (map.size - hsize, sizeof (guint) * width * height);
+
+    for (j = 0; j < width * height; j++)
+      EXPECT_EQ (cropped[j], expected[j]);
+
+    gst_memory_unmap (mem, &map);
+  }
+
+  gst_buffer_unref (out_buf);
+  _crop_test_free (&crop_test);
+}
+
+/**
  * @brief Test for tensor_crop, a region starting outside the frame is skipped.
  * @details Without the fix the clamped width is 0 and the element aborts; here
  *          it is the only region, so the buffer as a whole has nothing to crop.
@@ -10667,9 +10755,44 @@ TEST (testTensorCrop, cropRegionOutOfFrame_n)
   _crop_test_set_raw_caps (&crop_test);
   _crop_test_push_raw_buffer (&crop_test, crop_test.ts_raw);
   _crop_test_push_info_buffer (&crop_test, crop_test.ts_info);
-  crop_test.received = _crop_test_wait_for_no_output (&crop_test);
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test, 0U);
   EXPECT_EQ (crop_test.received, 0U);
 
+  _crop_test_free (&crop_test);
+}
+
+/**
+ * @brief Test for tensor_crop, a buffer it cannot crop posts an element error.
+ * @details The chain function returns GST_FLOW_ERROR when nothing can be
+ *          cropped, and it must post GST_ELEMENT_ERROR so the reason reaches
+ *          the bus rather than only the debug log.
+ */
+TEST (testTensorCrop, cropChainPostsBusError_n)
+{
+  crop_test_data_s crop_test;
+  GstBus *bus;
+  GstMessage *msg;
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+
+  /* the only region starts past the right edge of the 10-wide frame */
+  _crop_test_set_region (&crop_test, 10U, 0U, 2U, 1U);
+
+  bus = gst_bus_new ();
+  gst_element_set_bus (crop_test.crop->element, bus);
+
+  _crop_test_set_raw_caps (&crop_test);
+  _crop_test_push_raw_buffer (&crop_test, crop_test.ts_raw);
+  _crop_test_push_info_buffer (&crop_test, crop_test.ts_info);
+
+  msg = gst_bus_timed_pop_filtered (bus, 2 * GST_SECOND, GST_MESSAGE_ERROR);
+  EXPECT_TRUE (msg != NULL);
+  if (msg)
+    gst_message_unref (msg);
+
+  gst_element_set_bus (crop_test.crop->element, NULL);
+  gst_object_unref (bus);
   _crop_test_free (&crop_test);
 }
 
@@ -10690,7 +10813,7 @@ TEST (testTensorCrop, cropInfoElementCount_n)
   _crop_test_push_raw_buffer (&crop_test, crop_test.ts_raw);
   _crop_test_push_info_dimension (&crop_test, 3U, 1U);
 
-  crop_test.received = _crop_test_wait_for_no_output (&crop_test);
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test, 0U);
   EXPECT_EQ (crop_test.received, 0U);
 
   _crop_test_free (&crop_test);
@@ -10709,9 +10832,9 @@ TEST (testTensorCrop, cropInfoShortHeader_n)
 
   _crop_test_set_raw_caps (&crop_test);
   _crop_test_push_raw_buffer (&crop_test, crop_test.ts_raw);
-  _crop_test_push_guarded_memory (crop_test.info_q, 16U);
+  ASSERT_TRUE (_crop_test_push_guarded_memory (crop_test.info_q, 16U));
 
-  crop_test.received = _crop_test_wait_for_no_output (&crop_test);
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test, 0U);
   EXPECT_EQ (crop_test.received, 0U);
 
   _crop_test_free (&crop_test);
@@ -10732,10 +10855,67 @@ TEST (testTensorCrop, cropRawShortHeader_n)
   crop_test.raw_format = _NNS_TENSOR_FORMAT_FLEXIBLE;
 
   _crop_test_set_raw_caps (&crop_test);
-  _crop_test_push_guarded_memory (crop_test.raw_q, 16U);
+  ASSERT_TRUE (_crop_test_push_guarded_memory (crop_test.raw_q, 16U));
   _crop_test_push_info_buffer (&crop_test, crop_test.ts_info);
 
-  crop_test.received = _crop_test_wait_for_no_output (&crop_test);
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test, 0U);
+  EXPECT_EQ (crop_test.received, 0U);
+
+  _crop_test_free (&crop_test);
+}
+
+/**
+ * @brief Test for tensor_crop, a raw header whose dimensions overflow.
+ * @details gst_tensor_meta_info_get_data_size() multiplies the dimensions with
+ *          no overflow check, so a header can declare a frame whose byte size
+ *          wraps below the buffer size and passes the size check. Without the
+ *          element's own overflow-checked bound, the copy then reads far past
+ *          the mapping; the guarded page makes that a deterministic fault.
+ */
+TEST (testTensorCrop, cropRawDimensionOverflow_n)
+{
+  crop_test_data_s crop_test;
+  GstTensorMetaInfo meta;
+  GstBuffer *buf;
+  GstMemory *mem;
+  gpointer filler;
+  guint8 header[128] = { 0 };
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+  _crop_test_set_region (&crop_test, 0U, 0U, 1U, 1U);
+  crop_test.raw_format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+
+  /* a valid v1 header declaring uint8 65536:65536:65536:65536 */
+  gst_tensor_meta_info_init (&meta);
+  meta.type = _NNS_UINT8;
+  meta.dimension[0] = 65536U;
+  meta.dimension[1] = 65536U;
+  meta.dimension[2] = 65536U;
+  meta.dimension[3] = 65536U;
+  meta.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  ASSERT_EQ (gst_tensor_meta_info_get_header_size (&meta), sizeof (header));
+  gst_tensor_meta_info_update_header (&meta, header);
+
+  mem = _crop_test_new_guarded_memory (sizeof (header), header);
+  ASSERT_TRUE (mem != NULL);
+  buf = gst_buffer_new ();
+  gst_buffer_append_memory (buf, mem);
+  /**
+   * The second memory keeps gst_tensor_buffer_from_config() from re-splitting.
+   * It is a zeroed g_malloc0 wrap rather than gst_buffer_memset(), which would
+   * make the whole buffer writable and copy the read-only guarded memory into a
+   * plain allocation, dropping the guard page the over-read has to hit.
+   */
+  filler = g_malloc0 (sizeof (header));
+  gst_buffer_append_memory (buf, gst_memory_new_wrapped ((GstMemoryFlags) 0, filler,
+                                     sizeof (header), 0, sizeof (header), filler, g_free));
+
+  _crop_test_set_raw_caps (&crop_test);
+  ASSERT_EQ (gst_harness_push (crop_test.raw_q, buf), GST_FLOW_OK);
+  _crop_test_push_info_buffer (&crop_test, crop_test.ts_info);
+
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test, 0U);
   EXPECT_EQ (crop_test.received, 0U);
 
   _crop_test_free (&crop_test);
@@ -10761,7 +10941,7 @@ TEST (testTensorCrop, cropRawConfigMismatch_n)
   _crop_test_push_two_memories (crop_test.raw_q, 16U, 16U);
   _crop_test_push_info_buffer (&crop_test, crop_test.ts_info);
 
-  crop_test.received = _crop_test_wait_for_no_output (&crop_test);
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test, 0U);
   EXPECT_EQ (crop_test.received, 0U);
 
   _crop_test_free (&crop_test);
@@ -10814,15 +10994,97 @@ TEST (testTensorCrop, cropNoResultBuffer_n)
   handler_id = g_log_set_handler ("GStreamer",
       (GLogLevelFlags) (G_LOG_LEVEL_CRITICAL | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION),
       _crop_record_critical, NULL);
+
+  /* the assertion below says nothing unless the handler is live */
+  g_log ("GStreamer", G_LOG_LEVEL_CRITICAL, "tensor_crop test probe");
+  EXPECT_TRUE (tensor_crop_logged_critical);
+  tensor_crop_logged_critical = FALSE;
+
   _crop_test_set_raw_caps (&crop_test);
   _crop_test_push_raw_buffer (&crop_test, crop_test.ts_raw);
   _crop_test_push_info_buffer (&crop_test, crop_test.ts_info);
-  crop_test.received = _crop_test_wait_for_no_output (&crop_test);
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test, 0U);
   g_log_remove_handler ("GStreamer", handler_id);
 
   EXPECT_EQ (crop_test.received, 0U);
   EXPECT_FALSE (tensor_crop_logged_critical);
 
+  _crop_test_free (&crop_test);
+}
+
+/**
+ * @brief Drop the CAPS sticky event of a pad, as if it had never been negotiated.
+ */
+static gboolean
+_crop_test_drop_caps (GstPad *pad, GstEvent **event, gpointer user_data)
+{
+  UNUSED (pad);
+  UNUSED (user_data);
+
+  if (GST_EVENT_TYPE (*event) == GST_EVENT_CAPS) {
+    gst_event_unref (*event);
+    *event = NULL;
+  }
+
+  return TRUE;
+}
+
+/**
+ * @brief Test for tensor_crop, a raw pad that has lost its caps is refused quietly.
+ * @details gst_tensor_crop_negotiate() checks the raw pad caps before every
+ *          buffer, so the cropping is never reached without them. Should that
+ *          check go, the output meta still has to refuse a NULL caps on its own,
+ *          without a critical.
+ */
+TEST (testTensorCrop, cropRawPadLosesCaps_n)
+{
+  crop_test_data_s crop_test;
+  GstPad *raw;
+  GstCaps *caps;
+  guint handler_id;
+
+  _crop_test_init (&crop_test);
+  _crop_test_prepare_single_region (&crop_test);
+  _crop_test_set_region (&crop_test, 0U, 0U, 1U, 1U);
+
+  /* crop once, so that every pad has been negotiated */
+  _crop_test_push_buffer (&crop_test);
+  ASSERT_EQ (crop_test.received, 1U);
+
+  raw = gst_element_get_static_pad (crop_test.crop->element, "raw");
+  ASSERT_TRUE (raw != NULL);
+  gst_pad_sticky_events_foreach (raw, _crop_test_drop_caps, NULL);
+  caps = gst_pad_get_current_caps (raw);
+  EXPECT_TRUE (caps == NULL);
+  if (caps)
+    gst_caps_unref (caps);
+
+  tensor_crop_logged_critical = FALSE;
+  handler_id = g_log_set_handler ("GStreamer",
+      (GLogLevelFlags) (G_LOG_LEVEL_CRITICAL | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION),
+      _crop_record_critical, NULL);
+
+  /* the assertion below says nothing unless the handler is live */
+  g_log ("GStreamer", G_LOG_LEVEL_CRITICAL, "tensor_crop test probe");
+  EXPECT_TRUE (tensor_crop_logged_critical);
+  tensor_crop_logged_critical = FALSE;
+
+  _crop_test_push_raw_buffer (&crop_test, crop_test.ts_raw);
+  _crop_test_push_info_buffer (&crop_test, crop_test.ts_info);
+  /* the second pair must not produce a buffer beyond the first */
+  crop_test.received = _crop_test_wait_for_no_output (&crop_test, 1U);
+  g_log_remove_handler ("GStreamer", handler_id);
+
+  EXPECT_EQ (crop_test.received, 1U);
+  EXPECT_FALSE (tensor_crop_logged_critical);
+
+  /**
+   * The refused pair is still held by the collect pads, with a queue thread
+   * waiting on it. Stop the element before the queues, the way a bin shuts a
+   * pipeline down from the sink side; the other way round the teardown hangs.
+   */
+  gst_element_set_state (crop_test.crop->element, GST_STATE_NULL);
+  gst_object_unref (raw);
   _crop_test_free (&crop_test);
 }
 


### PR DESCRIPTION
Two memory-safety items of #4920 in `gst/nnstreamer/elements/gsttensor_crop.c`, taken together because they live in the same file.

## C11 — the region clamp wraps in 32-bit

`gsttensor_crop.c:676-681` bounds a crop region with `_x + w - 1 < mw` in `guint` arithmetic. `w` comes from the info tensor through a typecast into a `guint` field, so a negative width arrives as `G_MAXUINT32` and the sum wraps back under `mw`: the width survives unclamped and the element allocates and `memcpy()`s ~17 GB per row out of a small mapping. The same holds for the height.

The same expression yields `_w == 0` for a region that starts on or past the right edge, and for a zero-width region that does not start at 0, which `g_assert (_w > 0 && _h > 0)` turns into an `abort()`.

Fixed by clamping with `MIN()` on a subtraction that cannot underflow, so no addition is left to wrap. **A region of zero size keeps meaning the rest of the frame**, which is what the old expression did for `{0, 0, 0, 0}` and what the `tensor_region` decoder depends on: it allocates the crop-info tensor for `option1` regions, zeroes it and fills only the slots it has a detection for. A region left with nothing to crop after clamping is skipped rather than failing the whole buffer; only a buffer in which no region survives is an error.

Behaviour is byte-identical to the current `main` for every input the old code did not abort on.

## C12 — headers parsed past the mapping, and unchecked NULL results

- `gst_tensor_crop_prepare_out_meta()` and `gst_tensor_crop_get_crop_info()` parse a v1 meta header out of a mapped memory with no size check. `gst_tensor_meta_info_parse_header()` reads 84 bytes before it validates anything, so a shorter memory is read out of bounds. Both sites now check the header size first, mirroring `gst_tensor_meta_info_parse_memory()`.
- `gst_tensor_buffer_from_config()` may return NULL, and the chain function used the result unchecked — `GST_BUFFER_TIMESTAMP()` dereferences it while `lateness` is set. Now `GST_FLOW_ERROR`.
- The NULL result of the cropping was handed to `gst_pad_push()`, which rejected it with a `GStreamer-CRITICAL`. Now `GST_FLOW_ERROR`.
- The two `g_assert()`s on buffer content are reachable from a peer (a buffer with no memory; an info tensor whose element count is not a multiple of four) and are `GST_FLOW_ERROR` now.
- The two mapping-failure paths no longer unmap a `GstMapInfo` that was never filled.
- `do_cropping()` never released the `GstTensorInfo` it parses; `gst_tensor_info_copy()` duplicates the tensor name, so a static stream whose caps carry `names=` leaked one string per buffer.

Design note: `gst_tensor_buffer_from_config()` itself is item A2, fixed separately in #4937. The tests here avoid depending on either behaviour by pushing two-memory buffers, which that function passes through untouched.

## Raw frame dimensions can overflow the size check

`gst_tensor_meta_info_get_data_size()` multiplies the tensor dimensions with no overflow check, so a flexible raw header can declare a frame whose byte size wraps below the buffer size and slips past the `hsize + dsize == map.size` test; `do_cropping()` then reads `ch * mw * mh` elements out of a small mapping. It now recomputes the frame with `g_size_checked_mul()` and requires it to fit the mapped payload before allocating. The shared root cause — the unchecked product in `gst_tensor_get_element_count()` — is tracked as #4960 A2; this is an element-local guard against it, and it is also what #4920 C37 should point at, since crop's `hsize + dsize == map.size` test is not sufficient on its own.

## Tests

14 cases added to `testTensorCrop` in `tests/nnstreamer_plugins/unittest_plugins.cc` (21 total). Measured on the pre-fix element, and the 7 pre-existing cases still pass:

| case | pre-fix outcome |
|---|---|
| `cropRegionWidthOverflow` | 139 — the wrapped read runs and faults |
| `cropRegionHeightOverflow` | 139 — same, on the height |
| `cropRegionZeroWidth` | 134 — `g_assert (_w > 0 && _h > 0)` |
| `cropRegionOutOfFrame_n` | 134 — same, region starts at the right edge |
| `cropInfoElementCount_n` | 134 — `g_assert ((dsize % (esize * 4)) == 0)` |
| `cropInfoShortHeader_n` | 139 — header read past the info memory |
| `cropRawShortHeader_n` | 139 — header read past the raw memory |
| `cropRawDimensionOverflow_n` | 139 — a wrapped dimension product read past a guard page |
| `cropRawConfigMismatch_n` | 139 — `GST_BUFFER_TIMESTAMP()` on NULL |
| `cropNoResultBuffer_n` | 1 — the `gst_pad_push (pad, NULL)` critical |

The two overflow cases fault in the `memcpy` rather than in the allocator: the wrapped size makes `g_malloc0()` ask for about 17 GB, which overcommit grants, so the out-of-bounds read actually executes and its result would have been pushed downstream. (An earlier revision of this text said 133; that came from a local negative control run under `ulimit -v`, which is not what the element does on a normal machine.)

`cropRegionPartiallyOutOfFrame` pins the skip as a per-region decision — one usable region plus one starting past the edge still yields the usable one. It is the only case that separates that from rejecting the whole buffer.

`cropRawPadLosesCaps_n` strips the caps from the negotiated raw pad and pushes again: the pair must be refused with no output and no critical. It passes with either the negotiate-time check or the new NULL-caps guard in place, and fails only when both are gone. `cropChainPostsBusError_n` attaches a bus to the element and requires the `GST_ELEMENT_ERROR` to arrive on it, so dropping the element error on a flow-error return is caught.

The two over-reads cannot be caught by an assertion in a released build, and the CI valgrind step for gtest binaries cannot fail a job, so those cases back the short memory with a page followed by a `PROT_NONE` one — the over-read faults deterministically without valgrind.

`cropRegionZeroIsWholeFrame` is a behaviour-preservation guard for the shape `tensor_region` emits — one detected region plus one the decoder left empty — and compares both cropped tensors element by element. It passes on the current `main` (that is the point) and fails on a version that rejects or skips the empty region.

The SSAT case added to `tests/nnstreamer_decoder_tensor_region/runTest.sh` asks the decoder for more regions than the image has detections, which is the shortest way to reach that path through the two elements, and requires the cropped stream to be at least two whole frames — a size derived from the frame format, not from a recorded golden, that only the empty regions can contribute.

The leak fix is the one change with no test of its own: it is observable only under valgrind, and a leak cannot fail a job — the gtest valgrind step is wrapped in `|| echo` today, and the checker proposed in #4936 counts leaks but deliberately never gates on them, because a leak is reported at its allocation.

Local verification (Ubuntu 22.04, WSL, on this branch rebased onto current `main`): `meson test` 19/21 — the two failures (`unittest_filter_python3`, `unittest_trainer`) are pre-existing on this machine and unrelated. SSAT `nnstreamer_decoder_tensor_region` 4/4. `clang-format` clean; `gst-indent` reports only a hunk that is already dirty on `main` and untouched here.

Refs #4920

🤖 Generated with [Claude Code](https://claude.com/claude-code)



