### PR TITLE
[Decoder] Bound the pose decoder to its tensors and refuse empty label files

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -71,6 +71,7 @@
  *	                    	(e.g., 17 x 9 x 9 )
  *   			Tensor[1]: #labels x 2: width : height (float32, Offset position within heatmap grid)
  *	                    	(e.g., 34 x 9 x 9 )
+ *   			Width and height have to be 2 or larger, and the same in both tensors.
  *
  * Pipeline:
  * 	v4l2src
@@ -279,6 +280,9 @@ pose_load_metadata_from_file (pose_data * pd, const gchar * file_path)
     return FALSE;
   }
 
+  if (pd->metadata != pose_metadata_default)
+    g_free (pd->metadata);
+
   pd->total_labels = g_strv_length (lines);
   pd->metadata = g_new0 (pose_metadata_t, pd->total_labels);
 
@@ -320,7 +324,7 @@ pose_get_metadata_by_id (pose_data * data, guint id)
 {
   pose_metadata_t *md = data->metadata;
 
-  if (id > data->total_labels)
+  if (id >= data->total_labels)
     return NULL;
 
   return &md[id];
@@ -460,6 +464,61 @@ _check_tensors (const GstTensorsConfig * config)
 }
 
 /**
+ * @brief Check the input tensors against what pose_decode () reads from them.
+ * @param[in] data The pose-estimation internal data.
+ * @param[in] config The configuration of the input tensors.
+ * @return TRUE if decoding the tensors stays within them, otherwise FALSE.
+ */
+static gboolean
+pose_check_input (const pose_data * data, const GstTensorsConfig * config)
+{
+  const GstTensorInfo *heatmap = &config->info.info[0];
+  const GstTensorInfo *offset = &config->info.info[1];
+  gboolean with_offset = (data->mode == HEATMAP_OFFSET);
+  guint i;
+
+  if (data->i_width == 0 || data->i_height == 0) {
+    GST_ERROR
+        ("The input video dimension of the model is zero. Set option2 of pose_estimation to the WIDTH:HEIGHT the model takes.");
+    return FALSE;
+  }
+
+  if (heatmap->type != _NNS_FLOAT32
+      || heatmap->dimension[0] != data->total_labels) {
+    GST_ERROR
+        ("The heatmap tensor of pose_estimation has to be float32 with the %u labels as its first dimension.",
+        data->total_labels);
+    return FALSE;
+  }
+
+  if (with_offset && (heatmap->dimension[1] < 2 || heatmap->dimension[2] < 2)) {
+    GST_ERROR
+        ("The heatmap of pose_estimation in heatmap-offset mode needs at least two cells in each direction.");
+    return FALSE;
+  }
+
+  if (with_offset && (config->info.num_tensors < 2
+          || offset->type != _NNS_FLOAT32
+          || offset->dimension[0] != 2 * data->total_labels
+          || offset->dimension[1] != heatmap->dimension[1]
+          || offset->dimension[2] != heatmap->dimension[2])) {
+    GST_ERROR
+        ("The offset tensor of pose_estimation has to be float32 with two values per label for each cell of the heatmap.");
+    return FALSE;
+  }
+
+  for (i = 3; i < NNS_TENSOR_RANK_LIMIT; i++) {
+    if (heatmap->dimension[i] > 1 || (with_offset && offset->dimension[i] > 1)) {
+      GST_ERROR
+          ("The tensors of pose_estimation cannot have more than three dimensions.");
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
  * @brief tensordec-plugin's TensorDecDef callback
  *
  * [Pose Estimation]
@@ -473,30 +532,10 @@ pose_getOutCaps (void **pdata, const GstTensorsConfig * config)
 {
   pose_data *data = *pdata;
   GstCaps *caps;
-  int i;
   char *str;
-  guint pose_size;
 
-  const uint32_t *dim;
-
-  if (!_check_tensors (config))
+  if (!_check_tensors (config) || !pose_check_input (data, config))
     return NULL;
-
-  pose_size = data->total_labels;
-
-  /* Check if the first tensor is compatible */
-  dim = config->info.info[0].dimension;
-  g_return_val_if_fail (dim[0] == pose_size, NULL);
-  for (i = 3; i < NNS_TENSOR_RANK_LIMIT; i++)
-    g_return_val_if_fail (dim[i] <= 1, NULL);
-
-  if (data->mode == HEATMAP_OFFSET) {
-    dim = config->info.info[1].dimension;
-    g_return_val_if_fail (dim[0] == (2 * pose_size), NULL);
-
-    for (i = 3; i < NNS_TENSOR_RANK_LIMIT; i++)
-      g_return_val_if_fail (dim[i] <= 1, NULL);
-  }
 
   str = g_strdup_printf ("video/x-raw, format = RGBA, " /* Use alpha channel to make the background transparent */
       "width = %u, height = %u", data->width, data->height);
@@ -725,7 +764,7 @@ draw (GstMapInfo * out_info, pose_data * data, GArray * results)
     for (j = 0; j < smd->num_connections; j++) {
       guint k = smd->connections[j];
       /* Have we already drawn the connection ? */
-      if ((k > data->total_labels) || (k < i))
+      if ((k >= data->total_labels) || (k < i))
         continue;
       /* Is the body point valid ? */
       if (XYdata[k]->valid == FALSE)
@@ -757,6 +796,11 @@ pose_decode (void **pdata, const GstTensorsConfig * config,
   guint pose_size, index;
 
   g_assert (outbuf); /** GST Internal Bug */
+
+  /* An option may have changed since pose_getOutCaps () approved the stream */
+  if (!pose_check_input (data, config))
+    return GST_FLOW_ERROR;
+
   /* Ensure we have outbuf properly allocated */
   if (gst_buffer_get_size (outbuf) == 0) {
     out_mem = gst_allocator_alloc (NULL, size, NULL);

--- a/ext/nnstreamer/tensor_decoder/tensordec-pose.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-pose.c
@@ -262,16 +262,23 @@ pose_load_metadata_from_file (pose_data * pd, const gchar * file_path)
     return FALSE;
   }
 
-  if (!g_file_get_contents (file_path, &contents, &len, &err) || len <= 0) {
+  if (!g_file_get_contents (file_path, &contents, &len, &err)) {
     ml_loge ("Unable to read file %s with error %s.", file_path, err->message);
     g_clear_error (&err);
     return FALSE;
   }
 
-  if (contents[len - 1] == '\n')
+  if (len > 0 && contents[len - 1] == '\n')
     contents[len - 1] = '\0';
 
   lines = g_strsplit (contents, "\n", -1);
+  if (g_strv_length (lines) == 0) {
+    ml_loge ("The label file %s has no label.", file_path);
+    g_strfreev (lines);
+    g_free (contents);
+    return FALSE;
+  }
+
   pd->total_labels = g_strv_length (lines);
   pd->metadata = g_new0 (pose_metadata_t, pd->total_labels);
 
@@ -282,6 +289,11 @@ pose_load_metadata_from_file (pose_data * pd, const gchar * file_path)
     g_strstrip (lines[i]);
     tokens = g_strsplit (lines[i], " ", -1);
     n_tokens = g_strv_length (tokens);
+    if (n_tokens == 0) {
+      /* A blank line is a keypoint without a label or connections */
+      g_strfreev (tokens);
+      continue;
+    }
     if (n_tokens > POSE_MD_MAX_CONNECTIONS_SZ) {
       GST_WARNING ("Too many connections (%d) declared, clamping (%d)\n",
           n_tokens, POSE_MD_MAX_CONNECTIONS_SZ);

--- a/ext/nnstreamer/tensor_decoder/tensordecutil.c
+++ b/ext/nnstreamer/tensor_decoder/tensordecutil.c
@@ -34,17 +34,22 @@ loadImageLabels (const char *label_path, imglabel_t * l)
   _free_labels (l);
 
   /* Read file contents */
-  if (!g_file_get_contents (label_path, &contents, &len, &err) || len <= 0) {
+  if (!g_file_get_contents (label_path, &contents, &len, &err)) {
     ml_loge ("Unable to read file %s with error %s.", label_path, err->message);
     g_clear_error (&err);
     return;
   }
 
-  if (contents[len - 1] == '\n')
+  if (len > 0 && contents[len - 1] == '\n')
     contents[len - 1] = '\0';
 
   _labels = g_strsplit (contents, "\n", -1);
   l->total_labels = g_strv_length (_labels);
+  if (l->total_labels == 0) {
+    ml_loge ("The label file %s has no label.", label_path);
+    goto error;
+  }
+
   l->labels = g_new0 (char *, l->total_labels);
   if (l->labels == NULL) {
     ml_loge ("Failed to allocate memory for label data.");

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -112,6 +112,15 @@ if gtest_dep.found()
     )
     test('unittest_decoder_boundingbox', unittest_decoder_boundingbox, env: testenv)
 
+    # RUN unittest_decoder_pose
+    unittest_decoder_pose = executable('unittest_decoder_pose',
+      join_paths('nnstreamer_decoder_pose', 'unittest_decoder_pose.cc'),
+      dependencies: [nnstreamer_unittest_deps, nnstreamer_internal_deps],
+      install: get_option('install-test'),
+      install_dir: unittest_install_dir
+    )
+    test('unittest_decoder_pose', unittest_decoder_pose, env: testenv)
+
     # Run unittest_plugins
     unittest_plugins = executable('unittest_plugins',
       join_paths('nnstreamer_plugins', 'unittest_plugins.cc'),

--- a/tests/nnstreamer_decoder_pose/runTest.sh
+++ b/tests/nnstreamer_decoder_pose/runTest.sh
@@ -26,8 +26,8 @@ CASEEND=1
 # THIS SHOULD EMIT ERROR
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc ! videoconvert ! videoscale ! video/x-raw,width=640,height=480,format=RGB ! tensor_converter ! tensor_split name=a tensorseg=1:640:480:1,2:640:480:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=640:480 ! fakesink" 0_n 0 1 $PERFORMANCE
 
-# THIS WON'T FAIL, BUT NOT MUCH MEANINGFUL.
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 1 0 0 $PERFORMANCE
+# THIS SHOULD EMIT ERROR: the heatmap is uint8, and the decoder reads it as float32
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=4 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 1_n 0 1 $PERFORMANCE
 
 # TEST WITH MORE BUFFERS
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=20 ! videoconvert ! videoscale ! video/x-raw,width=14,height=14,format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:128,div:255 ! tensor_split name=a tensorseg=1:14:14:1,2:14:14:1 a.src_0 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_decoder mode=pose_estimation option1=320:240 option2=14:14 ! fakesink" 2 0 0 $PERFORMANCE

--- a/tests/nnstreamer_decoder_pose/unittest_decoder_pose.cc
+++ b/tests/nnstreamer_decoder_pose/unittest_decoder_pose.cc
@@ -1,0 +1,736 @@
+/**
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * @file        unittest_decoder_pose.cc
+ * @date        10 Sep 2026
+ * @brief       Unit test for the pose_estimation mode of tensor_decoder and
+ *              the label file loader of the image-based decoder modes
+ * @see         https://github.com/nnstreamer/nnstreamer
+ * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug         No known bugs
+ */
+
+#include <gtest/gtest.h>
+#include <glib.h>
+#include <gst/gst.h>
+#include <string.h>
+#include <unittest_util.h>
+
+#include <nnstreamer_plugin_api_decoder.h>
+#include <nnstreamer_plugin_api_util.h>
+
+/* The number of labels pose_estimation assumes without a label file */
+#define DEFAULT_LABELS (14U)
+
+#define LABELS (2U)
+#define GRID (5U)
+#define HEATMAP_ELEMENTS (LABELS * GRID * GRID)
+#define OFFSET_ELEMENTS (2U * HEATMAP_ELEMENTS)
+
+#define OUT_SIZE (40U)
+#define OUT_PIXELS (OUT_SIZE * OUT_SIZE)
+
+#define POSE_PIXEL (0xFFFFFFFFU)
+
+/** The two labels, connected to each other */
+#define LABEL_TEXT "a 1\nb 0\n"
+/** The first label connects to an id one past the last label */
+#define LABEL_TEXT_PAST_LAST "a 2\nb\n"
+
+/**
+ * @brief Test fixture holding an instance of the pose_estimation decoder.
+ */
+class tensorDecoderPose : public ::testing::Test
+{
+  protected:
+  const GstTensorDecoderDef *decoder;
+  void *pdata;
+  gchar *label_file;
+
+  /**
+   * @brief Initialize the decoder instance.
+   */
+  void SetUp () override
+  {
+    pdata = NULL;
+    label_file = NULL;
+    decoder = nnstreamer_decoder_find ("pose_estimation");
+    ASSERT_TRUE (decoder != NULL);
+    ASSERT_TRUE (decoder->init (&pdata));
+  }
+
+  /**
+   * @brief Release the decoder instance and the label file.
+   */
+  void TearDown () override
+  {
+    if (pdata != NULL)
+      decoder->exit (&pdata);
+    removeTempFile (&label_file);
+  }
+
+  /**
+   * @brief Write a label file and hand it to the decoder as option3.
+   */
+  gboolean setLabels (const gchar *text)
+  {
+    removeTempFile (&label_file);
+    label_file = getTempFilename ();
+    if (label_file == NULL || !g_file_set_contents (label_file, text, -1, NULL))
+      return FALSE;
+
+    return decoder->setOption (&pdata, 2, label_file);
+  }
+
+  /**
+   * @brief Whether the decoder negotiates an output for the given input.
+   */
+  gboolean accepts (const GstTensorsConfig *config)
+  {
+    GstCaps *caps = decoder->getOutCaps (&pdata, config);
+
+    if (caps == NULL)
+      return FALSE;
+
+    gst_caps_unref (caps);
+    return TRUE;
+  }
+};
+
+/**
+ * @brief Describe a heatmap tensor, and an offset tensor if offset_grid is not 0.
+ */
+static void
+setPoseConfig (GstTensorsConfig *config, tensor_type type, guint labels,
+    guint grid, guint offset_grid)
+{
+  GstTensorInfo *info;
+
+  gst_tensors_config_init (config);
+  config->rate_n = 0;
+  config->rate_d = 1;
+  config->info.num_tensors = (offset_grid > 0) ? 2 : 1;
+
+  info = gst_tensors_info_get_nth_info (&config->info, 0);
+  info->type = type;
+  info->dimension[0] = labels;
+  info->dimension[1] = grid;
+  info->dimension[2] = grid;
+  info->dimension[3] = 1;
+
+  if (offset_grid > 0) {
+    info = gst_tensors_info_get_nth_info (&config->info, 1);
+    info->type = type;
+    info->dimension[0] = 2 * labels;
+    info->dimension[1] = offset_grid;
+    info->dimension[2] = offset_grid;
+    info->dimension[3] = 1;
+  }
+}
+
+/**
+ * @brief Decode one heatmap, allocated to its exact size, with the given decoder.
+ */
+static GstFlowReturn
+decodeHeatmap (const GstTensorDecoderDef *decoder, void **pdata, const GstTensorsConfig *config)
+{
+  GstTensorMemory input;
+  GstBuffer *outbuf = gst_buffer_new ();
+  GstFlowReturn ret;
+
+  input.size = gst_tensor_info_get_size (&config->info.info[0]);
+  input.data = g_malloc0 (input.size);
+
+  ret = decoder->decode (pdata, config, &input, outbuf);
+
+  g_free (input.data);
+  gst_buffer_unref (outbuf);
+  return ret;
+}
+
+/**
+ * @brief Set one cell of a heatmap tensor (label, x, y).
+ */
+static void
+setHeatmap (float *heatmap, guint label, guint x, guint y, float value)
+{
+  heatmap[(y * GRID + x) * LABELS + label] = value;
+}
+
+/**
+ * @brief Write the given floats to a new temp file.
+ * @return the file name, to be released with removeTempFile ()
+ */
+static gchar *
+writeTensorFile (const float *data, guint elements)
+{
+  gchar *name = getTempFilename ();
+
+  if (name != NULL
+      && !g_file_set_contents (name, (const gchar *) data, elements * sizeof (float), NULL))
+    removeTempFile (&name);
+
+  return name;
+}
+
+/**
+ * @brief Run the pipeline to its end.
+ * @return GST_MESSAGE_EOS or GST_MESSAGE_ERROR, GST_MESSAGE_ANY if the
+ *         pipeline could not be built and GST_MESSAGE_UNKNOWN on a timeout.
+ */
+static GstMessageType
+runPipeline (const gchar *pipeline_str)
+{
+  GstElement *pipeline = gst_parse_launch (pipeline_str, NULL);
+  GstMessageType type = GST_MESSAGE_UNKNOWN;
+  GstBus *bus;
+  GstMessage *msg;
+
+  if (pipeline == NULL)
+    return GST_MESSAGE_ANY;
+
+  /* A refused negotiation may fail the state change itself */
+  setPipelineStateSync (pipeline, GST_STATE_PLAYING, UNITTEST_STATECHANGE_TIMEOUT);
+
+  bus = gst_element_get_bus (pipeline);
+  msg = gst_bus_timed_pop_filtered (bus, 10 * GST_SECOND,
+      (GstMessageType) (GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+  if (msg != NULL) {
+    type = GST_MESSAGE_TYPE (msg);
+    gst_message_unref (msg);
+  }
+  gst_object_unref (bus);
+
+  setPipelineStateSync (pipeline, GST_STATE_NULL, UNITTEST_STATECHANGE_TIMEOUT);
+  gst_object_unref (pipeline);
+
+  return type;
+}
+
+/**
+ * @brief Decode a heatmap (and its offsets, if given) into a frame.
+ * @param[in] heatmap HEATMAP_ELEMENTS floats
+ * @param[in] offset OFFSET_ELEMENTS floats for heatmap-offset, NULL for heatmap-only
+ * @param[in] label_text the content of the label file
+ * @param[in] model_size option2 of the decoder
+ * @param[out] frame OUT_PIXELS RGBA pixels drawn by the decoder
+ */
+static GstMessageType
+decodePose (const float *heatmap, const float *offset, const gchar *label_text,
+    guint model_size, uint32_t *frame)
+{
+  float tensors[HEATMAP_ELEMENTS + OFFSET_ELEMENTS];
+  guint elements = HEATMAP_ELEMENTS;
+  gchar *in_file, *label_file, *out_file, *pipeline_str, *dims, *types;
+  gchar *content = NULL;
+  gsize len = 0;
+  GstMessageType ret = GST_MESSAGE_ANY;
+
+  memcpy (tensors, heatmap, HEATMAP_ELEMENTS * sizeof (float));
+  if (offset != NULL) {
+    memcpy (tensors + HEATMAP_ELEMENTS, offset, OFFSET_ELEMENTS * sizeof (float));
+    elements += OFFSET_ELEMENTS;
+    dims = g_strdup_printf (
+        "%u:%u:%u:1,%u:%u:%u:1", LABELS, GRID, GRID, 2 * LABELS, GRID, GRID);
+    types = g_strdup ("float32,float32");
+  } else {
+    dims = g_strdup_printf ("%u:%u:%u:1", LABELS, GRID, GRID);
+    types = g_strdup ("float32");
+  }
+
+  in_file = writeTensorFile (tensors, elements);
+  label_file = getTempFilename ();
+  out_file = getTempFilename ();
+
+  if (in_file != NULL && label_file != NULL && out_file != NULL
+      && g_file_set_contents (label_file, label_text, -1, NULL)) {
+    pipeline_str = g_strdup_printf (
+        "filesrc location=%s blocksize=%u ! application/octet-stream ! "
+        "tensor_converter input-dim=%s input-type=%s ! "
+        "tensor_decoder mode=pose_estimation option1=%u:%u option2=%u:%u "
+        "option3=%s option4=%s ! "
+        "filesink location=%s buffer-mode=unbuffered sync=false async=false",
+        in_file, (guint) (elements * sizeof (float)), dims, types, OUT_SIZE,
+        OUT_SIZE, model_size, model_size, label_file,
+        offset != NULL ? "heatmap-offset" : "heatmap-only", out_file);
+
+    ret = runPipeline (pipeline_str);
+    g_free (pipeline_str);
+
+    if (ret == GST_MESSAGE_EOS) {
+      if (g_file_get_contents (out_file, &content, &len, NULL)
+          && len == OUT_PIXELS * sizeof (uint32_t))
+        memcpy (frame, content, len);
+      else
+        ret = GST_MESSAGE_ANY;
+      g_free (content);
+    }
+  }
+
+  g_free (dims);
+  g_free (types);
+  removeTempFile (&in_file);
+  removeTempFile (&label_file);
+  removeTempFile (&out_file);
+
+  return ret;
+}
+
+/**
+ * @brief Count the pixels the decoder has drawn.
+ */
+static guint
+countDrawnPixels (const uint32_t *frame, guint pixels)
+{
+  guint i, count = 0;
+
+  for (i = 0; i < pixels; i++) {
+    if (frame[i] != 0U)
+      count++;
+  }
+
+  return count;
+}
+
+/**
+ * @brief A float32 heatmap with one row per label is accepted.
+ */
+TEST_F (tensorDecoderPose, acceptFloat32Heatmap)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS, GRID, 0);
+  EXPECT_TRUE (accepts (&config));
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief A heatmap of another element type is refused.
+ * @details The decoder reads the heatmap as float32, so a uint8 heatmap of the
+ *          same dimensions used to be read four times past its end.
+ */
+TEST_F (tensorDecoderPose, refuseUint8Heatmap_n)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+
+  setPoseConfig (&config, _NNS_UINT8, DEFAULT_LABELS, GRID, 0);
+  EXPECT_FALSE (accepts (&config));
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief A heatmap whose first dimension is not the number of labels is refused.
+ */
+TEST_F (tensorDecoderPose, refuseLabelCountMismatch_n)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS - 1, GRID, 0);
+  EXPECT_FALSE (accepts (&config));
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief A heatmap or an offset tensor with more than three dimensions is refused.
+ */
+TEST_F (tensorDecoderPose, refuseHigherRank_n)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS, GRID, 0);
+  config.info.info[0].dimension[3] = 2;
+  EXPECT_FALSE (accepts (&config));
+  gst_tensors_config_free (&config);
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 3, "heatmap-offset"));
+
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS, GRID, GRID);
+  config.info.info[1].dimension[3] = 2;
+  EXPECT_FALSE (accepts (&config));
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief A stream is refused while the model input size (option2) is not given.
+ * @details The decoder divides by the model input size.
+ */
+TEST_F (tensorDecoderPose, refuseMissingModelSize_n)
+{
+  GstTensorsConfig config;
+
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS, GRID, 0);
+  EXPECT_FALSE (accepts (&config));
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+  EXPECT_TRUE (accepts (&config));
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, ""));
+  EXPECT_FALSE (accepts (&config));
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief An offset tensor of the heatmap's grid is accepted in heatmap-offset mode.
+ */
+TEST_F (tensorDecoderPose, acceptOffsetGrid)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+  EXPECT_TRUE (decoder->setOption (&pdata, 3, "heatmap-offset"));
+
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS, GRID, GRID);
+  EXPECT_TRUE (accepts (&config));
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief An offset tensor smaller than the heatmap's grid is refused.
+ * @details The offset of a keypoint is looked up at the heatmap cell it was
+ *          found in, so a smaller offset tensor used to be read past its end.
+ */
+TEST_F (tensorDecoderPose, refuseOffsetGridMismatch_n)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+  EXPECT_TRUE (decoder->setOption (&pdata, 3, "heatmap-offset"));
+
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS, GRID, GRID);
+  config.info.info[1].dimension[1] = GRID - 1;
+  EXPECT_FALSE (accepts (&config));
+  gst_tensors_config_free (&config);
+
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS, GRID, GRID);
+  config.info.info[1].dimension[2] = GRID - 1;
+  EXPECT_FALSE (accepts (&config));
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief A heatmap of a single cell in a direction is refused in heatmap-offset mode.
+ * @details heatmap-offset places a keypoint at its cell index over the number
+ *          of cells minus one, which is a division by zero for a single cell.
+ */
+TEST_F (tensorDecoderPose, refuseSingleCellOffsetGrid_n)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+  EXPECT_TRUE (decoder->setOption (&pdata, 3, "heatmap-offset"));
+
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS, GRID, GRID);
+  config.info.info[0].dimension[1] = config.info.info[1].dimension[1] = 1;
+  EXPECT_FALSE (accepts (&config));
+  gst_tensors_config_free (&config);
+
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS, GRID, GRID);
+  config.info.info[0].dimension[2] = config.info.info[1].dimension[2] = 1;
+  EXPECT_FALSE (accepts (&config));
+  gst_tensors_config_free (&config);
+
+  /* heatmap-only does not divide by the grid */
+  EXPECT_TRUE (decoder->setOption (&pdata, 3, "heatmap-only"));
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS, 1, 0);
+  EXPECT_TRUE (accepts (&config));
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief A single tensor is refused in heatmap-offset mode.
+ */
+TEST_F (tensorDecoderPose, refuseMissingOffsetTensor_n)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+  EXPECT_TRUE (decoder->setOption (&pdata, 3, "heatmap-offset"));
+
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS, GRID, 0);
+  EXPECT_FALSE (accepts (&config));
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief A label file without a label is refused and the labels in use are kept.
+ * @details Reading a file of 0 bytes succeeds without an error to report,
+ *          and the error message used to be read from the NULL error. A file
+ *          of a single newline used to be taken as a file of no labels. The
+ *          labels in use come from a file, so a refusal that released them
+ *          first leaves a dangling table that exit () frees again.
+ */
+TEST_F (tensorDecoderPose, refuseEmptyLabelFile_n)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+  EXPECT_TRUE (setLabels (LABEL_TEXT));
+  EXPECT_FALSE (setLabels (""));
+  EXPECT_FALSE (setLabels ("\n"));
+
+  setPoseConfig (&config, _NNS_FLOAT32, LABELS, GRID, 0);
+  EXPECT_TRUE (accepts (&config));
+  gst_tensors_config_free (&config);
+
+  setPoseConfig (&config, _NNS_FLOAT32, DEFAULT_LABELS, GRID, 0);
+  EXPECT_FALSE (accepts (&config));
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief Count the critical messages of the GLib domain.
+ */
+static void
+countGLibCritical (const gchar *, GLogLevelFlags, const gchar *, gpointer user_data)
+{
+  guint *count = (guint *) user_data;
+
+  (*count)++;
+}
+
+/**
+ * @brief A blank line in a label file is a keypoint without a label or connections.
+ * @details The label was copied from the NULL first token of the blank line.
+ */
+TEST_F (tensorDecoderPose, loadLabelFileWithBlankLine)
+{
+  GstTensorsConfig config;
+  guint critical = 0;
+  guint handler = g_log_set_handler ("GLib",
+      (GLogLevelFlags) (G_LOG_LEVEL_CRITICAL | G_LOG_FLAG_FATAL),
+      countGLibCritical, &critical);
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+  EXPECT_TRUE (setLabels ("a 2\n\nb 0\n"));
+  EXPECT_EQ (critical, 0U);
+
+  /* The handler is live: a critical of the domain is counted */
+  g_log ("GLib", G_LOG_LEVEL_CRITICAL, "self-check of the counter");
+  EXPECT_EQ (critical, 1U);
+  g_log_remove_handler ("GLib", handler);
+
+  setPoseConfig (&config, _NNS_FLOAT32, 3, GRID, 0);
+  EXPECT_TRUE (accepts (&config));
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief A label file given again replaces the labels of the previous one.
+ */
+TEST_F (tensorDecoderPose, reloadLabelFile)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+  EXPECT_TRUE (setLabels (LABEL_TEXT));
+  EXPECT_TRUE (setLabels ("a 1\nb 2\nc 0\n"));
+
+  setPoseConfig (&config, _NNS_FLOAT32, 3, GRID, 0);
+  EXPECT_TRUE (accepts (&config));
+  gst_tensors_config_free (&config);
+
+  setPoseConfig (&config, _NNS_FLOAT32, LABELS, GRID, 0);
+  EXPECT_FALSE (accepts (&config));
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief A heatmap is decoded when the options match the negotiated stream.
+ */
+TEST_F (tensorDecoderPose, decodeHeatmap)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 0, "40:40"));
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+  EXPECT_TRUE (setLabels (LABEL_TEXT));
+
+  setPoseConfig (&config, _NNS_FLOAT32, LABELS, GRID, 0);
+  EXPECT_EQ (decodeHeatmap (decoder, &pdata, &config), GST_FLOW_OK);
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief Decoding stops when the model input size is cleared after negotiation.
+ * @details The decoder divides by the model input size, which an option set
+ *          while streaming can clear without a renegotiation.
+ */
+TEST_F (tensorDecoderPose, decodeAfterModelSizeCleared_n)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 0, "40:40"));
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+  EXPECT_TRUE (setLabels (LABEL_TEXT));
+
+  setPoseConfig (&config, _NNS_FLOAT32, LABELS, GRID, 0);
+  EXPECT_TRUE (accepts (&config));
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, ""));
+  EXPECT_EQ (decodeHeatmap (decoder, &pdata, &config), GST_FLOW_ERROR);
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief Decoding stops when a label file with more labels arrives after negotiation.
+ * @details The decoder reads one heatmap row per label, so more labels than
+ *          the negotiated heatmap has are read past its end.
+ */
+TEST_F (tensorDecoderPose, decodeAfterLabelsChanged_n)
+{
+  GstTensorsConfig config;
+
+  EXPECT_TRUE (decoder->setOption (&pdata, 0, "40:40"));
+  EXPECT_TRUE (decoder->setOption (&pdata, 1, "5:5"));
+  EXPECT_TRUE (setLabels (LABEL_TEXT));
+
+  setPoseConfig (&config, _NNS_FLOAT32, LABELS, GRID, 0);
+  EXPECT_TRUE (accepts (&config));
+
+  EXPECT_TRUE (setLabels ("a 1\nb 2\nc 0\n"));
+  EXPECT_EQ (decodeHeatmap (decoder, &pdata, &config), GST_FLOW_ERROR);
+  gst_tensors_config_free (&config);
+}
+
+/**
+ * @brief Two connected keypoints are drawn with the line between them.
+ */
+TEST (tensorDecoderPosePipeline, drawConnection)
+{
+  float heatmap[HEATMAP_ELEMENTS] = { 0.0f };
+  uint32_t frame[OUT_PIXELS] = { 0U };
+
+  /* heatmap-only scales the grid by option1 / option2: 40 / 5 = 8 pixels a cell */
+  setHeatmap (heatmap, 0, 1, 1, 1.0f);
+  setHeatmap (heatmap, 1, 3, 3, 1.0f);
+  ASSERT_EQ (decodePose (heatmap, NULL, LABEL_TEXT, GRID, frame), GST_MESSAGE_EOS);
+
+  /* The keypoints are at (8, 8) and (24, 24), the line passes (16, 16) */
+  EXPECT_EQ (frame[24 * OUT_SIZE + 24], POSE_PIXEL);
+  EXPECT_EQ (frame[16 * OUT_SIZE + 16], POSE_PIXEL);
+}
+
+/**
+ * @brief A connection to an id past the last label is not drawn.
+ * @details The id equal to the number of labels passed the bounds test and
+ *          was looked up one past the end of the keypoint array.
+ */
+TEST (tensorDecoderPosePipeline, skipConnectionPastLastLabel_n)
+{
+  float heatmap[HEATMAP_ELEMENTS] = { 0.0f };
+  uint32_t frame[OUT_PIXELS] = { 0U };
+
+  setHeatmap (heatmap, 0, 1, 1, 1.0f);
+  setHeatmap (heatmap, 1, 3, 3, 1.0f);
+  ASSERT_EQ (decodePose (heatmap, NULL, LABEL_TEXT_PAST_LAST, GRID, frame), GST_MESSAGE_EOS);
+
+  /* The labels are drawn, the line is not */
+  EXPECT_GT (countDrawnPixels (frame, OUT_PIXELS), 0U);
+  EXPECT_EQ (frame[16 * OUT_SIZE + 16], 0U);
+}
+
+/**
+ * @brief The offset tensor moves a keypoint within its heatmap cell.
+ * @details The offsets of a keypoint are read at the heatmap cell it was
+ *          found in, y first and x after the offsets of all the labels.
+ */
+TEST (tensorDecoderPosePipeline, drawWithOffset)
+{
+  float heatmap[HEATMAP_ELEMENTS];
+  float offset[OFFSET_ELEMENTS] = { 0.0f };
+  uint32_t frame[OUT_PIXELS] = { 0U };
+  guint i;
+
+  for (i = 0; i < HEATMAP_ELEMENTS; i++)
+    heatmap[i] = -10.0f;
+  setHeatmap (heatmap, 0, 1, 1, 10.0f);
+  setHeatmap (heatmap, 1, 2, 2, 10.0f);
+
+  /* The cell (1, 1) holds label 0's y offset at 0 and its x offset at LABELS */
+  offset[(1 * GRID + 1) * 2 * LABELS] = 3.0f;
+  offset[(1 * GRID + 1) * 2 * LABELS + LABELS] = 2.0f;
+
+  /* heatmap-offset scales the grid to option2: cell 1 of 5 is at 40 / 4 = 10 */
+  ASSERT_EQ (decodePose (heatmap, offset, LABEL_TEXT, OUT_SIZE, frame), GST_MESSAGE_EOS);
+
+  /* The first keypoint moves from (10, 10) to (12, 13), the second stays at (20, 20) */
+  EXPECT_EQ (frame[13 * OUT_SIZE + 12], POSE_PIXEL);
+  EXPECT_EQ (frame[20 * OUT_SIZE + 20], POSE_PIXEL);
+  EXPECT_EQ (frame[10 * OUT_SIZE + 10], 0U);
+}
+
+/**
+ * @brief A pipeline without the model input size fails instead of dividing by it.
+ */
+TEST (tensorDecoderPosePipeline, refuseMissingModelSize_n)
+{
+  float heatmap[HEATMAP_ELEMENTS] = { 0.0f };
+  uint32_t frame[OUT_PIXELS] = { 0U };
+
+  setHeatmap (heatmap, 0, 1, 1, 1.0f);
+  setHeatmap (heatmap, 1, 3, 3, 1.0f);
+  EXPECT_EQ (decodePose (heatmap, NULL, LABEL_TEXT, 0, frame), GST_MESSAGE_ERROR);
+}
+
+/**
+ * @brief A label file without a label is refused by the loader image_labeling shares.
+ * @details loadImageLabels () serves image_labeling, bounding_boxes and
+ *          tensor_region. Reading a file of 0 bytes succeeds without an error
+ *          to report, and the error message used to be read from the NULL error.
+ */
+TEST (tensorDecoderLabelFile, refuseEmptyLabelFile_n)
+{
+  const GstTensorDecoderDef *decoder = nnstreamer_decoder_find ("image_labeling");
+  gchar *label_file = getTempFilename ();
+  void *pdata = NULL;
+
+  ASSERT_TRUE (decoder != NULL);
+  ASSERT_TRUE (label_file != NULL);
+  ASSERT_TRUE (g_file_set_contents (label_file, "", 0, NULL));
+  ASSERT_TRUE (decoder->init (&pdata));
+
+  EXPECT_FALSE (decoder->setOption (&pdata, 0, label_file));
+
+  EXPECT_TRUE (g_file_set_contents (label_file, "\n", -1, NULL));
+  EXPECT_FALSE (decoder->setOption (&pdata, 0, label_file));
+
+  /* The decoder still takes a label file after refusing one */
+  EXPECT_TRUE (g_file_set_contents (label_file, "orange\n", -1, NULL));
+  EXPECT_TRUE (decoder->setOption (&pdata, 0, label_file));
+
+  decoder->exit (&pdata);
+  removeTempFile (&label_file);
+}
+
+/**
+ * @brief Main GTest
+ */
+int
+main (int argc, char **argv)
+{
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch testing::internal::ClassUniqueToAlwaysTrue");
+  }
+
+  gst_init (&argc, &argv);
+
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch testing::internal::GoogleTestFailureException");
+  }
+
+  return result;
+}


