### PR TITLE
[Element/Merge] Refuse inputs that do not fit the merged tensor

### DIFF
--- a/Documentation/component-description.md
+++ b/Documentation/component-description.md
@@ -107,6 +107,7 @@ In this page, we focus on the status of each elements. For requirements and desi
   - This combines multiple single-tensored (```other/tensors,num_tensors=1```) streams into a single-tensored stream by merging dimensions of incoming tensor streams. For example, it may merge two ```dimensions=640:480``` streams into ```dimensions=1280:480```, ```dimensions=640:960```, or ```dimensions=640:480:2```, according to a given configuration.
   - Users can adjust sync-mode and sync-option to change its behaviors of when to create output tensors and how to choose input tensors.
   - Users can adjust how dimensions are merged (the rank merged, the order of merged streams).
+  - The incoming streams must share the type and every dimension except the one being merged, and merging is defined over four dimensions, so every stream should declare all four (```dimensions=3:640:480:1```, not ```dimensions=3:640:480```). A stream that disagrees, or whose shape does not fit those four dimensions, is refused — while the caps are negotiated when the disagreement is visible there, and when its first buffer arrives otherwise.
 - [tensor\_split](https://github.com/nnstreamer/nnstreamer/tree/main/gst/nnstreamer/elements/gsttensor_split.c) (stable)
   - This is the opposite of ```tensor_merge```. This splits a single-tensored (```other/tensors,num_tensors=1```) stream into multiple single-tensored streams. For example, a stream of ```dimensions=1920:1080``` may split into ```dimensions=1080:1080``` and ```dimensions=840:1080```.
   - Users can adjust how dimensions are split

--- a/gst/nnstreamer/elements/gsttensor_merge.c
+++ b/gst/nnstreamer/elements/gsttensor_merge.c
@@ -374,6 +374,8 @@ gst_tensor_merge_sink_event (GstCollectPads * pads, GstCollectData * data,
  * @param in_config in tensors config data (multi tensors)
  * @param out_config out tensors config data (single tensor)
  * @return true / false
+ * @note Every FALSE return posts the reason on the bus, which is what lets
+ *       gst_tensor_merge_set_src_caps() give up without adding a vaguer one.
  */
 static gboolean
 gst_tensor_merge_get_merged_config (GstTensorMerge * tensor_merge,
@@ -398,8 +400,11 @@ gst_tensor_merge_get_merged_config (GstTensorMerge * tensor_merge,
   for (i = 1; i < in_config->info.num_tensors; i++) {
     _info = gst_tensors_info_get_nth_info (in_info, i);
 
-    if (type != _info->type)
-      GST_ELEMENT_ERROR (tensor_merge, CORE, NEGOTIATION, (NULL), (NULL));
+    if (type != _info->type) {
+      GST_ELEMENT_ERROR (tensor_merge, CORE, NEGOTIATION, (NULL),
+          ("The tensor type of the input %u does not match the input 0.", i));
+      return FALSE;
+    }
   }
 
   switch (tensor_merge->mode) {
@@ -413,9 +418,12 @@ gst_tensor_merge_get_merged_config (GstTensorMerge * tensor_merge,
           if (j == targetIdx) {
             dim[j] += _info->dimension[j];
           } else {
-            if (dim[j] != _info->dimension[j])
+            if (dim[j] != _info->dimension[j]) {
               GST_ELEMENT_ERROR (tensor_merge, CORE, NEGOTIATION, (NULL),
-                  (NULL));
+                  ("The dimension %d of the input %u does not match the input 0.",
+                      j, i));
+              return FALSE;
+            }
           }
         }
       }
@@ -431,6 +439,8 @@ gst_tensor_merge_get_merged_config (GstTensorMerge * tensor_merge,
     }
       break;
     default:
+      GST_ELEMENT_ERROR (tensor_merge, CORE, NEGOTIATION, (NULL),
+          ("The merge mode is not set to one this element knows."));
       ret = FALSE;
   }
 
@@ -465,6 +475,39 @@ gst_tensor_merge_collect_buffer (GstTensorMerge * tensor_merge,
 }
 
 /**
+ * @brief Get the number of bytes the merge reads from one input tensor.
+ * @details The copy loop takes the dimensions above the merge direction from
+ *          input 0 and the dimensions up to it from the input itself, and it
+ *          strides every input with the element size of input 0. What the loop
+ *          consumes is therefore not what the input's own caps declare: the two
+ *          part company as soon as a sink pad renegotiates, which does not
+ *          re-run the check in gst_tensor_merge_get_merged_config().
+ * @param tensor_merge tensor merger
+ * @param dim the dimensions of input 0
+ * @param element_size the element size of input 0
+ * @param info the tensor info of the input to measure
+ * @return the size in bytes, 0 if a dimension the loop needs is unset
+ * @note The direction is always one of the four the loop knows: an option
+ *       string it does not recognise leaves the previous one in place, and a
+ *       mode other than linear is refused while the source caps are negotiated.
+ */
+static gsize
+gst_tensor_merge_get_input_size (GstTensorMerge * tensor_merge,
+    const tensor_dim dim, gsize element_size, const GstTensorInfo * info)
+{
+  tensor_merge_linear_mode direction = tensor_merge->data_linear.direction;
+  gsize size = element_size;
+  guint i;
+
+  for (i = 0; i <= (guint) direction; i++)
+    size *= info->dimension[i];
+  for (i = (guint) direction + 1; i <= LINEAR_FOURTH; i++)
+    size *= dim[i];
+
+  return size;
+}
+
+/**
  * @brief Generate Output GstMemory
  * @param tensor_merge tensor merger
  * @param tensors_buf collected tensors buffer
@@ -487,7 +530,7 @@ gst_tensor_merge_generate_mem (GstTensorMerge * tensor_merge,
   guint i, j, k, l;
   size_t c, s;
   gsize outSize = 0;
-  gsize element_size;
+  gsize element_size, expected;
   tensor_dim dim;
   tensor_type type;
 
@@ -507,6 +550,21 @@ gst_tensor_merge_generate_mem (GstTensorMerge * tensor_merge,
       ret = GST_FLOW_ERROR;
       goto error_ret;
     }
+
+    _info = gst_tensors_info_get_nth_info (info, i);
+    expected = gst_tensor_merge_get_input_size (tensor_merge, dim,
+        element_size, _info);
+    if (mInfo[i].size != expected) {
+      GST_ELEMENT_ERROR (tensor_merge, STREAM, WRONG_TYPE,
+          ("An input does not fit the tensor the merge builds."),
+          ("The memory of the input %u holds %" G_GSIZE_FORMAT " bytes, "
+              "the merge reads %" G_GSIZE_FORMAT " from it.", i,
+              mInfo[i].size, expected));
+      num_mem = i + 1;
+      ret = GST_FLOW_ERROR;
+      goto error_ret;
+    }
+
     outSize += mInfo[i].size;
   }
 
@@ -637,7 +695,8 @@ gst_tensor_merge_set_src_caps (GstTensorMerge * tensor_merge)
 
     if (!gst_tensor_merge_get_merged_config (tensor_merge,
             &tensor_merge->tensors_config, &config)) {
-      goto nego_error;
+      /* the reason is already on the bus, do not post a second, vaguer one */
+      return FALSE;
     }
 
     /** Internal Logic Error? */
@@ -651,7 +710,6 @@ gst_tensor_merge_set_src_caps (GstTensorMerge * tensor_merge)
     gst_caps_unref (newcaps);
   }
 
