### PR TITLE
[Common] Refuse a tensor count that does not fit the info instead of dereferencing nothing

### DIFF
--- a/Documentation/data-type-and-flow-control.md
+++ b/Documentation/data-type-and-flow-control.md
@@ -68,7 +68,7 @@ The GStreamer pad capability of ```other/tensors``` is as follows:
 ```
 other/tensors
     format = {static, flexible, sparse}
-    num_tensors = (int) [1, 16]  # GST_MAX_MEMCHUNK_PER_BUFFER
+    num_tensors = (int) [1, 256]  # NNS_TENSOR_SIZE_LIMIT
     framerate = (fraction) [0/1, 2147483647/1]
     types = (string) Typestrings # Ignored with flexible and sparse
     dimensions = (string) Dimensions # Ignored with flexible and sparse

--- a/gst/nnstreamer/include/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api.h
@@ -44,6 +44,9 @@ gst_structure_get_media_type (const GstStructure * structure);
  * @param config tensors config structure to be filled
  * @param structure structure to be interpreted
  * @return TRUE if no error
+ * @note A static structure declaring a number of tensors outside 1 to
+ * NNS_TENSOR_SIZE_LIMIT is rejected, and the config is left initialized so
+ * that a caller ignoring the return value cannot index the info out of bounds.
  */
 extern gboolean
 gst_tensors_config_from_structure (GstTensorsConfig *config,

--- a/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_util.h
@@ -167,7 +167,7 @@ gst_tensors_info_parse_names_string (GstTensorsInfo * info,
 /**
  * @brief Get the string of dimensions in tensors info
  * @param info tensors info structure
- * @return string of dimensions in tensors info (NULL if the number of tensors is 0)
+ * @return string of dimensions in tensors info (NULL if the number of tensors is 0 or out of bound)
  * @note The returned value should be freed with g_free()
  */
 extern gchar *
@@ -178,7 +178,7 @@ gst_tensors_info_get_dimensions_string (const GstTensorsInfo * info);
  * @param info tensors info structure
  * @param rank rank count of given tensor dimension
  * @param padding fill 1 if actual rank is smaller than rank
- * @return Formatted string of given dimension
+ * @return Formatted string of given dimension (NULL if the number of tensors is 0 or out of bound)
  * @note If rank count is 3, then returned string is 'd1:d2:d3`.
  * The returned value should be freed with g_free()
  */
@@ -189,7 +189,7 @@ gst_tensors_info_get_rank_dimensions_string (const GstTensorsInfo * info,
 /**
  * @brief Get the string of types in tensors info
  * @param info tensors info structure
- * @return string of types in tensors info (NULL if the number of tensors is 0)
+ * @return string of types in tensors info (NULL if the number of tensors is 0 or out of bound)
  * @note The returned value should be freed with g_free()
  */
 extern gchar *
@@ -198,7 +198,7 @@ gst_tensors_info_get_types_string (const GstTensorsInfo * info);
 /**
  * @brief Get the string of tensor names in tensors info
  * @param info tensors info structure
- * @return string of names in tensors info (NULL if the number of tensors is 0)
+ * @return string of names in tensors info (NULL if the number of tensors is 0 or out of bound)
  * @note The returned value should be freed with g_free()
  */
 extern gchar *

--- a/gst/nnstreamer/include/tensor_typedef.h
+++ b/gst/nnstreamer/include/tensor_typedef.h
@@ -118,7 +118,7 @@
 /**
  * @brief Caps string for the caps template of flexible tensors.
  * This mimetype handles non-static, flexible tensor stream without specifying the data type and shape of the tensor.
- * The maximum number of tensors in a buffer is 16 (NNS_TENSOR_SIZE_LIMIT).
+ * The maximum number of tensors in a buffer is 256 (NNS_TENSOR_SIZE_LIMIT).
  */
 #define GST_TENSORS_FLEX_CAP_DEFAULT \
     GST_TENSORS_CAP_MAKE ("flexible")
@@ -126,7 +126,7 @@
 /**
  * @brief Caps string for the caps template of sparse tensors.
  * This mimetype handles non-static, sparse tensor stream without specifying the data type and shape of the tensor.
- * The maximum number of tensors in a buffer is 16 (NNS_TENSOR_SIZE_LIMIT).
+ * The maximum number of tensors in a buffer is 256 (NNS_TENSOR_SIZE_LIMIT).
  */
 #define GST_TENSORS_SPARSE_CAP_DEFAULT \
     GST_TENSORS_CAP_MAKE ("sparse")

--- a/gst/nnstreamer/nnstreamer_plugin_api_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_impl.c
@@ -974,7 +974,8 @@ _get_tensors_caps (const GstTensorsConfig * config)
     prev2 = gst_caps_from_string (GST_TENSORS_CAP_DEFAULT);
   }
 
