### PR TITLE
[Element/Sparse] Bound the sparse tensor data and handle the buffers the config cannot produce

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_sparsedec.c
+++ b/gst/nnstreamer/elements/gsttensor_sparsedec.c
@@ -24,7 +24,7 @@
  * <title>Example launch line</title>
  * |[
  * gst-launch-1.0 ... ! other/tensors,format=static ! \
- *    tensor_sparse_enc ! other/tensors,format=sparse ! \
+ *    tensor_sparse_enc ! other/tensors,format=sparse,framerate=0/1 ! \
  *    tensor_sparse_dec ! tensor_sink
  * ]|
  * </refsect2>
@@ -326,19 +326,27 @@ gst_tensor_sparse_dec_sink_event (GstPad * pad, GstObject * parent,
       silent_debug_caps (self, caps, "caps");
 
       /* set in_config */
-      gst_tensors_config_from_caps (&self->in_config, caps, TRUE);
+      if (!gst_tensors_config_from_caps (&self->in_config, caps, TRUE)) {
+        nns_loge ("Failed to configure the input, invalid caps.");
+        gst_event_unref (event);
+        return FALSE;
+      }
 
       /* set out_config as srcpad's peer */
-      gst_tensors_config_from_peer (self->srcpad, &self->out_config, NULL);
-      self->out_config.rate_n = self->in_config.rate_n;
-      self->out_config.rate_d = self->in_config.rate_d;
+      if (gst_tensors_config_from_peer (self->srcpad, &self->out_config, NULL)) {
+        self->out_config.rate_n = self->in_config.rate_n;
+        self->out_config.rate_d = self->in_config.rate_d;
 
-      out_caps = gst_tensor_pad_caps_from_config (self->srcpad,
-          &self->out_config);
+        out_caps = gst_tensor_pad_caps_from_config (self->srcpad,
+            &self->out_config);
 
-      silent_debug_caps (self, out_caps, "out_caps");
-      gst_pad_set_caps (self->srcpad, out_caps);
-      gst_caps_unref (out_caps);
+        silent_debug_caps (self, out_caps, "out_caps");
+        if (out_caps) {
+          if (gst_caps_is_fixed (out_caps))
+            gst_pad_set_caps (self->srcpad, out_caps);
+          gst_caps_unref (out_caps);
+        }
+      }
 
       gst_event_unref (event);
       return TRUE;
@@ -368,6 +376,11 @@ gst_tensor_sparse_dec_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
   UNUSED (pad);
 
   buf = gst_tensor_buffer_from_config (buf, &self->in_config);
+  if (!buf) {
+    nns_loge ("Failed to get the tensor buffer of the negotiated config");
+    return GST_FLOW_ERROR;
+  }
+
   outbuf = gst_buffer_new ();
 
   gst_tensors_info_init (&info);
@@ -405,6 +418,7 @@ done:
   gst_buffer_unref (buf);
   if (outbuf)
     gst_buffer_unref (outbuf);
+  gst_tensors_info_free (&info);
 
   return ret;
 }

--- a/gst/nnstreamer/elements/gsttensor_sparseenc.c
+++ b/gst/nnstreamer/elements/gsttensor_sparseenc.c
@@ -357,6 +357,11 @@ gst_tensor_sparse_enc_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
 
   info = &self->in_config.info;
   buf = gst_tensor_buffer_from_config (buf, &self->in_config);