-nego_error:
   if (!tensor_merge->negotiated) {
     GST_WARNING_OBJECT (tensor_merge, "failed to set caps");
     GST_ELEMENT_ERROR (tensor_merge, CORE, NEGOTIATION, (NULL), (NULL));
@@ -743,7 +801,11 @@ gst_tensor_merge_collected (GstCollectPads * pads,
     goto beach;
   }
 
-  gst_tensor_merge_generate_mem (tensor_merge, tensors_buf, tensor_buf);
+  ret = gst_tensor_merge_generate_mem (tensor_merge, tensors_buf, tensor_buf);
+  if (ret != GST_FLOW_OK) {
+    gst_buffer_unref (tensor_buf);
+    goto beach;
+  }
 
   ret = gst_pad_push (tensor_merge->srcpad, tensor_buf);
   tensor_merge->need_set_time = TRUE;

--- a/tests/nnstreamer_merge/runTest.sh
+++ b/tests/nnstreamer_merge/runTest.sh
@@ -163,6 +163,57 @@ callCompareTest testsynch08_1.golden testsynch08_1.log 19-2 "Compare 19-2" 1 0
 callCompareTest testsynch08_2.golden testsynch08_2.log 19-3 "Compare 19-3" 1 0
 callCompareTest testsynch08_3.golden testsynch08_3.log 19-4 "Compare 19-4" 1 0
 
+##
+## @brief Run a pipeline that the element has to refuse without crashing.
+## @details gstTest() passes a negative case on any non-zero exit, so it reads
+##          a segmentation fault as a refusal. gst-launch-1.0 exits 1 when the
+##          pipeline cannot start and 255 on a runtime error, while the shell
+##          reports a signal as 128 + n.
+##          A refusal that turns into a hang has to fail the case as well, so
+##          the pipeline runs under a time limit rather than holding the job.
+## @param $1 the pipeline to run
+## @param $2 the test case id
+function gstTestRefused() {
+    local prefix=""
+    local limit=30
+    local retcode
+
+    if [[ "$VALGRIND" -eq "1" ]]; then
+        prefix="valgrind --track-origins=yes ${VALGRIND_SUPPRESSION}"
+        limit=300
+    fi
+
+    if command -v timeout &> /dev/null; then
+        prefix="timeout ${limit} ${prefix}"
+    fi
+
+    if [[ "${SILENT}" -eq "1" ]]; then
+        eval $prefix gst-launch-1.0 -f -q $1 &> /dev/null
+    else
+        eval $prefix gst-launch-1.0 -f -q $1
+    fi
+    retcode=$?
+
+    if [[ "${retcode}" -eq "1" || "${retcode}" -eq "255" ]]; then
+        testResult 1 "$2" "gst-launch of case $2" 0
+    else
+        testResult 0 "$2" "gst-launch of case $2 exited with ${retcode}" 0
+    fi
+}
+
+# Inputs that differ outside the merge direction are refused. Merging them
+# reads 30000 bytes past the second input and writes 30000 past the output.
+gstTestRefused "--gst-plugin-path=${PATH_TO_PLUGIN}  tensor_merge name=merge mode=linear option=0 ! filesink location=mismatch.log filesrc location=channel_00.dat blocksize=60000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:50:100:1 input-type=float32 ! merge.sink_0 filesrc location=channel_01.dat blocksize=10000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=2:25:50:1 input-type=float32 ! merge.sink_1" 20_n
+
+# An input of another type is refused for the same reason: the element size of
+# input 0 decides the stride the copy loop uses for every input.
+gstTestRefused "--gst-plugin-path=${PATH_TO_PLUGIN}  tensor_merge name=merge mode=linear option=0 ! filesink location=mismatch.log filesrc location=channel_00.dat blocksize=60000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:50:100:1 input-type=float32 ! merge.sink_0 filesrc location=channel_01.dat blocksize=15000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:50:100:1 input-type=uint8 ! merge.sink_1" 21_n
+
+# The width direction, where merging 3:100:50:1 with 3:200:25:1 used to read
+# 60000 bytes past the second input and write 60000 past the output. The height
+# the two disagree on is what the element now refuses to negotiate.
+gstTestRefused "--gst-plugin-path=${PATH_TO_PLUGIN}  tensor_merge name=merge mode=linear option=1 ! filesink location=mismatch.log filesrc location=width_100.dat blocksize=60000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:100:50:1 input-type=float32 ! merge.sink_0 filesrc location=width_200.dat blocksize=60000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:200:25:1 input-type=float32 ! merge.sink_1" 22_n
+
 rm *.log *.bmp *.png *.golden *.raw *.dat
 
 report

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -11948,6 +11948,409 @@ TEST (testTensorDecoder, pushDirectVideoInputSizeTooLarge_n)
 }
 
 /**
+ * @brief What a tensor_merge test saw arrive at its tensor_sink.
+ */
+typedef struct {
+  guint received; /**< the number of buffers, bumped by the streaming thread */
+  gsize size; /**< the size of the last buffer */
+  guint8 head[12]; /**< the first bytes of the last buffer */
+  guint8 tail[12]; /**< the last bytes of the last buffer */
+  gchar error_src[32]; /**< the element an error was posted by, if any */
+  GQuark error_domain; /**< the domain of that error */
+  gint error_code; /**< the code of that error */
+} mergeOutput;
+
+/**
+ * @brief Record which element ended the run, so a refusal by something else in
+ *        the pipeline cannot stand in for the one the case is about.
+ */
+static void
+_record_merge_message (GstMessage *msg, mergeOutput *out)
+{
+  const gchar *name = NULL;
+  GError *err = NULL;
+
+  if (msg == NULL || GST_MESSAGE_TYPE (msg) != GST_MESSAGE_ERROR)
+    return;
+
+  if (GST_MESSAGE_SRC (msg))
+    name = GST_OBJECT_NAME (GST_MESSAGE_SRC (msg));
+  g_strlcpy (out->error_src, name ? name : "", sizeof (out->error_src));
+
+  gst_message_parse_error (msg, &err, NULL);
+  if (err) {
+    out->error_domain = err->domain;
+    out->error_code = err->code;
+    g_error_free (err);
+  }
+}
+
+/**
+ * @brief tensor_sink handler recording the merged buffer.
+ */
+static void
+_record_merge_output (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  mergeOutput *out = (mergeOutput *) user_data;
+  GstMapInfo info;
+
+  UNUSED (element);
+
+  if (gst_buffer_map (buffer, &info, GST_MAP_READ)) {
+    gsize taken = MIN (info.size, sizeof (out->head));
+
+    out->size = info.size;
+    memcpy (out->head, info.data, taken);
+    memcpy (out->tail, info.data + info.size - taken, taken);
+    gst_buffer_unmap (buffer, &info);
+  }
+
+  g_atomic_int_inc (&out->received);
+}
+
+/**
+ * @brief Run a tensor_merge pipeline until it ends and report what came out.
+ * @details The three ways this can end are told apart on purpose: a case that
+ *          expects a refusal has to fail, not pass, when the description no
+ *          longer builds or when the element hangs instead of refusing.
+ * @param[out] out what the tensor_sink named 'sinkx' received
+ * @return GST_MESSAGE_EOS or GST_MESSAGE_ERROR as the pipeline posted it,
+ *         GST_MESSAGE_ANY if it could not be built, GST_MESSAGE_UNKNOWN if it
+ *         posted neither within the time limit
+ */
+static GstMessageType
+_run_merge_pipeline (const gchar *desc, mergeOutput *out)
+{
+  GstElement *pipeline, *sink;
+  GstBus *bus;
+  GstMessage *msg;
+  GstMessageType type;
+
+  memset (out, 0, sizeof (mergeOutput));
+
+  pipeline = gst_parse_launch (desc, NULL);
+  if (pipeline == NULL)
+    return GST_MESSAGE_ANY;
+
+  sink = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  if (sink == NULL) {
+    gst_object_unref (pipeline);
+    return GST_MESSAGE_ANY;
+  }
+  g_signal_connect (sink, "new-data", G_CALLBACK (_record_merge_output), out);
+
+  setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT);
+
+  bus = gst_element_get_bus (pipeline);
+  msg = gst_bus_timed_pop_filtered (bus, 10 * GST_SECOND,
+      (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+  type = (msg != NULL) ? GST_MESSAGE_TYPE (msg) : GST_MESSAGE_UNKNOWN;
+  _record_merge_message (msg, out);
+  if (msg)
+    gst_message_unref (msg);
+  gst_object_unref (bus);
+
+  setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT);
+  gst_object_unref (sink);
+  gst_object_unref (pipeline);
+
+  return type;
+}
+
+/**
+ * @brief Two identical streams merged along the channel direction.
+ * @details The bytes pin the interleave the copy loop performs: one pixel of
+ *          the black stream, then one pixel of the white stream.
+ */
+TEST (testTensorMerge, linearFirstDirection)
+{
+  mergeOutput out;
+
+  EXPECT_EQ (_run_merge_pipeline ("tensor_merge name=merge mode=linear option=0 ! tensor_sink name=sinkx "
+                                  "videotestsrc num-buffers=1 pattern=black ! "
+                                  "video/x-raw,format=RGB,width=20,height=20,framerate=30/1 ! tensor_converter ! merge.sink_0 "
+                                  "videotestsrc num-buffers=1 pattern=white ! "
+                                  "video/x-raw,format=RGB,width=20,height=20,framerate=30/1 ! tensor_converter ! merge.sink_1",
+                 &out),
+      GST_MESSAGE_EOS);
+
+  EXPECT_EQ (out.received, 1U);
+  EXPECT_EQ (out.size, 2400U);
+  for (guint i = 0; i < 3; i++) {
+    EXPECT_EQ (out.head[i], 0);
+    EXPECT_EQ (out.head[i + 3], 255);
+  }
+}
+
+/**
+ * @brief Two streams of different heights merged along the height direction.
+ * @details Nothing else in the tree merges streams that differ in the merge
+ *          direction with option=2: the existing height cases all carry equal
+ *          sizes, so the per-input chunk of that copy loop is never told apart
+ *          from input 0's. The bytes at both ends pin the two chunks.
+ */
+TEST (testTensorMerge, linearThirdDirection)
+{
+  mergeOutput out;
+
+  EXPECT_EQ (_run_merge_pipeline ("tensor_merge name=merge mode=linear option=2 ! tensor_sink name=sinkx "
+                                  "videotestsrc num-buffers=1 pattern=black ! "
+                                  "video/x-raw,format=RGB,width=20,height=20,framerate=30/1 ! tensor_converter ! merge.sink_0 "
+                                  "videotestsrc num-buffers=1 pattern=white ! "
+                                  "video/x-raw,format=RGB,width=20,height=10,framerate=30/1 ! tensor_converter ! merge.sink_1",
+                 &out),
+      GST_MESSAGE_EOS);
+
+  EXPECT_EQ (out.received, 1U);
+  EXPECT_EQ (out.size, (gsize) (3 * 20 * 30));
+  for (guint i = 0; i < sizeof (out.head); i++) {
+    EXPECT_EQ (out.head[i], 0);
+    EXPECT_EQ (out.tail[i], 255);
+  }
+}
+
+/**
+ * @brief An input whose other dimensions differ is refused.
+ * @details The copy loop walks every input with the dimensions of input 0, so
+ *          a smaller input is read past its end and the output, sized from the
+ *          input sizes, is written past its end (1200 B read from 300 B, 2400 B
+ *          written into 1500 B). The mismatch used to be reported and ignored.
+ */
+TEST (testTensorMerge, dimensionMismatch_n)
+{
+  mergeOutput out;
+
+  EXPECT_EQ (_run_merge_pipeline ("tensor_merge name=merge mode=linear option=0 ! tensor_sink name=sinkx "
+                                  "videotestsrc num-buffers=1 ! "
+                                  "video/x-raw,format=RGB,width=20,height=20,framerate=30/1 ! tensor_converter ! merge.sink_0 "
+                                  "videotestsrc num-buffers=1 ! "
+                                  "video/x-raw,format=RGB,width=10,height=10,framerate=30/1 ! tensor_converter ! merge.sink_1",
+                 &out),
+      GST_MESSAGE_ERROR);
+
+  EXPECT_STREQ (out.error_src, "merge");
+  EXPECT_EQ (out.error_domain, (GQuark) GST_CORE_ERROR);
+  EXPECT_EQ (out.error_code, GST_CORE_ERROR_NEGOTIATION);
+  EXPECT_EQ (out.received, 0U);
+}
+
+/**
+ * @brief An input of another type is refused.
+ * @details The element size of input 0 decides the stride for every input, so
+ *          a float32 input 0 makes the loop read four times the uint8 input.
+ */
+TEST (testTensorMerge, typeMismatch_n)
+{
+  mergeOutput out;
+
+  EXPECT_EQ (_run_merge_pipeline (
+                 "tensor_merge name=merge mode=linear option=0 ! tensor_sink name=sinkx "
+                 "videotestsrc num-buffers=1 ! "
+                 "video/x-raw,format=RGB,width=20,height=20,framerate=30/1 ! tensor_converter ! "
+                 "tensor_transform mode=typecast option=float32 ! merge.sink_0 "
+                 "videotestsrc num-buffers=1 ! "
+                 "video/x-raw,format=RGB,width=20,height=20,framerate=30/1 ! tensor_converter ! merge.sink_1",
+                 &out),
+      GST_MESSAGE_ERROR);
+
+  EXPECT_STREQ (out.error_src, "merge");
+  EXPECT_EQ (out.error_domain, (GQuark) GST_CORE_ERROR);
+  EXPECT_EQ (out.error_code, GST_CORE_ERROR_NEGOTIATION);
+  EXPECT_EQ (out.received, 0U);
+}
+
+/**
+ * @brief A sink pad that renegotiates to another dimension is refused.
+ * @details The element negotiates its source caps once and never looks at a
+ *          later caps event, so the check that compares the inputs with each
+ *          other runs only on the first buffer. The copy still strides input 1
+ *          with the dimensions of input 0 afterwards, which is the same
+ *          overrun by another route.
+ */
+TEST (testTensorMerge, renegotiatedDimension_n)
+{
+  mergeOutput out;
+
+  EXPECT_EQ (_run_merge_pipeline (
+                 "tensor_merge name=merge mode=linear option=0 ! tensor_sink name=sinkx "
+                 "videotestsrc num-buffers=4 ! "
+                 "video/x-raw,format=RGB,width=20,height=20,framerate=30/1 ! tensor_converter ! merge.sink_0 "
+                 "concat name=c ! merge.sink_1 "
+                 "videotestsrc num-buffers=2 ! "
+                 "video/x-raw,format=RGB,width=20,height=20,framerate=30/1 ! tensor_converter ! c. "
+                 "videotestsrc num-buffers=2 ! "
+                 "video/x-raw,format=RGB,width=10,height=10,framerate=30/1 ! tensor_converter ! c.",
+                 &out),
+      GST_MESSAGE_ERROR);
+
+  EXPECT_STREQ (out.error_src, "merge");
+  EXPECT_EQ (out.error_domain, (GQuark) GST_STREAM_ERROR);
+  EXPECT_EQ (out.error_code, GST_STREAM_ERROR_WRONG_TYPE);
+  /* the two 20x20 buffers concat hands over first are merged, the third is not */
+  EXPECT_EQ (out.received, 2U);
+  EXPECT_EQ (out.size, 2400U);
+}
+
+/**
+ * @brief Feed two appsrc buffers of a chosen size into tensor_merge.
+ * @details appsrc lets the caps and the memory disagree, which no in-tree
+ *          source does. Each buffer is pushed with the caps of the dimension
+ *          given for it, so the element sees a self-consistent stream.
+ * @param[out] out what the tensor_sink named 'sinkx' received
+ * @return GST_MESSAGE_EOS or GST_MESSAGE_ERROR as the pipeline posted it,
+ *         GST_MESSAGE_UNKNOWN if it posted neither within the time limit
+ */
+static GstMessageType
+_run_merge_appsrc (const gchar *option, const gchar *dim0, gsize size0,
+    const gchar *dim1, gsize size1, mergeOutput *out)
+{
+  GstElement *pipeline, *src[2], *sink;
+  GstTensorsConfig config;
+  GstBus *bus;
+  GstMessage *msg;
+  GstFlowReturn ret;
+  GstMessageType type;
+  const gchar *dim[2] = { dim0, dim1 };
+  gsize size[2] = { size0, size1 };
+  gchar *desc;
+  guint i;
+
+  memset (out, 0, sizeof (mergeOutput));
+
+  desc = g_strdup_printf ("tensor_merge name=merge mode=linear option=%s ! "
+                          "tensor_sink name=sinkx "
+                          "appsrc name=src0 ! merge.sink_0 appsrc name=src1 ! merge.sink_1",
+      option);
+  pipeline = gst_parse_launch (desc, NULL);
+  g_free (desc);
+  if (pipeline == NULL)
+    return GST_MESSAGE_ANY;
+
+  sink = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  if (sink == NULL) {
+    gst_object_unref (pipeline);
+    return GST_MESSAGE_ANY;
+  }
+  g_signal_connect (sink, "new-data", G_CALLBACK (_record_merge_output), out);
+
+  for (i = 0; i < 2; i++) {
+    gchar *name = g_strdup_printf ("src%u", i);
+    GstCaps *caps;
+
+    src[i] = gst_bin_get_by_name (GST_BIN (pipeline), name);
+    g_free (name);
+
+    gst_tensors_config_init (&config);
+    config.info.num_tensors = 1;
+    config.info.info[0].type = _NNS_UINT8;
+    gst_tensor_parse_dimension (dim[i], config.info.info[0].dimension);
+    config.rate_n = 30;
+    config.rate_d = 1;
+    caps = gst_tensor_caps_from_config (&config);
+    g_object_set (src[i], "caps", caps, NULL);
+    gst_caps_unref (caps);
+    gst_tensors_config_free (&config);
+  }
+
+  /* the sink prerolls on a merged buffer, so it may never reach PLAYING */
+  gst_element_set_state (pipeline, GST_STATE_PLAYING);
+
+  for (i = 0; i < 2; i++) {
+    /* zeroed: append_memory() sniffs a meta header from the first bytes */
+    GstBuffer *buf = gst_buffer_new_allocate (NULL, size[i], NULL);
+
+    gst_buffer_memset (buf, 0, 0, size[i]);
+    /* the push-buffer action signal is transfer-none, unlike the C entry point */
+    g_signal_emit_by_name (src[i], "push-buffer", buf, &ret);
+    gst_buffer_unref (buf);
+    if (ret != GST_FLOW_OK)
+      break;
+  }
+
+  bus = gst_element_get_bus (pipeline);
+  msg = gst_bus_timed_pop_filtered (bus, 10 * GST_SECOND,
+      (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+  type = (msg != NULL) ? GST_MESSAGE_TYPE (msg) : GST_MESSAGE_UNKNOWN;
+  _record_merge_message (msg, out);
+  if (msg)
+    gst_message_unref (msg);
+  gst_object_unref (bus);
+
+  gst_element_set_state (pipeline, GST_STATE_NULL);
+  gst_object_unref (sink);
+  gst_object_unref (src[1]);
+  gst_object_unref (src[0]);
+  gst_object_unref (pipeline);
+
+  return type;
+}
+
+/**
+ * @brief A buffer smaller than the tensor its caps declare is refused.
+ * @details The dimensions agree here, so nothing at negotiation time can see
+ *          it; only the incoming memory tells the element the copy would run
+ *          past the end. Every direction is tried because the copy bounds are
+ *          written out once per direction, and so is the size they have to
+ *          agree with.
+ */
+TEST (testTensorMerge, undersizedMemory_n)
+{
+  mergeOutput out;
+
+  for (const gchar *option : { "0", "1", "2", "3" }) {
+    EXPECT_EQ (_run_merge_appsrc (option, "3:20:20:1", 3 * 20 * 20, "3:20:20:1",
+                   3 * 10 * 10, &out),
+        GST_MESSAGE_ERROR)
+        << "option=" << option;
+    EXPECT_STREQ (out.error_src, "merge") << "option=" << option;
+    EXPECT_EQ (out.error_domain, (GQuark) GST_STREAM_ERROR) << "option=" << option;
+    EXPECT_EQ (out.error_code, GST_STREAM_ERROR_WRONG_TYPE) << "option=" << option;
+    EXPECT_EQ (out.received, 0U) << "option=" << option;
+  }
+}
+
+/**
+ * @brief An input of a lower rank is refused in the batch direction.
+ * @details The dimension array ends at the first zero, so a rank 3 tensor has
+ *          dimension[3] == 0 and the batch-direction stride is zero: the input
+ *          is never copied and its share of the output, which is sized from
+ *          the input sizes, goes downstream uninitialised.
+ */
+TEST (testTensorMerge, lowerRankBatchDirection_n)
+{
+  mergeOutput out;
+
+  EXPECT_EQ (_run_merge_appsrc ("3", "3:4:4:1", 3 * 4 * 4, "3:4:4", 3 * 4 * 4, &out),
+      GST_MESSAGE_ERROR);
+  EXPECT_STREQ (out.error_src, "merge");
+  EXPECT_EQ (out.error_domain, (GQuark) GST_STREAM_ERROR);
+  EXPECT_EQ (out.error_code, GST_STREAM_ERROR_WRONG_TYPE);
+  EXPECT_EQ (out.received, 0U);
+}
+
+/**
+ * @brief A mode the element does not know is refused by the element itself.
+ * @details The source caps cannot be built without a mode, and the reason has
+ *          to come from here: the flow error alone only makes the source post
+ *          a generic stream error, which says nothing about what is wrong.
+ */
+TEST (testTensorMerge, unknownMode_n)
+{
+  mergeOutput out;
+
+  EXPECT_EQ (_run_merge_pipeline ("tensor_merge name=merge mode=nosuchmode ! tensor_sink name=sinkx "
+                                  "videotestsrc num-buffers=1 ! "
+                                  "video/x-raw,format=RGB,width=20,height=20,framerate=30/1 ! tensor_converter ! merge.sink_0",
+                 &out),
+      GST_MESSAGE_ERROR);
+
+  EXPECT_STREQ (out.error_src, "merge");
+  EXPECT_EQ (out.error_domain, (GQuark) GST_CORE_ERROR);
+  EXPECT_EQ (out.error_code, GST_CORE_ERROR_NEGOTIATION);
+  EXPECT_EQ (out.received, 0U);
+}
+
+/**
  * @brief Main function for unit test.
  */
 int


### PR DESCRIPTION
Addresses item **C19** of #4920.

`tensor_merge` reported a type or dimension mismatch between its inputs with `GST_ELEMENT_ERROR` and then merged them anyway. The copy loop walks every input with the dimensions and the element size of input 0, so a smaller or narrower input is read past its end and the output, sized from the input sizes, is written past its end.

Merging `3:50:100:1` float32 with `2:25:50:1` float32 along the channel direction reads 40000 bytes from a 10000-byte memory and writes 100000 bytes into a 70000-byte output. `gst-launch-1.0` exits 139 on it, three runs out of three.

### What changed

- `gst_tensor_merge_get_merged_config()` returns FALSE on a type or a dimension mismatch, and its two messages now name the input and the dimension that disagreed instead of passing `NULL` for both texts.
- `gst_tensor_merge_generate_mem()` compares every mapped input memory with the size of the tensor its caps declare. The dimensions come from the caps, the bytes come from the buffer, so the negotiation check alone does not bound the copy; this is also what makes the output large enough for what is written into it.
- `gst_tensor_merge_collected()` stops on a failed `generate_mem()`. It ignored the result, so the function's existing error paths pushed an empty buffer downstream.

The element is static-only on both pads (`GST_TENSOR_CAP_DEFAULT` / `GST_TENSORS_CAP_WITH_NUM ("1")`), so an incoming memory has to be exactly the size of its tensor, the same rule `tensor_filter` and `tensor_decoder` apply.

### Tests

`testTensorMerge` in `tests/nnstreamer_plugins/unittest_plugins.cc`:

| case | on this branch | on the element as it was |
| --- | --- | --- |
| `linearFirstDirection` | passes | passes |
| `dimensionMismatch_n` | passes | SIGABRT (glibc heap corruption) |
| `typeMismatch_n` | passes | SIGABRT |
| `undersizedMemory_n` | passes | SIGABRT |

The positive case pins the interleave the channel-direction copy performs (one pixel of a black stream, then one of a white stream), so a change to the copy strides is caught as well as a crash.

`tests/nnstreamer_merge/runTest.sh` gains cases `20_n` and `21_n`. They do not use `gstTest()`: it passes a negative case on **any** non-zero exit, so it reads a segmentation fault as a refusal and both cases pass on the unfixed element with it. `gstTestRefused()` requires the exit code of a refusal (1 or 255) and reports the unfixed element's 139. It honours `$VALGRIND`/`$VALGRIND_SUPPRESSION` the way `gstTest()` does.

### Verification

- `meson test -C build`: 19/21, the two failures being this machine's pre-existing `unittest_filter_python3` (numpy 2 ABI) and `unittest_trainer` (30 s timeout), identical before and after.
- `tests/nnstreamer_merge/runTest.sh`: whole group green, all 19 pre-existing positive cases and their golden comparisons included.
- `indent` with the CI flags, `clang-format`, `doxygen-tag.sh` and `newline.sh` clean on the changed files; a second build configured `-Dwerror=true -Dcpp_args="-Wextra -Wsign-compare"` builds the new tests without a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
