### PR TITLE
[Decoder] Refuse a stream the decoder cannot decode instead of dereferencing nothing

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
@@ -215,7 +215,8 @@ init_bb (void)
 
     nnstreamer_decoder_set_custom_property_desc (decoder_subplugin_bounding_box,
         "option1", custom_prop_desc, "option2",
-        "Location of the label file. This is independent from option1.", "option3",
+        "Location of the label file. Set option1 first: the labels are given to the box properties of its mode.",
+        "option3",
         "Sub-option values that depend on option1;\n"
         "\tfor yolov5 and yolov8 mode:\n"
         "\t\tThe option3 requires up to 3 numbers, which tell\n"
@@ -267,7 +268,7 @@ init_bb (void)
         "\t\t option3=0.5:4:0.2:0.8\n"
         "\t\t option3=0.5:4:1.0:1.0:0.5:0.5:8:16:16:16",
         "option4", "Video Output Dimension (WIDTH:HEIGHT). This is independent from option1.",
-        "option5", "Input Dimension (WIDTH:HEIGHT). Mandatory; the decoded boxes are scaled by this size. This is independent from option1.",
+        "option5", "Input Dimension (WIDTH:HEIGHT). Mandatory; the decoded boxes are scaled by this size. Set option1 first: the size is given to the box properties of its mode.",
         "option6",
         "Whether to track result bounding boxes or not\n"
         "\t\t 0 (default, do not track)\n"
@@ -902,16 +903,17 @@ BoundingBox::setBoxDecodingMode (const char *param)
   }
 
   const char *mode_name = updateDecodingMode (param);
+  BoxProperties *new_bdata = getProperties (mode_name);
+
+  if (new_bdata == nullptr) {
+    nns_loge ("Could not find box properties name %s", param);
+    return FALSE;
+  }
 
   if (g_strcmp0 (mode_name, "yolov8-obb") == 0) {
     mode = YOLOV8_ORIENTED_BOUNDING_BOX;
   }
-  bdata = getProperties (mode_name);
-
-  if (bdata == nullptr) {
-    nns_loge ("Could not find box properties name %s", param);
-    return FALSE;
-  }
+  bdata = new_bdata;
 
   return TRUE;
 }