### PR DESCRIPTION
Items **G1** and **G13** of #4920, taken together because both live in `tensordec-pose.c`.

The PR also fixes a division by zero in the same decoder: a missing `option2` crashes with SIGFPE. It is the `pose_estimation` counterpart of G19, and #4920 does not list it. It is fixed and tested here and is not added to #4920 as a separate item; see **New — no model input size** below.

## What was wrong

**G1 — empty label file.** `loadImageLabels ()` (used by `image_labeling`, `bounding_boxes`, `tensor_region`) and the `pose_estimation` label loader both did

```c
if (!g_file_get_contents (path, &contents, &len, &err) || len <= 0)
  ml_loge ("... %s", ..., err->message);
```

Reading a 0-byte file *succeeds*, so `err` is NULL on the `len == 0` branch. Pointing any of the four decoders at an existing empty file crashed the process as soon as the option was set (SIGSEGV, reproduced on `main` for `image_labeling option1=`, `tensor_region option2=` and `pose_estimation option3=`). `contents` leaked on the same branch.

The next shape of an empty file behaved wrongly too. A file holding a single newline (what `echo > labels.txt` writes) was accepted by the pose loader as a table of **no** labels, and the table in use was dropped. `loadImageLabels ()` refused that file only because `g_new0 ()` of 0 elements returns NULL, and it logged that it had run out of memory. A blank line *inside* a pose label file had no first token: its label was copied from NULL (a GLib critical), and its connection count became `-1`.

