### PR TITLE
[CI] Run an SSAT suite from the installed tree

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -139,7 +139,10 @@ jobs:
     - name: build and unit test
       if: env.rebuild == '1'
       run: |
-        meson setup build/ -Darmnn-support=enabled
+        # install-test only marks what gets installed; it builds and tests
+        # nothing extra. On x86, the last step installs the tree to run SSAT
+        # from it.
+        meson setup build/ -Darmnn-support=enabled -Dinstall-test=true
 
         # This job installs the newest meson from PyPI, so it configures
         # happily with a construct that the meson on a target distro does not
@@ -448,6 +451,57 @@ jobs:
         kill ${producer_id} || true
 
         popd
+    # A runTest.sh that probes for a sub-plugin looks in ../../build, and where
+    # that is absent - as in an installed tree - in the path it reads from
+    # /etc/nnstreamer.ini. Nothing else runs that second branch, and when it
+    # cannot find the sub-plugin the suite reports no cases, which SSAT passes.
+    # So install, run one suite from where it was installed, and require the
+    # very same result as its build-tree run above: a skip, or a script that
+    # stops early, then fails the step. ncnn is the suite because this leg
+    # asserts that its sub-plugin is built, so a skip can only be a regression.
+    #
+    # What gets installed is the tree the example app step rebuilt with
+    # tensorflow2-lite, while the build-tree run of the suite came before that
+    # rebuild; no ncnn case depends on the difference.
+    #
+    # It is the last step on purpose: it installs over the runner's prefix and
+    # replaces /etc/nnstreamer.ini, and no other step should see either.
+    # https://github.com/nnstreamer/nnstreamer/issues/4903
+    - name: SSAT run on filter-ncnn from the installed tree
+      if: env.rebuild == '1' && matrix.os == 'ubuntu-22.04'
+      timeout-minutes: 10
+      run: |
+        meson introspect build/ --buildoptions > "${RUNNER_TEMP}/buildoptions.json"
+        opt () {
+          jq -er --arg n "$1" '.[] | select(.name == $n) | .value' "${RUNNER_TEMP}/buildoptions.json"
+        }
+        prefix=$(opt prefix)
+        sysconfdir=$(opt sysconfdir)
+        libdir=$(opt libdir)
+        suite=${prefix}/$(opt bindir)/unittest-nnstreamer/tests/nnstreamer_filter_ncnn
+
+        sudo "$(command -v meson)" install -C build/ --no-rebuild --quiet
+        sudo ldconfig
+        # Where a package puts it, and the only place runTest.sh looks.
+        sudo cp "${prefix}/${sysconfdir}/nnstreamer.ini" /etc/nnstreamer.ini
+        # runTest.sh writes its output files next to itself.
+        sudo chown -R "$(id -u):$(id -g)" "${suite}"
+
+        # The installed plugin only; a fresh registry keeps the build tree's,
+        # which the steps above registered, out of the picture.
+        export GST_PLUGIN_PATH=${prefix}/${libdir}/gstreamer-1.0
+        export GST_REGISTRY=${RUNNER_TEMP}/gst-registry-installed.bin
+        pushd "${suite}"
+        ssat -n -p=1 --summary "${RUNNER_TEMP}/ncnn-installed-summary.txt"
+        popd
+
+        echo "build tree: $(cat tests/nnstreamer_filter_ncnn/summary.txt)"
+        echo "installed:  $(cat "${RUNNER_TEMP}/ncnn-installed-summary.txt")"
+        if ! grep -q '^passed=[1-9]' "${RUNNER_TEMP}/ncnn-installed-summary.txt" ||
+           ! cmp -s tests/nnstreamer_filter_ncnn/summary.txt "${RUNNER_TEMP}/ncnn-installed-summary.txt"; then
+          echo "::error::The ncnn SSAT suite did not run the same cases from the installed tree as from the build tree. Check the /etc/nnstreamer.ini branch of its runTest.sh, and what the install put in place."
+          exit 1
+        fi
 
 # TODO: add more subplugins to be built
 # TODO: add unit testing


### PR DESCRIPTION
Fixes #4903