@@ -922,6 +924,11 @@ BoundingBox::setBoxDecodingMode (const char *param)
 int
 BoundingBox::setLabelPath (const char *param)
 {
+  if (bdata == nullptr) {
+    GST_ERROR ("option1 of boundingbox selects the box decoding mode and has to be set before option2.");
+    return FALSE;
+  }
+
   if (mode == MP_PALM_DETECTION_BOUNDING_BOX) {
     /* palm detection does not need label information */
     return TRUE;
@@ -982,6 +989,11 @@ BoundingBox::setInputModelSize (const char *param)
   if (param == NULL || *param == '\0')
     return TRUE;
 
+  if (bdata == nullptr) {
+    GST_ERROR ("option1 of boundingbox selects the box decoding mode and has to be set before option5.");
+    return FALSE;
+  }
+
   rank = gst_tensor_parse_dimension (param, dim);
 
   if (rank < 2) {
@@ -1015,6 +1027,10 @@ BoundingBox::setOption (BoundingBoxOption option, const char *param)
     return setLabelPath (param);
   } else if (option == BoundingBoxOption::INTERNAL) {
     /* option3 = per-decoding-mode option */
+    if (bdata == nullptr) {
+      GST_ERROR ("option1 of boundingbox selects the box decoding mode and has to be set before option3.");
+      return FALSE;
+    }
     return bdata->setOptionInternal (param);
   } else if (option == BoundingBoxOption::VIDEO_SIZE) {
     return setVideoSize (param);
@@ -1043,6 +1059,11 @@ BoundingBox::getOutCaps (const GstTensorsConfig *config)
 {
   GstCaps *caps;
   char *str;
+
+  if (bdata == nullptr) {
+    GST_ERROR ("The box decoding mode is not configured. Set option1 of boundingbox to the mode the model was trained for.");
+    return NULL;
+  }
 
   int ret = bdata->checkCompatible (config);
   if (!ret)

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.h
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.h
@@ -35,7 +35,7 @@
  *                     tf-ssd (deprecated, recommend to use mobilenet-ssd-postprocess)
  *                     tflite-ssd (deprecated, recommend to use mobilenet-ssd)
  * option2: Location of label file
- *          This is independent from option1
+ *          Set option1 first: the labels are given to the box properties of its mode
  * option3: Any option1-dependent values
  *          !!This depends on option1 values!!
  *          for yolov5 and yolov8 mode:
@@ -89,7 +89,7 @@
  * option4: Video Output Dimension (WIDTH:HEIGHT)
  *          This is independent from option1
  * option5: Input Dimension (WIDTH:HEIGHT)
- *          This is independent from option1
+ *          Set option1 first: the size is given to the box properties of its mode
  *          Mandatory: the decoded boxes are scaled by this size
  * option6: Whether to track result bounding boxes or not
  *          0 (default, do not track)

--- a/gst/nnstreamer/elements/gsttensor_decoder.c
+++ b/gst/nnstreamer/elements/gsttensor_decoder.c
@@ -249,6 +249,14 @@ gst_tensordec_get_media_caps (GstTensorDecoder * self, const GstCaps * caps)
 
   if (gst_tensors_config_from_caps (&config, caps, TRUE)) {
     result = gst_tensordec_get_media_caps_from_config (self, &config);
+    gst_tensors_config_free (&config);
+
+    if (result == NULL) {
+      /* the sub-plugin cannot decode this config, so nothing may come out */
+      GST_ERROR_OBJECT (self,
+          "The decoder sub-plugin does not accept the coming tensor config.");
+      return gst_caps_new_empty ();
+    }
   }
 
   if (result == NULL) {
@@ -623,6 +631,7 @@ gst_tensordec_class_finalize (GObject * object)
 
   gst_tensor_decoder_clean_plugin (self);
 
+  gst_tensors_config_free (&self->tensor_config);
   g_free (self->config_path);
   for (i = 0; i < TensorDecMaxOpNum; ++i) {
     g_free (self->option[i]);
@@ -641,6 +650,7 @@ gst_tensordec_configure (GstTensorDecoder * self, const GstCaps * in_caps,
     const GstCaps * out_caps)
 {
   GstTensorsConfig config;
+  guint i;
 
   if (self->decoder == NULL && !self->is_custom) {
     GST_ERROR_OBJECT (self, "Decoder plugin is not yet configured.");
@@ -661,22 +671,36 @@ gst_tensordec_configure (GstTensorDecoder * self, const GstCaps * in_caps,
     gboolean compatible;
 
     supposed = gst_tensordec_get_media_caps_from_config (self, &config);
+    if (supposed == NULL) {
+      GST_ERROR_OBJECT (self,
+          "The decoder sub-plugin does not accept the coming tensor config.");
+      gst_tensors_config_free (&config);
+      return FALSE;
+    }
+
     compatible = gst_caps_is_always_compatible (out_caps, supposed);
     gst_caps_unref (supposed);
 
     /** Check if outcaps is compatible with new caps */
     if (!compatible) {
       GST_ERROR_OBJECT (self, "The coming tensor config is not valid.");
+      gst_tensors_config_free (&config);
       return FALSE;
     }
 
     gst_tensor_decoder_clean_plugin (self);
     if (self->decoder) {
-      /* not custom code */
-      self->decoder->init (&self->plugin_data);
+      /* not custom code; a fresh private data has none of the options yet */
+      if (self->decoder->init (&self->plugin_data)) {
+        for (i = 0; i < TensorDecMaxOpNum; i++)
+          if (!gst_tensordec_process_plugin_options (self, i))
+            GST_WARNING_OBJECT (self,
+                "Failed to configure while setting the option %d.", (i + 1));
+      }
     }
   }
 
+  gst_tensors_config_free (&self->tensor_config);
   self->tensor_config = config;
   self->configured = TRUE;
   return TRUE;
@@ -953,6 +977,22 @@ gst_tensordec_fixate_caps (GstBaseTransform * trans,
     supposed = gst_tensordec_get_media_caps (self, caps);
   }
 
+  /**
+   * An empty supposed is the refusal gst_tensordec_get_media_caps () reports,
+   * which must not reach the "keep othercaps" fallback below: that is there for
+   * an intersection which came out empty, not for a sub-plugin saying no.
+   * A refused config is normally turned away by transform_caps () before the
+   * fixation is reached, so this stands guard over whatever does not go there.
+   */
+  if (supposed == NULL || gst_caps_is_empty (supposed)) {
+    GST_ERROR_OBJECT (self,
+        "The decoder sub-plugin does not accept the coming tensor config.");
+    if (supposed)
+      gst_caps_unref (supposed);
+    gst_caps_unref (othercaps);
+    return gst_caps_new_empty ();
+  }
+
   result = gst_caps_intersect (othercaps, supposed);
   gst_caps_unref (supposed);
 
@@ -961,6 +1001,14 @@ gst_tensordec_fixate_caps (GstBaseTransform * trans,
     result = othercaps;
   } else {
     gst_caps_unref (othercaps);
+  }
+
+  if (gst_caps_is_any (result)) {
+    /* neither the config nor the peer says what to output, and ANY has no fixed form */
+    GST_ERROR_OBJECT (self,
+        "Cannot tell the output caps of the coming tensor config.");
+    gst_caps_unref (result);
+    return gst_caps_new_empty ();
   }
 
   GST_DEBUG_OBJECT (self, "now fixating %" GST_PTR_FORMAT, result);
@@ -988,12 +1036,26 @@ gst_tensordec_set_caps (GstBaseTransform * trans,
   silent_debug_caps (self, incaps, "from incaps");
   silent_debug_caps (self, outcaps, "from outcaps");
 
+  /**
+   * Answer for this negotiation only and leave the flag alone on a refusal: a
+   * refused caps event is not stored on the pad, and when the earlier caps
+   * come back, fixate_caps stores their config again while GstBaseTransform
+   * skips set_caps for caps equal to the current ones.
+   */
   if (gst_tensordec_configure (self, incaps, outcaps)) {
     GstCaps *supposed = gst_tensordec_get_media_caps_from_config (self,
         &self->tensor_config);
+    gboolean compatible;
+
+    if (supposed == NULL) {
+      GST_ERROR_OBJECT (self,
+          "The decoder sub-plugin does not accept the negotiated tensor config.");
+      return FALSE;
+    }
 
     /** Check if outcaps ==equivalent== supposed */
-    if (gst_caps_is_always_compatible (outcaps, supposed)) {
+    compatible = gst_caps_is_always_compatible (outcaps, supposed);
+    if (compatible) {
       self->negotiated = TRUE;
     } else {
       GST_ERROR_OBJECT (self,
@@ -1001,9 +1063,10 @@ gst_tensordec_set_caps (GstBaseTransform * trans,
     }
 
     gst_caps_unref (supposed);
+    return compatible;
   }
 
-  return self->negotiated;
+  return FALSE;
 }
 
 /**

--- a/gst/nnstreamer/elements/gsttensor_decoder.md
+++ b/gst/nnstreamer/elements/gsttensor_decoder.md
@@ -79,6 +79,9 @@ $ gst-launch videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! tensor
 $ gst-launch videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! tensor_converter ! tensor_decoder mode=flexbuf ! fakesink
 ```
 
+## Decoder sub-plugins
+A decoder sub-plugin registers a `GstTensorDecoderDef` (see `nnstreamer_plugin_api_decoder.h`), and its `getOutCaps ()` decides whether a tensor stream can be decoded at all. Returning `NULL` refuses the given config: tensor_decoder then offers no output for it and the pipeline fails to negotiate. Return `NULL` only for a config the sub-plugin cannot decode. Before this was stated, a `NULL` let the negotiation go on with any output caps, so a sub-plugin that used it for "not configured yet" now stops the pipeline instead.
+
 ## Custom decoder
 If you want to convert tensors to any media type, You can use custom mode of the tensor decoder.
 ### code mode

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_decoder.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_decoder.h
@@ -66,7 +66,10 @@ typedef struct _GstTensorDecoderDef
        *
        * @param[in/out] private_data A sub-plugin may save its internal private data here. The sub-plugin is responsible for alloc/free of this pointer.
        * @param[in] config The structure of input tensor info.
-       * @return GstCaps object describing media type.
+       * @return GstCaps object describing media type. NULL if the sub-plugin cannot decode the given config.
+       * @note Returning NULL refuses the config: tensor_decoder offers no output
+       *       for it and the negotiation fails. Do not use it to report a config
+       *       the sub-plugin has not been able to read yet.
        */
   GstFlowReturn (*decode) (void **private_data, const GstTensorsConfig *config,
       const GstTensorMemory *input, GstBuffer *outbuf);

--- a/tests/nnstreamer_decoder_boundingbox/runTest.sh
+++ b/tests/nnstreamer_decoder_boundingbox/runTest.sh
@@ -160,10 +160,6 @@ callCompareTest yolov8_obb_decoder_result_golden.raw yolo11n-obb_result.log "10 
 
 rm dota8-obb-label.txt
 
-# negative case for box properties
-
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=10 ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! videoconvert ! tensor_converter ! tensor_decoder mode=bounding_boxes option1=wrong_mode_name ! fakesink " 11_n 0 1
-
 # The label sprite must stay inside an output frame shorter than a character
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decoder mode=bounding_boxes option1=mobilenet-ssd option2=coco_labels_list.txt option3=box_priors.txt option4=160:12 option5=300:300 ! video/x-raw,format=RGBA ! filesink location=mobilenetssd_short_output.log  multifilesrc name=fs1 location=mobilenetssd_tensors.0.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=4:1:1917:1 input-type=float32 ! mux.sink_0  multifilesrc name=fs2 location=mobilenetssd_tensors.1.%d start-index=$CASESTART stop-index=$CASEEND caps=application/octet-stream ! tensor_converter input-dim=91:1917:1 input-type=float32 ! mux.sink_1  " 12 0 0 $PERFORMANCE
@@ -210,5 +206,25 @@ refusedTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${MODELSIZE_DEC} option5=0:0 ! 
 
 # A third element is warned about and ignored, not refused.
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${MODELSIZE_DEC} option5=300:300:3 ! fakesink ${MODELSIZE_SRC}" 16 0 0 $PERFORMANCE
+
+# The box properties of option1 are what every other option is given to, so a
+# mode that is missing or unknown leaves the decoder with none of them. These
+# also need a process each: gst-launch-1.0 sets the properties in the order
+# they are written, which is what puts an option ahead of the mode.
+BB_VIDEO_SRC="videotestsrc num-buffers=10 ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! videoconvert ! tensor_converter"
+
+refusedTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${BB_VIDEO_SRC} ! tensor_decoder mode=bounding_boxes option1=wrong_mode_name ! fakesink" 11_n
+
+refusedTest "--gst-plugin-path=${PATH_TO_PLUGIN} ${BB_VIDEO_SRC} ! tensor_decoder mode=bounding_boxes ! fakesink" 17_n
+
+refusedTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decoder mode=bounding_boxes option5=300:300 option1=mobilenet-ssd option2=coco_labels_list.txt option3=box_priors.txt option4=160:120 ! fakesink ${MODELSIZE_SRC}" 18_n
+
+# An option ahead of the mode is dropped rather than taken by the wrong mode,
+# and setting it again once the mode is there is what makes it count.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tensor_decoder mode=bounding_boxes option3=box_priors.txt option1=mobilenet-ssd option2=coco_labels_list.txt option3=box_priors.txt option4=160:120 option5=300:300 ! videoconvert ! video/x-raw,format=BGRx ! multifilesink location=mobilenetssd_output.%d ${MODELSIZE_SRC}" 19 0 0 $PERFORMANCE
+
+callCompareTest mobilenetssd_golden.0 mobilenetssd_output.0 19-1 "mobilenet-ssd Decode with option3 replayed" 0
+callCompareTest mobilenetssd_golden.1 mobilenetssd_output.1 19-2 "mobilenet-ssd Decode 2 with option3 replayed" 0
+rm mobilenetssd_output.*
 
 report

--- a/tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc
+++ b/tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc
@@ -11,10 +11,12 @@
 
 #include <gtest/gtest.h>
 #include <glib.h>
+#include <gst/check/gstharness.h>
 #include <gst/gst.h>
 #include <string.h>
 #include <unittest_util.h>
 
+#include <nnstreamer_plugin_api.h>
 #include <nnstreamer_plugin_api_decoder.h>
 #include <nnstreamer_plugin_api_util.h>
 
@@ -432,6 +434,209 @@ TEST (tensorDecoderBoundingBox, swapModeOfConfiguredDecoder_n)
   gst_buffer_unref (outbuf);
   gst_tensors_config_free (&config);
   decoder->exit (&pdata);
+}
+
+/**
+ * @brief Build a tensors config the ov-person-detection mode accepts.
+ */
+static void
+setOvDetectionConfig (GstTensorsConfig *config)
+{
+  gst_tensors_config_init (config);
+  config->info.num_tensors = 1;
+  config->info.info[0].type = _NNS_FLOAT32;
+  gst_tensor_parse_dimension ("7:200:1:1", config->info.info[0].dimension);
+  config->rate_n = 0;
+  config->rate_d = 1;
+}
+
+/**
+ * @brief The label path is refused while no decoding mode has been chosen.
+ * @details Every option but the mode is handed to the box properties of the
+ *          mode, which option1 has not looked up yet. The label file has to
+ *          hold a label, because an empty one is refused before the box
+ *          properties are reached and would pass for the wrong reason.
+ */
+TEST (tensorDecoderBoundingBox, setLabelPathBeforeMode_n)
+{
+  const GstTensorDecoderDef *decoder = nnstreamer_decoder_find ("bounding_boxes");
+  gchar *label_file = getTempFilename ();
+  void *pdata = NULL;
+
+  ASSERT_TRUE (decoder != NULL);
+  ASSERT_TRUE (label_file != NULL);
+  ASSERT_TRUE (g_file_set_contents (label_file, "person\n", -1, NULL));
+  ASSERT_TRUE (decoder->init (&pdata));
+
+  EXPECT_FALSE (decoder->setOption (&pdata, 1, label_file));
+
+  decoder->exit (&pdata);
+  removeTempFile (&label_file);
+}
+
+/**
+ * @brief The per-mode option is refused while no decoding mode has been chosen.
+ */
+TEST (tensorDecoderBoundingBox, setOptionInternalBeforeMode_n)
+{
+  const GstTensorDecoderDef *decoder = nnstreamer_decoder_find ("bounding_boxes");
+  void *pdata = NULL;
+
+  ASSERT_TRUE (decoder != NULL);
+  ASSERT_TRUE (decoder->init (&pdata));
+
+  EXPECT_FALSE (decoder->setOption (&pdata, 2, "0:0.25:0.45"));
+
+  decoder->exit (&pdata);
+}
+
+/**
+ * @brief The model input size is refused while no decoding mode has been chosen.
+ */
+TEST (tensorDecoderBoundingBox, setInputModelSizeBeforeMode_n)
+{
+  const GstTensorDecoderDef *decoder = nnstreamer_decoder_find ("bounding_boxes");
+  void *pdata = NULL;
+
+  ASSERT_TRUE (decoder != NULL);
+  ASSERT_TRUE (decoder->init (&pdata));
+
+  EXPECT_FALSE (decoder->setOption (&pdata, 4, "300:300"));
+
+  decoder->exit (&pdata);
+}
+
+/**
+ * @brief A decoder without a mode describes no output caps.
+ * @details This is the path a pipeline that never gives option1 takes, and the
+ *          caps query runs before any option can still arrive.
+ */
+TEST (tensorDecoderBoundingBox, getOutCapsBeforeMode_n)
+{
+  const GstTensorDecoderDef *decoder = nnstreamer_decoder_find ("bounding_boxes");
+  GstTensorsConfig config;
+  void *pdata = NULL;
+
+  ASSERT_TRUE (decoder != NULL);
+  ASSERT_TRUE (decoder->init (&pdata));
+
+  setOvDetectionConfig (&config);
+  EXPECT_TRUE (decoder->getOutCaps (&pdata, &config) == NULL);
+
+  gst_tensors_config_free (&config);
+  decoder->exit (&pdata);
+}
+
+/**
+ * @brief A mode that cannot be looked up leaves the configured one in place.
+ * @details option1 is writable while the pipeline runs, so a mode name that
+ *          matches no box properties must not replace the working ones with
+ *          the nothing the lookup returned.
+ */
+TEST (tensorDecoderBoundingBox, keepModeOnUnknownMode_n)
+{
+  const GstTensorDecoderDef *decoder = nnstreamer_decoder_find ("bounding_boxes");
+  GstTensorsConfig config;
+  GstCaps *caps;
+  void *pdata = NULL;
+
+  ASSERT_TRUE (decoder != NULL);
+  ASSERT_TRUE (decoder->init (&pdata));
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 0, "ov-person-detection"));
+  EXPECT_TRUE (decoder->setOption (&pdata, 3, "64:48"));
+  EXPECT_TRUE (decoder->setOption (&pdata, 4, "640:480"));
+
+  EXPECT_FALSE (decoder->setOption (&pdata, 0, "no-such-decoding-mode"));
+
+  setOvDetectionConfig (&config);
+  caps = decoder->getOutCaps (&pdata, &config);
+  EXPECT_TRUE (caps != NULL);
+  if (caps)
+    gst_caps_unref (caps);
+
+  gst_tensors_config_free (&config);
+  decoder->exit (&pdata);
+}
+
+/**
+ * @brief Push one ov-person-detection tensor and pull the frame drawn for it.
+ * @param[out] frame OUT_PIXELS RGBA pixels drawn by the decoder
+ */
+static gboolean
+pushAndPullFrame (GstHarness *h, const float *tensor, uint32_t *frame)
+{
+  GstBuffer *in = gst_buffer_new_allocate (NULL, OV_TENSOR_SIZE, NULL);
+  GstBuffer *out;
+  GstMapInfo map;
+  gboolean ret = FALSE;
+
+  gst_buffer_fill (in, 0, tensor, OV_TENSOR_SIZE);
+  if (gst_harness_push (h, in) != GST_FLOW_OK)
+    return FALSE;
+
+  out = gst_harness_try_pull (h);
+  if (out == NULL)
+    return FALSE;
+
+  if (gst_buffer_map (out, &map, GST_MAP_READ)) {
+    if (map.size == OUT_PIXELS * sizeof (uint32_t)) {
+      memcpy (frame, map.data, map.size);
+      ret = TRUE;
+    }
+    gst_buffer_unmap (out, &map);
+  }
+  gst_buffer_unref (out);
+
+  return ret;
+}
+
+/**
+ * @brief A renegotiated stream is decoded with the options it was given.
+ * @details A new tensor config re-initialises the sub-plugin, and the fresh
+ *          BoundingBox holds no decoding mode until the options are given
+ *          again. A framerate change is the least a config can change by, so
+ *          the frame drawn after it has to match the one drawn before.
+ */
+TEST (tensorDecoderBoundingBox, renegotiateKeepsOptions)
+{
+  float tensor[OV_TENSOR_ELEMENTS] = { 0.0f };
+  uint32_t before[OUT_PIXELS] = { 0U };
+  uint32_t after[OUT_PIXELS] = { 0U };
+  GstTensorsConfig config;
+  GstElement *dec;
+  GstHarness *h;
+  gchar *option4, *option5;
+
+  dec = gst_element_factory_make ("tensor_decoder", NULL);
+  ASSERT_TRUE (dec != NULL);
+  gst_object_ref_sink (dec);
+
+  option4 = g_strdup_printf ("%u:%u", OUT_WIDTH, OUT_HEIGHT);
+  option5 = g_strdup_printf ("%u:%u", MODEL_WIDTH, MODEL_HEIGHT);
+  g_object_set (dec, "mode", "bounding_boxes", "option1", "ov-person-detection",
+      "option4", option4, "option5", option5, NULL);
+  g_free (option4);
+  g_free (option5);
+
+  h = gst_harness_new_with_element (dec, "sink", "src");
+  gst_object_unref (dec);
+  ASSERT_TRUE (h != NULL);
+
+  setOvDetectionConfig (&config);
+  setDetection (tensor, 0.25f, 0.25f, 0.75f, 0.75f);
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+  EXPECT_TRUE (pushAndPullFrame (h, tensor, before));
+  EXPECT_GT (countDrawnPixels (before, OUT_PIXELS), 0U);
+
+  config.rate_n = 30;
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+  EXPECT_TRUE (pushAndPullFrame (h, tensor, after));
+  EXPECT_EQ (memcmp (before, after, sizeof (before)), 0);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
 }
 
 /**

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -11947,6 +11947,689 @@ TEST (testTensorDecoder, pushDirectVideoInputSizeTooLarge_n)
   gst_harness_teardown (h);
 }
 
+#define TEST_DECODER_MOCK_NAME "tdec_mock"
+
+/**
+ * @brief Set while the mock decoder sub-plugin describes no output caps.
+ */
+static gboolean decoder_mock_refuses;
+
+/**
+ * @brief Number of GStreamer critical logs of a tensor_decoder test.
+ */
+static guint decoder_gst_critical_count;
+
+/**
+ * @brief Last critical message of the GStreamer domain, for diagnostics.
+ */
+static gchar decoder_gst_critical_msg[256];
+
+/**
+ * @brief Log handler counting the critical logs of the GStreamer domain.
+ * @details A sub-plugin describing no output leaves the element with no caps
+ * to intersect, and GStreamer answers every NULL handed to its caps helpers
+ * with a critical, so a zero count is what tells a refusal apart from the
+ * element walking on through the NULL.
+ */
+static void
+_decoder_count_gst_critical (const gchar *domain, GLogLevelFlags level,
+    const gchar *message, gpointer udata)
+{
+  UNUSED (domain);
+  UNUSED (udata);
+
+  if (level & G_LOG_LEVEL_CRITICAL) {
+    decoder_gst_critical_count++;
+    g_strlcpy (decoder_gst_critical_msg, message, sizeof (decoder_gst_critical_msg));
+  }
+}
+
+/**
+ * @brief Start counting the critical logs of the GStreamer domain.
+ * @details The counter is proven live before it is used, so that a handler that
+ * silently stops matching cannot turn the zero-critical assertions into no-ops.
+ */
+static guint
+_decoder_watch_gst_critical (void)
+{
+  guint handler = g_log_set_handler ("GStreamer",
+      (GLogLevelFlags) (G_LOG_LEVEL_CRITICAL | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION),
+      _decoder_count_gst_critical, NULL);
+
+  decoder_gst_critical_count = 0;
+  g_log ("GStreamer", G_LOG_LEVEL_CRITICAL, "tensor_decoder test: counter self-check");
+  EXPECT_EQ (decoder_gst_critical_count, 1U);
+
+  decoder_gst_critical_count = 0;
+  decoder_gst_critical_msg[0] = '\0';
+  return handler;
+}
+
+/**
+ * @brief Mock decoder sub-plugin, object initialization.
+ */
+static int
+_decoder_mock_init (void **pdata)
+{
+  *pdata = NULL;
+  return TRUE;
+}
+
+/**
+ * @brief Mock decoder sub-plugin, object destruction.
+ */
+static void
+_decoder_mock_exit (void **pdata)
+{
+  UNUSED (pdata);
+}
+
+/**
+ * @brief Mock decoder sub-plugin, describing no output while it refuses.
+ */
+static GstCaps *
+_decoder_mock_get_out_caps (void **pdata, const GstTensorsConfig *config)
+{
+  UNUSED (pdata);
+  UNUSED (config);
+
+  if (decoder_mock_refuses)
+    return NULL;
+
+  return gst_caps_from_string ("application/octet-stream");
+}
+
+/**
+ * @brief Mock decoder sub-plugin, emitting a fixed-size output.
+ */
+static GstFlowReturn
+_decoder_mock_decode (void **pdata, const GstTensorsConfig *config,
+    const GstTensorMemory *input, GstBuffer *outbuf)
+{
+  UNUSED (pdata);
+  UNUSED (config);
+  UNUSED (input);
+
+  gst_buffer_append_memory (outbuf, gst_allocator_alloc (NULL, 4, NULL));
+  return GST_FLOW_OK;
+}
+
+/**
+ * @brief Register the mock decoder sub-plugin.
+ */
+static GstTensorDecoderDef *
+_decoder_mock_register (void)
+{
+  GstTensorDecoderDef *sub = g_new0 (GstTensorDecoderDef, 1);
+
+  sub->modename = g_strdup (TEST_DECODER_MOCK_NAME);
+  sub->init = _decoder_mock_init;
+  sub->exit = _decoder_mock_exit;
+  sub->getOutCaps = _decoder_mock_get_out_caps;
+  sub->decode = _decoder_mock_decode;
+
+  if (!nnstreamer_decoder_probe (sub)) {
+    g_free (sub->modename);
+    g_free (sub);
+    return NULL;
+  }
+
+  return sub;
+}
+
+/**
+ * @brief Unregister the mock decoder sub-plugin and release it.
+ */
+static void
+_decoder_mock_unregister (GstTensorDecoderDef *sub)
+{
+  nnstreamer_decoder_exit (TEST_DECODER_MOCK_NAME);
+  g_free (sub->modename);
+  g_free (sub);
+}
+
+/**
+ * @brief A sub-plugin that describes no output is refused, not dereferenced.
+ * @details The element intersects and unrefs whatever getOutCaps () hands back,
+ *          so a sub-plugin refusing the config used to take a NULL through the
+ *          whole of the caps fixation.
+ */
+TEST (testTensorDecoder, subpluginRefusesOutCaps_n)
+{
+  GstTensorDecoderDef *sub;
+  GstTensorsConfig config;
+  GstHarness *h;
+  guint handler;
+
+  sub = _decoder_mock_register ();
+  ASSERT_TRUE (sub != NULL);
+
+  decoder_mock_refuses = TRUE;
+  handler = _decoder_watch_gst_critical ();
+
+  _get_decoder_config (&config);
+  h = _get_decoder_harness (TEST_DECODER_MOCK_NAME, NULL, &config);
+  if (h == NULL) {
+    g_log_remove_handler ("GStreamer", handler);
+    gst_tensors_config_free (&config);
+    _decoder_mock_unregister (sub);
+  }
+  ASSERT_TRUE (h != NULL);
+
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, 4)), GST_FLOW_NOT_NEGOTIATED);
+  EXPECT_EQ (decoder_gst_critical_count, 0U) << decoder_gst_critical_msg;
+
+  g_log_remove_handler ("GStreamer", handler);
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  _decoder_mock_unregister (sub);
+}
+
+/**
+ * @brief A sub-plugin refusing a renegotiated config is refused, not dereferenced.
+ * @details The element asks the sub-plugin again when a new caps event does not
+ *          match what it was configured with, which is a second place the NULL
+ *          used to reach gst_caps_unref ().
+ */
+TEST (testTensorDecoder, subpluginRefusesNewConfig_n)
+{
+  GstTensorDecoderDef *sub;
+  GstTensorsConfig config;
+  GstHarness *h;
+  gsize data_size;
+  guint handler;
+
+  sub = _decoder_mock_register ();
+  ASSERT_TRUE (sub != NULL);
+
+  decoder_mock_refuses = FALSE;
+
+  _get_decoder_config (&config);
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+  h = _get_decoder_harness (TEST_DECODER_MOCK_NAME, NULL, &config);
+  if (h == NULL) {
+    gst_tensors_config_free (&config);
+    _decoder_mock_unregister (sub);
+  }
+  ASSERT_TRUE (h != NULL);
+
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_OK);
+
+  handler = _decoder_watch_gst_critical ();
+  decoder_mock_refuses = TRUE;
+
+  gst_tensor_parse_dimension ("3:64:64:1", config.info.info[0].dimension);
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+
+  EXPECT_NE (gst_harness_push (h, gst_harness_create_buffer (h, 4)), GST_FLOW_OK);
+  EXPECT_EQ (decoder_gst_critical_count, 0U) << decoder_gst_critical_msg;
+
+  g_log_remove_handler ("GStreamer", handler);
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  _decoder_mock_unregister (sub);
+}
+
+/**
+ * @brief A sub-plugin that describes an output is negotiated as before.
+ * @details The refusal must be told apart from an ordinary caps query, whose
+ *          config the element cannot read yet.
+ */
+TEST (testTensorDecoder, subpluginAcceptsOutCaps)
+{
+  GstTensorDecoderDef *sub;
+  GstTensorsConfig config;
+  GstHarness *h;
+  gsize data_size;
+  guint handler;
+
+  sub = _decoder_mock_register ();
+  ASSERT_TRUE (sub != NULL);
+
+  decoder_mock_refuses = FALSE;
+  handler = _decoder_watch_gst_critical ();
+
+  _get_decoder_config (&config);
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+  h = _get_decoder_harness (TEST_DECODER_MOCK_NAME, NULL, &config);
+  if (h == NULL) {
+    g_log_remove_handler ("GStreamer", handler);
+    gst_tensors_config_free (&config);
+    _decoder_mock_unregister (sub);
+  }
+  ASSERT_TRUE (h != NULL);
+
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_OK);
+  EXPECT_EQ (gst_harness_buffers_received (h), 1U);
+  EXPECT_EQ (decoder_gst_critical_count, 0U) << decoder_gst_critical_msg;
+
+  g_log_remove_handler ("GStreamer", handler);
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  _decoder_mock_unregister (sub);
+}
+
+/**
+ * @brief The refusal of a config carrying extra tensors walks the release path.
+ * @details The config the element parses out of a caps query allocates the
+ *          records of the 17th and later tensors on the heap, and the refusal
+ *          leaves the element holding it. A single-tensor config keeps that
+ *          allocation empty, so it takes a stream this wide to walk the path
+ *          the release is there for.
+ */
+TEST (testTensorDecoder, subpluginRefusesExtraTensors_n)
+{
+  GstTensorDecoderDef *sub;
+  GstTensorsConfig config;
+  GstHarness *h;
+  guint i, handler;
+
+  sub = _decoder_mock_register ();
+  ASSERT_TRUE (sub != NULL);
+
+  decoder_mock_refuses = TRUE;
+  handler = _decoder_watch_gst_critical ();
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = NNS_TENSOR_MEMORY_MAX + 1;
+  for (i = 0; i < config.info.num_tensors; i++) {
+    GstTensorInfo *info = gst_tensors_info_get_nth_info (&config.info, i);
+    info->type = _NNS_UINT8;
+    gst_tensor_parse_dimension (TEST_DECODER_DIM, info->dimension);
+  }
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  h = _get_decoder_harness (TEST_DECODER_MOCK_NAME, NULL, &config);
+  if (h == NULL) {
+    g_log_remove_handler ("GStreamer", handler);
+    gst_tensors_config_free (&config);
+    _decoder_mock_unregister (sub);
+  }
+  ASSERT_TRUE (h != NULL);
+
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, 4)), GST_FLOW_NOT_NEGOTIATED);
+  EXPECT_EQ (decoder_gst_critical_count, 0U) << decoder_gst_critical_msg;
+
+  g_log_remove_handler ("GStreamer", handler);
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  _decoder_mock_unregister (sub);
+}
+
+/**
+ * @brief A caps query the element cannot read a config from still offers caps.
+ * @details Only a config the sub-plugin has seen and turned down is a refusal.
+ *          A query carrying no fixed config says nothing about what the
+ *          sub-plugin would accept, so answering it with the refusal would
+ *          stop every decoder from negotiating at all. The mock refuses
+ *          everything it is asked, which is what tells the two apart.
+ */
+TEST (testTensorDecoder, capsQueryWithoutConfig)
+{
+  GstTensorDecoderDef *sub;
+  GstElement *dec;
+  GstHarness *h;
+  GstCaps *queried;
+
+  sub = _decoder_mock_register ();
+  ASSERT_TRUE (sub != NULL);
+
+  decoder_mock_refuses = TRUE;
+
+  dec = gst_element_factory_make ("tensor_decoder", NULL);
+  if (dec == NULL)
+    _decoder_mock_unregister (sub);
+  ASSERT_TRUE (dec != NULL);
+  gst_object_ref_sink (dec);
+  g_object_set (dec, "mode", TEST_DECODER_MOCK_NAME, NULL);
+
+  h = gst_harness_new_with_element (dec, "sink", "src");
+  gst_object_unref (dec);
+  if (h == NULL)
+    _decoder_mock_unregister (sub);
+  ASSERT_TRUE (h != NULL);
+
+  /* no caps event yet, so the sink pad still carries the unfixed template */
+  queried = gst_pad_peer_query_caps (h->sinkpad, NULL);
+  ASSERT_TRUE (queried != NULL);
+  EXPECT_FALSE (gst_caps_is_empty (queried));
+
+  gst_caps_unref (queried);
+  gst_harness_teardown (h);
+  _decoder_mock_unregister (sub);
+}
+
+/**
+ * @brief Hand the decoder a caps pair straight through its set_caps vfunc.
+ * @details GstBaseTransform refuses a stream before set_caps whenever
+ *          transform_caps already has, so a decoder that was negotiated once
+ *          is the only way to ask set_caps about a config on its own.
+ */
+static gboolean
+_decoder_set_caps (GstHarness *h, const GstTensorsConfig *config, const gchar *out_str)
+{
+  GstBaseTransform *trans = GST_BASE_TRANSFORM (h->element);
+  GstCaps *incaps = gst_tensors_caps_from_config (config);
+  GstCaps *outcaps = gst_caps_from_string (out_str);
+  gboolean ret;
+
+  ret = GST_BASE_TRANSFORM_GET_CLASS (trans)->set_caps (trans, incaps, outcaps);
+
+  gst_caps_unref (incaps);
+  gst_caps_unref (outcaps);
+  return ret;
+}
+
+/**
+ * @brief set_caps fails when the sub-plugin refuses the renegotiated config.
+ * @details The refusal made gst_tensordec_configure () return FALSE, but
+ *          set_caps then returned what the flag held from the negotiation
+ *          before, which reported success for a config it had just refused.
+ */
+TEST (testTensorDecoder, setCapsRefusedRenegotiation_n)
+{
+  GstTensorDecoderDef *sub;
+  GstTensorsConfig config;
+  GstHarness *h;
+  gsize data_size;
+
+  sub = _decoder_mock_register ();
+  ASSERT_TRUE (sub != NULL);
+
+  decoder_mock_refuses = FALSE;
+
+  _get_decoder_config (&config);
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+  h = _get_decoder_harness (TEST_DECODER_MOCK_NAME, NULL, &config);
+  if (h == NULL) {
+    gst_tensors_config_free (&config);
+    _decoder_mock_unregister (sub);
+  }
+  ASSERT_TRUE (h != NULL);
+
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_OK);
+
+  decoder_mock_refuses = TRUE;
+  gst_tensor_parse_dimension ("3:64:64:1", config.info.info[0].dimension);
+  EXPECT_FALSE (_decoder_set_caps (h, &config, "application/octet-stream"));
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  _decoder_mock_unregister (sub);
+}
+
+/**
+ * @brief set_caps fails when the output caps are not what the sub-plugin makes.
+ * @details The same stale flag answered for this branch too: the mismatch
+ *          was logged and the earlier success returned anyway. The refusal
+ *          must not stop the stream either, since the stored config still
+ *          describes the pad caps, which a refused caps event leaves as they
+ *          were.
+ */
+TEST (testTensorDecoder, setCapsIncompatibleOutput_n)
+{
+  GstTensorDecoderDef *sub;
+  GstTensorsConfig config;
+  GstHarness *h;
+  gsize data_size;
+
+  sub = _decoder_mock_register ();
+  ASSERT_TRUE (sub != NULL);
+
+  decoder_mock_refuses = FALSE;
+
+  _get_decoder_config (&config);
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+  h = _get_decoder_harness (TEST_DECODER_MOCK_NAME, NULL, &config);
+  if (h == NULL) {
+    gst_tensors_config_free (&config);
+    _decoder_mock_unregister (sub);
+  }
+  ASSERT_TRUE (h != NULL);
+
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_OK);
+
+  EXPECT_FALSE (_decoder_set_caps (h, &config, "video/x-raw"));
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_OK);
+  EXPECT_TRUE (_decoder_set_caps (h, &config, "application/octet-stream"));
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  _decoder_mock_unregister (sub);
+}
+
+/**
+ * @brief A stream that goes back to its caps after a refused change flows again.
+ * @details Caps without dimensions reach set_caps, since no config can be
+ *          read out of them any earlier, and are refused there. A refused caps
+ *          event is not stored on the pad, and GstBaseTransform does not call
+ *          set_caps for caps equal to the pad's current ones, so the element
+ *          has to still hold the earlier negotiation when those come back.
+ */
+TEST (testTensorDecoder, recoverAfterRefusedCaps)
+{
+  GstTensorDecoderDef *sub;
+  GstTensorsConfig config;
+  GstElement *dec;
+  GstHarness *h;
+  gsize data_size;
+
+  sub = _decoder_mock_register ();
+  ASSERT_TRUE (sub != NULL);
+
+  decoder_mock_refuses = FALSE;
+
+  dec = gst_element_factory_make ("tensor_decoder", NULL);
+  if (dec == NULL)
+    _decoder_mock_unregister (sub);
+  ASSERT_TRUE (dec != NULL);
+  gst_object_ref_sink (dec);
+  g_object_set (dec, "mode", TEST_DECODER_MOCK_NAME, NULL);
+
+  h = gst_harness_new_with_element (dec, "sink", "src");
+  gst_object_unref (dec);
+  if (h == NULL)
+    _decoder_mock_unregister (sub);
+  ASSERT_TRUE (h != NULL);
+
+  _get_decoder_config (&config);
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+  gst_harness_set_sink_caps_str (h, "application/octet-stream");
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_OK);
+
+  gst_harness_set_src_caps_str (
+      h, "other/tensors,format=static,num_tensors=1,types=uint8,framerate=0/1");
+
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_OK);
+  EXPECT_EQ (gst_harness_buffers_received (h), 2U);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  _decoder_mock_unregister (sub);
+}
+
+/**
+ * @brief Caps nothing can be read out of are refused, not fixated as ANY.
+ * @details Without dimensions the element cannot tell its output, and a
+ *          downstream that takes anything does not tell it either, so the
+ *          fixation is left with ANY, which has no fixed form.
+ */
+TEST (testTensorDecoder, unreadableCapsToAnyDownstream_n)
+{
+  GstTensorDecoderDef *sub;
+  GstElement *dec;
+  GstHarness *h;
+  guint handler;
+
+  sub = _decoder_mock_register ();
+  ASSERT_TRUE (sub != NULL);
+
+  decoder_mock_refuses = FALSE;
+  handler = _decoder_watch_gst_critical ();
+
+  dec = gst_element_factory_make ("tensor_decoder", NULL);
+  if (dec == NULL) {
+    g_log_remove_handler ("GStreamer", handler);
+    _decoder_mock_unregister (sub);
+  }
+  ASSERT_TRUE (dec != NULL);
+  gst_object_ref_sink (dec);
+  g_object_set (dec, "mode", TEST_DECODER_MOCK_NAME, NULL);
+
+  h = gst_harness_new_with_element (dec, "sink", "src");
+  gst_object_unref (dec);
+  if (h == NULL) {
+    g_log_remove_handler ("GStreamer", handler);
+    _decoder_mock_unregister (sub);
+  }
+  ASSERT_TRUE (h != NULL);
+
+  gst_harness_set_src_caps_str (
+      h, "other/tensors,format=static,num_tensors=1,types=uint8,framerate=0/1");
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, 4)), GST_FLOW_NOT_NEGOTIATED);
+  EXPECT_EQ (decoder_gst_critical_count, 0U) << decoder_gst_critical_msg;
+
+  g_log_remove_handler ("GStreamer", handler);
+  gst_harness_teardown (h);
+  _decoder_mock_unregister (sub);
+}
+
+/**
+ * @brief A stream wider than the inline tensor records is decoded as before.
+ * @details Negotiation stores the config twice, at fixation and again at
+ *          set_caps, so the config holding the extra records is replaced and
+ *          released before the first buffer reads the one that replaced it.
+ */
+TEST (testTensorDecoder, subpluginAcceptsExtraTensors)
+{
+  GstTensorDecoderDef *sub;
+  GstTensorsConfig config;
+  GstHarness *h;
+  GstBuffer *buf;
+  GstMemory *mem;
+  GstMapInfo map;
+  gsize data_size;
+  guint i, handler;
+
+  sub = _decoder_mock_register ();
+  ASSERT_TRUE (sub != NULL);
+
+  decoder_mock_refuses = FALSE;
+  handler = _decoder_watch_gst_critical ();
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = NNS_TENSOR_MEMORY_MAX + 1;
+  for (i = 0; i < config.info.num_tensors; i++) {
+    GstTensorInfo *info = gst_tensors_info_get_nth_info (&config.info, i);
+    info->type = _NNS_UINT8;
+    gst_tensor_parse_dimension (TEST_DECODER_DIM, info->dimension);
+  }
+  config.rate_n = 0;
+  config.rate_d = 1;
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+
+  h = _get_decoder_harness (TEST_DECODER_MOCK_NAME, NULL, &config);
+  if (h == NULL) {
+    g_log_remove_handler ("GStreamer", handler);
+    gst_tensors_config_free (&config);
+    _decoder_mock_unregister (sub);
+  }
+  ASSERT_TRUE (h != NULL);
+
+  buf = gst_buffer_new ();
+  for (i = 0; i < config.info.num_tensors; i++) {
+    mem = gst_allocator_alloc (NULL, data_size, NULL);
+    if (gst_memory_map (mem, &map, GST_MAP_WRITE)) {
+      memset (map.data, 0, map.size);
+      gst_memory_unmap (mem, &map);
+    }
+    EXPECT_TRUE (gst_tensor_buffer_append_memory (
+        buf, mem, gst_tensors_info_get_nth_info (&config.info, i)));
+  }
+
+  EXPECT_EQ (gst_harness_push (h, buf), GST_FLOW_OK);
+  EXPECT_EQ (gst_harness_buffers_received (h), 1U);
+  EXPECT_EQ (decoder_gst_critical_count, 0U) << decoder_gst_critical_msg;
+
+  g_log_remove_handler ("GStreamer", handler);
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+  _decoder_mock_unregister (sub);
+}
+
+/**
+ * @brief The video format a decoder negotiated for the stream, or NULL.
+ */
+static gchar *
+_decoder_output_format (GstHarness *h)
+{
+  GstCaps *caps = gst_pad_get_current_caps (h->sinkpad);
+  gchar *format = NULL;
+
+  if (caps) {
+    const gchar *f = gst_structure_get_string (gst_caps_get_structure (caps, 0), "format");
+    format = g_strdup (f);
+    gst_caps_unref (caps);
+  }
+
+  return format;
+}
+
+/**
+ * @brief A resolution change keeps the video format option1 chose.
+ * @details Renegotiating a new tensor config re-initialises the sub-plugin,
+ *          which starts with none of the options, so direct_video describes
+ *          RGB for a 3-channel tensor against the BGR caps just fixated. A
+ *          set_caps that answered with a stale success let that pass; one
+ *          that refuses it renegotiates the stream to RGB with its red and
+ *          blue swapped, or fails where the downstream takes only BGR.
+ */
+TEST (testTensorDecoder, directVideoResolutionChangeKeepsFormat)
+{
+  GstTensorsConfig config;
+  GstElement *dec;
+  GstHarness *h;
+  gsize data_size;
+  gchar *format;
+
+  dec = gst_element_factory_make ("tensor_decoder", NULL);
+  ASSERT_TRUE (dec != NULL);
+  gst_object_ref_sink (dec);
+  g_object_set (dec, "mode", "direct_video", "option1", "BGR", NULL);
+
+  h = gst_harness_new_with_element (dec, "sink", "src");
+  gst_object_unref (dec);
+  ASSERT_TRUE (h != NULL);
+
+  gst_harness_set_sink_caps_str (h, "video/x-raw");
+
+  _get_decoder_config (&config);
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_OK);
+
+  format = _decoder_output_format (h);
+  EXPECT_STREQ (format, "BGR");
+  g_free (format);
+
+  gst_tensor_parse_dimension ("3:8:8", config.info.info[0].dimension);
+  gst_harness_set_src_caps (h, gst_tensors_caps_from_config (&config));
+  data_size = gst_tensors_info_get_size (&config.info, 0);
+  EXPECT_EQ (gst_harness_push (h, gst_harness_create_buffer (h, data_size)), GST_FLOW_OK);
+  EXPECT_EQ (gst_harness_buffers_received (h), 2U);
+
+  format = _decoder_output_format (h);
+  EXPECT_STREQ (format, "BGR");
+  g_free (format);
+
+  gst_tensors_config_free (&config);
+  gst_harness_teardown (h);
+}
+
 /**
  * @brief What a tensor_merge test saw arrive at its tensor_sink.
  */