**G13 — pose decoder reads past its tensors.** `pose_getOutCaps ()` checked only the first dimension:
- the heatmap is always read as float32, so a heatmap of any other type was read past its end. `tests/nnstreamer_decoder_pose` case 1 did exactly this and passed: a uint8 `14:14:1` heatmap, 784 bytes read out of a 196-byte tensor.
- in `heatmap-offset` mode the offset is looked up at the heatmap cell, but the offset tensor's grid was never compared with the heatmap's.
- a connection id equal to the number of labels passed `k > total_labels` and read `XYdata[total_labels]`, one past the end of the array (SIGSEGV, reproduced).
- giving `option3` again leaked the previous metadata.

**New — no model input size.** `pose_decode ()` divides by `option2`'s width and height, which default to 0. A pipeline without `option2` died with SIGFPE on the first frame (reproduced, exit 136).

## The fix

- G1: split the condition. A failed read reports its error as before. A file is refused when splitting it yields no line at all, which covers the 0-byte file and the single-newline file, and `contents` is released. The two loaders keep their existing failure semantics:
  - The pose loader keeps the table in use, as it already did for an unreadable file.
  - `loadImageLabels ()` clears its labels first, as it already did for an unreadable file. That is how its callers (`image_labeling`, `bounding_boxes`, `tensor_region`) see the refusal: they report success as `total_labels > 0`, after replacing their `label_path`. A blank line in a pose label file becomes a keypoint without a label or connections, so the keypoint ids of the lines after it stay where the file puts them.
