### PR TITLE
[Filter] Validate the flexible input header and the dynamic output info

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -117,7 +117,7 @@ typedef struct _GstTensorFilterProperties
   int num_models; /**< number of model files. Some frameworks need multiple model files to initialize the graph (caffe, caffe2) */
 
   int input_configured; /**< TRUE if input tensor is configured. Use int instead of gboolean because this is referred by custom plugins. */
-  GstTensorsInfo input_meta; /**< configured input tensor info */
+  GstTensorsInfo input_meta; /**< configured input tensor info. With invoke_dynamic and a flexible input, tensor-filter updates the type and dimension of each tensor from its meta header before invoke; otherwise a flexible input is checked against it and it is left as configured. */
   tensors_layout input_layout; /**< data layout info provided as a property to tensor_filter for the input, defaults to _NNS_LAYOUT_ANY for all the tensors */
   unsigned int input_ranks[NNS_TENSOR_SIZE_LIMIT];  /**< the rank list of input tensors, it is calculated based on the dimension string. */
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -1725,6 +1725,7 @@ gst_tensor_filter_set_caps (GstBaseTransform * trans,
         ("Set-caps failed. Invalid output config (padcaps) for tensor-filter (%s:%s): its format is static, but not equal to the internal configuration: %s\nThis might be an internal error. Please report to https://github.com/nnstreamer/nnstreamer/issues .",
             GST_STR_NULL (prop->fwname), TF_MODELNAME (prop), compare));
     g_free (compare);