### PR DESCRIPTION
Two NULL-pointer defects of the tensor_decoder path from #4920: **C22** in the element and **G5** in the `bounding_boxes` sub-plugin. They meet on the same path -- a sub-plugin that cannot take the stream -- so they are fixed together, one commit each.

## G5 -- the box decoding mode is used before option1 chooses one

`BoundingBox` keeps a `BoxProperties *` that `option1` looks up in a table, and every other option is handed to it. Nothing checked it, and it starts out as nothing:

| trigger | on `main` |
| --- | --- |
| `mode=bounding_boxes` with no `option1` | SIGSEGV in `getOutCaps ()` |
| `option1=wrong_mode_name` (SSAT case `11_n`) | SIGSEGV |
| `option5=...` / `option2=...` / `option3=...` ahead of `option1` | SIGSEGV in `setInputModelSize ()` / `setLabelPath ()` / `setOptionInternal ()` |
| `option1` set to an unknown name on a running pipeline | SIGSEGV on the next buffer |

`gst-launch-1.0` sets properties in the order they are written, so the option order alone is enough. The last row is a second way in: `setBoxDecodingMode ()` stored the lookup result *before* testing it.

The options now refuse, negotiation refuses while no mode has been chosen, and the mode is taken only when the lookup answered. `option2` and `option5` no longer describe themselves as independent from `option1`, in the header or the property description; `option4` and `option7` still are.