## What

Every `runTest.sh` finds its sub-plugin either in `../../build` or, where that is absent as in an installed tree, in the `filters` path it reads from `/etc/nnstreamer.ini`. CI only ever took the first branch: RPM runs `%check` before `%install`, and debhelper runs `dh_auto_test` before `dh_auto_install`. When the second branch cannot find the sub-plugin, the suite reports no cases and SSAT still passes, so a regression there stays green everywhere.

This PR changes one file, `ubuntu_clean_meson_build.yml`, and only its x86 leg:

- **Setup:** configure with `-Dinstall-test=true`. The option only sets `install:` flags and the `install_subdir` block, so the job builds and tests nothing extra. I checked every `get_option('install-test')` in the tree.
- **New last step:** `sudo meson install --no-rebuild`, then copy the installed `nnstreamer.ini` to `/etc/nnstreamer.ini`, where a package puts it and where `runTest.sh` looks. Then run `nnstreamer_filter_ncnn` from `<prefix>/bin/unittest-nnstreamer/tests/`. Only the installed GStreamer plugin is visible to that run: `GST_PLUGIN_PATH` points at the installed dir, and `GST_REGISTRY` is a fresh file.
- **Pass condition:** the installed run's `--summary` must match the build-tree run of the same suite byte for byte, and must have `passed` ≥ 1. A skip (`0 passed among 0 cases`) fails the step, and so does a script that stops early.

Why ncnn: this leg already asserts `libnnstreamer_filter_ncnn.so` is built (`test -f`), so a skip can only be a regression. It is also fast.

Why last: the step installs over the runner's `/usr/local` and replaces `/etc/nnstreamer.ini`, which the example-app step also writes. No other step should see either.

The prefix is left at the default `/usr/local`. Changing it would change `-DNNSTREAMER_CONF_FILE` (meson.build:142) and recompile everything.

## Cost

Measured on 60 PR runs in September:

- The x86 leg's median is 18.7 min. It is the slowest check of a PR 29/60 times (48%).
- The step adds about 5–10 s: the install copies about 100 MB (223 files), and the suite takes about 1 s. The existing build-tree ncnn/litert steps take 1 s each.
- For comparison, the valgrind step alone varies from 6.6 to 23 min between runs.

## Verification

I extracted the step's `run:` text from the YAML and ran it unchanged in an `ubuntu:22.04` container. The container used the job's packages, the same pinned ncnn prebuilt, and `ssat` from `ppa:nnstreamer/ppa`. The step ran as a non-root user with passwordless sudo, under `bash -e` with a clean environment, the way Actions runs it.

| Scenario | SSAT alone | This step |
|---|---|---|
| As is | 23/23 passed | **pass**: `build tree: passed=23` = `installed: passed=23` |
| Installed-mode branch greps a key the ini lacks (the #4903 failure mode) | `[PASSED] (0 passed among 0 cases)`, exit 0 | **fail** with `::error::` |
| Installed-mode run stops before case 9 | `[PASSED] (8 passed among 8 cases)`, exit 0 | **fail** with `::error::` |
| Restored | 23/23 | **pass** |

In that environment, `gst-inspect-1.0 tensor_filter` reports `Filename /usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/libnnstreamer.so`, i.e. the installed plugin.

## Scope and limits

- Only the probe shape of the 16 older suites is exercised (`key=${path%=*}`). #4900 added a newer shape (`${sub_plugin_line%%=*}`) to 7 suites, and those need lua or python flatbuffers. Neither is installed on this leg, and adding them would change what `meson test` covers here.
- Found while verifying, not fixed here: in `tests/meson.build`, the condition that installs `test_models` (`tensor_filter_ext_enabled`) lacks `ncnn`, `deepview_rt` and `dali`. `nnstreamer_decoder_tensor_region` is installed unconditionally but reads `../test_models/data/orange.png`. So a build whose only external filter is ncnn installs the ncnn suite without its models. The first container run, before I made the condition true there, failed 13 cases for exactly this reason. This job is unaffected because litert makes the condition true, and the PPA and Tizen builds are unaffected because tflite does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