- G13 and the model size: one helper, `pose_check_input ()`, decides whether decoding the tensors stays inside them: model size non-zero, heatmap float32 with one row per label, offset tensor float32 with `2 × labels` and the heatmap's grid, rank ≤ 3. In `heatmap-offset` mode the heatmap also needs at least two cells in each direction, because a keypoint is placed at `cell / (cells - 1)`, which is 0/0 for a single cell. `pose_getOutCaps ()` refuses what it rejects. `pose_decode ()` calls it again, because `option2`/`option3` set while streaming change what gets read without a renegotiation (same reasoning as the `BoundingBox::decode ()` guard added for G19). The existing dimension checks move into the helper as plain checks rather than `g_return_val_if_fail ()`, which disappears with `G_DISABLE_CHECKS` and reports a user's configuration error as a programming error.
- `>` becomes `>=` in both places that bound a label id. A reloaded label file frees the previous metadata, but only once the new file has been read into lines, so a refused file leaves the table in use untouched.
- SSAT `nnstreamer_decoder_pose` case 1 (the uint8 heatmap) becomes `1_n`, because that case is the defect.

## Behaviour changes

Each of these was a crash or an out-of-bounds read before. None is reachable by a pipeline that decoded correctly:
- a label file without a label (0 bytes or a single newline) is refused instead of crashing. For `pose_estimation` the labels in use are kept, where a single-newline file used to wipe them.
- `pose_estimation` refuses a non-float32 heatmap, a mismatched offset grid, a single-cell heatmap in `heatmap-offset` mode, and a missing `option2`. The file header already documents both tensors as float32. It marks `option3`/`option4` as optional but not `option2`.
- A refused `pose_estimation` config now logs `GST_ERROR` instead of a GLib critical.