## C22 -- the element dereferenced the sub-plugin's refusal

`getOutCaps ()` returning NULL is how a sub-plugin says it cannot decode a config. The element passed that NULL to `gst_caps_intersect ()`, `gst_caps_is_always_compatible ()` and `gst_caps_unref ()`, which are guarded only by GLib's own checks, compiled out of a release build. Driving `direct_video` with a float32 tensor logged **6 GStreamer criticals**; now **0** and a clean `not-negotiated`.

- **Refusal.** The three sites that ask the sub-plugin directly fail the negotiation. `gst_tensordec_get_media_caps ()` stops answering ANY for a refusal -- only a caps query it could not *read* means "anything may come out" -- so a refused config offers empty caps and is turned away before fixation. `fixate_caps ()` keeps that empty out of its "keep othercaps" fallback, and refuses ANY instead of handing it to `gst_caps_fixate ()` (caps without dimensions to an any-caps downstream logged 8 criticals that way).
- **`set_caps` result.** It returned whatever the negotiated flag already held when configuring failed, so after one successful negotiation it reported success for a config it had just refused -- including the refusal above -- and for output caps the sub-plugin does not produce. It now returns what this negotiation decided and leaves the flag alone on a refusal: a refused caps event is not stored on the pad, and when the earlier caps come back `fixate_caps ()` (which configures as well) stores their config again while GstBaseTransform skips `set_caps` for caps equal to the current ones.
- **Options after a re-init.** That honest answer exposed a defect the stale one had hidden: renegotiating a new config re-initialises the sub-plugin, and the fresh private data had none of the options. `direct_video` then described RGB for a 3-channel tensor against the BGR caps `option1` had chosen -- a resolution change failed to negotiate or came out with red and blue swapped -- and a re-initialised `bounding_boxes` had no mode at all. The options are now given again after a successful `init ()`, in index order, as setting the mode does. **This applies on every renegotiation, for every sub-plugin, including out-of-tree ones.**
- **Config lifetime.** Every tensors config the element parses is released: the one a caps query parses, the one a failed configuration drops, the stored one the next configuration replaces (negotiation stores twice, at fixation and at `set_caps`, so this leaked on every negotiation), and the last one at finalize. All of them are touched only from the streaming thread.