+  if (!buf) {
+    nns_loge ("Failed to get the tensor buffer of the negotiated config");
+    return GST_FLOW_ERROR;
+  }
+
   outbuf = gst_buffer_new ();
 
   for (i = 0; i < info->num_tensors; ++i) {

--- a/gst/nnstreamer/elements/gsttensor_sparseutil.c
+++ b/gst/nnstreamer/elements/gsttensor_sparseutil.c
@@ -31,11 +31,18 @@ gst_tensor_sparse_to_dense (GstTensorMetaInfo * meta, GstMemory * mem)
   guint i, nnz;
   guint8 *output, *input;
   guint *indices;
-  gsize output_size, element_size;
+  gsize output_size, element_size, header_size;
+  gulong element_count;
 
   if (!gst_memory_map (mem, &map, GST_MAP_READ)) {
     nns_loge ("Failed to map given memory");
     return NULL;
+  }
+
+  gst_tensor_meta_info_init (meta);
+  if (map.size < gst_tensor_meta_info_get_header_size (meta)) {
+    nns_loge ("Given memory is too small to hold a tensor meta header");
+    goto done;
   }
 
   if (!gst_tensor_meta_info_parse_header (meta, map.data)) {
@@ -43,9 +50,19 @@ gst_tensor_sparse_to_dense (GstTensorMetaInfo * meta, GstMemory * mem)
     goto done;
   }
 
+  nnz = meta->sparse_info.nnz;
+  header_size = gst_tensor_meta_info_get_header_size (meta);
+
+  if (header_size == 0) {
+    nns_loge ("Cannot get the header size of the meta info, version 0x%x",
+        meta->version);
+    goto done;
+  }
+
   meta->format = _NNS_TENSOR_FORMAT_STATIC;
 
   element_size = gst_tensor_get_element_size (meta->type);
+  element_count = gst_tensor_get_element_count (meta->dimension);
   output_size = gst_tensor_meta_info_get_data_size (meta);
 
   if (element_size == 0 || output_size == 0) {
@@ -53,43 +70,68 @@ gst_tensor_sparse_to_dense (GstTensorMetaInfo * meta, GstMemory * mem)
     goto done;
   }
 
-  output = (guint8 *) g_malloc0 (output_size);
+  if (element_count != output_size / element_size) {
+    nns_loge ("The %lu elements of the meta info do not fit the %"
+        G_GSIZE_FORMAT " bytes of the tensor they describe", element_count,
+        output_size);
+    goto done;
+  }
 
-  nnz = meta->sparse_info.nnz;
-  input = map.data + gst_tensor_meta_info_get_header_size (meta);
+  if (nnz > (map.size - header_size) / (element_size + sizeof (guint))) {
+    nns_loge ("Given memory holds %" G_GSIZE_FORMAT
+        " bytes, too small for the %u non-zero elements of the meta info",
+        map.size, nnz);
+    goto done;
+  }
+
+  input = map.data + header_size;
   indices = (guint *) (input + element_size * nnz);
 
+  output = (guint8 *) g_malloc0 (output_size);
+
   for (i = 0; i < nnz; ++i) {
+    guint index;
+
+    /* one read: unaligned for some types, and check and use must agree */
+    memcpy (&index, (guint8 *) indices + i * sizeof (guint), sizeof (guint));
+
+    if (index >= element_count) {
+      nns_loge ("Sparse tensor index %u is out of the %lu elements of the meta"
+          " info", index, element_count);
+      g_free (output);
+      goto done;
+    }
+
     switch (meta->type) {
       case _NNS_INT32:
-        ((int32_t *) output)[indices[i]] = ((int32_t *) input)[i];
+        ((int32_t *) output)[index] = ((int32_t *) input)[i];
         break;
       case _NNS_UINT32:
-        ((uint32_t *) output)[indices[i]] = ((uint32_t *) input)[i];
+        ((uint32_t *) output)[index] = ((uint32_t *) input)[i];
         break;
       case _NNS_INT16:
-        ((int16_t *) output)[indices[i]] = ((int16_t *) input)[i];
+        ((int16_t *) output)[index] = ((int16_t *) input)[i];
         break;
       case _NNS_UINT16:
-        ((uint16_t *) output)[indices[i]] = ((uint16_t *) input)[i];
+        ((uint16_t *) output)[index] = ((uint16_t *) input)[i];
         break;
       case _NNS_INT8:
-        ((int8_t *) output)[indices[i]] = ((int8_t *) input)[i];
+        ((int8_t *) output)[index] = ((int8_t *) input)[i];
         break;
       case _NNS_UINT8:
-        ((uint8_t *) output)[indices[i]] = ((uint8_t *) input)[i];
+        ((uint8_t *) output)[index] = ((uint8_t *) input)[i];
         break;
       case _NNS_FLOAT64:
-        ((double *) output)[indices[i]] = ((double *) input)[i];
+        ((double *) output)[index] = ((double *) input)[i];
         break;
       case _NNS_FLOAT32:
-        ((float *) output)[indices[i]] = ((float *) input)[i];
+        ((float *) output)[index] = ((float *) input)[i];
         break;
       case _NNS_INT64:
-        ((int64_t *) output)[indices[i]] = ((int64_t *) input)[i];
+        ((int64_t *) output)[index] = ((int64_t *) input)[i];
         break;
       case _NNS_UINT64:
-        ((uint64_t *) output)[indices[i]] = ((uint64_t *) input)[i];
+        ((uint64_t *) output)[index] = ((uint64_t *) input)[i];
         break;
       default:
         nns_loge ("Error occurred during get tensor value");
@@ -136,6 +178,14 @@ gst_tensor_sparse_from_dense (GstTensorMetaInfo * meta, GstMemory * mem)
 
   if (element_size == 0 || element_count == 0) {
     nns_loge ("Got invalid meta info");
+    goto done;
+  }
+
+  if (element_count > map.size / element_size
+      || element_count > G_MAXSIZE / sizeof (guint)) {
+    nns_loge ("Given memory holds %" G_GSIZE_FORMAT
+        " bytes, too small for the %lu elements of the meta info",
+        map.size, element_count);
     goto done;
   }
 

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -10898,6 +10898,369 @@ TEST (testTensorSparse, encUnsupportedType_n)
 }
 
 /**
+ * @brief Build a sparse int32 tensor memory from the given header fields.
+ * @details Unlike _sparse_new_sparse_memory(), the header fields and the size
+ * of the memory are set independently of each other, so that a header
+ * describing more data than the memory holds can be handed to the decoder.
+ * @param dimension the dimension the meta info declares
+ * @param nnz the number of non-zero elements the meta info declares
+ * @param indices the indices to write after the values, NULL to leave them 0
+ * @param size the number of bytes the memory actually holds
+ */
+static GstMemory *
+_sparse_new_raw_memory_dim (const gchar *dimension, guint nnz, const guint *indices, gsize size)
+{
+  GstTensorMetaInfo meta;
+  guint8 *data;
+  gsize header_size;
+
+  gst_tensor_meta_info_init (&meta);
+  meta.type = _NNS_INT32;
+  gst_tensor_parse_dimension (dimension, meta.dimension);
+  meta.format = _NNS_TENSOR_FORMAT_SPARSE;
+  meta.media_type = _NNS_TENSOR;
+  meta.sparse_info.nnz = nnz;
+
+  header_size = gst_tensor_meta_info_get_header_size (&meta);
+  data = (guint8 *) g_malloc0 (size);
+
+  if (size >= header_size) {
+    gst_tensor_meta_info_update_header (&meta, data);
+
+    if (indices && size >= header_size + (gsize) nnz * (sizeof (gint32) + sizeof (guint)))
+      memcpy (data + header_size + (gsize) nnz * sizeof (gint32), indices,
+          (gsize) nnz * sizeof (guint));
+  }
+
+  return gst_memory_new_wrapped ((GstMemoryFlags) 0, data, size, 0, size, data, g_free);
+}
+
+/**
+ * @brief Build a sparse int32 tensor memory of a one-dimensional tensor.
+ */
+static GstMemory *
+_sparse_new_raw_memory (guint element_count, guint nnz, const guint *indices, gsize size)
+{
+  GstMemory *mem;
+  gchar *dim_str = g_strdup_printf ("%u", element_count);
+
+  mem = _sparse_new_raw_memory_dim (dim_str, nnz, indices, size);
+  g_free (dim_str);
+
+  return mem;
+}
+
+/**
+ * @brief Test for tensor_sparse util, a memory too short to hold a meta header.
+ * @details Without the length check gst_tensor_meta_info_parse_header() reads
+ * 88 bytes out of the 64 the memory holds, which only valgrind reports.
+ */
+TEST (testTensorSparse, utilToDenseShortHeader_n)
+{
+  GstTensorMetaInfo meta;
+  GstMemory *in, *out;
+
+  in = _sparse_new_raw_memory (40U, 0U, NULL, 64U);
+  ASSERT_TRUE (in != NULL);
+
+  out = gst_tensor_sparse_to_dense (&meta, in);
+  EXPECT_TRUE (out == NULL);
+
+  gst_memory_unref (in);
+}
+
+/**
+ * @brief Fill the given bytes with the start of a valid sparse int32 header.
+ * @details The header declares 40 elements and no non-zero one, and is cut to
+ * the given size, so that a memory can hold every field the parse reads while
+ * being shorter than the header it describes.
+ * @param data the bytes to fill
+ * @param size the number of header bytes to copy, at most the header size
+ */
+static void
+_sparse_fill_truncated_header (guint8 *data, gsize size)
+{
+  GstTensorMetaInfo meta;
+  guint8 header[128];
+
+  gst_tensor_meta_info_init (&meta);
+  meta.type = _NNS_INT32;
+  gst_tensor_parse_dimension ("40", meta.dimension);
+  meta.format = _NNS_TENSOR_FORMAT_SPARSE;
+  meta.media_type = _NNS_TENSOR;
+  meta.sparse_info.nnz = 0U;
+
+  ASSERT_LE (gst_tensor_meta_info_get_header_size (&meta), sizeof (header));
+  ASSERT_LE (size, sizeof (header));
+  ASSERT_TRUE (gst_tensor_meta_info_update_header (&meta, header));
+  memcpy (data, header, size);
+}
+
+/**
+ * @brief Test for tensor_sparse util, a memory that holds every field of a
+ *        header but is shorter than the header itself.
+ * @details gst_tensor_meta_info_parse_header() reads 88 bytes, so a 100-byte
+ * memory parses as a valid header whose payload starts at byte 128, past the
+ * end of the memory. Without the length check map.size - header_size
+ * underflows, the payload bound passes, and the memory decodes into a whole
+ * tensor. utilToDenseShortHeader_n covers a memory shorter than what the parse
+ * reads; this covers the one in between.
+ */
+TEST (testTensorSparse, utilToDenseTruncatedHeader_n)
+{
+  GstTensorMetaInfo meta;
+  GstMemory *in, *out;
+  guint8 *data;
+  const gsize size = 100U;
+
+  data = (guint8 *) g_malloc0 (size);
+  _sparse_fill_truncated_header (data, size);
+  in = gst_memory_new_wrapped ((GstMemoryFlags) 0, data, size, 0, size, data, g_free);
+
+  out = gst_tensor_sparse_to_dense (&meta, in);
+  EXPECT_TRUE (out == NULL);
+  if (out)
+    gst_memory_unref (out);
+
+  gst_memory_unref (in);
+}
+
+/**
+ * @brief Test for tensor_sparse util, a header declaring more data than the
+ *        memory holds.
+ */
+TEST (testTensorSparse, utilToDenseShortPayload_n)
+{
+  GstTensorMetaInfo meta;
+  GstMemory *in, *out;
+
+  /* 1000 non-zero elements need 128 + 1000 * 8 bytes, the memory holds 200. */
+  in = _sparse_new_raw_memory (40U, 1000U, NULL, 200U);
+  ASSERT_TRUE (in != NULL);
+
+  out = gst_tensor_sparse_to_dense (&meta, in);
+  EXPECT_TRUE (out == NULL);
+
+  gst_memory_unref (in);
+}
+
+/**
+ * @brief Test for tensor_sparse util, a non-zero count that overflows the
+ *        offset of the index array.
+ */
+TEST (testTensorSparse, utilToDenseNnzOverflow_n)
+{
+  GstTensorMetaInfo meta;
+  GstMemory *in, *out;
+
+  in = _sparse_new_raw_memory (40U, G_MAXUINT32, NULL, 136U);
+  ASSERT_TRUE (in != NULL);
+
+  out = gst_tensor_sparse_to_dense (&meta, in);
+  EXPECT_TRUE (out == NULL);
+
+  gst_memory_unref (in);
+}
+
+/**
+ * @brief Test for tensor_sparse util, an index past the end of the dense tensor.
+ * @details The index is the offset of the write into the decoded tensor, so
+ * without the bound check this writes about 2 GB past a 160-byte allocation.
+ */
+TEST (testTensorSparse, utilToDenseIndexOutOfRange_n)
+{
+  GstTensorMetaInfo meta;
+  GstMemory *in, *out;
+  const guint indices[] = { 0x20000000U };
+
+  in = _sparse_new_raw_memory (40U, 1U, indices, 136U);
+  ASSERT_TRUE (in != NULL);
+
+  out = gst_tensor_sparse_to_dense (&meta, in);
+  EXPECT_TRUE (out == NULL);
+
+  gst_memory_unref (in);
+}
+
+/**
+ * @brief Test for tensor_sparse util, a header of a version this build cannot
+ *        size.
+ * @details gst_tensor_meta_info_validate() asks only for the magic of the
+ * version marker, while gst_tensor_meta_info_get_header_size() answers 128 for
+ * version 1 and 0 for every other. A header of an unknown version therefore
+ * validated and then placed the payload at offset 0, so the header itself was
+ * decoded as tensor data. Reported as item A7 of #4920, and refused here
+ * because the offset of the payload is what this function is bounding.
+ */
+TEST (testTensorSparse, utilToDenseUnknownVersion_n)
+{
+  GstTensorMetaInfo meta;
+  GstMemory *in, *out;
+  GstMapInfo map;
+
+  /* no non-zero element, so only the version decides the result */
+  in = _sparse_new_raw_memory (40U, 0U, NULL, 136U);
+  ASSERT_TRUE (in != NULL);
+
+  /* the magic of the version marker, with a major version of 0 */
+  ASSERT_TRUE (gst_memory_map (in, &map, GST_MAP_WRITE));
+  ((uint32_t *) map.data)[1] = 0xDE000000U;
+  gst_memory_unmap (in, &map);
+
+  out = gst_tensor_sparse_to_dense (&meta, in);
+  EXPECT_TRUE (out == NULL);
+
+  gst_memory_unref (in);
+}
+
+/**
+ * @brief Test for tensor_sparse util, a dimension whose byte size has overflowed.
+ * @details gst_tensor_meta_info_get_data_size() multiplies the element count by
+ * the element size in a gsize, so a dimension can name more elements than the
+ * size of the tensor it computes: 3340214413 x 1380655685 int32 elements are
+ * 2^62 + 1, whose 2^64 + 4 bytes wrap to 4. Bounding the indices by the element
+ * count alone would let an index of 2^62 through and write it into a four-byte
+ * allocation. The same wrap happens far sooner where gsize is 32 bits, which
+ * the armv7l build of the Tizen target is.
+ */
+TEST (testTensorSparse, utilToDenseDimensionOverflow_n)
+{
+  GstTensorMetaInfo meta;
+  GstMemory *in, *out;
+  const guint indices[] = { 0x20000000U };
+
+  in = _sparse_new_raw_memory_dim ("3340214413:1380655685", 1U, indices, 136U);
+  ASSERT_TRUE (in != NULL);
+
+  out = gst_tensor_sparse_to_dense (&meta, in);
+  EXPECT_TRUE (out == NULL);
+
+  gst_memory_unref (in);
+}
+
+/**
+ * @brief Test for tensor_sparse util, the last valid index is still decoded.
+ */
+TEST (testTensorSparse, utilToDenseLastIndex)
+{
+  GstTensorMetaInfo meta;
+  GstMemory *in, *out;
+  GstMapInfo map;
+  const guint indices[] = { 39U };
+
+  in = _sparse_new_raw_memory (40U, 1U, indices, 136U);
+  ASSERT_TRUE (in != NULL);
+
+  out = gst_tensor_sparse_to_dense (&meta, in);
+  ASSERT_TRUE (out != NULL);
+
+  ASSERT_TRUE (gst_memory_map (out, &map, GST_MAP_READ));
+  EXPECT_EQ (map.size, 40U * sizeof (gint32));
+  gst_memory_unmap (out, &map);
+
+  gst_memory_unref (out);
+  gst_memory_unref (in);
+}
+
+/**
+ * @brief Test for tensor_sparse util, a dense memory shorter than the meta info.
+ * @details Without the length check the encoder reads 64 MB out of the 64 bytes
+ * the memory holds.
+ */
+TEST (testTensorSparse, utilFromDenseShortMemory_n)
+{
+  GstTensorMetaInfo meta;
+  GstMemory *in, *out;
+  guint8 *data;
+  const gsize data_size = 64U;
+
+  gst_tensor_meta_info_init (&meta);
+  meta.type = _NNS_INT32;
+  gst_tensor_parse_dimension ("16777216", meta.dimension);
+  meta.media_type = _NNS_TENSOR;
+
+  data = (guint8 *) g_malloc0 (data_size);
+  in = gst_memory_new_wrapped (
+      GST_MEMORY_FLAG_READONLY, data, data_size, 0, data_size, data, g_free);
+
+  out = gst_tensor_sparse_from_dense (&meta, in);
+  EXPECT_TRUE (out == NULL);
+
+  gst_memory_unref (in);
+}
+
+/**
+ * @brief Test for tensor_sparse_dec, a flexible buffer whose last bytes cannot
+ *        hold a whole tensor.
+ * @details gst_tensor_buffer_from_config() hands the bytes after the last
+ * tensor it can size to the caller as one more memory, and leaves it to the
+ * caller to refuse them. Here they are a 100-byte tail carrying a valid header,
+ * which the decoder has to refuse after it has already decoded the tensor
+ * before it. Without the length check the tail decodes into a second tensor,
+ * the buffer no longer matches the negotiated config, and it is dropped with
+ * GST_FLOW_OK instead of being reported. The split is checked first, so that
+ * the case cannot keep passing by another route if that contract changes.
+ */
+TEST (testTensorSparse, decTrailingRemainder_n)
+{
+  GstHarness *h;
+  GstMemory *sparse, *all;
+  GstBuffer *in, *split;
+  GstCaps *caps;
+  GstMapInfo smap, amap;
+  GstTensorInfo info;
+  GstTensorsConfig config;
+  gsize sparse_size;
+  guint handler;
+  const gsize tail = 100U;
+
+  h = gst_harness_new ("tensor_sparse_dec");
+  ASSERT_TRUE (h != NULL);
+
+  gst_harness_set_sink_caps_str (h, SPARSE_DENSE_CAPS_STR);
+  gst_harness_set_src_caps_str (h, "other/tensors,format=sparse,framerate=0/1");
+
+  sparse = _sparse_new_sparse_memory (&info);
+  ASSERT_TRUE (sparse != NULL);
+  ASSERT_TRUE (gst_memory_map (sparse, &smap, GST_MAP_READ));
+
+  /* one memory: a whole sparse tensor, then a tail shorter than a header */
+  all = gst_allocator_alloc (NULL, smap.size + tail, NULL);
+  ASSERT_TRUE (gst_memory_map (all, &amap, GST_MAP_WRITE));
+  memcpy (amap.data, smap.data, smap.size);
+  _sparse_fill_truncated_header (amap.data + smap.size, tail);
+  sparse_size = smap.size;
+  gst_memory_unmap (all, &amap);
+  gst_memory_unmap (sparse, &smap);
+  gst_memory_unref (sparse);
+
+  in = gst_buffer_new ();
+  gst_buffer_append_memory (in, all);
+
+  /* the premise: the decoder is handed the tensor and the tail as two memories */
+  caps = gst_caps_from_string ("other/tensors,format=sparse,framerate=0/1");
+  ASSERT_TRUE (gst_tensors_config_from_caps (&config, caps, TRUE));
+  gst_caps_unref (caps);
+  split = gst_tensor_buffer_from_config (gst_buffer_ref (in), &config);
+  ASSERT_TRUE (split != NULL);
+  ASSERT_EQ (gst_buffer_n_memory (split), 2U);
+  EXPECT_EQ (gst_memory_get_sizes (gst_buffer_peek_memory (split, 0), NULL, NULL), sparse_size);
+  EXPECT_EQ (gst_memory_get_sizes (gst_buffer_peek_memory (split, 1), NULL, NULL), tail);
+  gst_buffer_unref (split);
+  gst_tensors_config_free (&config);
+
+  handler = _sparse_watch_gst_critical ();
+  EXPECT_EQ (gst_harness_push (h, in), GST_FLOW_ERROR);
+  g_log_remove_handler ("GStreamer", handler);
+
+  EXPECT_EQ (sparse_gst_critical_count, 0U) << sparse_gst_critical_msg;
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_tensor_info_free (&info);
+  gst_harness_teardown (h);
+}
+
+/**
  * @brief Rendezvous used to set a property from the test thread exactly while
  *        the streaming thread is adding a source pad.
  */

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -11261,6 +11261,358 @@ TEST (testTensorSparse, decTrailingRemainder_n)
 }
 
 /**
+ * @brief Test for tensor_sparse_dec, a buffer that cannot be split into the
+ *        tensors of the negotiated config.
+ * @details The single memory carries two meta headers, the second of which
+ * declares more data than is left, so gst_tensor_buffer_from_config() fails.
+ */
+TEST (testTensorSparse, decBufferFromConfigFailure_n)
+{
+  GstHarness *h;
+  GstBuffer *in;
+  GstMemory *mem;
+  GstMapInfo map;
+  GstTensorMetaInfo meta;
+  guint handler;
+  guint8 *data;
+  const gsize data_size = 300U;
+
+  h = gst_harness_new ("tensor_sparse_dec");
+  ASSERT_TRUE (h != NULL);
+
+  gst_harness_set_sink_caps_str (h, SPARSE_DENSE_CAPS_STR);
+  gst_harness_set_src_caps_str (h, "other/tensors,format=sparse,framerate=0/1");
+
+  data = (guint8 *) g_malloc0 (data_size);
+  mem = gst_memory_new_wrapped (
+      (GstMemoryFlags) 0, data, data_size, 0, data_size, data, g_free);
+  ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_WRITE));
+
+  gst_tensor_meta_info_init (&meta);
+  meta.type = _NNS_INT32;
+  gst_tensor_parse_dimension ("40", meta.dimension);
+  meta.format = _NNS_TENSOR_FORMAT_SPARSE;
+  meta.media_type = _NNS_TENSOR;
+
+  /* 128 + 2 * 8 bytes, so the second header starts at 144. */
+  meta.sparse_info.nnz = 2U;
+  gst_tensor_meta_info_update_header (&meta, map.data);
+
+  /* 128 + 1000 * 8 bytes, far past the 156 bytes that are left. */
+  meta.sparse_info.nnz = 1000U;
+  gst_tensor_meta_info_update_header (&meta, map.data + 144U);
+
+  gst_memory_unmap (mem, &map);
+
+  in = gst_buffer_new ();
+  gst_buffer_append_memory (in, mem);
+
+  handler = _sparse_watch_gst_critical ();
+  EXPECT_EQ (gst_harness_push (h, in), GST_FLOW_ERROR);
+  g_log_remove_handler ("GStreamer", handler);
+
+  EXPECT_EQ (sparse_gst_critical_count, 0U) << sparse_gst_critical_msg;
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_sparse_enc, a buffer smaller than the negotiated caps.
+ */
+TEST (testTensorSparse, encBufferFromConfigFailure_n)
+{
+  GstHarness *h;
+  GstMemory *mem;
+  gpointer data;
+  guint handler;
+  const gsize data_size = 16U;
+
+  h = gst_harness_new ("tensor_sparse_enc");
+  ASSERT_TRUE (h != NULL);
+
+  /* Two tensors of 160 bytes are declared, one memory of 16 bytes is pushed. */
+  gst_harness_set_src_caps_str (h, "other/tensors,format=static,num_tensors=2,"
+                                   "dimensions=(string)40:1:1:1.40:1:1:1,types=(string)int32.int32,"
+                                   "framerate=0/1");
+
+  data = g_malloc0 (data_size);
+  mem = gst_memory_new_wrapped (
+      GST_MEMORY_FLAG_READONLY, data, data_size, 0, data_size, data, g_free);
+
+  handler = _sparse_watch_gst_critical ();
+  EXPECT_EQ (gst_harness_push (h, _sparse_new_buffer (mem)), GST_FLOW_ERROR);
+  g_log_remove_handler ("GStreamer", handler);
+
+  EXPECT_EQ (sparse_gst_critical_count, 0U) << sparse_gst_critical_msg;
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Number of the glib critical logs raised by gst_pad_set_caps().
+ */
+static guint sparse_setcaps_critical_count;
+
+/**
+ * @brief Log handler counting the caps assertions of gst_pad_set_caps().
+ * @details gst_pad_set_caps() is a static inline of gstcompat.h, so it is
+ * compiled into the caller rather than into GStreamer, and nnstreamer defines
+ * no G_LOG_DOMAIN of its own; its assertion therefore lands in the default
+ * domain, where the elements' own error messages are. Matching the name of the
+ * function is what keeps the two apart.
+ */
+static void
+_sparse_count_setcaps_critical (const gchar *domain, GLogLevelFlags level,
+    const gchar *message, gpointer udata)
+{
+  UNUSED (domain);
+  UNUSED (udata);
+
+  if ((level & G_LOG_LEVEL_CRITICAL) && message && strstr (message, "gst_pad_set_caps") != NULL)
+    sparse_setcaps_critical_count++;
+}
+
+/**
+ * @brief Start counting the caps assertions, proving the counter live first.
+ */
+static guint
+_sparse_watch_setcaps_critical (void)
+{
+  guint handler = g_log_set_handler (NULL,
+      (GLogLevelFlags) (G_LOG_LEVEL_CRITICAL | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION),
+      _sparse_count_setcaps_critical, NULL);
+
+  sparse_setcaps_critical_count = 0;
+  g_critical ("tensor_sparse test: gst_pad_set_caps counter self-check");
+  EXPECT_EQ (sparse_setcaps_critical_count, 1U);
+
+  sparse_setcaps_critical_count = 0;
+  return handler;
+}
+
+/**
+ * @brief Test for tensor_sparse_dec, caps that cannot be read into a config are
+ *        refused rather than kept.
+ * @details gst_harness_push_event() reports success either way, so what the
+ * refusal changes is that the pad does not end up carrying caps the element
+ * cannot work with.
+ */
+TEST (testTensorSparse, decUnreadableCaps_n)
+{
+  GstHarness *h;
+  GstPad *sinkpad;
+  GstCaps *caps, *current;
+
+  h = gst_harness_new ("tensor_sparse_dec");
+  ASSERT_TRUE (h != NULL);
+
+  /* a sparse stream with no framerate, which no config can be built from */
+  caps = gst_caps_from_string ("other/tensors,format=sparse");
+  gst_harness_push_event (h, gst_event_new_caps (caps));
+  gst_caps_unref (caps);
+
+  sinkpad = gst_element_get_static_pad (h->element, "sink");
+  ASSERT_TRUE (sinkpad != NULL);
+
+  current = gst_pad_get_current_caps (sinkpad);
+  EXPECT_TRUE (current == NULL);
+  if (current)
+    gst_caps_unref (current);
+
+  gst_object_unref (sinkpad);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_sparse_dec, a downstream that leaves the decoded caps
+ *        unfixed is negotiated without a caps assertion.
+ * @details The tensors a sparse buffer decodes into are described by the buffer
+ * itself, so a downstream that does not constrain them leaves the config read
+ * back from the peer unfixed, and the caps built from it are not fixed either.
+ * They used to go straight into gst_pad_set_caps(), which rejects them with an
+ * assertion. The SSAT cases of tests/nnstreamer_sparse carry a caps filter that
+ * fixes the caps, which is why nothing had caught this.
+ */
+TEST (testTensorSparse, decUnfixedSrcCaps_n)
+{
+  GstHarness *h;
+  guint handler;
+
+  h = gst_harness_new ("tensor_sparse_dec");
+  ASSERT_TRUE (h != NULL);
+
+  handler = _sparse_watch_setcaps_critical ();
+  /* no sink caps, so the peer of the src pad keeps its template caps */
+  gst_harness_set_src_caps_str (h, "other/tensors,format=sparse,framerate=0/1");
+  g_log_remove_handler (NULL, handler);
+
+  EXPECT_EQ (sparse_setcaps_critical_count, 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_sparse_dec, a pipeline that never negotiates fails
+ *        without raising a critical.
+ * @details tensor_sparse_enc does not carry the framerate of the stream into
+ * its sparse src caps, so a decoder linked to it directly is negotiated with a
+ * config it cannot validate. gst_tensor_buffer_from_config() then returns NULL
+ * for every buffer, which the chain used to count the tensors of and unref, so
+ * glib reported two critical logs of the GStreamer domain per buffer and an
+ * empty buffer went downstream. The SSAT cases of tests/nnstreamer_sparse cover
+ * the same pipeline with the caps filter that makes it work.
+ */
+TEST (testTensorSparse, decUnnegotiatedPipeline_n)
+{
+  GstElement *pipeline;
+  GstBus *bus;
+  GstMessage *msg;
+  guint handler;
+  const gchar *str_pipeline
+      = "videotestsrc num-buffers=1 ! "
+        "video/x-raw,format=RGB,width=10,height=10,framerate=0/1 ! videoconvert ! "
+        "tensor_converter ! tensor_sparse_enc ! tensor_sparse_dec ! fakesink";
+
+  pipeline = gst_parse_launch (str_pipeline, NULL);
+  ASSERT_TRUE (pipeline != nullptr);
+
+  handler = _sparse_watch_gst_critical ();
+
+  setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT);
+
+  bus = gst_element_get_bus (pipeline);
+  msg = gst_bus_timed_pop_filtered (bus, 10 * GST_SECOND,
+      (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+  /* the pipeline has to settle either way, so a time-out is a failure of its own */
+  EXPECT_TRUE (msg != nullptr);
+  if (msg)
+    gst_message_unref (msg);
+  gst_object_unref (bus);
+
+  setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT);
+  g_log_remove_handler ("GStreamer", handler);
+
+  EXPECT_EQ (sparse_gst_critical_count, 0U) << sparse_gst_critical_msg;
+
+  gst_object_unref (pipeline);
+}
+
+/**
+ * @brief The number of tensors of the tensor_sparse extra-tensor test.
+ */
+#define SPARSE_EXTRA_TENSORS_NUM (18U)
+
+/**
+ * @brief Create a sparse tensor memory as long as the dense tensor it encodes.
+ * @details Four non-zero elements of 40 int32 encode into 128 + 4 * 8 bytes,
+ * exactly the 160 bytes the static tensor info declares. The two sizes have to
+ * agree because gst_tensor_buffer_append_memory() records only the dense size
+ * of an extra tensor, which truncates a longer sparse memory (item A6 of #4920,
+ * issue #4934).
+ */
+static GstMemory *
+_sparse_new_extra_memory (GstTensorInfo *info)
+{
+  GstMemory *dense, *sparse;
+  GstTensorMetaInfo meta;
+  gpointer data;
+  gsize data_size;
+  guint i;
+
+  gst_tensor_info_init (info);
+  info->type = _NNS_INT32;
+  gst_tensor_parse_dimension ("40", info->dimension);
+
+  data_size = gst_tensor_info_get_size (info);
+  data = g_malloc0 (data_size);
+  for (i = 0; i < 40U; i++)
+    ((gint32 *) data)[i] = (i % 10U == 0U) ? (gint32) (i + 1) : 0;
+
+  dense = gst_memory_new_wrapped (
+      GST_MEMORY_FLAG_READONLY, data, data_size, 0, data_size, data, g_free);
+
+  gst_tensor_info_convert_to_meta (info, &meta);
+  meta.format = _NNS_TENSOR_FORMAT_SPARSE;
+  meta.media_type = _NNS_TENSOR;
+
+  sparse = gst_tensor_sparse_from_dense (&meta, dense);
+  gst_memory_unref (dense);
+
+  return sparse;
+}
+
+/**
+ * @brief Test for tensor_sparse_dec, a buffer of more tensors than
+ *        NNS_TENSOR_MEMORY_MAX is decoded and its tensors info is released.
+ * @details The decoder allocates GstTensorsInfo.extra for the 17th tensor, so
+ * this is the case in which the tensors info of the chain function has to be
+ * freed. The leak itself is reported by the valgrind step of the CI.
+ */
+TEST (testTensorSparse, decExtraTensors)
+{
+  GstHarness *h;
+  GstBuffer *in, *out;
+  GstMemory *mem;
+  GstMapInfo map;
+  GstTensorsConfig config;
+  GstTensorInfo *_info;
+  guint i, j;
+
+  h = gst_harness_new ("tensor_sparse_dec");
+  ASSERT_TRUE (h != NULL);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = SPARSE_EXTRA_TENSORS_NUM;
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  for (i = 0; i < SPARSE_EXTRA_TENSORS_NUM; i++) {
+    _info = gst_tensors_info_get_nth_info (&config.info, i);
+    _info->type = _NNS_INT32;
+    gst_tensor_parse_dimension ("40", _info->dimension);
+  }
+
+  gst_harness_set_sink_caps (h, gst_tensors_caps_from_config (&config));
+  gst_harness_set_src_caps_str (h, "other/tensors,format=sparse,framerate=0/1");
+
+  in = gst_buffer_new ();
+  for (i = 0; i < SPARSE_EXTRA_TENSORS_NUM; i++) {
+    GstTensorInfo info;
+
+    mem = _sparse_new_extra_memory (&info);
+    ASSERT_TRUE (mem != NULL);
+    ASSERT_TRUE (gst_tensor_buffer_append_memory (
+        in, mem, gst_tensors_info_get_nth_info (&config.info, i)));
+    gst_tensor_info_free (&info);
+  }
+  ASSERT_EQ (gst_tensor_buffer_get_count (in), SPARSE_EXTRA_TENSORS_NUM);
+
+  ASSERT_EQ (gst_harness_push (h, in), GST_FLOW_OK);
+  EXPECT_EQ (gst_harness_buffers_received (h), 1U);
+
+  out = gst_harness_pull (h);
+  ASSERT_TRUE (out != NULL);
+  ASSERT_EQ (gst_tensor_buffer_get_count (out), SPARSE_EXTRA_TENSORS_NUM);
+
+  for (i = 0; i < SPARSE_EXTRA_TENSORS_NUM; i++) {
+    mem = gst_tensor_buffer_get_nth_memory (out, i);
+    ASSERT_TRUE (mem != NULL);
+    ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));
+    ASSERT_EQ (map.size, 40U * sizeof (gint32));
+    for (j = 0; j < 40U; j++)
+      EXPECT_EQ (((gint32 *) map.data)[j], (j % 10U == 0U) ? (gint32) (j + 1) : 0);
+    gst_memory_unmap (mem, &map);
+    gst_memory_unref (mem);
+  }
+
+  gst_buffer_unref (out);
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+}
+
+/**
  * @brief Rendezvous used to set a property from the test thread exactly while
  *        the streaming thread is adding a source pad.
  */


### PR DESCRIPTION
Five memory-safety items of #4920 in the `tensor_sparse` element family, taken together because they live in the same three files. No open PR touches them.

## C13 / C15 — the sparse layout is taken from the data, never checked against it

`gst_tensor_sparse_to_dense()` (`gsttensor_sparseutil.c:26-107`) read the meta header of the memory it was decoding and trusted every field in it:

```c
if (!gst_tensor_meta_info_parse_header (meta, map.data))   /* reads 88 bytes, no size check */
  ...
output = (guint8 *) g_malloc0 (output_size);               /* sized from the dimensions alone */
nnz = meta->sparse_info.nnz;                               /* uint32, up to 2^32-1 */
input = map.data + gst_tensor_meta_info_get_header_size (meta);
indices = (guint *) (input + element_size * nnz);          /* up to 32 GB past the mapping */

for (i = 0; i < nnz; ++i)
  ((int32_t *) output)[indices[i]] = ((int32_t *) input)[i];  /* index is the write offset */
```

- **The header** is parsed from a memory that may be shorter than the 88 bytes `gst_tensor_meta_info_parse_header()` reads before it validates anything — out-of-bounds read.
- **`nnz`** is never compared with the length of the memory, so both `input[i]` and `indices[i]` are read far past it.
- **`indices[i]`** is the offset of a **write** into a block sized from the dimensions. An index of `0x20000000` in a 40-element int32 tensor writes 2 GB past a 160-byte allocation — an arbitrary-offset write whose value the same buffer supplies.

`gst_tensor_sparse_from_dense()` had the mirror hole: it read `element_count` elements out of the dense memory regardless of `map.size`.

Every field involved arrives with the data, so a crafted buffer from a file, an `appsrc`, `tensor_query` or `edge` decides all of them.

The size of the tensor is not a reliable bound on its own either. `gst_tensor_meta_info_get_data_size()` multiplies the element count by the element size in a `gsize`, and `gst_tensor_dimension_is_valid()` bounds only the *shape* of a dimension, never the product: `3340214413:1380655685` int32 elements are `2^62 + 1`, whose `2^64 + 4` bytes wrap to **4**. Bounding the indices by the element count alone would let an index of `2^62` through and write it into a four-byte allocation — the same primitive, now reached *through* the check. Where `gsize` is 32 bits, which the armv7l build of the Tizen target is, the wrap needs only `2^30` elements.

The offset of the payload was not sound either: a header carrying the magic of the version marker but a version other than 1 validates, while `gst_tensor_meta_info_get_header_size()` can size only version 1 and answers **0** for the rest — so the header itself was decoded as tensor data. That is item **A7**, but the offset of the payload is exactly what this function has to bound, so an unsizable version is refused here rather than left to the caller.

`gst_tensor_sparse_from_dense()` sizes its index array in bytes from the same element count, which wraps where `gsize` is 32 bits, so the count is bounded by both the mapping and `G_MAXSIZE / sizeof (guint)`.

The length check ahead of the parse is also what keeps the payload bound sound. A memory that holds every field the parse reads but is shorter than the 128-byte header parses as valid, and without the check `map.size - header_size` underflows, the payload bound passes, and the memory decodes into a whole tensor. Since #4937 that is exactly what `gst_tensor_buffer_from_config()` hands on when the last bytes of a flexible buffer cannot hold a tensor, so the decoder meets it from an ordinary pipeline.

**Fixed** by checking the header size, the version and the declared payload size before the output is allocated, by requiring the element count and the byte size to agree so that neither can be the wrapped one, and by bounding each index in the loop that uses it. The size checks are written as divisions so that the products which would themselves overflow are never formed. Each index is read once with `memcpy()`: the on-wire layout does not align the array for every element type, and the value that is checked has to be the value that is used, or an unaligned load that rounds its address down would write with an index the check never saw.

## C34 — the chains use a buffer the helper refused to build

`gst_tensor_buffer_from_config()` returns NULL when the config is invalid or when the buffer cannot be split into the tensors the config declares, and it takes the ownership of the input buffer either way. Neither chain checked:

- `gst_tensor_sparse_dec_chain()` called `gst_tensor_buffer_get_count (NULL)`, took the 0 tensors that reports, and **pushed the resulting empty buffer downstream** as if it had decoded something;
- `gst_tensor_sparse_enc_chain()` walked `gst_tensor_buffer_get_nth_memory (NULL, i)`;
- both reached `gst_buffer_unref (NULL)` in the common tail.

Reachable from any pipeline in which the buffer and the caps disagree, which a peer decides — caps declaring two tensors of 160 bytes against a buffer of 16 bytes is enough. Both now return `GST_FLOW_ERROR` **before** `outbuf` is allocated, so the common tail has nothing to release and is left as PR #4938 (item C14) made it.

## C36 — unfixed caps handed to `gst_pad_set_caps()`

The decoder's caps event had two problems. It kept going when the caps could not be read into a config at all (the clause item C15 points at), and it read the config of the peer without checking whether the peer had one — so a downstream that leaves the decoded caps unfixed ends in `gst_pad_set_caps()` refusing the caps with an assertion.

Any downstream does leave them unfixed, because only the buffer describes the tensors a sparse stream decodes into. The `tests/nnstreamer_sparse` pipelines all carry an explicit `other/tensors,format=sparse,framerate=0/1` caps filter, which is why nothing had caught this.

Caps that cannot be read are refused now — they used to be kept, leaving the pad carrying caps the element cannot work with — the negotiation runs only when the peer has a config, and the caps are set only when they are fixed. Those pipelines negotiate exactly as before, verified byte-identical below.

## C35 — the per-buffer tensors info is never freed

`gst_tensor_sparse_dec_chain()` fills a local `GstTensorsInfo` per buffer. `gst_tensors_info_get_nth_info()` heap-allocates a 240-entry `extra` array once the index reaches `NNS_TENSOR_MEMORY_MAX`, and only `gst_tensors_info_free()` releases it. A stream of more than 16 tensors leaked one such array per buffer. Freed in the common tail.

## Behaviour change

A pipeline whose buffers do not match its caps now fails with `GST_FLOW_ERROR` instead of silently pushing empty buffers downstream and logging three glib criticals per buffer. Two cases that used to limp along now stop:

- `tensor_sparse_enc ! tensor_sparse_dec` with no caps filter, which never decoded anything (the encoder does not carry the framerate into its sparse src caps, so the decoder's config never validates);
- a sparse stream of more than 16 tensors, whose 17th memory `gst_tensor_buffer_append_memory()` truncates — item **A6**, issue #4934. On `main` the decoder read past the end of that memory's mapping and produced a wrong tensor from it; it is now refused.

Everything that negotiated correctly stays byte-identical, which the round trips below check.

## Tests

Sixteen cases in `tests/nnstreamer_plugins/unittest_plugins.cc`, building on the `tensor_sparse` helpers PR #4938 added. Verified against unfixed sources, one test at a time:

| Test | Without the fix |
| --- | --- |
| `utilToDenseShortPayload_n` | SIGSEGV |
| `utilToDenseNnzOverflow_n` | SIGSEGV |
| `utilToDenseIndexOutOfRange_n` | SIGSEGV |
| `utilToDenseDimensionOverflow_n` | SIGSEGV |
| `utilToDenseUnknownVersion_n` | FAIL (the unsizable header is accepted and decoded) |
| `utilToDenseTruncatedHeader_n` | FAIL (a 100-byte memory holding a valid header decodes into a whole tensor) |
| `decTrailingRemainder_n` | FAIL (the tail decodes, the buffer no longer matches the config and is dropped with `GST_FLOW_OK`). It first asserts that `gst_tensor_buffer_from_config()` really hands the tail on as a second memory, so a change to that contract fails the case instead of letting it pass through the chain's own refusal |
| `utilFromDenseShortMemory_n` | SIGSEGV |
| `decBufferFromConfigFailure_n` | FAIL (criticals + an empty buffer pushed) |
| `encBufferFromConfigFailure_n` | FAIL (criticals) |
| `decUnreadableCaps_n` | FAIL (the pad keeps caps the element cannot use) |
| `decUnfixedSrcCaps_n` | FAIL (the `gst_pad_set_caps` assertion) |
| `decUnnegotiatedPipeline_n` | FAIL (criticals + an empty buffer pushed) |
| `utilToDenseShortHeader_n` | passes as a test; the out-of-bounds read is an invalid read in our own frame, so the Valgrind step gates it. `utilToDenseTruncatedHeader_n` is the functional gate for the same check |
| `utilToDenseLastIndex` | passes; pins the upper bound of the index check |
| `decExtraTensors` | passes; exercises the >16-tensor path, which nothing covered |

The negative cases count the criticals of the GStreamer domain with the handler PR #4938 introduced, which self-checks that it is live, so "handled gracefully" cannot silently become a no-op. `decUnfixedSrcCaps_n` needs a second counter: `gst_pad_set_caps()` is a `static inline` of `gstcompat.h`, so it is compiled into the caller rather than into GStreamer, and nnstreamer defines no `G_LOG_DOMAIN` of its own — its assertion therefore lands in the *default* domain, next to the elements' own error messages, and the name of the function is what keeps the two apart.

`decUnfixedSrcCaps_n` gates the two halves of the C36 change **as a pair**: the peer-config check and the fixed-caps check are alternative defences against the same assertion, so reverting either one alone still passes and only reverting both fails. That is the shape of the fix rather than a gap in the test, but it does mean neither line is individually pinned.

`decExtraTensors` is the case in which the leaked `extra` array is allocated. **The C35 leak has no automated gate**: `tools/debugging/check_valgrind_log.sh` counts and prints leaks but only fails the build on memcheck *errors*, so removing `gst_tensors_info_free()` again would go green. This test pins the functional path; the leak is left as a code-review-level guarantee. The same holds for the `g_free (output)` on the new index-rejection path of `gst_tensor_sparse_to_dense()` — the tests reach it, but deleting the free would stay green, so it too rests on review rather than on CI. Its tensors are sized so that the sparse memory is exactly as long as the dense one it encodes, because `gst_tensor_buffer_append_memory()` records only the dense size of an extra tensor (item **A6**, issue #4934, unfixed); a longer sparse memory comes back truncated.

## Verification

- `meson test -C build`: 22/23 suites pass. `unittest_filter_python3` fails on this box for an unrelated environment reason (a numpy 1.x/2.x ABI mismatch raising `ImportError` before any nnstreamer code runs).
- Both commits build and pass on their own.
- The `tensor_sparse_enc` → caps filter → `tensor_sparse_dec` round trip of `tests/nnstreamer_sparse` cases 1, 4 and 5 (driven through `tensor_converter`, since lua is not built here) is byte-identical to the input, with no criticals.
- `gst-indent` clean on the three C files, `clang-format` 16 clean on the test file, and `doxygen-tag.sh` clean — the checker confirmed live with a negative control.

The decoder's own example launch line is corrected with it. `other/tensors,format=sparse` is fixed on its own, but its intersection with the encoder's src template carries the template's framerate *range*, so the caps filter has nothing fixed to push and the decoder never receives a caps event. It now carries the `framerate=0/1` that `tests/nnstreamer_sparse` has always used.

## Out of scope, worth filing

A dimension naming an enormous tensor still reaches `g_malloc0()` directly, so a 136-byte memory declaring `1000000000:1000000000:1:1` aborts the process on the allocation. That is unchanged by this PR — measured identically at the merge base — and closing it needs `g_try_malloc0()` or a ceiling on the declared size rather than a bounds check, so it is left as a candidate item for #4920.

`gst_tensor_sparse_to_dense()` reaches the index array at `header + element_size * nnz`, which is not 4-byte aligned for a 1- or 2-byte element type with an odd `nnz`. Every index is now read through `memcpy()`, so the value that is checked is the value that is written and no unaligned word load is left in the decode path — but the *values* beside it are still read as `((int16_t *) input)[i]` and the like, unchanged from `main`. That is a real fault on a strict-alignment target such as armv7l, and the fix belongs with the on-wire layout rather than with a bounds check, so it is left as a candidate item for #4920.

Closes items **C13**, **C15**, **C34**, **C35** and **C36** of #4920.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
