### PR TITLE
[Element/If] Bound the compared value to the tensor it is read from

### DIFF
--- a/gst/nnstreamer/elements/gsttensor_if.c
+++ b/gst/nnstreamer/elements/gsttensor_if.c
@@ -940,7 +940,12 @@ gst_tensor_if_calculate_cv (GstTensorIf * tensor_if, GstBuffer * buf,
       GstMemory *in_mem;
       GstMapInfo in_info;
       GList *list;
-      uint32_t idx = 0, nth, i, offset = 1;
+      uint32_t nth, i, n = 0;
+      guint64 idx = 0, offset;
+#if GLIB_CHECK_VERSION (2, 48, 0)
+      guint64 term;
+#endif
+      gsize esize;
       tensor_dim target;
       const uint32_t *in_dim;
       tensor_type in_type;
@@ -951,7 +956,7 @@ gst_tensor_if_calculate_cv (GstTensorIf * tensor_if, GstBuffer * buf,
         return FALSE;
       }
       for (list = tensor_if->cv_option; list->next != NULL; list = list->next) {
-        target[idx++] = GPOINTER_TO_INT (list->data);
+        target[n++] = GPOINTER_TO_INT (list->data);
       }
 
       nth = GPOINTER_TO_INT (list->data);
@@ -964,6 +969,39 @@ gst_tensor_if_calculate_cv (GstTensorIf * tensor_if, GstBuffer * buf,
       in_type = _info->type;
       in_dim = _info->dimension;
 
+      esize = gst_tensor_get_element_size (in_type);
+      if (esize == 0) {
+        GST_ERROR_OBJECT (tensor_if, "The type of the tensor %u is invalid.",
+            nth);
+        return FALSE;
+      }
+
+      /* Find the byte offset of the element for mem access */
+      offset = esize;
+      for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
+        uint32_t dim = (in_dim[i] > 0) ? in_dim[i] : 1;
+
+        if (target[i] >= dim) {
+          GST_ERROR_OBJECT (tensor_if,
+              "The compared value index %u of the dimension %u is out of bound, it should be less than %u.",
+              target[i], i, dim);
+          return FALSE;
+        }
+#if GLIB_CHECK_VERSION (2, 48, 0)
+        if (!g_uint64_checked_mul (&term, target[i], offset) ||
+            !g_uint64_checked_add (&idx, idx, term) ||
+            !g_uint64_checked_mul (&offset, offset, dim)) {
+          GST_ERROR_OBJECT (tensor_if,
+              "The offset of the compared value in the tensor %u overflows.",
+              nth);
+          return FALSE;
+        }
+#else
+        idx += (guint64) target[i] * offset;
+        offset *= dim;
+#endif
+      }
+
       in_mem = gst_tensor_buffer_get_nth_memory (buf, nth);
       if (!gst_memory_map (in_mem, &in_info, GST_MAP_READ)) {
         GST_WARNING_OBJECT (tensor_if, "Failed to map the input buffer.");
@@ -971,14 +1009,15 @@ gst_tensor_if_calculate_cv (GstTensorIf * tensor_if, GstBuffer * buf,
         return FALSE;
       }
 
-      /* Find data index for mem access */
-      idx = target[0];
-      for (i = 1; i < NNS_TENSOR_RANK_LIMIT; i++) {
-        offset *= in_dim[i - 1];
-        idx += (target[i]) * offset;
+      if (in_info.size < esize || idx > in_info.size - esize) {
+        GST_ERROR_OBJECT (tensor_if,
+            "The compared value of the tensor %u is at offset %"
+            G_GUINT64_FORMAT ", but the memory has %" G_GSIZE_FORMAT " bytes.",
+            nth, idx, in_info.size);
+        gst_memory_unmap (in_mem, &in_info);
+        gst_memory_unref (in_mem);
+        return FALSE;
       }
-
-      idx *= gst_tensor_get_element_size (in_type);
 
       gst_tensor_data_set (cv, in_type, in_info.data + idx);
       gst_memory_unmap (in_mem, &in_info);
@@ -1138,7 +1177,8 @@ gst_tensor_if_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
   g_assert (gst_tensor_buffer_get_count (buf) == num_tensors);
 
   if (!gst_tensor_if_check_condition (tensor_if, buf, &condition_result)) {
-    GST_ERROR_OBJECT (tensor_if, " Failed to check condition");
+    GST_ELEMENT_ERROR (tensor_if, STREAM, WRONG_TYPE, (NULL),
+        ("Failed to check the condition of the incoming buffer."));
     return GST_FLOW_ERROR;
   }
 

--- a/gst/nnstreamer/elements/gsttensor_if.md
+++ b/gst/nnstreamer/elements/gsttensor_if.md
@@ -19,6 +19,7 @@ The input and output stream data type is either `other/tensor` or `other/tensors
 - compared-value-option: Specifies an element of the nth tensor or you can pick one from the tensors.
   * [C][W][H][B],n: used for A_VALUE of the compared-value, for example 0:1:2:3,0 means [0][1][2][3] value of first tensor.
   * nth tensor: used for TENSOR_AVERAGE_VALUE of the compared-value, and specifies which tensor is used.
+  * Each element index should be less than the corresponding dimension of the tensor, and the buffer is refused if it is not.
 
 - supplied-value: Specifies the supplied value (SV) from the user.
   * SV

--- a/tests/nnstreamer_if/unittest_if.cc
+++ b/tests/nnstreamer_if/unittest_if.cc
@@ -1123,6 +1123,286 @@ TEST (tensorIfCustom, invalidParam3_n)
 }
 
 /**
+ * @brief Callback counting the buffers that reach the sink.
+ */
+static void
+count_data_cb (GstElement *element, GstBuffer *buffer, gpointer user_data)
+{
+  guint *received = (guint *) user_data;
+
+  *received = *received + 1;
+}
+
+/**
+ * @brief Caps and size of the test frame test_frames[0].
+ */
+#define TEST_FRAME_CAPS \
+  "other/tensor,dimension=(string)3:4:2:2,type=(string)int32,framerate=(fraction)0/1"
+#define TEST_FRAME_SIZE (192U)
+
+/**
+ * @brief Push the first bytes of test_frames[0] as one buffer through a tensor_if.
+ * @param caps the caps the buffer is pushed with
+ * @param size the size of the buffer, at most TEST_FRAME_SIZE
+ * @param if_props the properties of the tensor_if element under test
+ * @param error_src name of the element the first bus error came from, or NULL
+ * @param error the first bus error, or NULL
+ * @param received number of the buffers that reached the sink
+ * @return the first bus message type, GST_MESSAGE_ANY if the pipeline could not
+ * be built and GST_MESSAGE_UNKNOWN if neither an error nor EOS arrived in time.
+ */
+static GstMessageType
+_push_if_frame (const gchar *caps, gsize size, const gchar *if_props,
+    gchar **error_src, GError **error, guint *received)
+{
+  GstElement *pipeline, *appsrc_handle, *sink_handle;
+  GstBuffer *buf;
+  GstBus *bus;
+  GstMessage *msg;
+  GstMessageType type = GST_MESSAGE_UNKNOWN;
+  gchar *str_pipeline;
+
+  *error_src = NULL;
+  *error = NULL;
+  *received = 0;
+
+  str_pipeline = g_strdup_printf ("appsrc name=appsrc ! %s ! tensor_if name=tif %s ! "
+                                  "tensor_sink name=sinkx async=false",
+      caps, if_props);
+
+  pipeline = gst_parse_launch (str_pipeline, NULL);
+  g_free (str_pipeline);
+  if (pipeline == NULL)
+    return GST_MESSAGE_ANY;
+
+  appsrc_handle = gst_bin_get_by_name (GST_BIN (pipeline), "appsrc");
+  sink_handle = gst_bin_get_by_name (GST_BIN (pipeline), "sinkx");
+  g_signal_connect (sink_handle, "new-data", (GCallback) count_data_cb, received);
+
+  buf = gst_buffer_new_allocate (NULL, size, NULL);
+  gst_buffer_fill (buf, 0, test_frames[0], size);
+
+  setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT);
+  gst_app_src_push_buffer (GST_APP_SRC (appsrc_handle), buf);
+  gst_app_src_end_of_stream (GST_APP_SRC (appsrc_handle));
+
+  bus = gst_element_get_bus (pipeline);
+  msg = gst_bus_timed_pop_filtered (bus, 5 * GST_SECOND,
+      (GstMessageType) (GST_MESSAGE_ERROR | GST_MESSAGE_EOS));
+  if (msg) {
+    type = GST_MESSAGE_TYPE (msg);
+    if (type == GST_MESSAGE_ERROR) {
+      *error_src = g_strdup (GST_OBJECT_NAME (GST_MESSAGE_SRC (msg)));
+      gst_message_parse_error (msg, error, NULL);
+    }
+    gst_message_unref (msg);
+  }
+  gst_object_unref (bus);
+
+  setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT);
+
+  gst_object_unref (sink_handle);
+  gst_object_unref (appsrc_handle);
+  gst_object_unref (pipeline);
+
+  return type;
+}
+
+/**
+ * @brief Push one buffer through tensor_if compared-value=A_VALUE.
+ * @param caps the caps the buffer is pushed with
+ * @param size the size of the buffer
+ * @param cv_option the compared-value-option to test
+ * @param supplied_value the value the element compares the picked element with
+ * @param error_src name of the element the first bus error came from, or NULL
+ * @param error the first bus error, or NULL
+ * @param received number of the buffers that reached the sink
+ * @return the first bus message type, as _push_if_frame() returns it.
+ */
+static GstMessageType
+_push_a_value_frame (const gchar *caps, gsize size, const gchar *cv_option,
+    const gchar *supplied_value, gchar **error_src, GError **error, guint *received)
+{
+  GstMessageType type;
+  gchar *if_props = g_strdup_printf ("compared-value=A_VALUE compared-value-option=%s supplied-value=%s "
+                                     "operator=EQ then=PASSTHROUGH else=SKIP",
+      cv_option, supplied_value);
+
+  type = _push_if_frame (caps, size, if_props, error_src, error, received);
+  g_free (if_props);
+
+  return type;
+}
+
+/**
+ * @brief Check that tensor_if refused the buffer instead of reading out of bounds.
+ */
+static void
+_expect_refused_cv_option (const gchar *caps, gsize size, const gchar *cv_option)
+{
+  gchar *error_src = NULL;
+  GError *error = NULL;
+  guint received = 0;
+
+  EXPECT_EQ (GST_MESSAGE_ERROR, _push_a_value_frame (caps, size, cv_option,
+                                    "1224", &error_src, &error, &received));
+  EXPECT_STREQ ("tif", error_src);
+  ASSERT_NE (error, nullptr);
+  EXPECT_EQ (GST_STREAM_ERROR, error->domain);
+  EXPECT_EQ (GST_STREAM_ERROR_WRONG_TYPE, error->code);
+  EXPECT_EQ (0U, received);
+
+  g_clear_error (&error);
+  g_free (error_src);
+}
+
+/**
+ * @brief Compare the elements at both ends of the tensor.
+ * @note Every element of the test frame is unique, so the buffer reaches the
+ * sink only if the element the option describes is the one that was read.
+ */
+TEST (tensorIfAppsrc, comparedValueBothEnds)
+{
+  gchar *error_src = NULL;
+  GError *error = NULL;
+  guint received = 0;
+
+  /* test_frames[0][0] */
+  EXPECT_EQ (GST_MESSAGE_EOS, _push_a_value_frame (TEST_FRAME_CAPS, TEST_FRAME_SIZE,
+                                  "0:0:0:0,0", "1101", &error_src, &error, &received));
+  EXPECT_EQ (1U, received);
+
+  /* test_frames[0][2 + 3 * 3 + 1 * 12 + 1 * 24], the last offset that fits */
+  EXPECT_EQ (GST_MESSAGE_EOS, _push_a_value_frame (TEST_FRAME_CAPS, TEST_FRAME_SIZE,
+                                  "2:3:1:1,0", "1224", &error_src, &error, &received));
+  EXPECT_EQ (1U, received);
+
+  g_clear_error (&error);
+  g_free (error_src);
+}
+
+/**
+ * @brief The element index of the first dimension is not in the tensor.
+ */
+TEST (tensorIfAppsrc, comparedValueIndexOverFirstDim_n)
+{
+  _expect_refused_cv_option (TEST_FRAME_CAPS, TEST_FRAME_SIZE, "3:0:0:0,0");
+}
+
+/**
+ * @brief The element index of the last dimension is one past the tensor.
+ */
+TEST (tensorIfAppsrc, comparedValueIndexOverLastDim_n)
+{
+  _expect_refused_cv_option (TEST_FRAME_CAPS, TEST_FRAME_SIZE, "0:0:0:2,0");
+}
+
+/**
+ * @brief The element index stays inside the tensor but not inside its dimension.
+ */
+TEST (tensorIfAppsrc, comparedValueIndexOverInnerDim_n)
+{
+  _expect_refused_cv_option (TEST_FRAME_CAPS, TEST_FRAME_SIZE, "0:4:0:0,0");
+}
+
+/**
+ * @brief The element index refers to a dimension the tensor does not have.
+ */
+TEST (tensorIfAppsrc, comparedValueIndexOverRank_n)
+{
+  _expect_refused_cv_option (TEST_FRAME_CAPS, TEST_FRAME_SIZE, "0:0:0:0:1,0");
+}
+
+/**
+ * @brief A negative element index wraps around the unsigned dimension index.
+ */
+TEST (tensorIfAppsrc, comparedValueNegativeIndex_n)
+{
+  _expect_refused_cv_option (TEST_FRAME_CAPS, TEST_FRAME_SIZE, "-1:0:0:0,0");
+}
+
+/**
+ * @brief An element index far past its dimension, which wrapped the 32-bit offset of main.
+ */
+TEST (tensorIfAppsrc, comparedValueHugeIndex_n)
+{
+  _expect_refused_cv_option (TEST_FRAME_CAPS, TEST_FRAME_SIZE, "2000000000:0:0:0,0");
+}
+
+/**
+ * @brief The caps declare more data than the buffer carries.
+ * @note The element is inside the dimensions, so only the size of the mapped
+ * memory can refuse it.
+ */
+TEST (tensorIfAppsrc, comparedValueBufferShorterThanCaps_n)
+{
+  _expect_refused_cv_option ("other/tensor,dimension=(string)4:2:1,type=(string)uint8,framerate=(fraction)0/1",
+      4, "0:1:0,0");
+}
+
+/**
+ * @brief The byte offset of the element is 2^64 - 1, one short of wrapping to 0.
+ * @note (2^32 - 1) * 2 + (2^32 - 1)^2 = 2^64 - 1, so a size check that adds the
+ * element size to the offset wraps and reads the byte before the buffer.
+ */
+TEST (tensorIfAppsrc, comparedValueOffsetWrapsAround_n)
+{
+  _expect_refused_cv_option ("other/tensor,dimension=(string)4294967295:4294967295:2,type=(string)uint8,framerate=(fraction)0/1",
+      4, "0:2:1,0");
+}
+
+#if GLIB_CHECK_VERSION(2, 48, 0)
+/**
+ * @brief The offset arithmetic overflows and wraps back into the buffer.
+ * @note 2^31 * 2^31 * 4 wraps to 0, so without the overflow check the last
+ * index adds nothing and the first byte of the buffer is compared silently.
+ */
+TEST (tensorIfAppsrc, comparedValueOffsetOverflow_n)
+{
+  _expect_refused_cv_option ("other/tensor,dimension=(string)2147483648:2147483648:4:2,type=(string)uint8,framerate=(fraction)0/1",
+      4, "0:0:0:1,0");
+}
+#endif
+
+/**
+ * @brief Custom callback that cannot tell the condition of the buffer.
+ */
+static gboolean
+tensor_if_custom_fail_cb (const GstTensorsInfo *info,
+    const GstTensorMemory *input, void *user_data, gboolean *result)
+{
+  return FALSE;
+}
+
+/**
+ * @brief The element reports the buffer a custom callback could not handle.
+ */
+TEST (tensorIfAppsrc, customCallbackFailure_n)
+{
+  gchar *error_src = NULL;
+  GError *error = NULL;
+  guint received = 0;
+  GstMessageType type;
+
+  ASSERT_EQ (0, nnstreamer_if_custom_register ("tif_fail", tensor_if_custom_fail_cb, NULL));
+
+  type = _push_if_frame (TEST_FRAME_CAPS, TEST_FRAME_SIZE,
+      "compared-value=CUSTOM compared-value-option=tif_fail then=PASSTHROUGH else=SKIP",
+      &error_src, &error, &received);
+  EXPECT_EQ (0, nnstreamer_if_custom_unregister ("tif_fail"));
+
+  EXPECT_EQ (GST_MESSAGE_ERROR, type);
+  EXPECT_STREQ ("tif", error_src);
+  ASSERT_NE (error, nullptr);
+  EXPECT_EQ (GST_STREAM_ERROR, error->domain);
+  EXPECT_EQ (GST_STREAM_ERROR_WRONG_TYPE, error->code);
+  EXPECT_EQ (0U, received);
+
+  g_clear_error (&error);
+  g_free (error_src);
+}
+
+/**
  * @brief Main GTest
  */
 int


### PR DESCRIPTION
Fixes item **C17** of #4920.

## The defect

`tensor_if compared-value=A_VALUE` picks a single element of the nth tensor, addressed by `compared-value-option=[C]:[W]:[H]:[B],n`. `gst_tensor_if_calculate_cv()` built the byte offset from that option alone: no index was ever compared with the dimension it indexes, and the resulting offset was never compared with the mapped memory.

On a `3:4:2:2` int32 tensor (192 bytes):

| `compared-value-option` | on main |
| --- | --- |
| `0:0:0:2,0` | reads the first element past the buffer |
| `0:4:0:0,0` | reads an element of another row, silently |
| `-1:0:0:0,0` | the index wraps to `0xFFFFFFFF`, the process dies |
| `2000000000:0:0:0,0` | SIGSEGV on the first buffer |

Reproduced on main with a plain pipeline:

```
gst-launch-1.0 videotestsrc num-buffers=1 ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=160,height=120 ! tensor_converter ! tensor_if compared-value=A_VALUE compared-value-option=2000000000:0:0:0,0 supplied-value=100 operator=GT then=PASSTHROUGH else=SKIP ! fakesink
```

`Caught SIGSEGV` before this change, a refused buffer after it.

## The fix

- An element index has to be inside the dimension it indexes; an index into a dimension the tensor does not have (dimension `0`) has to be `0`.
- The byte offset is accumulated in 64 bits.
- After the memory is mapped, the element has to fit in it. The comparison is `in_info.size < esize || idx > in_info.size - esize`, which cannot wrap: caps may declare far more data than the buffer carries, and with `dimension=4294967295:4294967295:2` uint8 and `0:2:1,0` the offset is `2^64 - 1`, so the earlier `idx + esize > in_info.size` wrapped to 0 and read the byte before the buffer.
- With GLib 2.48 or later (`#if GLIB_CHECK_VERSION (2, 48, 0)`), the offset arithmetic uses `g_uint64_checked_mul()` / `g_uint64_checked_add()`, so caps whose offset does not fit in 64 bits are refused instead of wrapping back onto an in-bounds element nobody asked for. Older GLib keeps the plain arithmetic, where the non-wrapping size check still keeps every read inside the mapping.
- The element posts `GST_ELEMENT_ERROR (STREAM, WRONG_TYPE)` when it refuses a buffer, so the bus error names `tensor_if` rather than leaving the source to report a bare internal data stream error.

The element that a valid option picks is unchanged: the offset the new loop computes is the same one the old loop computed for every index that was already inside the tensor.

## Tests

`tests/nnstreamer_if/unittest_if.cc`. Each case pushes one buffer cut from a 3:4:2:2 int32 frame whose elements are all distinct, with `operator=EQ then=PASSTHROUGH else=SKIP`, so a buffer reaches the sink only when the element that was read is the one the option describes. Every `_n` case expects the error `tensor_if` posts (source `tif`, `GST_STREAM_ERROR_WRONG_TYPE`) and no buffer at the sink.

- `comparedValueBothEnds` — the first and the last element of the tensor, the last offset that still fits. Passes on main too: it pins the offset arithmetic this PR rewrites.
- `comparedValueIndexOverFirstDim_n`, `comparedValueIndexOverLastDim_n`, `comparedValueIndexOverInnerDim_n`, `comparedValueIndexOverRank_n`, `comparedValueNegativeIndex_n`, `comparedValueHugeIndex_n` — options outside the tensor, refused by the per-dimension check.
- `comparedValueBufferShorterThanCaps_n` — caps `4:2:1` uint8, a 4-byte buffer, `0:1:0,0`: inside the caps, past the buffer, so only the size of the mapping can refuse it.
- `comparedValueOffsetWrapsAround_n` — the wraparound case from the review: `4294967295:4294967295:2` uint8, a 4-byte buffer, `0:2:1,0`.
- `comparedValueOffsetOverflow_n` (GLib >= 2.48) — `2147483648:2147483648:4:2` uint8, `0:0:0:1,0`: the offset wraps to exactly 0, so without the overflow check the first byte of the buffer is compared silently.
- `customCallbackFailure_n` — a `CUSTOM` callback that returns `FALSE` gets the same element error.

Mutation matrix for the three buffer-smaller-than-caps cases (each variant rebuilt from this head, the named guard changed, cases run one by one):

| variant | ShorterThanCaps | WrapsAround | Overflow | BothEnds |
| --- | --- | --- | --- | --- |
| main | FAIL | CRASH (139) | FAIL | pass |
| no overflow check, `idx + esize > size` (the reviewed head) | pass | **FAIL** | FAIL | pass |
| no overflow check, non-wrapping size check | pass | pass | **FAIL** | pass |
| overflow check, no size check after mapping | **FAIL** | pass | pass | pass |
| this PR | pass | pass | pass | pass |

Rows 2-3 show that the non-wrapping comparison is what closes the wraparound on a build without the overflow check. With the overflow check compiled in, an offset near `2^64` is refused earlier, so that comparison is what protects GLib < 2.48 builds.

Mutation control for the rest: with only `gsttensor_if.c` reverted to main, every other `_n` case fails as well — the bounded ones report no error, `comparedValueNegativeIndex_n` takes the whole binary down with a segmentation fault, and `customCallbackFailure_n` reads `appsrc` / `GST_STREAM_ERROR_FAILED`.

Local verification: `unittest_if` 33/33, the `gstreamer_join` SSAT group (the only other in-tree user of `tensor_if`) 11/11, `gst-indent` and clang-format 16 clean, `doxygen-tag.sh` and `newline.sh` clean, both changed objects recompiled with `-Wextra -Wsign-compare -Werror`, and the `#else` branch compiled under the project's `-Werror` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