**Behaviour change for out-of-tree sub-plugins**, documented in the `getOutCaps` doxygen and in a new "Decoder sub-plugins" section of `gst/nnstreamer/elements/gsttensor_decoder.md`: a NULL from `getOutCaps ()` used to let negotiation continue with any output caps and now refuses the config, so a sub-plugin that used NULL for "not configured yet" now stops the pipeline.

## Tests

Every case below was run against the unfixed sources.

**`tests/nnstreamer_decoder_boundingbox/unittest_decoder_boundingbox.cc`** (G5, sub-plugin vtable and one harness case):

- `setLabelPathBeforeMode_n`, `setOptionInternalBeforeMode_n`, `setInputModelSizeBeforeMode_n`, `getOutCapsBeforeMode_n`, `keepModeOnUnknownMode_n`: all five SIGSEGV (139) on `main`.
- `renegotiateKeepsOptions`: a framerate change must redraw the same frame byte for byte. It fails when only the option replay is removed, and on `main`.

**`tests/nnstreamer_plugins/unittest_plugins.cc`** (C22) uses a mock decoder sub-plugin, plus a GStreamer-domain critical counter that is proven live before use:

- `subpluginRefusesOutCaps_n`, `subpluginRefusesNewConfig_n`, `subpluginRefusesExtraTensors_n`: all three fail on `main`; the first two log 24 and 12 criticals there. All three log 0 now.
- `setCapsRefusedRenegotiation_n`, `setCapsIncompatibleOutput_n`: call `set_caps` directly on a negotiated element.
  - Both fail on `main` (stale success).
  - The second also pushes a buffer right after the refusal, so it fails if the flag is cleared.
