### PR TITLE
[Test/Split] Verify the critical log handler

### DIFF
--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -12159,15 +12159,26 @@ _record_critical (const gchar *domain, GLogLevelFlags level,
 TEST (testTensorSplit, finalizeWithoutTensorseg)
 {
   GstElement *split = gst_element_factory_make ("tensor_split", NULL);
-  GLogFunc old_handler;
+  guint handler;
+  GLogLevelFlags fatal_mask;
 
   ASSERT_TRUE (split != NULL);
   gst_object_ref_sink (split);
 
+  /* g_array_unref() reports invalid arguments in the GLib domain. */
+  handler = g_log_set_handler ("GLib",
+      (GLogLevelFlags) (G_LOG_LEVEL_CRITICAL | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION),
+      _record_critical, NULL);
   tensor_split_logged_critical = FALSE;
-  old_handler = g_log_set_default_handler (_record_critical, NULL);
+  /* Only the intentional probe may bypass G_DEBUG=fatal-criticals. */
+  fatal_mask = g_log_set_always_fatal ((GLogLevelFlags) G_LOG_FATAL_MASK);
+  g_log ("GLib", G_LOG_LEVEL_CRITICAL, "tensor_split test: handler self-check");
+  g_log_set_always_fatal (fatal_mask);
+  EXPECT_TRUE (tensor_split_logged_critical);
+
+  tensor_split_logged_critical = FALSE;
   gst_object_unref (split);
-  g_log_set_default_handler (old_handler, NULL);
+  g_log_remove_handler ("GLib", handler);
 
   EXPECT_FALSE (tensor_split_logged_critical);
 }


### PR DESCRIPTION
### Summary

`testTensorSplit.finalizeWithoutTensorseg` checks that destroying an unconfigured `tensor_split` emits no critical. Its recorder had no positive check, so disabling the recorder still left the test passing.

This change installs a handler for the `GLib` domain used by `g_array_unref()`, emits a synthetic critical to verify that the recorder is live, and resets it before finalization. The handler is removed afterwards without replacing the process-wide default handler. The fatal mask is relaxed only for the intentional probe and restored before the operation under test.

Related to #4947. This covers the `tensor_split` test; the LiteRT sites remain separate. The existing test detects the current finalizer regression already; this change guards against the recorder itself silently becoming ineffective.

### Validation

- Linux x86_64, GCC 13.3, GLib 2.80, GStreamer 1.24; optional ML backends disabled.
- Full `unittest_plugins`: 229 passed. The local `build-committer` directory was also exposed as `build` for the existing custom-filter fixture path.
- `testTensorSplit.*`: 9 passed.
- Focused case with `G_DEBUG=fatal-criticals`: passed.
- Mutation check: disabling the recorder passes on the original test and fails at the new self-check after this change.
- Mutation check: removing the `tensorseg` null guard fails at the finalization assertion. All mutations were reverted.
- clang-format 16 on the changed lines and `git diff --check`: passed.

### How to evaluate

```sh
CC=gcc CXX=g++ meson setup build -Dauto_features=disabled -Denable-test=true -Dvideo-support=enabled -Daudio-support=enabled
meson compile -C build -j 2
meson test -C build unittest_plugins --test-args='--gtest_filter=testTensorSplit.*' --print-errorlogs
G_DEBUG=fatal-criticals meson test -C build unittest_plugins --test-args='--gtest_filter=testTensorSplit.finalizeWithoutTensorseg' --print-errorlogs
```

Prepared with OpenAI Codex assistance.