## Tests

New gtest binary `unittest_decoder_pose` (20 cases). It calls the sub-plugin directly where a single guard has to be pinned, and runs a `filesrc` → `tensor_converter` → `tensor_decoder` → `filesink` pipeline where the drawn frame is what tells cases apart. That is the same fixture shape as `unittest_decoder_boundingbox`, and it is built unconditionally.

- **Negative control** (pre-fix sources, new tests): 11 of 20 fail.
  - By SIGSEGV: `refuseEmptyLabelFile_n` ×2 and `skipConnectionPastLastLabel_n`.
  - By SIGFPE: `decodeAfterModelSizeCleared_n` and the pipeline `refuseMissingModelSize_n`.
  - By assertion: `refuseUint8Heatmap_n`, `refuseOffsetGridMismatch_n`, `refuseSingleCellOffsetGrid_n`, `refuseMissingModelSize_n`, `decodeAfterLabelsChanged_n`, and `loadLabelFileWithBlankLine`. The last one counts GLib criticals, with a self-check that proves the counter is live.
  - Every positive case passes on both sides.
- **Mutation control**: each guard removed on its own fails at least one case. Measured for each of these:
  - the decode-time check, `>=`, and the type check
  - each grid dimension separately, each tensor's half of the rank check, and the single-cell grid
  - the model size
  - the pose no-label check and the blank-line handling
  - moving the metadata release ahead of the refusals: `refuseEmptyLabelFile_n` starts from a table loaded from a file, so the move turns it into a double free (SIGABRT).

  Three removals are not visible to a gtest assertion, stated rather than papered over:
  - dropping the release itself is a leak, and the memcheck gate does not fail on leaks.
  - without the no-label check in `loadImageLabels ()`, the file is still refused, because `g_new0 ()` of 0 elements returns NULL. Only the log message changes.
  - without the `len > 0` guard, a 0-byte file is read one byte before its buffer, which only the memcheck step sees.