- `recoverAfterRefusedCaps`: A → B (refused at `set_caps`) → A must flow again.
- `unreadableCapsToAnyDownstream_n`: the ANY refusal; 8 criticals on `main`.
- `directVideoResolutionChangeKeepsFormat`: the negotiated format stays BGR across a resolution change. It fails when only the replay is removed.
- Positive controls that pass on both sides: `subpluginAcceptsOutCaps`, `subpluginAcceptsExtraTensors` (a 17-tensor stream decoded after the stored config is replaced and freed, so a wrong free would trip the memcheck-error gate), and `capsQueryWithoutConfig` (a query with no readable config still offers caps; a tripwire against collapsing both branches, not a regression test).

**`tests/nnstreamer_decoder_boundingbox/runTest.sh`**:

- `11_n` moves from `gstTest` to the file's `refusedTest`. `gstTest` accepts any non-zero exit, so it passed on the segfault it was meant to catch.
- Added `17_n`, `18_n`, and `19` with two golden comparisons.
- On `main`: `11_n`, `17_n` and `18_n` exit 139, and `19` fails.

## Verification

- Local WSL tree on `192b4ddf`:
  - meson test 22/23; SSAT 799 passed.
  - `unittest_plugins` 227, `unittest_decoder_boundingbox` 17.
  - Decoder SSAT: boundingbox 60/60, decoder 60/60, pose 7/7, tensor_region 2/2.
  - The failing python3 groups and `unittest_filter_python3` fail identically on pristine `main` in this environment (NumPy 2 ABI).
- Style: `gst-indent`, `clang-format`, `doxygen-tag.sh`, `newline.sh` and a `-Dwerror=true -Dcpp_args="-Wextra -Wsign-compare"` build are clean.
- Both commits were built and tested on their own.
- CI 21/21 green at `7505ff26`.
- Reviews: eight relayed agent rounds and two `myungjoo-bot` reviews (the second APPROVED). The four-variant tables (fixed / previous head / `main` / replay removed) are in the review replies.

Related items filed or updated on #4920 along the way:

- **C38**: a caps query can run `getOutCaps ()` on private data a renegotiation is releasing. This needs a lock and is out of scope here.
- A hand-off note for the rest of **C23**.
- A note on **G5/G10** option-replay interactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

