### PR TITLE
[Test/Join] Hold the pad release feeder to a lead over the sink

### DIFF
--- a/tests/gstreamer_join/unittest_join.cc
+++ b/tests/gstreamer_join/unittest_join.cc
@@ -457,7 +457,20 @@ TEST (join, eosAfterPadRelease)
 typedef struct {
   GstElement *appsrc;
   gint stop;
+  guint *received;
+  guint pushed;
+  guint max_lead;
 } JoinFeeder;
+
+/**
+ * @brief Buffers the feeder may push before the sink has taken them.
+ * @detail appsrc queues whatever it is given, so an unheld feeder runs ahead
+ *         by as much as the test thread is slow - milliseconds natively, and
+ *         minutes under a memory checker, where the queue it leaves behind is
+ *         then torn down one buffer at a time. A lead keeps the pad streaming
+ *         without letting that cost grow with the environment.
+ */
+#define JOIN_FEEDER_LEAD (8U)
 
 /**
  * @brief Push buffers into an appsrc until the caller asks it to stop.
@@ -468,10 +481,24 @@ join_feeder_thread (gpointer data)
   JoinFeeder *feeder = (JoinFeeder *) data;
 
   while (!g_atomic_int_get (&feeder->stop)) {
-    GstBuffer *buf = gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192);
+    GstBuffer *buf;
+    guint taken = g_atomic_int_get (feeder->received);
+    guint lead = feeder->pushed > taken ? feeder->pushed - taken : 0;
+
+    if (lead > feeder->max_lead)
+      feeder->max_lead = lead;
+
+    if (lead >= JOIN_FEEDER_LEAD) {
+      g_thread_yield ();
+      continue;
+    }
+
+    buf = gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192);
 
     if (gst_app_src_push_buffer (GST_APP_SRC (feeder->appsrc), buf) != GST_FLOW_OK)
       break;
+
+    feeder->pushed++;
   }
 
   return NULL;
@@ -501,7 +528,7 @@ run_pad_release_while_streaming (void)
 {
   GstElement *appsrc_0, *join_handle, *sink_handle;
   GstPad *sinkpad_0, *active_pad = NULL;
-  JoinFeeder feeder = { NULL, 0 };
+  JoinFeeder feeder = {};
   GThread *thread;
   guint received = 0, n_pads = 0;
   gboolean released = FALSE, started = TRUE;
@@ -526,6 +553,7 @@ run_pad_release_while_streaming (void)
     started = FALSE;
 
   feeder.appsrc = appsrc_0;
+  feeder.received = &received;
   thread = g_thread_new ("join-feeder", join_feeder_thread, &feeder);
   if (!wait_pipeline_process_buffers (&received, 1, TEST_TIMEOUT_LIMIT_MS))
     started = FALSE;
@@ -536,6 +564,8 @@ run_pad_release_while_streaming (void)
 
   g_atomic_int_set (&feeder.stop, 1);
   g_thread_join (thread);
+  EXPECT_LE (feeder.max_lead, JOIN_FEEDER_LEAD);
+  EXPECT_GT (feeder.max_lead, 0U);
 
   g_object_get (join_handle, "active-pad", &active_pad, NULL);
   g_object_get (join_handle, "n-pads", &n_pads, NULL);


### PR DESCRIPTION
`join.padReleaseWhileStreaming` is the largest and by far the most variable item left in the Valgrind step. Under memcheck in CI it has taken 19, 29, 72, 103, 204 and 219 s across six consecutive runs and **830 s** in a seventh — against 250 ms natively. That 830 s run spent **22.5 of the step's 30-minute budget**, and since #4936 a step timeout is the one failure that step cannot absorb, so one bad draw turns a contributor's PR red.

## Why it varies

The test keeps a pad streaming while it is released. The feeder thread pushed as fast as it could:

```c
while (!g_atomic_int_get (&feeder->stop)) {
  GstBuffer *buf = gst_buffer_new_wrapped (_g_memdup (test_frames[0], 192), 192);
  if (gst_app_src_push_buffer (GST_APP_SRC (feeder->appsrc), buf) != GST_FLOW_OK)
    break;
}
```

appsrc queues whatever it is given, so how much that thread leaves behind is set by how long the *test* thread takes to reach the release — and the queue is torn down one buffer at a time at the end of the attempt. The slower the environment, the more there is to tear down. Timing a 22 s local run with `GST_DEBUG=GST_STATES:4`, 12.9 s and 7.8 s of it were single gaps inside the last pipeline's teardown.

That is the feedback loop, and it is why the same test costs 250 ms natively and 830 s under a checker.

## The change

Hold the feeder to a lead of eight buffers over what the sink has taken. It pushes again as soon as the sink takes one, so the pad keeps streaming; the queue simply cannot grow with how slow the rest is.

Measured on one machine, memcheck against native:

| | time | attempts |
|---|---|---|
| before, memcheck | 14.9 s | 4 of 20 |
| **after, memcheck** | **1.2 s** | **20 of 20** |
| native | 213 ms | 20 of 20 |

Quicker *and* more thorough. The 10 s budget in this test exists to stop a checker paying for every attempt, and it was doing that by cutting the run short at 4 — exactly where each attempt had become expensive. With the queue bounded the budget is no longer reached at all, so memcheck now gets the full twenty.

The whole `unittest_join` binary under memcheck goes from 160 s (a healthy CI run) to 8.8 s locally.

The review put an A/B on the same CI infrastructure an hour apart, which is better evidence than any of my local numbers:

| | native | memcheck |
|---|---|---|
| main, unmodified (job of #4937) | 249 ms | **93,996 ms** |
| this PR | 213 ms | **760 ms** |

## It catches the race sooner, not later

This is a race regression test, so faster is worthless if it stops catching the race. I reintroduced the defect it was written for — releasing the pad without stopping its streaming thread first, so the thread can make the released pad active again after the release has cleared it — by moving `gst_pad_set_active` and `gst_element_remove_pad` after the locked section in `gst_join_release_pad`, and counted attempts until the test noticed:

| feeder | attempts to first detection | per attempt |
|---|---|---|
| before | 14, 64, 25, 32, 50 | ~1 in 38 |
| **after** | **1, 1, 2, 2, 4** | **~1 in 2** |

I first reported this as whole runs of the test caught it — 10 of 20 before, 20 of 20 after. Those numbers follow from the rates above and the 20-attempt budget, but they are a poor thing to quote: at one attempt in 38, whether a run notices is close to a coin toss against machine load, and a reviewer running the same control on this same machine saw no detection either way. The attempt counts above are what is stable, and the reviewer's independent higher-N measurement agreed with them: about 4-5% per attempt unthrottled against 37-49% throttled.

A first attempt at that control moved only `gst_pad_set_active` and caught nothing with either feeder — `gst_element_remove_pad` deactivates the pad itself, so that mutation was a no-op. Worth recording for the next person who needs this control.

## The lead is not a tuned number

Sweeping it, with the correct element for cost and the reintroduced defect for detection:

| lead | memcheck | attempts to first detection |
|---|---|---|
| 2 | 1074 ms | 3 |
| 4 | 1111 ms | 4 |
| 8 | 1136 ms | 2 |
| 16 | 1133 ms | 3 |
| 64 | 1178 ms | 3 |

No trend in either column across a 32x range. What matters is that a bound exists at all — unbounded is the 14.9 s and one-in-38 above — so eight is a round number in a wide flat region rather than a tuned one.

## The wait is a yield, and that is measured too

Review suggested `g_usleep (100)` in place of the `g_thread_yield ()`, to stop the feeder competing for CPU with the pipeline on a 2-vCPU runner. Measured, it costs the race:

| wait | memcheck | native | attempts to first detection |
|---|---|---|---|
| `g_thread_yield ()` | 1.1 s | 211 ms | 5, 1, 1, 1, 1 — mean 1 |
| `g_usleep (100)` | 1.1 s | 211 ms | 11, 60, 17, 45, 3 — mean **27** |

Same cost either way, and detection goes most of the way back to the unbounded 38. The pad sits idle for the sleep after every buffer the sink takes, which is a long time next to the window this test is aiming at. Keeping the yield.

## Testing

`JOIN_FEEDER_LEAD` is asserted from both sides rather than merely applied: the feeder records the largest lead it reached, and the test checks it is at most the lead — so removing the hold fails the test rather than only showing up as a slow job — and more than none, so a hold that stopped the feeder outright would fail too. Neither assertion missed in 30 native runs or 3 under memcheck.

All 13 `unittest_join` cases pass natively and under memcheck against the unmodified element. clang-format clean.

## Not in this change

The other two ways to bound this were considered and dropped. `appsrc`'s `leaky-type` would be the idiomatic answer but needs GStreamer 1.20, above what this project builds against elsewhere. `block=true` risks the opposite failure: after the pad is released nothing drains the queue, so a blocked push would never return and `g_thread_join` would hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