-  if (config->info.num_tensors > 0) {
+  if (config->info.num_tensors > 0 &&
+      config->info.num_tensors <= NNS_TENSOR_SIZE_LIMIT) {
     g_autofree gchar *type_str =
         gst_tensors_info_get_types_string (&config->info);
     g_autofree gchar *dim_str =
@@ -1484,6 +1485,9 @@ gst_tensor_caps_from_config (const GstTensorsConfig * config)
  * @param config tensors config structure to be filled
  * @param structure structure to be interpreted
  * @return TRUE if no error
+ * @note A static structure declaring a number of tensors outside 1 to
+ * NNS_TENSOR_SIZE_LIMIT is rejected, and the config is left initialized so
+ * that a caller ignoring the return value cannot index the info out of bounds.
  */
 gboolean
 gst_tensors_config_from_structure (GstTensorsConfig * config,
@@ -1534,8 +1538,17 @@ gst_tensors_config_from_structure (GstTensorsConfig * config,
     config->info.format = format;
 
     if (config->info.format == _NNS_TENSOR_FORMAT_STATIC) {
-      gst_structure_get_int (structure, "num_tensors",
-          (gint *) (&config->info.num_tensors));
+      gint num_tensors = 0;
+
+      if (gst_structure_get_int (structure, "num_tensors", &num_tensors)) {
+        if (num_tensors < 1 || num_tensors > NNS_TENSOR_SIZE_LIMIT) {
+          nns_logw ("Invalid num_tensors %d, it should be between 1 and %d.\n",
+              num_tensors, NNS_TENSOR_SIZE_LIMIT);
+          return FALSE;
+        }
+
+        config->info.num_tensors = (guint) num_tensors;
+      }
 
       /* parse dimensions */
       if (gst_structure_has_field (structure, "dimensions")) {

--- a/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
+++ b/gst/nnstreamer/nnstreamer_plugin_api_util_impl.c
@@ -679,7 +679,7 @@ gst_tensors_info_parse_names_string (GstTensorsInfo * info,
 /**
  * @brief Get the string of dimensions in tensors info
  * @param info tensors info structure
- * @return string of dimensions in tensors info (NULL if the number of tensors is 0)
+ * @return string of dimensions in tensors info (NULL if the number of tensors is 0 or out of bound)
  * @note The returned value should be freed with g_free()
  */
 gchar *
@@ -694,7 +694,7 @@ gst_tensors_info_get_dimensions_string (const GstTensorsInfo * info)
  * @param info tensors info structure
  * @param rank rank count of given tensor dimension
  * @param padding fill 1 if actual rank is smaller than rank
- * @return Formatted string of given dimension
+ * @return Formatted string of given dimension (NULL if the number of tensors is 0 or out of bound)
  * @note If rank count is 3, then returned string is 'd1:d2:d3`.
  * The returned value should be freed with g_free()
  */
@@ -707,7 +707,7 @@ gst_tensors_info_get_rank_dimensions_string (const GstTensorsInfo * info,
 
   g_return_val_if_fail (info != NULL, NULL);
 
-  if (info->num_tensors > 0) {
+  if (info->num_tensors > 0 && info->num_tensors <= NNS_TENSOR_SIZE_LIMIT) {
     guint i;
     GString *dimensions = g_string_new (NULL);
 
@@ -734,7 +734,7 @@ gst_tensors_info_get_rank_dimensions_string (const GstTensorsInfo * info,
 /**
  * @brief Get the string of types in tensors info
  * @param info tensors info structure
- * @return string of types in tensors info (NULL if the number of tensors is 0)
+ * @return string of types in tensors info (NULL if the number of tensors is 0 or out of bound)
  * @note The returned value should be freed with g_free()
  */
 gchar *
@@ -745,7 +745,7 @@ gst_tensors_info_get_types_string (const GstTensorsInfo * info)
 
   g_return_val_if_fail (info != NULL, NULL);
 
-  if (info->num_tensors > 0) {
+  if (info->num_tensors > 0 && info->num_tensors <= NNS_TENSOR_SIZE_LIMIT) {
     guint i;
     GString *types = g_string_new (NULL);
 
@@ -769,7 +769,7 @@ gst_tensors_info_get_types_string (const GstTensorsInfo * info)
 /**
  * @brief Get the string of tensor names in tensors info
  * @param info tensors info structure
- * @return string of names in tensors info (NULL if the number of tensors is 0)
+ * @return string of names in tensors info (NULL if the number of tensors is 0 or out of bound)
  * @note The returned value should be freed with g_free()
  */
 gchar *
@@ -780,7 +780,7 @@ gst_tensors_info_get_names_string (const GstTensorsInfo * info)
 
   g_return_val_if_fail (info != NULL, NULL);
 
-  if (info->num_tensors > 0) {
+  if (info->num_tensors > 0 && info->num_tensors <= NNS_TENSOR_SIZE_LIMIT) {
     guint i;
     GString *names = g_string_new (NULL);
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -2263,13 +2263,13 @@ gst_tensor_filter_common_get_combined_in_info (GstTensorFilterPrivate * priv,
         goto error;
       }
 
-      gst_tensor_info_copy (gst_tensors_info_get_nth_info (combined, idx++),
-          gst_tensors_info_get_nth_info ((GstTensorsInfo *) in, i));
-
       if (idx >= NNS_TENSOR_SIZE_LIMIT) {
         nns_loge ("The max number of tensors is %d.", NNS_TENSOR_SIZE_LIMIT);
         goto error;
       }
+
+      gst_tensor_info_copy (gst_tensors_info_get_nth_info (combined, idx++),
+          gst_tensors_info_get_nth_info ((GstTensorsInfo *) in, i));
     }
 
     combined->num_tensors = idx;
@@ -2311,6 +2311,11 @@ gst_tensor_filter_common_get_combined_out_info (GstTensorFilterPrivate * priv,
           goto error;
         }
 
+        if (idx >= NNS_TENSOR_SIZE_LIMIT) {
+          nns_loge ("The max number of tensors is %d.", NNS_TENSOR_SIZE_LIMIT);
+          goto error;
+        }
+
         gst_tensor_info_copy (gst_tensors_info_get_nth_info (combined, idx++),
             gst_tensors_info_get_nth_info ((GstTensorsInfo *) in, i));
       }
@@ -2322,6 +2327,11 @@ gst_tensor_filter_common_get_combined_out_info (GstTensorFilterPrivate * priv,
 
         if (i >= out->num_tensors) {
           nns_loge ("Invalid output index %u, failed to combine info.", i);
+          goto error;
+        }
+
+        if (idx >= NNS_TENSOR_SIZE_LIMIT) {
+          nns_loge ("The max number of tensors is %d.", NNS_TENSOR_SIZE_LIMIT);
           goto error;
         }
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -1813,6 +1813,7 @@ _gtfc_setprop_INPUTCOMBINATION (GstTensorFilterPrivate * priv,
   *prop_list = NULL;
 
   for (i = 0; i < num; i++) {
+    errno = 0;
     val = g_ascii_strtoull (strv[i], NULL, 10);
     if (errno == ERANGE || val >= NNS_TENSOR_SIZE_LIMIT) {
       ml_loge ("Invalid value %s, cannot set combination option.", strv[i]);
@@ -1845,6 +1846,7 @@ _gtfc_setprop_OUTPUTCOMBINATION (GstTensorFilterPrivate * priv,
   *prop_list1 = *prop_list2 = NULL;
 
   for (i = 0; i < num; i++) {
+    errno = 0;
     if (strv[i][0] == 'i') {
       val = g_ascii_strtoull (&strv[i][1], NULL, 10);
       *prop_list1 = g_list_append (*prop_list1, GUINT_TO_POINTER (val));

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -988,6 +988,100 @@ TEST (commonTensorsInfo, getNameInvalidParam1_n)
 }
 
 /**
+ * @brief Test for getting dimension when the number of tensors is out of bound.
+ */
+TEST (commonTensorsInfo, getDimOverLimit_n)
+{
+  GstTensorsInfo info;
+
+  gst_tensors_info_init (&info);
+  info.num_tensors = NNS_TENSOR_SIZE_LIMIT + 1;
+
+  EXPECT_EQ (NULL, gst_tensors_info_get_dimensions_string (&info));
+
+  gst_tensors_info_free (&info);
+}
+
+/**
+ * @brief Test for getting type when the number of tensors is out of bound.
+ */
+TEST (commonTensorsInfo, getTypeOverLimit_n)
+{
+  GstTensorsInfo info;
+
+  gst_tensors_info_init (&info);
+  info.num_tensors = NNS_TENSOR_SIZE_LIMIT + 1;
+
+  EXPECT_EQ (NULL, gst_tensors_info_get_types_string (&info));
+
+  gst_tensors_info_free (&info);
+}
+
+/**
+ * @brief Test for getting name when the number of tensors is out of bound.
+ */
+TEST (commonTensorsInfo, getNameOverLimit_n)
+{
+  GstTensorsInfo info;
+
+  gst_tensors_info_init (&info);
+  info.num_tensors = NNS_TENSOR_SIZE_LIMIT + 1;
+
+  EXPECT_EQ (NULL, gst_tensors_info_get_names_string (&info));
+
+  gst_tensors_info_free (&info);
+}
+
+/**
+ * @brief Test for getting the strings of tensors info with the max number of tensors.
+ */
+TEST (commonTensorsInfo, getStringsMaxNumTensors_p)
+{
+  GstTensorsInfo info;
+  GstTensorInfo *_info;
+  GString *dims = g_string_new (NULL);
+  GString *types = g_string_new (NULL);
+  GString *names = g_string_new (NULL);
+  gchar *str;
+  guint i;
+
+  gst_tensors_info_init (&info);
+  info.num_tensors = NNS_TENSOR_SIZE_LIMIT;
+
+  /* Every tensor differs from its neighbours, so a dropped or reordered entry changes the string. */
+  for (i = 0; i < info.num_tensors; i++) {
+    _info = gst_tensors_info_get_nth_info (&info, i);
+    _info->type = (i % 2) ? _NNS_INT16 : _NNS_UINT8;
+    _info->dimension[0] = i + 1;
+    _info->name = g_strdup_printf ("t%u", i);
+
+    g_string_append_printf (dims, "%s%u", i > 0 ? "," : "", i + 1);
+    g_string_append_printf (types, "%s%s", i > 0 ? "," : "", (i % 2) ? "int16" : "uint8");
+    g_string_append_printf (names, "%st%u", i > 0 ? "," : "", i);
+  }
+
+  str = gst_tensors_info_get_dimensions_string (&info);
+  ASSERT_TRUE (str != NULL);
+  EXPECT_TRUE (gst_tensor_dimension_string_is_equal (str, dims->str));
+  g_free (str);
+
+  str = gst_tensors_info_get_types_string (&info);
+  ASSERT_TRUE (str != NULL);
+  EXPECT_STREQ (types->str, str);
+  g_free (str);
+
+  str = gst_tensors_info_get_names_string (&info);
+  ASSERT_TRUE (str != NULL);
+  EXPECT_STREQ (names->str, str);
+  g_free (str);
+
+  g_string_free (dims, TRUE);
+  g_string_free (types, TRUE);
+  g_string_free (names, TRUE);
+  gst_tensors_info_free (&info);
+}
+
+/**
  * @brief Test for printing tensors info with invalid param.
  */
 TEST (commonTensorsInfo, printInvalidParam_n)
@@ -1385,6 +1479,200 @@ TEST (commonTensorsConfig, parseUnfixedCaps_n)
   gst_tensors_config_free (&config);
 
   gst_caps_unref (caps);
+}
+
+/**
+ * @brief Internal util function to build static tensors caps with given number of tensors.
+ */
+static GstCaps *
+_caps_with_num_tensors (gint num_tensors)
+{
+  return gst_caps_new_simple ("other/tensors", "format", G_TYPE_STRING, "static", "num_tensors",
+      G_TYPE_INT, num_tensors, "framerate", GST_TYPE_FRACTION, 0, 1, NULL);
+}
+
+/**
+ * @brief Test for parsing tensor cap with the max number of tensors.
+ */
+TEST (commonTensorsConfig, parseCapsMaxNumTensors_p)
+{
+  GstTensorsConfig config;
+  GstCaps *caps = _caps_with_num_tensors (NNS_TENSOR_SIZE_LIMIT);
+
+  EXPECT_TRUE (gst_tensors_config_from_caps (&config, caps, FALSE));
+  EXPECT_EQ ((guint) NNS_TENSOR_SIZE_LIMIT, config.info.num_tensors);
+
+  gst_tensors_config_free (&config);
+  gst_caps_unref (caps);
+}
+
+/**
+ * @brief Test for parsing tensor cap with too many tensors.
+ */
+TEST (commonTensorsConfig, parseCapsNumTensorsOverLimit_n)
+{
+  GstTensorsConfig config;
+  GstCaps *caps = _caps_with_num_tensors (NNS_TENSOR_SIZE_LIMIT + 1);
+
+  EXPECT_FALSE (gst_tensors_config_from_caps (&config, caps, FALSE));
+  EXPECT_EQ (0U, config.info.num_tensors);
+
+  gst_tensors_config_free (&config);
+  gst_caps_unref (caps);
+}
+
+/**
+ * @brief Test for parsing tensor cap with a negative number of tensors.
+ */
+TEST (commonTensorsConfig, parseCapsNumTensorsNegative_n)
+{
+  GstTensorsConfig config;
+  GstCaps *caps = _caps_with_num_tensors (-1);
+
+  EXPECT_FALSE (gst_tensors_config_from_caps (&config, caps, FALSE));
+  EXPECT_EQ (0U, config.info.num_tensors);
+
+  gst_tensors_config_free (&config);
+  gst_caps_unref (caps);
+}
+
+/**
+ * @brief Test for parsing tensor cap with no tensor.
+ */
+TEST (commonTensorsConfig, parseCapsNumTensorsZero_n)
+{
+  GstTensorsConfig config;
+  GstCaps *caps = _caps_with_num_tensors (0);
+
+  EXPECT_FALSE (gst_tensors_config_from_caps (&config, caps, FALSE));
+  EXPECT_EQ (0U, config.info.num_tensors);
+
+  gst_tensors_config_free (&config);
+  gst_caps_unref (caps);
+}
+
+/**
+ * @brief Test for parsing a structure with too many tensors, the config is left initialized.
+ */
+TEST (commonTensorsConfig, fromStructureNumTensorsOverLimit_n)
+{
+  GstTensorsConfig config;
+  GstCaps *caps = _caps_with_num_tensors (NNS_TENSOR_SIZE_LIMIT + 1);
+
+  /* Unlike gst_tensors_config_from_caps (), this does not reset the config on failure. */
+  EXPECT_FALSE (
+      gst_tensors_config_from_structure (&config, gst_caps_get_structure (caps, 0)));
+  EXPECT_EQ (0U, config.info.num_tensors);
+
+  gst_tensors_config_free (&config);
+  gst_caps_unref (caps);
+}
+
+/**
+ * @brief Test for getting tensors cap when the number of tensors is out of bound.
+ */
+TEST (commonTensorsConfig, capsFromOverLimitInfo_n)
+{
+  GstTensorsConfig config;
+  GstCaps *caps;
+  GstStructure *structure;
+  gint num_tensors = 0;
+
+  gst_tensors_config_init (&config);
+  config.info.num_tensors = NNS_TENSOR_SIZE_LIMIT + 1;
+
+  caps = gst_tensors_caps_from_config (&config);
+  ASSERT_TRUE (caps != nullptr);
+
+  /* The count stays the range of the template instead of the one it cannot describe. */
+  structure = gst_caps_get_structure (caps, 0);
+  EXPECT_FALSE (gst_structure_get_int (structure, "num_tensors", &num_tensors));
+  EXPECT_FALSE (gst_structure_has_field (structure, "dimensions"));
+  EXPECT_FALSE (gst_structure_has_field (structure, "types"));
+
+  gst_caps_unref (caps);
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief Pad probe counting the caps queries answered with more tensors than an info holds.
+ */
+static GstPadProbeReturn
+_count_over_limit_caps_query (GstPad *, GstPadProbeInfo *info, gpointer user_data)
+{
+  GstQuery *query = GST_PAD_PROBE_INFO_QUERY (info);
+  GstCaps *caps = NULL;
+  gint num = 0;
+
+  /* The probe runs again with PULL set once the peer has answered. */
+  if (!(GST_PAD_PROBE_INFO_TYPE (info) & GST_PAD_PROBE_TYPE_PULL)
+      || GST_QUERY_TYPE (query) != GST_QUERY_CAPS)
+    return GST_PAD_PROBE_OK;
+
+  gst_query_parse_caps_result (query, &caps);
+  if (caps && gst_caps_get_size (caps) > 0
+      && gst_structure_get_int (gst_caps_get_structure (caps, 0), "num_tensors", &num)
+      && num > NNS_TENSOR_SIZE_LIMIT)
+    g_atomic_int_inc ((gint *) user_data);
+
+  return GST_PAD_PROBE_OK;
+}
+
+/**
+ * @brief Test for a peer declaring too many tensors in a pipeline.
+ */
+TEST (commonTensorsConfig, parseCapsNumTensorsOverLimitPipeline_n)
+{
+  GstElement *pipeline, *appsrc, *dec, *filter;
+  GstPad *pad;
+  GstCaps *caps;
+  GstBuffer *buf;
+  guint over_limit = 0U;
+
+  pipeline = gst_parse_launch ("appsrc name=appsrc caps=other/tensors,format=sparse,framerate=(fraction)0/1 ! "
+                               "tensor_sparse_dec name=dec ! capsfilter name=cf caps=other/tensors,format=static ! "
+                               "fakesink async=false sync=false",
+      NULL);
+  ASSERT_TRUE (pipeline != nullptr);
+
+  appsrc = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc");
+  ASSERT_TRUE (appsrc != nullptr);
+  dec = gst_bin_get_by_name (GST_BIN (pipeline), "dec");
+  ASSERT_TRUE (dec != nullptr);
+  filter = gst_bin_get_by_name (GST_BIN (pipeline), "cf");
+  ASSERT_TRUE (filter != nullptr);
+
+  pad = gst_element_get_static_pad (dec, "src");
+  ASSERT_TRUE (pad != nullptr);
+  gst_pad_add_probe (pad, GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM,
+      _count_over_limit_caps_query, &over_limit, NULL);
+  gst_object_unref (pad);
+
+  /* A capsfilter holding the over-limit count cannot be linked, the pad template caps it. */
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  caps = _caps_with_num_tensors (NNS_TENSOR_SIZE_LIMIT + 1);
+  g_object_set (filter, "caps", caps, NULL);
+  gst_caps_unref (caps);
+
+  /* New caps on the source make the decoder read its peer again. */
+  caps = gst_caps_new_simple ("other/tensors", "format", G_TYPE_STRING,
+      "sparse", "framerate", GST_TYPE_FRACTION, 1, 1, NULL);
+  gst_app_src_set_caps (GST_APP_SRC (appsrc), caps);
+  gst_caps_unref (caps);
+
+  buf = gst_buffer_new_allocate (NULL, 128, NULL);
+  gst_buffer_memset (buf, 0, 0, 128);
+  EXPECT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc), buf), GST_FLOW_OK);
+
+  EXPECT_TRUE (wait_pipeline_process_buffers (&over_limit, 1U, TEST_TIMEOUT_LIMIT_MS));
+
+  EXPECT_EQ (setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT), 0);
+
+  gst_object_unref (filter);
+  gst_object_unref (dec);
+  gst_object_unref (appsrc);
+  gst_object_unref (pipeline);
 }
 
 /**

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -8,6 +8,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <errno.h>
 #include <glib/gstdio.h>
 #include <gst/app/gstappsrc.h>
 #include <gst/gst.h>
@@ -5215,6 +5216,51 @@ TEST (tensorStreamTest, filterOutCombinationMixedOverLimit_n)
   EXPECT_EQ (0U, combined.num_tensors);
 
   gst_tensors_info_free (&combined);
+}
+
+/**
+ * @brief Internal util function to set a combination property with errno set beforehand.
+ */
+static gboolean
+_set_combination_with_errno (guint prop_id, const gchar *param, int err)
+{
+  GstTensorFilterPrivate priv;
+  GValue value = G_VALUE_INIT;
+  gboolean ret;
+
+  gst_tensor_filter_common_init_property (&priv);
+
+  g_value_init (&value, G_TYPE_STRING);
+  g_value_set_string (&value, param);
+  errno = err;
+  ret = gst_tensor_filter_common_set_property (&priv, prop_id, &value, NULL);
+  g_value_unset (&value);
+
+  gst_tensor_filter_common_free_property (&priv);
+
+  return ret;
+}
+
+/**
+ * @brief Test for combination properties when an earlier call left errno at ERANGE.
+ */
+TEST (tensorStreamTest, filterCombinationStaleErrno)
+{
+  EXPECT_TRUE (_set_combination_with_errno (PROP_INPUTCOMBINATION, "0,1", ERANGE));
+  EXPECT_TRUE (_set_combination_with_errno (PROP_OUTPUTCOMBINATION, "i0,o0", ERANGE));
+}
+
+/**
+ * @brief Test for combination properties with an index past the range of the parser.
+ */
+TEST (tensorStreamTest, filterCombinationIndexOverflow_n)
+{
+  EXPECT_FALSE (
+      _set_combination_with_errno (PROP_INPUTCOMBINATION, "99999999999999999999", 0));
+  EXPECT_FALSE (_set_combination_with_errno (
+      PROP_OUTPUTCOMBINATION, "i99999999999999999999", 0));
+  EXPECT_FALSE (_set_combination_with_errno (
+      PROP_OUTPUTCOMBINATION, "o99999999999999999999", 0));
 }
 
 /**

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -5057,6 +5057,167 @@ TEST (tensorStreamTest, subpluginV0PreservedName_n)
 }
 
 /**
+ * @brief Internal util function to fill tensors info with the given number of uint8 tensors.
+ */
+static void
+_fill_combination_info (GstTensorsInfo *info, guint num)
+{
+  GstTensorInfo *_info;
+  guint i;
+
+  gst_tensors_info_init (info);
+  info->num_tensors = num;
+
+  for (i = 0; i < num; i++) {
+    _info = gst_tensors_info_get_nth_info (info, i);
+    _info->type = _NNS_UINT8;
+    gst_tensor_parse_dimension ("3:4:4:1", _info->dimension);
+  }
+}
+
+/**
+ * @brief Internal util function to run a combination with the given number of entries.
+ * @param is_input TRUE for input-combination, FALSE for output-combination
+ * @param num_i the number of entries selecting input tensors
+ * @param num_o the number of entries selecting output tensors (output-combination only)
+ * @param[out] combined combined tensors info, left initialized when this returns FALSE
+ * @return the result of combining the info with the combination property
+ * @note Entries select distinct tensors as far as the limit allows, so only a list longer than the limit repeats an index.
+ */
+static gboolean
+_run_combination (gboolean is_input, guint num_i, guint num_o, GstTensorsInfo *combined)
+{
+  GstTensorFilterPrivate priv;
+  GstTensorsInfo in, out;
+  GString *param = g_string_new (NULL);
+  GValue value = G_VALUE_INIT;
+  guint in_num = CLAMP (num_i, 1U, (guint) NNS_TENSOR_SIZE_LIMIT);
+  guint out_num = CLAMP (num_o, 1U, (guint) NNS_TENSOR_SIZE_LIMIT);
+  gboolean ret;
+  guint i;
+
+  for (i = 0; i < num_i; i++)
+    g_string_append_printf (param, "%s%s%u", param->len > 0 ? "," : "",
+        is_input ? "" : "i", i % in_num);
+  for (i = 0; i < num_o; i++)
+    g_string_append_printf (param, "%so%u", param->len > 0 ? "," : "", i % out_num);
+
+  gst_tensor_filter_common_init_property (&priv);
+
+  g_value_init (&value, G_TYPE_STRING);
+  g_value_take_string (&value, g_string_free (param, FALSE));
+  EXPECT_TRUE (gst_tensor_filter_common_set_property (&priv,
+      is_input ? PROP_INPUTCOMBINATION : PROP_OUTPUTCOMBINATION, &value, NULL));
+  g_value_unset (&value);
+
+  _fill_combination_info (&in, in_num);
+  _fill_combination_info (&out, out_num);
+
+  if (is_input)
+    ret = gst_tensor_filter_common_get_combined_in_info (&priv, &in, combined);
+  else
+    ret = gst_tensor_filter_common_get_combined_out_info (&priv, &in, &out, combined);
+
+  gst_tensors_info_free (&in);
+  gst_tensors_info_free (&out);
+  gst_tensor_filter_common_free_property (&priv);
+
+  return ret;
+}
+
+/**
+ * @brief Test for input combination with the max number of tensors.
+ */
+TEST (tensorStreamTest, filterInCombinationMax)
+{
+  GstTensorsInfo combined;
+
+  EXPECT_TRUE (_run_combination (TRUE, NNS_TENSOR_SIZE_LIMIT, 0U, &combined));
+  EXPECT_EQ ((guint) NNS_TENSOR_SIZE_LIMIT, combined.num_tensors);
+
+  gst_tensors_info_free (&combined);
+}
+
+/**
+ * @brief Test for input combination with too many tensors.
+ */
+TEST (tensorStreamTest, filterInCombinationOverLimit_n)
+{
+  GstTensorsInfo combined;
+
+  EXPECT_FALSE (_run_combination (TRUE, NNS_TENSOR_SIZE_LIMIT + 1, 0U, &combined));
+  EXPECT_EQ (0U, combined.num_tensors);
+
+  gst_tensors_info_free (&combined);
+}
+
+/**
+ * @brief Test for output combination with the max number of input tensors.
+ */
+TEST (tensorStreamTest, filterOutCombinationMax)
+{
+  GstTensorsInfo combined;
+
+  EXPECT_TRUE (_run_combination (FALSE, NNS_TENSOR_SIZE_LIMIT, 0U, &combined));
+  EXPECT_EQ ((guint) NNS_TENSOR_SIZE_LIMIT, combined.num_tensors);
+
+  gst_tensors_info_free (&combined);
+}
+
+/**
+ * @brief Test for output combination with the max number of tensors, taken from both input and output.
+ */
+TEST (tensorStreamTest, filterOutCombinationMixedMax)
+{
+  GstTensorsInfo combined;
+
+  EXPECT_TRUE (_run_combination (
+      FALSE, NNS_TENSOR_SIZE_LIMIT / 2, NNS_TENSOR_SIZE_LIMIT / 2, &combined));
+  EXPECT_EQ ((guint) NNS_TENSOR_SIZE_LIMIT, combined.num_tensors);
+
+  gst_tensors_info_free (&combined);
+}
+
+/**
+ * @brief Test for output combination with too many input tensors.
+ */
+TEST (tensorStreamTest, filterOutCombinationOverLimit_n)
+{
+  GstTensorsInfo combined;
+
+  EXPECT_FALSE (_run_combination (FALSE, NNS_TENSOR_SIZE_LIMIT + 1, 0U, &combined));
+  EXPECT_EQ (0U, combined.num_tensors);
+
+  gst_tensors_info_free (&combined);
+}
+
+/**
+ * @brief Test for output combination with too many output tensors.
+ */
+TEST (tensorStreamTest, filterOutCombinationModelOverLimit_n)
+{
+  GstTensorsInfo combined;
+
+  EXPECT_FALSE (_run_combination (FALSE, 0U, NNS_TENSOR_SIZE_LIMIT + 1, &combined));
+  EXPECT_EQ (0U, combined.num_tensors);
+
+  gst_tensors_info_free (&combined);
+}
+
+/**
+ * @brief Test for output combination of distinct tensors where the output tensors exceed what the input tensors left.
+ */
+TEST (tensorStreamTest, filterOutCombinationMixedOverLimit_n)
+{
+  GstTensorsInfo combined;
+
+  EXPECT_FALSE (_run_combination (FALSE, NNS_TENSOR_SIZE_LIMIT, 1U, &combined));
+  EXPECT_EQ (0U, combined.num_tensors);
+
+  gst_tensors_info_free (&combined);
+}
+
+/**
  * @brief Test for plugin registration with invalid param.
  */
 TEST (tensorStreamTest, subpluginV0NullName_n)


### PR DESCRIPTION
Items **A4** and **B4** of #4920.

## The defect

`gst_tensors_config_from_structure()` stored whatever integer a caps structure
carried in `num_tensors`, with no ceiling and no sign check. Three helpers then
walk that count and dereference the NULL that `gst_tensors_info_get_nth_info()`
returns for an index of `NNS_TENSOR_SIZE_LIMIT` or more:
`gst_tensors_info_get_rank_dimensions_string()`,
`gst_tensors_info_get_types_string()` and `gst_tensors_info_get_names_string()`.

The element that asks is the one that dies. `tensor_sparse_dec` reads the peer's
count on every caps event (`gst_tensors_config_from_peer()`, no validation) and
hands the config straight to `gst_tensor_pad_caps_from_config()`, which builds
the `dimensions` and `types` strings from it.

**B4** is a second producer of the same shape:
`gst_tensor_filter_common_get_combined_out_info()` had no ceiling on the
combined index while `_get_combined_in_info()` did, so an `output-combination`
of more than `NNS_TENSOR_SIZE_LIMIT` entries fetched a NULL destination.
`gst_tensor_info_copy()` refused that copy with a GLib critical, so nothing was
written through it, but the info was left reporting 257 tensors - which then
reaches the A4 helpers through `transform_caps`.

## The fix

- Refuse a static structure whose count is not between 1 and
  `NNS_TENSOR_SIZE_LIMIT` *before anything is stored*, so a caller that ignores
  the return value (tensor_transform, tensor_converter, tensor_query_client and
  tensor_sparse_dec all do) finds the config as initialized.
- The three string helpers test the same bound up front and return NULL. The
  caps builder already treats a NULL string as "no such field", so no caller
  gains a new failure path.
- The caps builder (`_get_tensors_caps()`) fills the tensor fields only for a
  count it can describe, so an over-limit info keeps the template's `[1, 256]`
  range instead of advertising a fixed count no peer can parse.
- *(Separate commit, `[Filter]`.)* Both combination property setters clear
  `errno` before each `g_ascii_strtoull()`; they tested `errno == ERANGE`
  without clearing it, so an
  `ERANGE` left over from any earlier call refused a valid combination.
- Both combination helpers test the index *before* the copy. That also admits a
  combination of exactly `NNS_TENSOR_SIZE_LIMIT` entries, which the input twin
  used to refuse - its check sat after the post-increment.

## Reachability, corrected

The issue text gives the trigger as
`... ! tensor_sparse_dec ! other/tensors,num_tensors=300,format=static ! fakesink`.
That does not link: `GST_TENSOR_NUM_TENSORS_RANGE` caps the field at
`NNS_TENSOR_SIZE_LIMIT` in the pad template, so `gst_parse_launch` refuses the
pair with *"tensorsparsedec0 can't handle caps ... num_tensors=(int)300"*, and an
explicit `capsfilter` with those caps is refused at link time for the same
reason.

What does reach it is a caps change while the pipeline runs: link a plain
`other/tensors,format=static` capsfilter, set its `caps` to the over-limit count,
then push a buffer with new caps so the decoder re-reads its peer.
`parseCapsNumTensorsOverLimitPipeline_n` does exactly that; a query probe on the
decoder's src pad counts the peer answers carrying the over-limit count and the
case waits for one, so it cannot pass without exercising the path. It exits 139
without this fix.

## Verification

Mutation matrix, exit codes (139 = SIGSEGV). "main" reverts all three source
files and keeps the tests; every other row changes one guard of the fixed tree
and lists the cases that then fail. The fixed tree passes all 20 new cases.

| tree | failing cases |
|---|---|
| main | helpers x3 and `capsFromOverLimitInfo_n` and the pipeline case (139); `parseCapsNumTensors{OverLimit,Negative,Zero}_n`, `fromStructureNumTensorsOverLimit_n`, `filterInCombinationMax`, `filterOutCombination{OverLimit,ModelOverLimit,MixedOverLimit}_n`, `filterCombinationStaleErrno` (1) |
| − `from_structure` bound | `parseCapsNumTensors{OverLimit,Negative,Zero}_n`, `fromStructureNumTensorsOverLimit_n` |
| count stored before the check | `fromStructureNumTensorsOverLimit_n` |
| − helper bound | `get{Dim,Type,Name}OverLimit_n` (139) |
| helper bound `<` instead of `<=` | `getStringsMaxNumTensors_p` |
| − caps-builder guard | `capsFromOverLimitInfo_n` |
| − out `i` guard | `filterOutCombinationOverLimit_n` |
| − out `o` guard | `filterOutCombinationModelOverLimit_n`, `filterOutCombinationMixedOverLimit_n` |
| in guard one short (`idx + 1 >=`) | `filterInCombinationMax` |
| out `i` guard one short | `filterOutCombinationMax` |
| out `o` guard one short | `filterOutCombinationMixedMax` |
| − `errno = 0` in the setters | `filterCombinationStaleErrno` |

Each guard, and each guard placed one short, has a case that catches it alone.
The end-to-end pipeline case only fails when every layer is missing, which is
the point of layering them; what it pins is that the crash on `main` is
reachable from a real pipeline. The combination entries select distinct
tensors wherever the counts allow, so `filterOutCombinationMixedOverLimit_n`
(all 256 inputs, then one model output) keeps testing its guard even if
repeated indices are refused later.

Also run locally: `meson test` for `unittest_common` and `unittest_sink`, and the full suite 22/23 (the one failure is
`unittest_filter_python3`, the NumPy 1.x/2.x mismatch of this box, unrelated to a
C change); `clang-format` 16 clean; `gst-indent` clean on the changed hunks;
`doxygen-tag.sh` advanced clean with `ctags` present, verified against a negative
control; `newline.sh` clean; every changed object recompiled with
`-Wextra -Wsign-compare -Werror` clean.

## Not covered here

- The `gst_pad_set_caps()` critical that `tensor_sparse_dec` used to log after
  the peer was refused was item **C36**, fixed by #4943, which is now in this
  branch's base. With it, the pipeline case logs only the refusal and two chain
  criticals about the zero-filled buffer it pushes; the outcome is unchanged,
  and the case still exits 139 on `main`'s sources.
- `D1`'s local clamp and the other `A`-group items stay open; this change closes
  the caps entry point and the one filter-side producer.

`Documentation/data-type-and-flow-control.md` gave the `num_tensors` range as
`[1, 16]`, and the flexible/sparse caps comments in `tensor_typedef.h` called
`NNS_TENSOR_SIZE_LIMIT` 16; both now say 256, the range this change enforces.

## Commits

1. `[Common] Bound the tensor count a peer declares in caps` - the A4/B4 fix,
   with the documentation and header comments that describe the enforced range.
2. `[Test/Common] Cover the tensor counts that do not fit an info` - its tests.
3. `[Filter] Clear errno before parsing a combination index` - the stale-`errno`
   false refusal in the combination property parser, with its two tests. It is
   a different defect from A4/B4 (a valid value refused, not a bound), kept
   apart so that reverting or bisecting either does not carry the other.

Each of the first two and all three together build and pass `unittest_common`
and `unittest_sink` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