+    gst_tensors_config_free (&config);
     return FALSE;
   }
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -1010,8 +1010,9 @@ _gst_tensor_filter_transform_check_invoke_result (GstBaseTransform * trans,
 
 /**
  * @brief Internal function to make output buffer.
+ * @return FALSE if the dynamic invoke has left an output tensor info invalid. The output data not appended to the buffer is released.
  */
-static void
+static gboolean
 _gst_tensor_filter_transform_update_outbuf (GstBaseTransform * trans,
     FilterTransformData * in_trans_data, FilterTransformData * out_trans_data,
     GstBuffer * outbuf)
@@ -1089,6 +1090,16 @@ _gst_tensor_filter_transform_update_outbuf (GstBaseTransform * trans,
     if (prop->invoke_dynamic) {
       GstTensorMetaInfo meta;
 
+      if (!gst_tensor_info_validate (_info)) {
+        ml_loge_stacktrace
+            ("gst_tensor_filter_transform: The tensor-filter subplugin (%s : %s) has returned an invalid tensor info for the %u'th output tensor with the dynamic invoke.\n",
+            prop->fwname, TF_MODELNAME (prop), i);
+        for (; i < prop->output_meta.num_tensors; i++)
+          gst_tensor_filter_destroy_notify_util (priv,
+              out_trans_data->tensors[i].data);
+        return FALSE;
+      }
+
       /* Convert to flexible tensors */
       gst_tensor_info_convert_to_meta (_info, &meta);
       meta.media_type = _NNS_TENSOR;
@@ -1115,6 +1126,8 @@ _gst_tensor_filter_transform_update_outbuf (GstBaseTransform * trans,
     /* append the memory block to outbuf */
     gst_tensor_buffer_append_memory (outbuf, out_trans_data->mem[i], _info);
   }
+
+  return TRUE;
 }
 
 /**
@@ -1185,8 +1198,12 @@ gst_tensor_filter_async_output_callback (GstTensorMemory * data,
     out_trans_data->tensors[i].size = data[i].size;
   }
 
-  _gst_tensor_filter_transform_update_outbuf (trans, NULL, out_trans_data,
-      outbuf);
+  if (!_gst_tensor_filter_transform_update_outbuf (trans, NULL, out_trans_data,
+          outbuf)) {
+    g_clear_pointer (&outbuf, gst_buffer_unref);
+    g_clear_pointer (&out_trans_data, g_free);
+    return -1;
+  }
   g_clear_pointer (&out_trans_data, g_free);
 
   if (gst_pad_push (trans->srcpad, outbuf) != GST_FLOW_OK) {
@@ -1280,8 +1297,9 @@ gst_tensor_filter_transform (GstBaseTransform * trans,
     goto done;
   }
 
-  _gst_tensor_filter_transform_update_outbuf (trans, in_trans_data,
-      out_trans_data, outbuf);
+  if (!_gst_tensor_filter_transform_update_outbuf (trans, in_trans_data,
+          out_trans_data, outbuf))
+    retval = GST_FLOW_ERROR;
 
   goto done;
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -675,26 +675,47 @@ _gst_tensor_filter_release_mem_until_idx (FilterTransformData * trans_data,
 }
 
 /**
- * @brief Internal function to convert tensor meta and get header size of flexible tensor.
+ * @brief Internal function to parse the meta header of a flexible input tensor and get its header size.
+ * @details The configured input info is left as it is unless the dynamic invoke is enabled, which takes the type and dimension of each incoming tensor.
+ * @return FALSE if the memory does not carry a header describing the data after it.
  */
-static gsize
+static gboolean
 _gst_tensor_filter_convert_meta (FilterTransformData * trans_data,
-    GstTensorsInfo * info, guint idx)
+    GstTensorFilterProperties * prop, guint idx, gsize * hsize)
 {
-  gsize header_size = 0;
   GstTensorMetaInfo *_meta;
-  GstTensorInfo *_info;
+  GstMapInfo *map;
+  GstTensorInfo info, *_info;
 
-  if (trans_data->is_flexible) {
-    _meta = &trans_data->meta[idx];
-    _info = gst_tensors_info_get_nth_info (info, idx);
+  *hsize = 0;
+  if (!trans_data->is_flexible)
+    return TRUE;
 
-    gst_tensor_meta_info_parse_header (_meta, trans_data->info[idx].data);
-    header_size = gst_tensor_meta_info_get_header_size (_meta);
-    gst_tensor_meta_info_convert (_meta, _info);
+  _meta = &trans_data->meta[idx];
+  map = &trans_data->info[idx];
+
+  /* parse_header () reads a whole header of the default version before validating it */
+  gst_tensor_meta_info_init (_meta);
+  if (map->size < gst_tensor_meta_info_get_header_size (_meta) ||
+      !gst_tensor_meta_info_parse_header (_meta, map->data))
+    return FALSE;
+
+  *hsize = gst_tensor_meta_info_get_header_size (_meta);
+  if (*hsize == 0 || *hsize > map->size ||
+      _meta->format == _NNS_TENSOR_FORMAT_SPARSE)
+    return FALSE;
+
+  if (!gst_tensor_meta_info_convert (_meta, &info) ||
+      gst_tensor_info_get_size (&info) != map->size - *hsize)
+    return FALSE;
+
+  if (prop->invoke_dynamic) {
+    _info = gst_tensors_info_get_nth_info (&prop->input_meta, idx);
+    _info->type = info.type;
+    memcpy (_info->dimension, info.dimension, sizeof (info.dimension));
   }
 
-  return header_size;
+  return TRUE;
 }
 
 /**
@@ -735,7 +756,14 @@ _gst_tensor_filter_transform_get_all_input_data (GstBaseTransform * trans,
       return NULL;
     }
 
-    hsize = _gst_tensor_filter_convert_meta (trans_data, &prop->input_meta, i);
+    if (!_gst_tensor_filter_convert_meta (trans_data, prop, i, &hsize)) {
+      GST_ELEMENT_ERROR_BTRACE (self, STREAM, WRONG_TYPE,
+          ("The %u'th memory chunk (%zu bytes) of the flexible input buffer for tensor-filter (%s : %s) does not start with a valid tensor meta header that describes the data after it.",
+              i, trans_data->info[i].size, prop->fwname, TF_MODELNAME (prop)));
+      _gst_tensor_filter_release_mem_until_idx (trans_data, i + 1);
+      g_free (trans_data);
+      return NULL;
+    }
 
     trans_data->tensors[i].data = trans_data->info[i].data + hsize;
     trans_data->tensors[i].size = trans_data->info[i].size - hsize;
@@ -813,7 +841,7 @@ _gst_tensor_filter_transform_get_invoke_tensors (GstBaseTransform * trans,
       expected = gst_tensor_filter_get_tensor_size (self, i, TRUE);
       if (expected != trans_data->tensors[i].size) {
         ml_loge_stacktrace
-            ("gst_tensor_filter_transform: Input buffer size (%u'th memory chunk: %zd) is invalid, which is expected to be %zd, which is the frame size of the corresponding tensor. Maybe, the pad capability is not consistent with the actual input stream; if the size is supposed to change dynamically and the given neural network, framework, and the subpluigins can handle it, please consider using format=flexible.\n",
+            ("gst_tensor_filter_transform: Input buffer size (%u'th memory chunk: %zd) is invalid, which is expected to be %zd, which is the frame size of the corresponding tensor. Maybe, the pad capability is not consistent with the actual input stream; if the size is supposed to change dynamically and the given neural network, framework, and the subpluigins can handle it, please consider using format=flexible with invoke-dynamic=true.\n",
             i, trans_data->tensors[i].size, expected);
         g_free (invoke_tensors);
         return NULL;

--- a/tests/nnstreamer_filter_custom/unittest_filter_custom.cc
+++ b/tests/nnstreamer_filter_custom/unittest_filter_custom.cc
@@ -9,12 +9,15 @@
 
 #include <gtest/gtest.h>
 #include <glib/gstdio.h>
+#include <gst/check/gstharness.h>
 #include <gst/gst.h>
 #include <nnstreamer_plugin_api.h>
 #include <nnstreamer_plugin_api_util.h>
 #include <nnstreamer_util.h>
 #include <stdlib.h>
+#include <sys/mman.h>
 #include <tensor_filter_custom_easy.h>
+#include <unistd.h>
 #include <unittest_util.h>
 
 /** @brief User data for new_data_cb and custom filter */
@@ -480,6 +483,625 @@ TEST (tensorFilterCustom, dynamicRegisterInvalidParam_n)
       "temp_name", _custom_easy_filter_dynamic, NULL, NULL);
   EXPECT_NE (0, ret);
   g_mutex_clear (&data.lock);
+}
+
+#define FLEX_IN_HSIZE (128U)
+#define FLEX_IN_MODEL_SIZE (176U)
+
+/**
+ * @brief What the custom-easy filters of the flexible input tests have seen.
+ */
+typedef struct {
+  guint invoked;
+  gsize in_size;
+  guint in_dim;
+  tensor_type in_type;
+  gchar *in_name;
+  guint num_out;
+  gint invalid_out;
+} flex_in_data;
+
+/**
+ * @brief Static custom-easy filter recording its input and the configured input info.
+ */
+static int
+_flex_in_static (void *data, const GstTensorFilterProperties *prop,
+    const GstTensorMemory *input, GstTensorMemory *output)
+{
+  flex_in_data *d = (flex_in_data *) data;
+
+  d->invoked++;
+  d->in_size = input[0].size;
+  g_free (d->in_name);
+  d->in_name = g_strdup (prop->input_meta.info[0].name);
+  memcpy (output[0].data, input[0].data, MIN (input[0].size, output[0].size));
+  return 0;
+}
+
+/**
+ * @brief Dynamic custom-easy filter recording its input info, leaving the output info of @a invalid_out unset.
+ */
+static int
+_flex_in_dynamic (void *data, const GstTensorsInfo *in_info,
+    GstTensorsInfo *out_info, const GstTensorMemory *input, GstTensorMemory *output)
+{
+  flex_in_data *d = (flex_in_data *) data;
+  guint i;
+
+  d->invoked++;
+  d->in_size = input[0].size;
+  d->in_dim = in_info->info[0].dimension[0];
+  d->in_type = in_info->info[0].type;
+  g_free (d->in_name);
+  d->in_name = g_strdup (in_info->info[0].name);
+
+  gst_tensors_info_free (out_info);
+  gst_tensors_info_init (out_info);
+  out_info->num_tensors = d->num_out;
+  out_info->format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+
+  for (i = 0; i < d->num_out; i++) {
+    if ((gint) i != d->invalid_out) {
+      out_info->info[i].type = _NNS_UINT8;
+      out_info->info[i].dimension[0] = (guint) input[0].size;
+    }
+    output[i].size = input[0].size;
+    output[i].data = _g_memdup (input[0].data, input[0].size);
+  }
+  return 0;
+}
+
+/**
+ * @brief Register a custom-easy model taking one uint8 tensor named "in0".
+ * @details The static model takes and returns FLEX_IN_MODEL_SIZE bytes; the dynamic one takes anything.
+ */
+static int
+_flex_in_register (const gchar *model, gboolean dynamic, flex_in_data *d)
+{
+  GstTensorsInfo in_info, out_info;
+  int ret;
+
+  memset (d, 0, sizeof (*d));
+  d->num_out = 1;
+  d->invalid_out = -1;
+
+  gst_tensors_info_init (&in_info);
+  gst_tensors_info_init (&out_info);
+  in_info.num_tensors = out_info.num_tensors = 1;
+  in_info.info[0].name = g_strdup ("in0");
+
+  if (dynamic) {
+    in_info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+    ret = NNS_custom_easy_dynamic_register (model, _flex_in_dynamic, d, &in_info);
+  } else {
+    in_info.info[0].type = out_info.info[0].type = _NNS_UINT8;
+    gst_tensor_parse_dimension ("176:1:1:1", in_info.info[0].dimension);
+    gst_tensor_parse_dimension ("176:1:1:1", out_info.info[0].dimension);
+    ret = NNS_custom_easy_register (model, _flex_in_static, d, &in_info, &out_info);
+  }
+
+  gst_tensors_info_free (&in_info);
+  gst_tensors_info_free (&out_info);
+  return ret;
+}
+
+/**
+ * @brief Harness a tensor_filter running the given custom-easy model on a flexible stream, with a bus to catch its errors.
+ */
+static GstHarness *
+_flex_in_harness (const gchar *model, gboolean dynamic)
+{
+  GstHarness *h;
+  GstBus *bus;
+  gchar *desc;
+
+  desc = g_strdup_printf ("tensor_filter framework=custom-easy model=%s invoke-dynamic=%s",
+      model, dynamic ? "true" : "false");
+  h = gst_harness_new_parse (desc);
+  g_free (desc);
+
+  bus = gst_bus_new ();
+  gst_element_set_bus (h->element, bus);
+  gst_object_unref (bus);
+
+  if (dynamic)
+    gst_harness_set_sink_caps_str (h, "other/tensors,format=flexible");
+  gst_harness_set_src_caps_str (h, "other/tensors,format=flexible,framerate=(fraction)0/1");
+  return h;
+}
+
+/**
+ * @brief Fill @a raw with a flexible uint8 tensor of @a dim bytes: a meta header, then 0, 1, 2, ...
+ */
+static void
+_flex_in_fill (guint8 *raw, guint dim)
+{
+  GstTensorInfo info;
+  GstTensorMetaInfo meta;
+  guint i;
+
+  gst_tensor_info_init (&info);
+  info.type = _NNS_UINT8;
+  info.dimension[0] = dim;
+
+  ASSERT_TRUE (gst_tensor_info_convert_to_meta (&info, &meta));
+  meta.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  meta.media_type = _NNS_TENSOR;
+  ASSERT_TRUE (gst_tensor_meta_info_update_header (&meta, raw));
+
+  for (i = 0; i < dim; i++)
+    raw[FLEX_IN_HSIZE + i] = (guint8) i;
+}
+
+/**
+ * @brief Push one memory of @a size bytes copied from @a raw.
+ */
+static GstFlowReturn
+_flex_in_push (GstHarness *h, const guint8 *raw, gsize size)
+{
+  return gst_harness_push (h, gst_buffer_new_wrapped (_g_memdup (raw, size), size));
+}
+
+/**
+ * @brief Whether tensor_filter has posted the STREAM/WRONG_TYPE error that reports a refused input header.
+ */
+static gboolean
+_flex_in_refused_header (GstHarness *h)
+{
+  GstBus *bus = gst_element_get_bus (h->element);
+  GstMessage *msg;
+  GError *err = NULL;
+  gboolean refused = FALSE;
+
+  msg = gst_bus_pop_filtered (bus, GST_MESSAGE_ERROR);
+  if (msg) {
+    gst_message_parse_error (msg, &err, NULL);
+    refused = g_error_matches (err, GST_STREAM_ERROR, GST_STREAM_ERROR_WRONG_TYPE)
+              && g_str_equal (G_OBJECT_TYPE_NAME (GST_MESSAGE_SRC (msg)), "GstTensorFilter");
+    g_clear_error (&err);
+    gst_message_unref (msg);
+  }
+
+  gst_object_unref (bus);
+  return refused;
+}
+
+/**
+ * @brief A flexible memory shorter than a meta header is refused before a header is read from it.
+ * @details The memory ends where an inaccessible page starts, so reading a header from it faults.
+ */
+TEST (tensorFilterFlexInput, shortMemory_n)
+{
+  const gsize page = (gsize) sysconf (_SC_PAGESIZE);
+  guint8 raw[FLEX_IN_HSIZE + FLEX_IN_MODEL_SIZE];
+  flex_in_data data;
+  GstHarness *h;
+  guint8 *pages, *tail;
+
+  ASSERT_EQ (_flex_in_register ("flex_in_short", FALSE, &data), 0);
+  _flex_in_fill (raw, FLEX_IN_MODEL_SIZE);
+
+  pages = (guint8 *) mmap (NULL, 2 * page, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE (pages, MAP_FAILED);
+  ASSERT_EQ (mprotect (pages + page, page, PROT_NONE), 0);
+  tail = pages + page - 8;
+  memcpy (tail, raw, 8);
+
+  h = _flex_in_harness ("flex_in_short", FALSE);
+  EXPECT_EQ (gst_harness_push (h, gst_buffer_new_wrapped_full (GST_MEMORY_FLAG_READONLY,
+                                      tail, 8, 0, 8, NULL, NULL)),
+      GST_FLOW_ERROR);
+  EXPECT_EQ (data.invoked, 0U);
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+  EXPECT_TRUE (_flex_in_refused_header (h));
+
+  gst_harness_teardown (h);
+  munmap (pages, 2 * page);
+  EXPECT_EQ (NNS_custom_easy_unregister ("flex_in_short"), 0);
+  g_free (data.in_name);
+}
+
+/**
+ * @brief A flexible memory not starting with a meta header is refused, though the whole memory is the size the model takes.
+ */
+TEST (tensorFilterFlexInput, brokenHeaderMagic_n)
+{
+  guint8 raw[FLEX_IN_HSIZE + FLEX_IN_MODEL_SIZE];
+  flex_in_data data;
+  GstHarness *h;
+
+  ASSERT_EQ (_flex_in_register ("flex_in_magic", FALSE, &data), 0);
+  _flex_in_fill (raw, FLEX_IN_MODEL_SIZE);
+  ((guint32 *) raw)[0] = 0;
+
+  h = _flex_in_harness ("flex_in_magic", FALSE);
+  EXPECT_EQ (_flex_in_push (h, raw, FLEX_IN_MODEL_SIZE), GST_FLOW_ERROR);
+  EXPECT_EQ (data.invoked, 0U);
+  EXPECT_TRUE (_flex_in_refused_header (h));
+
+  gst_harness_teardown (h);
+  EXPECT_EQ (NNS_custom_easy_unregister ("flex_in_magic"), 0);
+  g_free (data.in_name);
+}
+
+/**
+ * @brief A meta header with an invalid type is refused, though the data after it is the size the model takes.
+ */
+TEST (tensorFilterFlexInput, brokenHeaderType_n)
+{
+  guint8 raw[FLEX_IN_HSIZE + FLEX_IN_MODEL_SIZE];
+  flex_in_data data;
+  GstHarness *h;
+
+  ASSERT_EQ (_flex_in_register ("flex_in_type", FALSE, &data), 0);
+  _flex_in_fill (raw, FLEX_IN_MODEL_SIZE);
+  ((guint32 *) raw)[2] = _NNS_END;
+
+  h = _flex_in_harness ("flex_in_type", FALSE);
+  EXPECT_EQ (_flex_in_push (h, raw, sizeof (raw)), GST_FLOW_ERROR);
+  EXPECT_EQ (data.invoked, 0U);
+  EXPECT_TRUE (_flex_in_refused_header (h));
+
+  gst_harness_teardown (h);
+  EXPECT_EQ (NNS_custom_easy_unregister ("flex_in_type"), 0);
+  g_free (data.in_name);
+}
+
+/**
+ * @brief A header describing fewer bytes than follow it is refused, though the memory holds what the model takes.
+ */
+TEST (tensorFilterFlexInput, headerSizeMismatch_n)
+{
+  guint8 raw[FLEX_IN_HSIZE + FLEX_IN_MODEL_SIZE];
+  flex_in_data data;
+  GstHarness *h;
+
+  ASSERT_EQ (_flex_in_register ("flex_in_mismatch", FALSE, &data), 0);
+  _flex_in_fill (raw, FLEX_IN_MODEL_SIZE);
+  ((guint32 *) raw)[3] = 16;
+
+  h = _flex_in_harness ("flex_in_mismatch", FALSE);
+  EXPECT_EQ (_flex_in_push (h, raw, sizeof (raw)), GST_FLOW_ERROR);
+  EXPECT_EQ (data.invoked, 0U);
+  EXPECT_TRUE (_flex_in_refused_header (h));
+
+  gst_harness_teardown (h);
+  EXPECT_EQ (NNS_custom_easy_unregister ("flex_in_mismatch"), 0);
+  g_free (data.in_name);
+}
+
+/**
+ * @brief A well-formed flexible tensor smaller than the model's input does not reach the model.
+ * @details The header itself is valid, so the refusal is the model size check's, not the header check's.
+ */
+TEST (tensorFilterFlexInput, smallerThanModel_n)
+{
+  guint8 raw[FLEX_IN_HSIZE + 16];
+  flex_in_data data;
+  GstHarness *h;
+
+  ASSERT_EQ (_flex_in_register ("flex_in_smaller", FALSE, &data), 0);
+  _flex_in_fill (raw, 16);
+
+  h = _flex_in_harness ("flex_in_smaller", FALSE);
+  EXPECT_EQ (_flex_in_push (h, raw, sizeof (raw)), GST_FLOW_ERROR);
+  EXPECT_EQ (data.invoked, 0U);
+  EXPECT_FALSE (_flex_in_refused_header (h));
+
+  gst_harness_teardown (h);
+  EXPECT_EQ (NNS_custom_easy_unregister ("flex_in_smaller"), 0);
+  g_free (data.in_name);
+}
+
+/**
+ * @brief A sparse header is refused with and without the dynamic invoke, though its dense size matches the data.
+ */
+TEST (tensorFilterFlexInput, sparseHeader_n)
+{
+  const gchar *models[] = { "flex_in_sparse", "flex_in_sparse_dynamic" };
+  guint8 raw[FLEX_IN_HSIZE + FLEX_IN_MODEL_SIZE];
+  flex_in_data data;
+  GstHarness *h;
+  guint i;
+
+  _flex_in_fill (raw, FLEX_IN_MODEL_SIZE);
+  ((guint32 *) raw)[19] = _NNS_TENSOR_FORMAT_SPARSE;
+
+  for (i = 0; i < G_N_ELEMENTS (models); i++) {
+    ASSERT_EQ (_flex_in_register (models[i], i == 1, &data), 0);
+
+    h = _flex_in_harness (models[i], i == 1);
+    EXPECT_EQ (_flex_in_push (h, raw, sizeof (raw)), GST_FLOW_ERROR);
+    EXPECT_EQ (data.invoked, 0U);
+    EXPECT_TRUE (_flex_in_refused_header (h));
+
+    gst_harness_teardown (h);
+    EXPECT_EQ (NNS_custom_easy_unregister (models[i]), 0);
+    g_free (data.in_name);
+  }
+}
+
+/**
+ * @brief A header of a version that validates but cannot be sized is refused.
+ * @details The dimension covers the whole memory, so taking the header size of 0 at its word would pass every size check.
+ */
+TEST (tensorFilterFlexInput, unknownVersion_n)
+{
+  guint8 raw[FLEX_IN_HSIZE + FLEX_IN_MODEL_SIZE];
+  GstTensorMetaInfo meta;
+  flex_in_data data;
+  GstHarness *h;
+
+  ASSERT_EQ (_flex_in_register ("flex_in_version", TRUE, &data), 0);
+  _flex_in_fill (raw, FLEX_IN_MODEL_SIZE);
+  ((guint32 *) raw)[1] = 0xDE002000U;
+  ((guint32 *) raw)[3] = sizeof (raw);
+
+  EXPECT_TRUE (gst_tensor_meta_info_parse_header (&meta, raw));
+  EXPECT_EQ (gst_tensor_meta_info_get_header_size (&meta), 0U);
+
+  h = _flex_in_harness ("flex_in_version", TRUE);
+  EXPECT_EQ (_flex_in_push (h, raw, sizeof (raw)), GST_FLOW_ERROR);
+  EXPECT_EQ (data.invoked, 0U);
+  EXPECT_TRUE (_flex_in_refused_header (h));
+
+  gst_harness_teardown (h);
+  EXPECT_EQ (NNS_custom_easy_unregister ("flex_in_version"), 0);
+  g_free (data.in_name);
+}
+
+/**
+ * @brief A flexible tensor of the model's size reaches the model with the configured input info intact.
+ */
+TEST (tensorFilterFlexInput, keepsConfiguredInfo)
+{
+  guint8 raw[FLEX_IN_HSIZE + FLEX_IN_MODEL_SIZE];
+  flex_in_data data;
+  GstHarness *h;
+  GstElement *filter;
+  GstBuffer *out;
+  GstMapInfo map;
+  gchar *str;
+
+  ASSERT_EQ (_flex_in_register ("flex_in_keeps", FALSE, &data), 0);
+  _flex_in_fill (raw, FLEX_IN_MODEL_SIZE);
+
+  h = _flex_in_harness ("flex_in_keeps", FALSE);
+  EXPECT_EQ (_flex_in_push (h, raw, sizeof (raw)), GST_FLOW_OK);
+  EXPECT_EQ (data.invoked, 1U);
+  EXPECT_EQ (data.in_size, FLEX_IN_MODEL_SIZE);
+  EXPECT_STREQ (data.in_name, "in0");
+
+  out = gst_harness_pull (h);
+  ASSERT_TRUE (out != NULL);
+  ASSERT_TRUE (gst_buffer_map (out, &map, GST_MAP_READ));
+  EXPECT_EQ (map.size, FLEX_IN_MODEL_SIZE);
+  EXPECT_EQ (memcmp (map.data, raw + FLEX_IN_HSIZE, MIN (map.size, FLEX_IN_MODEL_SIZE)), 0);
+  gst_buffer_unmap (out, &map);
+  gst_buffer_unref (out);
+
+  filter = gst_harness_find_element (h, "tensor_filter");
+  ASSERT_TRUE (filter != NULL);
+  g_object_get (filter, "inputname", &str, NULL);
+  EXPECT_STREQ (str, "in0");
+  g_free (str);
+  g_object_get (filter, "input", &str, NULL);
+  EXPECT_STREQ (str, "176:1:1:1");
+  g_free (str);
+  gst_object_unref (filter);
+  EXPECT_FALSE (_flex_in_refused_header (h));
+
+  gst_harness_teardown (h);
+  EXPECT_EQ (NNS_custom_easy_unregister ("flex_in_keeps"), 0);
+  g_free (data.in_name);
+}
+
+/**
+ * @brief The dynamic invoke takes the type and dimension of each incoming tensor, keeping the configured name.
+ */
+TEST (tensorFilterFlexInput, dynamicTakesEachHeader)
+{
+  guint8 raw[FLEX_IN_HSIZE + 24];
+  const guint dims[] = { 16, 24 };
+  GstTensorMetaInfo meta;
+  flex_in_data data;
+  GstHarness *h;
+  GstBuffer *out;
+  GstMemory *mem;
+  GstMapInfo map;
+  guint i;
+
+  ASSERT_EQ (_flex_in_register ("flex_in_dynamic", TRUE, &data), 0);
+  h = _flex_in_harness ("flex_in_dynamic", TRUE);
+
+  for (i = 0; i < G_N_ELEMENTS (dims); i++) {
+    _flex_in_fill (raw, dims[i]);
+    EXPECT_EQ (_flex_in_push (h, raw, FLEX_IN_HSIZE + dims[i]), GST_FLOW_OK);
+    EXPECT_EQ (data.invoked, i + 1);
+    EXPECT_EQ (data.in_size, dims[i]);
+    EXPECT_EQ (data.in_dim, dims[i]);
+    EXPECT_EQ (data.in_type, _NNS_UINT8);
+    EXPECT_STREQ (data.in_name, "in0");
+
+    out = gst_harness_pull (h);
+    ASSERT_TRUE (out != NULL);
+    EXPECT_EQ (gst_buffer_n_memory (out), 1U);
+    mem = gst_buffer_peek_memory (out, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &map, GST_MAP_READ));
+    ASSERT_EQ (map.size, FLEX_IN_HSIZE + dims[i]);
+    EXPECT_TRUE (gst_tensor_meta_info_parse_header (&meta, map.data));
+    EXPECT_EQ (meta.dimension[0], dims[i]);
+    EXPECT_EQ (memcmp (map.data + FLEX_IN_HSIZE, raw + FLEX_IN_HSIZE, dims[i]), 0);
+    gst_memory_unmap (mem, &map);
+    gst_buffer_unref (out);
+  }
+
+  gst_harness_teardown (h);
+  EXPECT_EQ (NNS_custom_easy_unregister ("flex_in_dynamic"), 0);
+  g_free (data.in_name);
+}
+
+/**
+ * @brief An output tensor info the dynamic invoke leaves invalid fails the buffer instead of pushing a broken one.
+ * @details The invalid output sits between two valid ones, so both an appended and a pending output are released.
+ */
+TEST (tensorFilterFlexInput, dynamicInvalidOutputInfo_n)
+{
+  guint8 raw[FLEX_IN_HSIZE + 16];
+  flex_in_data data;
+  GstHarness *h;
+
+  ASSERT_EQ (_flex_in_register ("flex_in_invalid_out", TRUE, &data), 0);
+  data.num_out = 3;
+  data.invalid_out = 1;
+  _flex_in_fill (raw, 16);
+
+  h = _flex_in_harness ("flex_in_invalid_out", TRUE);
+  EXPECT_EQ (_flex_in_push (h, raw, sizeof (raw)), GST_FLOW_ERROR);
+  EXPECT_EQ (data.invoked, 1U);
+  EXPECT_EQ (gst_harness_buffers_received (h), 0U);
+
+  data.invalid_out = -1;
+  EXPECT_EQ (_flex_in_push (h, raw, sizeof (raw)), GST_FLOW_OK);
+  EXPECT_EQ (gst_harness_buffers_received (h), 1U);
+
+  gst_harness_teardown (h);
+  EXPECT_EQ (NNS_custom_easy_unregister ("flex_in_invalid_out"), 0);
+  g_free (data.in_name);
+}
+
+static guint flex_in_async_dispatched = 0; /**< outputs dispatched by the async sub-plugin */
+
+/**
+ * @brief Framework info of the async test sub-plugin.
+ */
+static int
+_flex_in_async_fw_info (const GstTensorFilterFramework *self,
+    const GstTensorFilterProperties *prop, void *private_data,
+    GstTensorFilterFrameworkInfo *fw_info)
+{
+  UNUSED (self);
+  UNUSED (prop);
+  UNUSED (private_data);
+  memset (fw_info, 0, sizeof (*fw_info));
+  fw_info->name = "flex_in_async";
+  fw_info->allocate_in_invoke = 1;
+  fw_info->run_without_model = 1;
+  return 0;
+}
+
+/**
+ * @brief Model info of the async test sub-plugin: one uint8 tensor, like the custom-easy models above.
+ */
+static int
+_flex_in_async_model_info (const GstTensorFilterFramework *self,
+    const GstTensorFilterProperties *prop, void *private_data,
+    model_info_ops ops, GstTensorsInfo *in_info, GstTensorsInfo *out_info)
+{
+  UNUSED (self);
+  UNUSED (prop);
+  UNUSED (private_data);
+  if (ops != GET_IN_OUT_INFO)
+    return -ENOENT;
+
+  gst_tensors_info_init (in_info);
+  gst_tensors_info_init (out_info);
+  in_info->num_tensors = out_info->num_tensors = 1;
+  in_info->format = out_info->format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+  return 0;
+}
+
+/**
+ * @brief Event handler of the async test sub-plugin, leaving the release of the output data to tensor-filter.
+ */
+static int
+_flex_in_async_event (const GstTensorFilterFramework *self,
+    const GstTensorFilterProperties *prop, void *private_data, event_ops ops,
+    GstTensorFilterFrameworkEventData *data)
+{
+  UNUSED (self);
+  UNUSED (prop);
+  UNUSED (private_data);
+  UNUSED (ops);
+  UNUSED (data);
+  return -ENOENT;
+}
+
+/**
+ * @brief Invoke of the async test sub-plugin: dispatches three outputs twice, the middle output info of the second left invalid.
+ */
+static int
+_flex_in_async_invoke (const GstTensorFilterFramework *self, GstTensorFilterProperties *prop,
+    void *private_data, const GstTensorMemory *input, GstTensorMemory *output)
+{
+  GstTensorMemory out[3];
+  guint i, k;
+
+  UNUSED (self);
+  UNUSED (private_data);
+  UNUSED (output);
+
+  for (k = 0; k < 2; k++) {
+    gst_tensors_info_free (&prop->output_meta);
+    gst_tensors_info_init (&prop->output_meta);
+    prop->output_meta.num_tensors = G_N_ELEMENTS (out);
+    prop->output_meta.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+
+    for (i = 0; i < G_N_ELEMENTS (out); i++) {
+      if (k == 0 || i != 1) {
+        prop->output_meta.info[i].type = _NNS_UINT8;
+        prop->output_meta.info[i].dimension[0] = (guint) input[0].size;
+      }
+      out[i].size = input[0].size;
+      out[i].data = _g_memdup (input[0].data, input[0].size);
+    }
+
+    flex_in_async_dispatched++;
+    nnstreamer_filter_dispatch_output_async (prop, out);
+  }
+
+  /* everything went out through the async callback, drop the buffer of this invoke */
+  return 1;
+}
+
+/**
+ * @brief An output info left invalid fails the async output instead of pushing a broken buffer.
+ */
+TEST (tensorFilterFlexInput, asyncInvalidOutputInfo_n)
+{
+  guint8 raw[FLEX_IN_HSIZE + 16];
+  GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
+  GstHarness *h;
+  GstBuffer *out;
+
+  fw->version = GST_TENSOR_FILTER_FRAMEWORK_V1;
+  fw->invoke = _flex_in_async_invoke;
+  fw->getFrameworkInfo = _flex_in_async_fw_info;
+  fw->getModelInfo = _flex_in_async_model_info;
+  fw->eventHandler = _flex_in_async_event;
+  ASSERT_TRUE (nnstreamer_filter_probe (fw));
+
+  _flex_in_fill (raw, 16);
+  flex_in_async_dispatched = 0;
+
+  h = gst_harness_new_parse (
+      "tensor_filter framework=flex_in_async invoke-dynamic=true invoke-async=true");
+  gst_harness_set_sink_caps_str (h, "other/tensors,format=flexible");
+  gst_harness_set_src_caps_str (h, "other/tensors,format=flexible,framerate=(fraction)0/1");
+
+  EXPECT_EQ (_flex_in_push (h, raw, sizeof (raw)), GST_FLOW_OK);
+  EXPECT_EQ (flex_in_async_dispatched, 2U);
+  EXPECT_EQ (gst_harness_buffers_received (h), 1U);
+
+  out = gst_harness_pull (h);
+  ASSERT_TRUE (out != NULL);
+  EXPECT_EQ (gst_buffer_n_memory (out), 3U);
+  gst_buffer_unref (out);
+
+  gst_harness_teardown (h);
+  nnstreamer_filter_exit ("flex_in_async");
+  g_free (fw);
 }
 
 /**


### PR DESCRIPTION
Fixes items **B6**, **B9** and **B7** of #4920, all in `gst/nnstreamer/tensor_filter/tensor_filter.c`.

## B6: flexible input header used before it is validated

`_gst_tensor_filter_convert_meta()` handled each flexible input memory like this:

- It parsed a meta header without looking at the memory's size. `gst_tensor_meta_info_parse_header()` reads 84 bytes before validating anything, so a memory shorter than a header was read past its end.
- It ignored the parse result. The header size still came back as 0 or 128, so `size - hsize` underflowed for a short memory. A memory whose header didn't parse went to the model as raw data whenever its whole size matched.
- It rewrote `prop->input_meta[i]` from the header with `gst_tensor_meta_info_convert()`, which re-initialises the entry. The size check that follows reads its expected size from that same entry, so it compared the buffer with **its own header** instead of the model. A well-formed flexible tensor smaller than the model's input reached a sub-plugin that reads the model's size from it (e.g. tensorflow-lite's zero-copy input).
- The re-initialisation also dropped the configured tensor name without freeing it. openvino's `invoke()` builds `std::string (info->name)` from it.

Refreshing `input_meta` per buffer can't simply be removed, as the issue text suggested ("convert into a local copy"). It is the **contract of the dynamic invoke**, added in 99aaa0df: litert's `invoke_dynamic()` and custom-easy's dynamic callback read each buffer's shape from `prop->input_meta`. So:

| | before | after |
|---|---|---|
| `invoke-dynamic=true` | `input_meta[i]` replaced by the header (name lost) | type and dimension taken from the header, name kept |
| `invoke-dynamic=false` | same as above | `input_meta` untouched; the data is checked against the configured (model) tensor |

The second row is what `gst_tensor_filter_configure_tensor()` already says transform does for a flexible input ("Need to compare buffer size in transform()"). Every in-tree pipeline that sends variable-sized flexible tensors to a filter uses `invoke-dynamic` (llamacpp, llama2c, executorch-llama, litert, custom-easy).

A flexible memory is now refused unless all of these hold:
1. It is at least a header long before anything is parsed (mirrors `gst_tensor_meta_info_parse_memory()`).
2. The header parses.
3. Its version can be sized (a header can validate while `get_header_size()` returns 0, which is item A7).
4. It does not declare a sparse tensor. The dense conversion drops the format, so a sparse payload would be read as dense.
5. Its dense size is exactly the data after the header.

The sparse refusal applies with and without `invoke-dynamic`. A refused header posts a `STREAM/WRONG_TYPE` element error from tensor_filter, like its caps-time refusals, before the buffer fails with `GST_FLOW_ERROR`.

Without `invoke-dynamic` a flexible tensor is now checked against the model's size. The existing size-mismatch message used to suggest `format=flexible` alone; it now names `invoke-dynamic=true`.

The `input_meta` doxygen in `nnstreamer_plugin_api_filter.h` now says which behaviour a sub-plugin gets.

## B9: dynamic invoke output info not validated

With `invoke-dynamic` the sub-plugin fills `output_meta` during invoke, and `_gst_tensor_filter_transform_update_outbuf()` ignored the result of `gst_tensor_info_convert_to_meta()`. For an invalid entry that function returns before initialising the meta, so the header was built from an uninitialised stack struct. Inside the loop that is the previous output's header, and the buffer went downstream with the tensor missing or described by another tensor's header. The entry is now validated first. On failure, the output data not yet in the buffer is released and the buffer fails: `GST_FLOW_ERROR` from `transform()`, and `-1` from the async output callback, which also unrefs the partial buffer.

## B7: set_caps mismatch leak

A one-line `gst_tensors_config_free()` on the static-output mismatch branch of `gst_tensor_filter_set_caps()`. **No test:** the branch is a consistency check behind negotiation. `transform_caps()` derives the output caps from the same config, and `gst_tensor_caps_update_dimension()` only replaces a dimension string with an equivalent one. A leak also can't fail a CI check (the valgrind gate counts memcheck errors only).

## Tests

New `tensorFilterFlexInput.*` cases in `tests/nnstreamer_filter_custom/unittest_filter_custom.cc`. They drive `tensor_filter framework=custom-easy` through a GstHarness on a flexible sink pad and push hand-built headers. A bus attached to the harness lets each header refusal assert the `STREAM/WRONG_TYPE` error from the filter. The model-size refusal (`smallerThanModel_n`) and the positive case assert that no such error was posted.

Result of each case against `main`'s `tensor_filter.c` (the new tests are unchanged):

| case | on main |
|---|---|
| `shortMemory_n` (8-byte memory ending at a `PROT_NONE` page) | **SIGSEGV** |
| `brokenHeaderMagic_n` (no header, whole memory = model size) | accepted, fails |
| `brokenHeaderType_n` (header with an invalid type) | accepted, fails |
| `smallerThanModel_n` | model invoked with 16 of its 176 bytes, fails |
| `sparseHeader_n` | accepted as dense, fails |
| `unknownVersion_n` (`0xDE002000`, header counted as data) | accepted, fails |
| `keepsConfiguredInfo` | name `NULL` inside invoke, fails |
| `dynamicTakesEachHeader` | name `NULL`, fails |
| `dynamicInvalidOutputInfo_n` | broken buffer pushed with `GST_FLOW_OK`, fails |
| `asyncInvalidOutputInfo_n` (mock V1 sub-plugin, `invoke-async`) | broken buffer pushed from the async callback, fails |
| `headerSizeMismatch_n` | refused, but no element error, fails |

On main `headerSizeMismatch_n` was refused as well, so its flow result alone doesn't discriminate. It pins the new consistency check: removing that check makes it fail.

Mutation controls, each removing one check of the fix:

| check removed | caught by |
|---|---|
| size check | `shortMemory_n` (SIGSEGV) |
| unsizable-version check | `unknownVersion_n` |
| sparse check | `sparseHeader_n` |
| sparse check limited to non-dynamic mode | `sparseHeader_n` (dynamic half) |
| consistency check | `headerSizeMismatch_n` |
| refreshing without invoke-dynamic | `smallerThanModel_n`, `keepsConfiguredInfo` |
| not refreshing with it | `dynamicTakesEachHeader`, `dynamicInvalidOutputInfo_n` |
| B9 check | `dynamicInvalidOutputInfo_n`, `asyncInvalidOutputInfo_n` |
| async callback ignoring the failure | `asyncInvalidOutputInfo_n` |
| element error on a refused header | the six header-refusal cases |

The one survivor is dropping the parse-result check. Without it `gst_tensor_meta_info_convert()` fails and leaves the local info uninitialised, so the outcome is undefined behaviour. The valgrind gate would report it as an uninitialised read; an assertion can't pin it.

The async-callback branch of B9 is driven by a mock V1 sub-plugin registered in the test with `nnstreamer_filter_probe()`. From one invoke it dispatches a valid set of three outputs and a set whose middle info is invalid. Exactly one buffer (three memories) must reach the sink. This was added after the first review round.

## Local verification (WSL, Ubuntu)

- Full `meson test`: 19/21. The two failures are this machine's environment and fail identically on `main`: `unittest_filter_python3` (numpy 2 ABI) and `unittest_trainer` (30 s timeout).
- `unittest_filter_custom` 19/19, `unittest_plugins`, `unittest_sink`, `unittest_common` all green.
- SSAT `nnstreamer_filter_custom` 23/23. `nnstreamer_filter_python3` fails identically on `main` (same numpy issue). tflite2 and litert aren't built here, so those legs are CI-only.
- Strict build (`-Dwerror=true -Dcpp_args="-Wextra -Wsign-compare"`) clean for every commit on its own. Each intermediate commit also passes the existing tests.
- clang-format: no diff on the test file. gst-indent on `tensor_filter.c` shows no new diff (main has the same 13 pre-existing lines). `doxygen-tag.sh` passes, and its negative control (one `@brief` removed) fails.

## Related

- **#4957** (fix for #4928) rewrites the same function, and the two PRs conflict. The agreed order ([coordination note](https://github.com/nnstreamer/nnstreamer/pull/4957#issuecomment-5628597833)) is **#4953 first, then #4957 rebased on top**. After the rebase, #4957 keeps only its type/dimension equality check.
- This PR now posts the `STREAM/WRONG_TYPE` element error that #4957's `flexibleInputInvalidHeader_n` and `flexibleInputSparseHeader_n` expect, so those two stay valid after the rebase.
- Without `invoke-dynamic`, this PR leaves the header's type unused rather than copying it. A same-size type change still passes the size check; refusing it is #4957's part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