- The refused-config pipeline case logs the `gst_caps_*` criticals of item **C22**, fixed separately in #4948. It does not depend on that fix.

Local runs (WSL, Ubuntu 22.04):
- `unittest_decoder_pose` 20/20. Each intermediate commit also builds with `-Dwerror=true` and passes SSAT `nnstreamer_decoder_pose`.
- SSAT `nnstreamer_decoder_pose` 7/7, `nnstreamer_decoder_boundingbox` 55/55, `nnstreamer_decoder_tensor_region` 2/2, `nnstreamer_decoder` 60/60.
- `meson test`: 23/24. The failure is `unittest_filter_python3`, from this machine's NumPy 2 ABI mismatch, unrelated.
- A strict `-Wextra -Wsign-compare -Werror` compile of every changed object is clean. gst-indent reproduces the C hunks exactly, clang-format 16 is clean on the test file, and `doxygen-tag.sh` passes with ctags (checked with a negative control).

## Not in this PR

Options are set without any lock while the streaming thread decodes (the same class as C32/B14). With the metadata now released on reload, an `option3` set *during* a `decode ()` call can free what `draw ()` is reading, where it used to leak instead. That race was already there for `total_labels`, which `decode ()` reads without a lock. Closing it needs the element to serialise options against `decode ()`, which is a change for all decoders, not for this one.

Refs #4920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
