### PR TITLE
[Element/Transform] Bound the tensor_transform kernels to the buffer and the option

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -2044,8 +2044,14 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
         goto done;
       }
 
-      gst_tensor_transform_convert_dimension (filter, GST_PAD_SINK,
-          i, in_info, out_info);
+      if (!gst_tensor_transform_convert_dimension (filter, GST_PAD_SINK,
+              i, in_info, out_info) || !gst_tensor_info_validate (out_info)) {
+        ml_loge
+            ("Cannot transform the tensor %u, the mode does not fit its dimension.\n",
+            i);
+        res = GST_FLOW_ERROR;
+        goto done;
+      }
 
       hsize = gst_tensor_meta_info_get_header_size (&meta);
       inptr += hsize;

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -1307,7 +1307,8 @@ gst_tensor_transform_dimchg (GstTensorTransform * filter,
         break;
       copyblocksize *= fromDim[i];
     }
-    for (i = 0; i < to; i++) {
+    /* the dims below 'from' are already counted in copyblocksize */
+    for (i = from; i < to; i++) {
       if (toDim[i] == 0)
         break;
       copyblocklimit *= toDim[i];

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -1967,9 +1967,28 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
       in_info = &in_flex_info;
       out_info = &out_flex_info;
 
-      gst_tensor_meta_info_parse_header (&meta, inptr);
       /** @todo max rank supported in tensor-transform is 4 */
-      if (!gst_tensor_meta_info_convert (&meta, in_info)) {
+      gst_tensor_meta_info_init (&meta);
+      hsize = gst_tensor_meta_info_get_header_size (&meta);
+      if (in_map[i].size < hsize) {
+        ml_loge ("Invalid buffer, the tensor %u has no meta header.\n", i);
+        res = GST_FLOW_ERROR;
+        goto done;
+      }
+
+      if (!gst_tensor_meta_info_parse_header (&meta, inptr) ||
+          !gst_tensor_meta_info_convert (&meta, in_info)) {
+        ml_loge
+            ("Invalid buffer, the meta header of the tensor %u is broken.\n",
+            i);
+        res = GST_FLOW_ERROR;
+        goto done;
+      }
+
+      if (meta.format == _NNS_TENSOR_FORMAT_SPARSE) {
+        ml_loge
+            ("The tensor %u is sparse, which tensor-transform cannot handle.\n",
+            i);
         res = GST_FLOW_ERROR;
         goto done;
       }
@@ -1979,6 +1998,15 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
 
       hsize = gst_tensor_meta_info_get_header_size (&meta);
       inptr += hsize;
+    }
+
+    if (in_map[i].size < (gsize) (inptr - in_map[i].data) +
+        gst_tensor_info_get_size (in_info)) {
+      ml_loge
+          ("Invalid buffer, the tensor %u is smaller than the size described by the stream.\n",
+          i);
+      res = GST_FLOW_ERROR;
+      goto done;
     }
 
     /* prepare output buffer */

--- a/gst/nnstreamer/elements/gsttensor_transform.c
+++ b/gst/nnstreamer/elements/gsttensor_transform.c
@@ -75,7 +75,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_tensor_transform_debug);
     "((([-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?)))$"
 #define REGEX_PADDING_OPTION "^((left|right|top|bottom|front|back):(\\d)(,)?)+(layout:(NCHW|NHWC))?$"
 #define REGEX_ARITH_OPTION "^(typecast:([u]?int(8|16|32|64)|float(16|32|64)),)?"\
-    "(per-channel:(false|true@[0-9]+),)?"\
+    "(per-channel:(false|true@(0*([0-9]|1[0-5]))),)?"\
     "(((add|mul|div)(:([-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?))+(@[0-9]+)?)(,|))+$"
 
 #define REGEX_ARITH_OPTION_TYPECAST "(typecast:([u]?int(8|16|32|64)|float(16|32|64)))"
@@ -192,7 +192,8 @@ gst_tensor_transform_mode_get_type (void)
       {GTT_TYPECAST, "Mode for casting type of tensor, "
             "option=" REGEX_TYPECAST_OPTION, "typecast"},
       {GTT_ARITHMETIC, "Mode for arithmetic operations with tensor, "
-            "option=[typecast:TYPE,][per-channel:(false|true@DIM),]add|mul|div:NUMBER[@CH_IDX], ...",
+            "option=[typecast:TYPE,][per-channel:(false|true@DIM),]add|mul|div:NUMBER[@CH_IDX], ..."
+            " (DIM is less than NNS_TENSOR_RANK_LIMIT, 16, and CH_IDX is one of the channels)",
           "arithmetic"},
       {GTT_TRANSPOSE, "Mode for transposing shape of tensor, "
             "option=D1\':D2\':D3\':D4 (fixed to 3)",
@@ -776,8 +777,8 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       if (!g_regex_match_simple (REGEX_ARITH_OPTION, str_option,
               G_REGEX_CASELESS, 0)) {
         ml_loge
-            ("%s: arithmetic: \'%s\' is not valid option string: it should be in the form of [typecast:TYPE,][per-channel:(false|true@DIM),]add|mul|div:NUMBER[@CH_IDX]..., ...\n",
-            filter_name, str_option);
+            ("%s: arithmetic: \'%s\' is not valid option string: it should be in the form of [typecast:TYPE,][per-channel:(false|true@DIM),]add|mul|div:NUMBER[@CH_IDX]..., ..., where DIM is less than %d\n",
+            filter_name, str_option, NNS_TENSOR_RANK_LIMIT);
         g_free (str_option);
         break;
       }
@@ -843,7 +844,10 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
                 }
 
                 if (filter->data_arithmetic.per_channel_arith && num_values > 1) {
-                  op_s->applying_ch = g_ascii_strtoll (values[1], NULL, 10);
+                  int64_t ch = g_ascii_strtoll (values[1], NULL, 10);
+
+                  /* the range check needs the channel count, saturate here */
+                  op_s->applying_ch = (int) MIN (ch, G_MAXINT);
                 }
 
               } else {
@@ -1378,6 +1382,48 @@ gst_tensor_transform_typecast (GstTensorTransform * filter,
 }
 
 /**
+ * @brief Check whether the per-channel arithmetic option fits the given tensor.
+ * @param[in] filter "this" pointer
+ * @param[in] in_info input tensor info
+ * @return TRUE if the channel dimension and every channel index are in range
+ */
+static gboolean
+gst_tensor_transform_check_per_channel (GstTensorTransform * filter,
+    const GstTensorInfo * in_info)
+{
+  guint i, ch_dim, num_ch;
+  GSList *walk;
+
+  ch_dim = filter->data_arithmetic.ch_dim;
+  if (ch_dim >= NNS_TENSOR_RANK_LIMIT) {
+    ml_loge ("The channel dimension index %u is out of range.\n", ch_dim);
+    return FALSE;
+  }
+
+  for (i = 0; i <= ch_dim; i++) {
+    if (in_info->dimension[i] == 0) {
+      ml_loge
+          ("The input tensor has no %u-th dimension, cannot apply the per-channel arithmetic to its %u-th dimension.\n",
+          i, ch_dim);
+      return FALSE;
+    }
+  }
+
+  num_ch = in_info->dimension[ch_dim];
+  for (walk = filter->operators; walk; walk = g_slist_next (walk)) {
+    int ch = ((tensor_transform_operator_s *) walk->data)->applying_ch;
+
+    if (ch < -1 || (ch >= 0 && (guint) ch >= num_ch)) {
+      ml_loge ("The channel index %d is out of range (0 <= index < %u).\n",
+          ch, num_ch);
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
  * @brief subrouting for tensor-transform, "arithmetic" case.
  * @param[in/out] filter "this" pointer
  * @param[in] in_info input tensor info
@@ -1399,6 +1445,10 @@ gst_tensor_transform_arithmetic (GstTensorTransform * filter,
   tensor_data_s value;
 
   num = gst_tensor_get_element_count (in_info->dimension);
+
+  if (filter->data_arithmetic.per_channel_arith &&
+      !gst_tensor_transform_check_per_channel (filter, in_info))
+    return GST_FLOW_ERROR;
 
 #ifdef HAVE_ORC
   if (filter->acceleration) {

--- a/gst/nnstreamer/elements/gsttensor_transform.md
+++ b/gst/nnstreamer/elements/gsttensor_transform.md
@@ -34,6 +34,7 @@ title: tensor_transform
     - (0): dimchg
       - A mode for changing tensor dimensions
       - An option should be provided as option=FROM_DIM:TO_DIM (with a regex, ^([0-9]|1[0-5]):([0-9]|1[0-5])$, where NNS_TENSOR_RANK_LIMIT is 16).
+      - FROM_DIM should be less than TO_DIM, and the incoming tensor should have a TO_DIM-th dimension.
       - Example: Move 1st dim to 2nd dim (i.e., [a][H][W][C] ==> [a][C][H][W])
 
         ```bash

--- a/gst/nnstreamer/elements/gsttensor_transform.md
+++ b/gst/nnstreamer/elements/gsttensor_transform.md
@@ -65,6 +65,7 @@ title: tensor_transform
         ```
 
       - For "per-channel", DIM means the dimension which should be viewed as channel and CH_IDX means the idx of channel the given operation should be applied to. When CH_IDX is not given, the operation is applied to all channels.
+      - DIM should be less than NNS_TENSOR_RANK_LIMIT (16), and the incoming tensor should have that dimension. CH_IDX should be one of the channels of that dimension. An option outside those ranges is refused, and so is a stream the option does not fit.
       - Example 3: Add 255 only for 1-th channel when 0-th dim is channel (for RGB image, add 255 for G channel)
 
         ```bash

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -2113,6 +2113,119 @@ TEST (testTensorTransform, pushSparseFlexibleTensor_n)
 }
 
 /**
+ * @brief Push a uint8 tensor through the dimchg mode and compare the result
+ *        with the reference permutation of the given dimension.
+ * @param dim_str dimension of the input tensor
+ * @param from index of the dimension to be moved
+ * @param to index the dimension is moved to
+ */
+static void
+_test_dimchg (const gchar *dim_str, guint from, guint to)
+{
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorsConfig config, out_config;
+  GstCaps *caps;
+  GstMemory *mem;
+  GstMapInfo info;
+  uint32_t *dim, expected[NNS_TENSOR_RANK_LIMIT];
+  gchar *option;
+  guint i, b, f, m, r;
+  guint below = 1, moved, between = 1, above = 1;
+  gsize data_size;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  option = g_strdup_printf ("%u:%u", from, to);
+  g_object_set (h->element, "mode", GTT_DIMCHG, "option", option, NULL);
+  g_free (option);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension (dim_str, config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+  dim = config.info.info[0].dimension;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+  ASSERT_LE (data_size, 256U);
+
+  in_buf = gst_harness_create_buffer (h, data_size);
+  mem = gst_buffer_peek_memory (in_buf, 0);
+  ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+  for (i = 0; i < data_size; i++)
+    ((uint8_t *) info.data)[i] = (uint8_t) i;
+  gst_memory_unmap (mem, &info);
+
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+  out_buf = gst_harness_pull (h);
+  ASSERT_TRUE (out_buf != NULL);
+  ASSERT_EQ (gst_buffer_get_size (out_buf), data_size);
+
+  /* the negotiated output dimension moves 'from' to 'to' as well */
+  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
+    expected[i] = (i < from || i > to) ? dim[i] : (i == to ? dim[from] : dim[i + 1]);
+
+  caps = gst_pad_get_current_caps (h->sinkpad);
+  ASSERT_TRUE (caps != NULL);
+  gst_tensors_config_init (&out_config);
+  ASSERT_TRUE (gst_tensors_config_from_structure (
+      &out_config, gst_caps_get_structure (caps, 0)));
+  gst_caps_unref (caps);
+  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
+    EXPECT_EQ (out_config.info.info[0].dimension[i], expected[i]);
+  gst_tensors_config_free (&out_config);
+
+  /* the moved dimension splits the tensor into below/between/above blocks */
+  for (i = 0; i < from; i++)
+    below *= dim[i];
+  moved = dim[from];
+  for (i = from + 1; i <= to; i++)
+    between *= dim[i];
+  for (i = to + 1; i < NNS_TENSOR_RANK_LIMIT; i++)
+    if (dim[i] > 0)
+      above *= dim[i];
+
+  mem = gst_buffer_peek_memory (out_buf, 0);
+  ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+  for (r = 0; r < above; r++)
+    for (f = 0; f < moved; f++)
+      for (m = 0; m < between; m++)
+        for (b = 0; b < below; b++)
+          EXPECT_EQ (((uint8_t *) info.data)[b + below * (m + between * (f + moved * r))],
+              (uint8_t) (b + below * (f + moved * (m + between * r))));
+  gst_memory_unmap (mem, &info);
+  gst_buffer_unref (out_buf);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform dimchg, moving the first dimension
+ */
+TEST (testTensorTransform, dimchg)
+{
+  _test_dimchg ("2:3:4:1", 0, 2);
+  _test_dimchg ("2:3:4:5", 0, 3);
+}
+
+/**
+ * @brief Test for tensor_transform dimchg, moving a dimension other than the first
+ */
+TEST (testTensorTransform, dimchgFromNonZeroDim)
+{
+  _test_dimchg ("2:3:4:1", 1, 2);
+  _test_dimchg ("2:3:4:5", 1, 2);
+  _test_dimchg ("2:3:4:5", 1, 3);
+  _test_dimchg ("2:3:4:5", 2, 3);
+  _test_dimchg ("2:3:4:2:2:2", 2, 4);
+}
+
+/**
  * @brief Test for tensor_transform arithmetic (float32, add .5)
  */
 TEST (testTensorTransform, arithmetic1)

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -2226,6 +2226,73 @@ TEST (testTensorTransform, dimchgFromNonZeroDim)
 }
 
 /**
+ * @brief Test for tensor_transform dimchg of a flexible tensor
+ */
+TEST (testTensorTransform, dimchgFlexible)
+{
+  GstHarness *h;
+  GstBuffer *buf, *out_buf;
+  GstCaps *caps;
+  GstMemory *mem;
+  GstTensorMetaInfo meta;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_DIMCHG, "option", "1:2", NULL);
+
+  caps = gst_caps_from_string (GST_TENSORS_FLEX_CAP_DEFAULT);
+  gst_caps_set_simple (caps, "framerate", GST_TYPE_FRACTION, 0, 1, NULL);
+  gst_harness_set_src_caps (h, caps);
+
+  buf = gst_buffer_new ();
+  gst_buffer_append_memory (buf, _new_flex_memory ("4:3:2", TRUE, 0U));
+  gst_buffer_append_memory (buf, _new_flex_memory ("4:3:2", TRUE, 0U));
+
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_OK);
+
+  out_buf = gst_harness_pull (h);
+  ASSERT_TRUE (out_buf != NULL);
+  mem = gst_buffer_peek_memory (out_buf, 0);
+  ASSERT_TRUE (gst_tensor_meta_info_parse_memory (&meta, mem));
+  EXPECT_EQ (meta.dimension[0], 4U);
+  EXPECT_EQ (meta.dimension[1], 2U);
+  EXPECT_EQ (meta.dimension[2], 3U);
+  gst_buffer_unref (out_buf);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform dimchg, a flexible tensor of a lower rank
+ */
+TEST (testTensorTransform, dimchgFlexibleShortRank_n)
+{
+  GstHarness *h;
+  GstBuffer *buf;
+  GstCaps *caps;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_DIMCHG, "option", "1:2", NULL);
+
+  caps = gst_caps_from_string (GST_TENSORS_FLEX_CAP_DEFAULT);
+  gst_caps_set_simple (caps, "framerate", GST_TYPE_FRACTION, 0, 1, NULL);
+  gst_harness_set_src_caps (h, caps);
+
+  /* the tensor has no third dimension for the second one to move to */
+  buf = gst_buffer_new ();
+  gst_buffer_append_memory (buf, _new_flex_memory ("4:3", TRUE, 0U));
+  gst_buffer_append_memory (buf, _new_flex_memory ("4:3", TRUE, 0U));
+
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_ERROR);
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
  * @brief Test for tensor_transform arithmetic (float32, add .5)
  */
 TEST (testTensorTransform, arithmetic1)

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -1861,6 +1861,258 @@ TEST_TRANSFORM_TYPECAST (typecast_14_accel, 3U, 5U, double, _NNS_FLOAT64,
     uint64_t, "uint64", _NNS_UINT64, TRUE)
 
 /**
+ * @brief Push a single buffer of the given size and return the flow status.
+ */
+static GstFlowReturn
+_push_tensor_of_size (GstHarness *h, gsize size)
+{
+  GstBuffer *buf = gst_harness_create_buffer (h, size);
+  GstMemory *mem = gst_buffer_peek_memory (buf, 0);
+  GstMapInfo info;
+
+  if (gst_memory_map (mem, &info, GST_MAP_WRITE)) {
+    memset (info.data, 1, info.size);
+    gst_memory_unmap (mem, &info);
+  }
+
+  return gst_harness_push (h, buf);
+}
+
+/**
+ * @brief Test for tensor_transform, a static tensor shorter than the caps
+ */
+TEST (testTensorTransform, pushShortTensor_n)
+{
+  GstHarness *h;
+  GstTensorsConfig config;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:1", NULL);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("3:4:4:1", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  /* the caps describe 48 bytes */
+  EXPECT_EQ (_push_tensor_of_size (h, 24U), GST_FLOW_ERROR);
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform, a static tensor larger than the caps
+ */
+TEST (testTensorTransform, pushLongTensor)
+{
+  GstHarness *h;
+  GstBuffer *out_buf;
+  GstTensorsConfig config;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:1", NULL);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("3:4:4:1", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  /* the caps describe 48 bytes, a memory holding more of them is not an error */
+  EXPECT_EQ (_push_tensor_of_size (h, 96U), GST_FLOW_OK);
+
+  out_buf = gst_harness_pull (h);
+  ASSERT_TRUE (out_buf != NULL);
+  EXPECT_EQ (gst_buffer_get_size (out_buf), 48U);
+  gst_buffer_unref (out_buf);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Build a uint8 flexible tensor memory of the given dimension.
+ * @param dim_str dimension the meta header describes
+ * @param with_data allocate the data the header describes, not the header alone
+ * @param size bytes the memory exposes, 0 for every allocated byte
+ */
+static GstMemory *
+_new_flex_memory (const gchar *dim_str, gboolean with_data, gsize size)
+{
+  GstTensorMetaInfo meta;
+  GstTensorInfo info;
+  guint8 *data;
+  gsize hsize, alloc;
+
+  gst_tensor_info_init (&info);
+  info.type = _NNS_UINT8;
+  gst_tensor_parse_dimension (dim_str, info.dimension);
+  gst_tensor_info_convert_to_meta (&info, &meta);
+
+  hsize = gst_tensor_meta_info_get_header_size (&meta);
+  alloc = hsize + (with_data ? gst_tensor_info_get_size (&info) : 0);
+  if (size == 0)
+    size = alloc;
+  g_assert (size <= alloc);
+
+  data = (guint8 *) g_malloc0 (alloc);
+  gst_tensor_meta_info_update_header (&meta, data);
+
+  return gst_memory_new_wrapped ((GstMemoryFlags) 0, data, alloc, 0, size, data, g_free);
+}
+
+/**
+ * @brief Test for tensor_transform, a flexible tensor without a complete header
+ */
+TEST (testTensorTransform, pushShortFlexibleHeader_n)
+{
+  GstHarness *h;
+  GstBuffer *buf;
+  GstCaps *caps;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:1", NULL);
+
+  caps = gst_caps_from_string (GST_TENSORS_FLEX_CAP_DEFAULT);
+  gst_caps_set_simple (caps, "framerate", GST_TYPE_FRACTION, 0, 1, NULL);
+  gst_harness_set_src_caps (h, caps);
+
+  /**
+   * The memory exposes 8 bytes of a fully allocated tensor, so an element that
+   * parses the header anyway reads a valid one and keeps going, which is what
+   * makes the refusal below the only possible outcome. The second memory keeps
+   * the buffer from being re-split by the header.
+   */
+  buf = gst_buffer_new ();
+  gst_buffer_append_memory (buf, _new_flex_memory ("3:4:4:1", TRUE, 8U));
+  gst_buffer_append_memory (buf, _new_flex_memory ("3:4:4:1", TRUE, 0U));
+
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_ERROR);
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform, a flexible tensor shorter than its header says
+ */
+TEST (testTensorTransform, pushShortFlexibleData_n)
+{
+  GstHarness *h;
+  GstBuffer *buf;
+  GstCaps *caps;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:1", NULL);
+
+  caps = gst_caps_from_string (GST_TENSORS_FLEX_CAP_DEFAULT);
+  gst_caps_set_simple (caps, "framerate", GST_TYPE_FRACTION, 0, 1, NULL);
+  gst_harness_set_src_caps (h, caps);
+
+  /* the header describes 48 bytes of data, nothing beyond it is allocated */
+  buf = gst_buffer_new ();
+  gst_buffer_append_memory (buf, _new_flex_memory ("3:4:4:1", FALSE, 0U));
+  gst_buffer_append_memory (buf, _new_flex_memory ("3:4:4:1", TRUE, 0U));
+
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_ERROR);
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform, a tensor whose header says it is flexible
+ * @details tensor_crop and a dynamic tensor_filter stamp that format on every
+ *          header they append, so only a sparse payload may be refused.
+ */
+TEST (testTensorTransform, pushFlexibleFormatTensor)
+{
+  GstHarness *h;
+  GstBuffer *buf, *out_buf;
+  GstCaps *caps;
+  GstMemory *mem;
+  GstMapInfo info;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:1", NULL);
+
+  caps = gst_caps_from_string (GST_TENSORS_FLEX_CAP_DEFAULT);
+  gst_caps_set_simple (caps, "framerate", GST_TYPE_FRACTION, 0, 1, NULL);
+  gst_harness_set_src_caps (h, caps);
+
+  buf = gst_buffer_new ();
+  mem = _new_flex_memory ("3:4:4:1", TRUE, 0U);
+  ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+  ((uint32_t *) info.data)[19] = (uint32_t) _NNS_TENSOR_FORMAT_FLEXIBLE;
+  gst_memory_unmap (mem, &info);
+  gst_buffer_append_memory (buf, mem);
+  gst_buffer_append_memory (buf, _new_flex_memory ("3:4:4:1", TRUE, 0U));
+
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_OK);
+
+  out_buf = gst_harness_pull (h);
+  ASSERT_TRUE (out_buf != NULL);
+  gst_buffer_unref (out_buf);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform, a flexible tensor declaring a sparse payload
+ */
+TEST (testTensorTransform, pushSparseFlexibleTensor_n)
+{
+  GstHarness *h;
+  GstBuffer *buf;
+  GstCaps *caps;
+  GstMemory *mem;
+  GstMapInfo info;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:1", NULL);
+
+  caps = gst_caps_from_string (GST_TENSORS_FLEX_CAP_DEFAULT);
+  gst_caps_set_simple (caps, "framerate", GST_TYPE_FRACTION, 0, 1, NULL);
+  gst_harness_set_src_caps (h, caps);
+
+  /**
+   * The memory is large enough for the dense size the element compares
+   * against, so nothing but the format tells the two payloads apart.
+   */
+  buf = gst_buffer_new ();
+  mem = _new_flex_memory ("3:4:4:1", TRUE, 0U);
+  ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+  ((uint32_t *) info.data)[19] = (uint32_t) _NNS_TENSOR_FORMAT_SPARSE;
+  gst_memory_unmap (mem, &info);
+  gst_buffer_append_memory (buf, mem);
+  gst_buffer_append_memory (buf, _new_flex_memory ("3:4:4:1", TRUE, 0U));
+
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_ERROR);
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
  * @brief Test for tensor_transform arithmetic (float32, add .5)
  */
 TEST (testTensorTransform, arithmetic1)

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -2942,6 +2942,244 @@ TEST (testTensorTransform, arithmeticPerChannel)
 }
 
 /**
+ * @brief Test for tensor_transform arithmetic, per-channel with acceleration
+ */
+TEST (testTensorTransform, arithmeticPerChannelAccel)
+{
+  const guint array_size = 6; /* 3 channels of 2 pixels */
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorsConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i;
+  gsize data_size;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option",
+      "per-channel:true@0,add:10@1", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("3:2:1:1", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+
+  in_buf = gst_harness_create_buffer (h, data_size);
+  mem = gst_buffer_peek_memory (in_buf, 0);
+  ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+  for (i = 0; i < array_size; i++)
+    ((uint8_t *) info.data)[i] = (uint8_t) i;
+  gst_memory_unmap (mem, &info);
+
+  EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+  out_buf = gst_harness_pull (h);
+  ASSERT_TRUE (out_buf != NULL);
+  ASSERT_EQ (gst_buffer_get_size (out_buf), data_size);
+
+  mem = gst_buffer_peek_memory (out_buf, 0);
+  ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+  for (i = 0; i < array_size; i++) {
+    uint8_t expected = (uint8_t) (i + ((i % 3 == 1) ? 10 : 0));
+    EXPECT_EQ (((uint8_t *) info.data)[i], expected);
+  }
+  gst_memory_unmap (mem, &info);
+  gst_buffer_unref (out_buf);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Configure tensor_transform for the per-channel arithmetic tests.
+ */
+static GstHarness *
+_arith_per_channel_harness (const gchar *option, gboolean accel)
+{
+  GstHarness *h;
+  GstTensorsConfig config;
+  gchar *str = NULL;
+
+  h = gst_harness_new ("tensor_transform");
+  if (!h)
+    return NULL;
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", option, NULL);
+  g_object_set (h->element, "acceleration", accel, NULL);
+
+  g_object_get (h->element, "option", &str, NULL);
+  if (!str) {
+    gst_harness_teardown (h);
+    return NULL;
+  }
+  g_free (str);
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = 1U;
+  config.info.info[0].type = _NNS_UINT8;
+  gst_tensor_parse_dimension ("3:4:4:1", config.info.info[0].dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+  return h;
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic, the documented channel dimension range
+ */
+TEST (testTensorTransform, arithmeticPerChannelDimBound)
+{
+  GstHarness *h;
+  gchar *str = NULL;
+
+  /* the option regex spells the rank limit out, keep the two in step */
+  ASSERT_EQ (NNS_TENSOR_RANK_LIMIT, 16);
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option",
+      "per-channel:true@15,add:1", NULL);
+
+  g_object_get (h->element, "option", &str, NULL);
+  EXPECT_STREQ (str, "per-channel:true@15,add:1");
+  g_free (str);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic, channel dimension out of the rank
+ */
+TEST (testTensorTransform, arithmeticPerChannelDimOutOfRank_n)
+{
+  GstHarness *h;
+  gchar *str = NULL;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option",
+      "per-channel:true@16,add:1", NULL);
+
+  g_object_get (h->element, "option", &str, NULL);
+  EXPECT_TRUE (str == NULL);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic, channel dimension wrapping the rank
+ */
+TEST (testTensorTransform, arithmeticPerChannelDimOverflow_n)
+{
+  GstHarness *h;
+  gchar *str = NULL;
+
+  h = gst_harness_new ("tensor_transform");
+  ASSERT_TRUE (NULL != h);
+
+  /* a dimension index out of the rank, which truncates to 0 in 32 bits */
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option",
+      "per-channel:true@4294967296,add:1", NULL);
+
+  g_object_get (h->element, "option", &str, NULL);
+  EXPECT_TRUE (str == NULL);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic, channel dimension not in the tensor
+ */
+TEST (testTensorTransform, arithmeticPerChannelDimNotInTensor_n)
+{
+  GstHarness *h;
+
+  h = _arith_per_channel_harness ("per-channel:true@5,add:1", FALSE);
+  ASSERT_TRUE (NULL != h);
+
+  EXPECT_EQ (_push_tensor_of_size (h, 48U), GST_FLOW_ERROR);
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic, channel dimension not in the tensor
+ */
+TEST (testTensorTransform, arithmeticPerChannelDimNotInTensorAccel_n)
+{
+  GstHarness *h;
+
+  h = _arith_per_channel_harness ("per-channel:true@5,add:1", TRUE);
+  ASSERT_TRUE (NULL != h);
+
+  EXPECT_EQ (_push_tensor_of_size (h, 48U), GST_FLOW_ERROR);
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic, channel index out of the channels
+ */
+TEST (testTensorTransform, arithmeticPerChannelIndexOutOfRange_n)
+{
+  GstHarness *h;
+
+  h = _arith_per_channel_harness ("per-channel:true@0,add:1@10", FALSE);
+  ASSERT_TRUE (NULL != h);
+
+  EXPECT_EQ (_push_tensor_of_size (h, 48U), GST_FLOW_ERROR);
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic, channel index out of the channels
+ */
+TEST (testTensorTransform, arithmeticPerChannelIndexOutOfRangeAccel_n)
+{
+  GstHarness *h;
+
+  h = _arith_per_channel_harness ("per-channel:true@0,add:1@10", TRUE);
+  ASSERT_TRUE (NULL != h);
+
+  EXPECT_EQ (_push_tensor_of_size (h, 48U), GST_FLOW_ERROR);
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic, channel index wrapping the int range
+ */
+TEST (testTensorTransform, arithmeticPerChannelIndexOverflow_n)
+{
+  GstHarness *h;
+
+  /* 4294967296 is 0 when it is truncated to a 32bit index */
+  h = _arith_per_channel_harness ("per-channel:true@0,add:1@4294967296", FALSE);
+  ASSERT_TRUE (NULL != h);
+
+  EXPECT_EQ (_push_tensor_of_size (h, 48U), GST_FLOW_ERROR);
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  gst_harness_teardown (h);
+}
+
+/**
  * @brief Test for tensor_transform arithmetic (changing option string dynamically)
  */
 TEST (testTensorTransform, arithmeticChangeOptionString)

--- a/tests/transform_arithmetic/runTest.sh
+++ b/tests/transform_arithmetic/runTest.sh
@@ -141,6 +141,11 @@ video/x-raw,format=RGB,width=8,height=4 ! filesink location=\"black_channel_op.l
 " 9 0 0 $PERFORMANCE
 callCompareTest black_channel_op.log red.log 9-1 "Compare red RGB value" 1 0
 
+# Fail Test for the per-channel operand of a channel the tensor does not have
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc pattern=2 num-buffers=1 ! videoscale ! \
+videoconvert ! video/x-raw,format=RGB,width=8,height=4 ! tensor_converter ! \
+tensor_transform mode=arithmetic option=per-channel:true@0,add:255@5 ! fakesink sync=true" 10_n 0 1 $PERFORMANCE
+
 rm *.log *.bmp *.png *.golden *.raw *.dat
 
 report


### PR DESCRIPTION
Three memory-safety defects of `tensor_transform`, all in
`gst/nnstreamer/elements/gsttensor_transform.c`, taken together because they
share the file and the same shape: a value that is never compared with what
it indexes. They are items **C4**, **C5** and **C6** of #4920.

### C6 — the incoming buffer is never compared with the size the stream describes

Every kernel reads `gst_tensor_info_get_size (in_info)` bytes from the mapped
input memory, and the flexible branch parses a 128-byte meta header from it,
with no check against the mapping. `gst_tensor_buffer_from_config()` passes a
buffer through untouched when the memory count already matches the tensor
count, so a short memory from a peer (appsrc, datareposrc, tensor_query, edge)
is read past its end. The element now refuses such a buffer with
`GST_FLOW_ERROR`, the way `tensor_crop` already does. A memory larger than the
described size stays acceptable.

### C5 — the per-channel arithmetic option is never bounded by the tensor

`per-channel:true@N` accepted any integer, so `dimension[N]` was read past the
tensor info; a dimension the tensor does not have makes the channel offset 0
and the kernel divides by it; and `add:1@N` with `N` beyond the channels makes
the ORC path write outside the output memory. `N` is now bounded in the option
regex, the way `dimchg` already bounds its own indices, and the two facts only
the negotiated tensor can settle are checked before either kernel runs (a
flexible stream carries its dimension in the buffer, so that half cannot be
done at negotiation time).

### C4 — `dimchg` with `from > 0` reads and writes out of bounds

The copy-block count was the product of every output dimension below `to`,
which counts the dimensions below `from` twice — once in the block size, once
in the block count. `option=1:2` on a `2:3:4:1` uint8 tensor writes 32 bytes
into the 24-byte output and reads 48 bytes of the 24-byte input. The product
now starts at `from`; `from == 0`, the only case covered so far, is unchanged
because the two products are then equal.

A fourth commit closes the same item for flexible streams, where the dimension
comes from the buffer rather than from caps: `dimchg` with a `to` the tensor
has no dimension for produces a dimension with a hole (`4:0:3` for a `4:3`
tensor with `option=1:2`), `gst_tensor_get_element_count()` stops at the hole,
and the output memory is allocated for 4 elements while the kernel writes 12.
The converted dimension is now validated before it is used to size anything.

### Compatibility

One user-visible behaviour change: `add:N@CH` with a `CH` the tensor does not
have used to be a silent no-op on the plain path (and an out-of-bounds write
on the ORC path) and is now a stream error. `per-channel:true@N` with
`N >= 16` is now refused as a malformed option instead of being accepted.
Both ranges are now stated in `gsttensor_transform.md`.

### Tests

`tests/nnstreamer_plugins/unittest_plugins.cc` gains 17 cases and
`tests/transform_arithmetic/runTest.sh` one negative SSAT case. Measured
against the pre-fix element, every regression test discriminates:

| case | pre-fix |
| --- | --- |
| `dimchgFromNonZeroDim` | **139 (SIGSEGV)** |
| `arithmeticPerChannelDimNotInTensor_n` | **136 (SIGFPE)** |
| `dimchgFlexible` | **139 (SIGSEGV)** |
| `dimchgFlexibleShortRank_n`, `pushShortTensor_n`, `pushShortFlexibleHeader_n`, `pushShortFlexibleData_n` | fail (the buffer is accepted) |
| `arithmeticPerChannelDimNotInTensorAccel_n`, `arithmeticPerChannelIndexOutOfRange_n`, `arithmeticPerChannelIndexOutOfRangeAccel_n`, `arithmeticPerChannelIndexOverflow_n` | fail (the buffer is accepted) |
| `arithmeticPerChannelDimOutOfRank_n`, `arithmeticPerChannelDimOverflow_n` | fail (the option is accepted) |
| SSAT `transform_arithmetic` `10_n` | fail (the pipeline succeeds) |

The behaviour-preserving side is pinned as well: `dimchg` (the `0:N` cases),
`pushLongTensor` (a memory larger than the described size) and
`arithmeticPerChannel` pass on both the pre-fix and the fixed element, and
`arithmeticPerChannelAccel` is new positive coverage of the ORC per-channel
path with an explicit channel index, which had none. `_test_dimchg()` compares
the whole output against an independently derived reference permutation and
asserts the negotiated output dimension, so a later change to either the
kernel or `convert_dimension()` cannot pass unnoticed.

Every intermediate commit builds and passes on its own. Locally 126/127
`testTensorTransform` cases pass (`negotiationChainWithFilter` needs a tflite
fixture this machine does not build), and SSAT `transform_arithmetic` 37/37,
`transform_dimchg` 13/13, `transform_typecast` 43/43, `transform_stand` 9/9,
`transform_transpose` 16/16, `transform_clamp` 10/10, `transform_padding`
10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
